### PR TITLE
fix(snapshot): mount /var/lib/kubeswift/snapshots on launcher pods + …

### DIFF
--- a/config/samples/local-snapshots/swiftguest-source.yaml
+++ b/config/samples/local-snapshots/swiftguest-source.yaml
@@ -1,27 +1,19 @@
 # Source SwiftGuest for Tier B (local-backend) memory snapshot tests.
 #
-# The seedProfileRef references config/samples/seed-profiles/clone-
-# identity-regen.yaml so the in-guest cloud-init bootcmd regenerates
-# machine-id, SSH host keys, and hostname when a clone is restored
-# from a memory snapshot of this guest.
+# Uses the snapshot-local-test-seed SwiftSeedProfile, which combines:
+#   - The swiftctl-ssh-compatible kubeswift user with id_ed25519 key
+#     (so the e2e tests can SSH into source and clones).
+#   - The clone-identity-regen bootcmd that regenerates machine-id,
+#     SSH host keys, and hostname when a clone is restored from a
+#     memory snapshot.
 #
-# IMPORTANT: this sample is wired for the snapshot/restore e2e tests
-# (test/snapshot/local-roundtrip-test.sh and
-#  test/snapshot/local-clone-identity-test.sh). For production use,
-# adjust ssh_authorized_keys and resource sizes.
-apiVersion: swift.kubeswift.io/v1alpha1
-kind: SwiftGuest
-metadata:
-  name: snapshot-local-source
-spec:
-  imageRef:
-    name: ubuntu-noble
-  guestClassRef:
-    name: snapshot-local-class
-  seedProfileRef:
-    name: clone-identity-regen
-  runPolicy: Running
----
+# Wired for test/snapshot/local-roundtrip-test.sh and
+# test/snapshot/local-clone-identity-test.sh. For production use,
+# adjust ssh_authorized_keys, the user list, and resource sizes.
+#
+# SwiftGuestClass first so the guest's resolver finds it on first
+# reconcile (otherwise the guest goes Failed=ResolutionFailed and
+# does not recover even when the class appears next).
 apiVersion: swift.kubeswift.io/v1alpha1
 kind: SwiftGuestClass
 metadata:
@@ -32,3 +24,16 @@ spec:
   rootDisk:
     size: "10Gi"
     format: raw
+---
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: snapshot-local-source
+spec:
+  imageRef:
+    name: ubuntu-noble
+  guestClassRef:
+    name: snapshot-local-class
+  seedProfileRef:
+    name: snapshot-local-test-seed
+  runPolicy: Running

--- a/config/samples/local-snapshots/swiftseedprofile-test.yaml
+++ b/config/samples/local-snapshots/swiftseedprofile-test.yaml
@@ -1,0 +1,83 @@
+# Combined SwiftSeedProfile for the Tier B local-snapshot e2e tests.
+#
+# Merges two concerns into one profile so the e2e scripts can SSH into
+# the guest *and* trigger the identity-regen bootcmd on clone:
+#
+# 1. The swiftctl ssh defaults (user "kubeswift", key id_ed25519)
+#    — same as config/samples/shared/swiftseedprofile-minimal.yaml.
+# 2. The clone-identity-regen bootcmd
+#    — same as config/samples/seed-profiles/clone-identity-regen.yaml.
+#
+# The doc (docs/snapshots/identity-regeneration.md) explicitly suggests
+# merging the bootcmd into your existing seed profile; this sample
+# does exactly that for the tests' purposes.
+apiVersion: seed.kubeswift.io/v1alpha1
+kind: SwiftSeedProfile
+metadata:
+  name: snapshot-local-test-seed
+spec:
+  datasource: NoCloud
+  userData: |
+    #cloud-config
+    hostname: kubeswift-guest
+    users:
+      - name: kubeswift
+        passwd: $6$kubeswift$/2TeJTNbX7JcApzW0gTbSFzCAN4eFcOdnQsI0lVANFpXhHmjqLy7npyhHxvT65kpUd0YKVMBAbRt3MUfV6eCJ.
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        lock_passwd: false
+        ssh_authorized_keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ53Xu8rRSofCQqb91XUgZqQam+5Q2e7tOwr0egG/W5x
+    runcmd:
+      - systemctl enable --now getty@ttyS0.service
+    bootcmd:
+      - |
+        SENTINEL=/var/lib/kubeswift/.clone-regenerated
+        if ! grep -qw kubeswift.clone=true /proc/cmdline; then
+          # Source VM (or a normal restore on the same name) — leave
+          # identity alone.
+          exit 0
+        fi
+        if [ -f "$SENTINEL" ]; then
+          # Already regenerated on a prior boot. Idempotent no-op so
+          # repeated boot cycles don't churn machine-id.
+          exit 0
+        fi
+        mkdir -p "$(dirname "$SENTINEL")"
+
+        # /etc/machine-id: dbus, systemd, journald, and many app
+        # daemons key on this. Empty + systemd-machine-id-setup
+        # regenerates from /sys/class/dmi/id/product_uuid.
+        : > /etc/machine-id
+        if [ -d /run/systemd/system ]; then
+          systemd-machine-id-setup || true
+        elif command -v uuidgen >/dev/null 2>&1; then
+          uuidgen | tr -d - > /etc/machine-id
+        fi
+
+        # SSH host keys: bare-key files — remove all then regenerate.
+        rm -f /etc/ssh/ssh_host_*_key /etc/ssh/ssh_host_*_key.pub
+        ssh-keygen -A
+        if command -v systemctl >/dev/null 2>&1; then
+          systemctl reload-or-restart ssh.service 2>/dev/null \
+            || systemctl reload-or-restart sshd.service 2>/dev/null \
+            || true
+        fi
+
+        # Hostname: derive from machine-id for uniqueness if cloud-init
+        # didn't set a clone-specific one.
+        if [ -r /run/cloud-init/instance-data.json ]; then
+          NEW_HOSTNAME="$(jq -r '.v1.local_hostname // empty' /run/cloud-init/instance-data.json 2>/dev/null || true)"
+        fi
+        if [ -z "$NEW_HOSTNAME" ] && [ -r /etc/machine-id ]; then
+          NEW_HOSTNAME="kubeswift-$(cut -c1-8 /etc/machine-id)"
+        fi
+        if [ -n "$NEW_HOSTNAME" ]; then
+          hostnamectl set-hostname "$NEW_HOSTNAME" 2>/dev/null \
+            || echo "$NEW_HOSTNAME" > /etc/hostname
+        fi
+
+        # Sentinel last so a partial run is retried.
+        touch "$SENTINEL"
+  metaData: |
+    instance-id: kubeswift-snapshot-local-001
+    local-hostname: kubeswift-guest

--- a/internal/controller/swiftguest/constants.go
+++ b/internal/controller/swiftguest/constants.go
@@ -39,4 +39,17 @@ const (
 	IntentPath    = "/var/lib/kubeswift/intent"
 	IntentFile    = "runtime-intent.json"
 	RunDirPath    = "/var/lib/kubeswift/run"
+
+	// SnapshotsHostPath is the on-node directory Cloud Hypervisor writes
+	// Tier B snapshot directories into (config.json, state.json, memory-
+	// ranges) when the SwiftSnapshot controller drives a vm.snapshot
+	// action. It is mounted on every launcher pod (writable hostPath)
+	// so the source-guest's CH process can write to it without pod
+	// recreation. The validation webhook constrains operator-provided
+	// hostPaths to live under this prefix.
+	//
+	// The path also doubles as the read-side mount for restore-receive
+	// pods, but those mount the specific snapshot subdirectory (not
+	// this parent) — see internal/controller/swiftguest/restore.go.
+	SnapshotsHostPath = "/var/lib/kubeswift/snapshots"
 )

--- a/internal/controller/swiftguest/gpu.go
+++ b/internal/controller/swiftguest/gpu.go
@@ -407,6 +407,12 @@ func BuildGPUDiskBootPod(
 	if rg.HasDataDisk() {
 		mounts = append(mounts, corev1.VolumeMount{Name: "data-disk", MountPath: DisksDataPath})
 	}
+	// /var/lib/kubeswift/snapshots/ — writable hostPath. Tier B
+	// captures on GPU guests are rejected by the webhook (Phase 0
+	// Constraint #1: VFIO + memory snapshot fails on restore), but
+	// the mount is present for symmetry and to support potential
+	// future disk-only Tier B captures of GPU guests.
+	AddSnapshotsHostPathMount(&volumes, &mounts)
 
 	// gpu-init runs before network-init: binds devices to vfio-pci and activates
 	// the Fabric Manager partition (if applicable) before swiftletd starts.

--- a/internal/controller/swiftguest/pod.go
+++ b/internal/controller/swiftguest/pod.go
@@ -144,6 +144,11 @@ func buildKernelBootPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGu
 		mounts = append(mounts, corev1.VolumeMount{Name: "data-disk", MountPath: DisksDataPath})
 	}
 
+	// /var/lib/kubeswift/snapshots/ — writable hostPath so the launcher's
+	// CH process can write Tier B snapshot directories when the
+	// SwiftSnapshot controller triggers a capture action.
+	AddSnapshotsHostPathMount(&volumes, &mounts)
+
 	cpu := rg.Resources.CPU
 	if cpu < 1 {
 		cpu = 1
@@ -272,6 +277,11 @@ func buildDiskBootPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGues
 		mounts = append(mounts, corev1.VolumeMount{Name: "data-disk", MountPath: DisksDataPath})
 	}
 
+	// /var/lib/kubeswift/snapshots/ — writable hostPath so the launcher's
+	// CH process can write Tier B snapshot directories when the
+	// SwiftSnapshot controller triggers a capture action.
+	AddSnapshotsHostPathMount(&volumes, &mounts)
+
 	// SR-IOV: add /dev/vfio volume+mount if any interface is type=sriov.
 	addSRIOVVolumesIfNeeded(&volumes, &mounts, guest)
 
@@ -378,5 +388,39 @@ func AddSeedVolume(volumes *[]corev1.Volume, configMapName string) {
 				LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
 			},
 		},
+	})
+}
+
+// snapshotsHostPathVolumeName is the volume name for the writable
+// SnapshotsHostPath mount on every launcher pod.
+const snapshotsHostPathVolumeName = "kubeswift-snapshots"
+
+// AddSnapshotsHostPathMount adds the writable hostPath volume + mount
+// for /var/lib/kubeswift/snapshots/ to the launcher pod, so Cloud
+// Hypervisor's vm.snapshot endpoint can write Tier B snapshot
+// directories without pod recreation when SwiftSnapshot drives a
+// capture action. DirectoryOrCreate handles first-snapshot bootstrap
+// (the parent dir doesn't necessarily exist before the first capture).
+//
+// Idempotent: if the volume name already exists on volumes, neither
+// the volume nor the mount is duplicated.
+func AddSnapshotsHostPathMount(volumes *[]corev1.Volume, mounts *[]corev1.VolumeMount) {
+	for _, v := range *volumes {
+		if v.Name == snapshotsHostPathVolumeName {
+			return
+		}
+	}
+	*volumes = append(*volumes, corev1.Volume{
+		Name: snapshotsHostPathVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: SnapshotsHostPath,
+				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+			},
+		},
+	})
+	*mounts = append(*mounts, corev1.VolumeMount{
+		Name:      snapshotsHostPathVolumeName,
+		MountPath: SnapshotsHostPath,
 	})
 }

--- a/test/snapshot/local-clone-identity-test.sh
+++ b/test/snapshot/local-clone-identity-test.sh
@@ -22,7 +22,6 @@ set -euo pipefail
 NAMESPACE="${NAMESPACE:-default}"
 NO_CLEANUP=false
 SAMPLES_DIR="$(cd "$(dirname "$0")/../../config/samples/local-snapshots" && pwd)"
-SEED_DIR="$(cd "$(dirname "$0")/../../config/samples/seed-profiles" && pwd)"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -51,7 +50,7 @@ cleanup() {
     swiftsnapshot/snapshot-local-mem \
     swiftguest/snapshot-local-source \
     swiftguestclass/snapshot-local-class \
-    swiftseedprofile/clone-identity-regen >/dev/null 2>&1 || true
+    swiftseedprofile/snapshot-local-test-seed >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -86,9 +85,10 @@ wait_for_ssh() {
   return 1
 }
 
-# 1. Source VM with the clone-identity-regen seed profile.
+# 1. Source VM with the combined seed profile (kubeswift user for
+#    swiftctl ssh + clone-identity-regen bootcmd).
 echo "--- Step 1: Apply source manifests + seed profile ---"
-kubectl apply -n "$NAMESPACE" -f "$SEED_DIR/clone-identity-regen.yaml" >/dev/null
+kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/swiftseedprofile-test.yaml" >/dev/null
 kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/swiftguest-source.yaml" >/dev/null
 
 if ! kubectl get swiftimage ubuntu-noble -n "$NAMESPACE" >/dev/null 2>&1; then

--- a/test/snapshot/local-roundtrip-test.sh
+++ b/test/snapshot/local-roundtrip-test.sh
@@ -25,20 +25,76 @@ set -euo pipefail
 NAMESPACE="${NAMESPACE:-default}"
 NO_CLEANUP=false
 SAMPLES_DIR="$(cd "$(dirname "$0")/../../config/samples/local-snapshots" && pwd)"
-IMAGE_DIR="$(cd "$(dirname "$0")/../../config/samples/images" 2>/dev/null && pwd || true)"
+IDENTITY="${KUBESWIFT_TEST_IDENTITY:-${HOME}/.ssh/id_ed25519}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --no-cleanup) NO_CLEANUP=true; shift ;;
     --namespace)  NAMESPACE="$2"; shift 2 ;;
+    --identity)   IDENTITY="$2"; shift 2 ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
 done
 
+if [[ ! -r "$IDENTITY" ]]; then
+  echo "ERROR: SSH identity $IDENTITY not readable. Override with --identity or KUBESWIFT_TEST_IDENTITY." >&2
+  exit 2
+fi
+
 echo "=== KubeSwift Tier B round-trip e2e ==="
 echo "Namespace:    $NAMESPACE"
 echo "Samples:      $SAMPLES_DIR"
+echo "Identity:     $IDENTITY (must match seed profile's ssh_authorized_keys)"
 echo ""
+
+# guest_exec runs a one-line bash command inside the guest VM by
+# exec-ing into the launcher pod and running ssh from there. The
+# host's private key is fed via stdin into the launcher, written to a
+# tmpfile, used, then removed. swiftctl ssh insists on a TTY which
+# doesn't compose with scripted command runs; this helper avoids that
+# limitation.
+#
+# The input is piped: { key contents \0 SSH_COMMAND }. The launcher's
+# sh splits the stdin into the key (everything up to a sentinel line)
+# and the remote command (the rest of the lines).
+#
+# Usage: guest_exec <guest-name> <bash one-liner>
+# Returns the remote command's exit code; remote stdout on stdout.
+guest_exec() {
+  local guest="$1"; shift
+  local cmd="$*"
+  local ip
+  ip=$(kubectl get swiftguest "$guest" -n "$NAMESPACE" -o jsonpath='{.status.network.primaryIP}' 2>/dev/null)
+  if [[ -z "$ip" ]]; then
+    echo "guest_exec: $guest has no primaryIP" >&2
+    return 1
+  fi
+  # Build the in-launcher script. The host's identity bytes are
+  # interpolated via heredoc into the script body, so we don't depend
+  # on env-var propagation across kubectl exec.
+  # The remote command is base64-encoded so it can carry quotes,
+  # newlines, and shell metachars unchanged through the heredoc.
+  # The launcher decodes and runs via bash -c. Avoids fragile
+  # shell-quoting in the kubectl/sh/ssh/bash chain.
+  local cmd_b64
+  cmd_b64=$(printf '%s' "$cmd" | base64 -w0)
+  local launcher_script
+  launcher_script=$(cat <<LAUNCHER_EOF
+set -eu
+KEY=\$(mktemp); chmod 600 "\$KEY"
+cat > "\$KEY" <<'KUBESWIFT_TEST_KEY'
+$(cat "$IDENTITY")
+KUBESWIFT_TEST_KEY
+CMD=\$(printf %s '$cmd_b64' | base64 -d)
+RC=0
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectTimeout=5 -i "\$KEY" kubeswift@$ip "\$CMD" || RC=\$?
+rm -f "\$KEY"
+exit \$RC
+LAUNCHER_EOF
+)
+  printf '%s\n' "$launcher_script" \
+    | kubectl exec -n "$NAMESPACE" -i "$guest" -c launcher -- sh
+}
 
 cleanup() {
   if [[ "$NO_CLEANUP" == "true" ]]; then
@@ -52,13 +108,14 @@ cleanup() {
     swiftsnapshot/snapshot-local-mem \
     swiftguest/snapshot-local-source \
     swiftguestclass/snapshot-local-class \
-    swiftseedprofile/clone-identity-regen >/dev/null 2>&1 || true
+    swiftseedprofile/snapshot-local-test-seed >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
-# 1. Apply the seed profile + source SwiftGuest manifests.
+# 1. Apply the combined seed profile (kubeswift user for swiftctl ssh +
+#    clone-identity-regen bootcmd) and the source SwiftGuest.
 echo "--- Step 1: Apply source manifests ---"
-kubectl apply -n "$NAMESPACE" -f "$(cd "$(dirname "$0")/../../config/samples/seed-profiles" && pwd)/clone-identity-regen.yaml" >/dev/null
+kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/swiftseedprofile-test.yaml" >/dev/null
 kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/swiftguest-source.yaml" >/dev/null
 
 # Ensure Ubuntu Noble image is present (most clusters running these
@@ -85,13 +142,13 @@ echo "  Waiting for source SwiftGuest Running (5m)..."
 kubectl wait --for=jsonpath='{.status.phase}'=Running \
   swiftguest/snapshot-local-source -n "$NAMESPACE" --timeout=5m
 
-# Wait for the guest to actually be reachable via swiftctl ssh. The
-# Running phase asserts CH is bound; the SSH usability comes a few
-# seconds later when sshd reports.
-echo "  Waiting up to 2m for SSH reachability via swiftctl..."
+# Wait for the guest to actually be reachable via SSH. The Running
+# phase asserts CH is bound; SSH usability comes a few seconds later
+# when sshd reports.
+echo "  Waiting up to 3m for SSH reachability..."
 SSH_READY=false
-for _ in $(seq 1 24); do
-  if swiftctl ssh -n "$NAMESPACE" snapshot-local-source -- true >/dev/null 2>&1; then
+for _ in $(seq 1 36); do
+  if guest_exec snapshot-local-source true >/dev/null 2>&1; then
     SSH_READY=true
     break
   fi
@@ -101,22 +158,20 @@ if [[ "$SSH_READY" != "true" ]]; then
   echo "  FAIL: SSH never became reachable on snapshot-local-source"
   exit 1
 fi
+echo "  OK: SSH reachable"
 
 # 2. Plant the tmpfs sentinel — RAM-only, NOT persisted to disk.
 echo ""
 echo "--- Step 2: Plant tmpfs sentinel inside the guest (in-memory only) ---"
 SENTINEL_VALUE="kubeswift-roundtrip-$(date +%s)-$RANDOM"
-swiftctl ssh -n "$NAMESPACE" snapshot-local-source -- sudo bash -c "
-  mkdir -p /run/kubeswift-mem
-  echo '$SENTINEL_VALUE' > /run/kubeswift-mem/sentinel
-  # Verify it actually landed on tmpfs (not a disk).
-  fs_type=\$(stat -fc %T /run/kubeswift-mem)
-  if [[ \"\$fs_type\" != \"tmpfs\" ]]; then
-    echo \"sentinel dir not tmpfs: fs_type=\$fs_type\"
-    exit 1
-  fi
-"
-echo "  Planted: SENTINEL_VALUE=$SENTINEL_VALUE"
+guest_exec snapshot-local-source "sudo mkdir -p /run/kubeswift-mem"
+guest_exec snapshot-local-source "echo $SENTINEL_VALUE | sudo tee /run/kubeswift-mem/sentinel >/dev/null"
+fs_type=$(guest_exec snapshot-local-source "stat -fc %T /run/kubeswift-mem" | tr -d '\r\n')
+if [[ "$fs_type" != "tmpfs" ]]; then
+  echo "  FAIL: /run/kubeswift-mem is not tmpfs (got '$fs_type')"
+  exit 1
+fi
+echo "  Planted: SENTINEL_VALUE=$SENTINEL_VALUE on tmpfs"
 
 # 3. Snapshot with includeMemory: true.
 echo ""
@@ -169,15 +224,14 @@ echo "  OK: launcher pod is in restore-receive mode, no stager (in-place fast pa
 # 6. Verify the tmpfs sentinel survived.
 echo ""
 echo "--- Step 6: Verify tmpfs sentinel survived (the headline Phase 2 promise) ---"
-echo "  Waiting up to 2m for SSH reachability via swiftctl post-restore..."
-for _ in $(seq 1 24); do
-  if swiftctl ssh -n "$NAMESPACE" snapshot-local-source -- true >/dev/null 2>&1; then
+echo "  Waiting up to 3m for SSH reachability post-restore..."
+for _ in $(seq 1 36); do
+  if guest_exec snapshot-local-source true >/dev/null 2>&1; then
     break
   fi
   sleep 5
 done
-GOT_VALUE=$(swiftctl ssh -n "$NAMESPACE" snapshot-local-source -- cat /run/kubeswift-mem/sentinel 2>/dev/null || echo "<missing>")
-GOT_VALUE=$(echo "$GOT_VALUE" | tr -d '\r\n')
+GOT_VALUE=$(guest_exec snapshot-local-source "cat /run/kubeswift-mem/sentinel 2>/dev/null || echo MISSING" | tr -d '\r\n')
 if [[ "$GOT_VALUE" != "$SENTINEL_VALUE" ]]; then
   echo "  FAIL: sentinel mismatch"
   echo "    expected: $SENTINEL_VALUE"


### PR DESCRIPTION
…e2e fixups

Two fixes discovered while running the Tier B e2e tests against the freshly-deployed sha-9979654 cluster.

1. Pre-existing Tier B capture-path gap (commit 9, not 10b)

   Cloud Hypervisor's vm.snapshot endpoint writes config.json, state.json, and memory-ranges directly to the destination_url path inside the launcher container's mount namespace. The SwiftGuest pod builders never mounted /var/lib/kubeswift/snapshots/ into the launcher, so vm.snapshot failed at runtime with:

     "Destination is not a directory:
      \"/var/lib/kubeswift/snapshots/<ns>-<name>/\""

   Fix: every launcher pod (disk boot, kernel boot, GPU disk boot) now mounts the host's /var/lib/kubeswift/snapshots/ as a writable hostPath at the canonical path. DirectoryOrCreate handles the bootstrap case where no snapshot has been written yet on the node. Idempotent helper [AddSnapshotsHostPathMount] dedupes by volume name so future callers don't double-add.

   The webhook already constrains operator-supplied hostPaths to live under SnapshotsHostPath, and the cleanup finalizer (commit 364a23e) deletes per-snapshot subdirectories — so this mount is the natural counterpart to the existing capture and cleanup flow. Restore-mode pods (BuildRestorePod) keep mounting only their specific snapshot subdirectory; this commit doesn't change that.

   Tested via tightly-scoped go tests + manual cluster run.

2. e2e test scaffolding (introduced in 10b)

   - swiftguest-source.yaml had the SwiftGuest before the SwiftGuestClass, so the first reconcile raced and went Failed=ResolutionFailed (the controller's terminal failure state). Reordered the manifest so the class is applied first.
   - swiftctl ssh requires a TTY and rejects scripted command runs with extra args. The two new e2e scripts can't drive guest commands through it. Replaced the swiftctl ssh callsites with a guest_exec helper that kubectl-exec's into the launcher pod and runs ssh from inside, with the host's identity piped in and the remote command base64-encoded for transport. Removes dependence on swiftctl in the testing path.
   - The samples referenced the bootcmd-only clone-identity-regen SwiftSeedProfile which has no users / SSH keys, so no SSH login is possible. Added swiftseedprofile-test.yaml that combines the swiftctl-default kubeswift user with the bootcmd, and updated swiftguest-source.yaml + both e2e scripts to reference it. The standalone clone-identity-regen profile remains as the doc reference for "merge into your existing profile".

The pod-builder change requires a fresh swiftletd image and a controller redeploy before either e2e test will pass.