### PR TITLE
fix(ci): repo-root build context for swiftletd image + gofmt pre-exis…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
       - name: Build swiftletd image
         uses: docker/build-push-action@v6
         with:
-          context: ./rust
+          context: .
           file: ./images/swiftletd/Containerfile
           push: false
           load: true

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Build and push swiftletd
         uses: docker/build-push-action@v6
         with:
-          context: ./rust
+          context: .
           file: ./images/swiftletd/Containerfile
           push: true
           tags: |

--- a/.github/workflows/release-rc.yaml
+++ b/.github/workflows/release-rc.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Build and push swiftletd
         uses: docker/build-push-action@v6
         with:
-          context: ./rust
+          context: .
           file: ./images/swiftletd/Containerfile
           push: true
           tags: |

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Build and push swiftletd
         uses: docker/build-push-action@v6
         with:
-          context: ./rust
+          context: .
           file: ./images/swiftletd/Containerfile
           push: true
           tags: |

--- a/cmd/swiftctl/restore.go
+++ b/cmd/swiftctl/restore.go
@@ -15,13 +15,13 @@ import (
 )
 
 var (
-	restoreSnapshot          string
-	restoreTarget            string
-	restoreOverwrite         bool
-	restoreNoResume          bool
-	restoreListAllNS         bool
-	restoreIdentityRegen     []string
-	restoreSkipVersionCheck  bool
+	restoreSnapshot         string
+	restoreTarget           string
+	restoreOverwrite        bool
+	restoreNoResume         bool
+	restoreListAllNS        bool
+	restoreIdentityRegen    []string
+	restoreSkipVersionCheck bool
 )
 
 var restoreCmd = &cobra.Command{
@@ -134,14 +134,14 @@ func runRestoreCreate(cmd *cobra.Command, args []string) error {
 // CLI level rather than letting them surface as a webhook rejection.
 func parseIdentityFlags(values []string) ([]snapshotv1alpha1.IdentityRegenerationItem, error) {
 	known := map[string]snapshotv1alpha1.IdentityRegenerationItem{
-		"hostname":     snapshotv1alpha1.RegenHostname,
-		"machineid":    snapshotv1alpha1.RegenMachineID,
-		"machine-id":   snapshotv1alpha1.RegenMachineID,
-		"sshhostkeys":  snapshotv1alpha1.RegenSSHHostKeys,
+		"hostname":      snapshotv1alpha1.RegenHostname,
+		"machineid":     snapshotv1alpha1.RegenMachineID,
+		"machine-id":    snapshotv1alpha1.RegenMachineID,
+		"sshhostkeys":   snapshotv1alpha1.RegenSSHHostKeys,
 		"ssh-host-keys": snapshotv1alpha1.RegenSSHHostKeys,
-		"macaddresses": snapshotv1alpha1.RegenMACAddresses,
+		"macaddresses":  snapshotv1alpha1.RegenMACAddresses,
 		"mac-addresses": snapshotv1alpha1.RegenMACAddresses,
-		"macs":         snapshotv1alpha1.RegenMACAddresses,
+		"macs":          snapshotv1alpha1.RegenMACAddresses,
 	}
 	var out []snapshotv1alpha1.IdentityRegenerationItem
 	seen := map[snapshotv1alpha1.IdentityRegenerationItem]bool{}

--- a/internal/controller/swiftsnapshot/cleanup.go
+++ b/internal/controller/swiftsnapshot/cleanup.go
@@ -174,7 +174,7 @@ func (r *SwiftSnapshotReconciler) createCleanupPod(
 			Name:      podName,
 			Namespace: snap.Namespace,
 			Labels: map[string]string{
-				"snapshot.kubeswift.io/role":         "hostpath-cleanup",
+				"snapshot.kubeswift.io/role":           "hostpath-cleanup",
 				"snapshot.kubeswift.io/swift-snapshot": snap.Name,
 			},
 			OwnerReferences: []metav1.OwnerReference{


### PR DESCRIPTION
…ting files

CI failures from the 10b push, both unrelated to the SwiftRestore work itself but blocking image publication:

1. The swiftletd image build context is hardcoded to ./rust in four workflow files (ci.yaml, release-dev.yaml, release-rc.yaml, release-stable.yaml). Commit 10b switched the Containerfile to the repo root so the same build can pull in cmd/snapshot-stager/ alongside the Rust workspace, and updated the Makefile to match — but the GitHub Actions workflows have their own build-context field that I missed. Result: every COPY in the Containerfile resolved against ./rust, so paths like rust/swiftletd/scripts/ gpu-init.sh became /rust/rust/... and didn't exist.

   Updated all four workflows to context: . — matching the Makefile.

2. cmd/swiftctl/restore.go and internal/controller/swiftsnapshot/ cleanup.go had whitespace alignment that gofmt -s rewrites. Pre-existing (introduced before commit 10b) but the Go job's format check rejected the push. gofmt'd both files; the diff is purely whitespace alignment in const/struct blocks.

Verified: `git ls-files '*.go' | xargs gofmt -s -l` is clean.