### PR TITLE
fix(snapshot): stable action-id from UID, not ResourceVersion

### DIFF
--- a/internal/controller/swiftrestore/local.go
+++ b/internal/controller/swiftrestore/local.go
@@ -402,7 +402,7 @@ func (r *SwiftRestoreReconciler) handleResumingLocal(
 		return true, 0, nil
 	}
 
-	actionID := restore.Name + "-" + restore.ResourceVersion
+	actionID := resumeActionID(restore)
 
 	// First reconcile in Resuming: write the resume action onto the
 	// launcher pod. Idempotent — patchPodActionAnnotations is a merge
@@ -720,4 +720,23 @@ func (r *SwiftRestoreReconciler) patchPodActionAnnotations(
 		return err
 	}
 	return r.Patch(ctx, pod, client.RawPatch(types.MergePatchType, data))
+}
+
+// resumeActionID returns a stable per-SwiftRestore action-id used to
+// drive (and later observe) the launcher pod's snapshot-action
+// annotations during the Resuming phase.
+//
+// Mirrors capturingActionID in internal/controller/swiftsnapshot:
+// derived from restore.Name and restore.UID (both immutable). Using
+// restore.ResourceVersion here would diverge across reconciles
+// because each status write bumps it — by the time the launcher
+// mirrors the action-id, the controller is computing a new one and
+// the comparison never matches. The same bug bit Tier B captures
+// before this fix.
+func resumeActionID(restore *snapshotv1alpha1.SwiftRestore) string {
+	uid := string(restore.UID)
+	if len(uid) > 8 {
+		uid = uid[:8]
+	}
+	return restore.Name + "-" + uid
 }

--- a/internal/controller/swiftsnapshot/local.go
+++ b/internal/controller/swiftsnapshot/local.go
@@ -153,9 +153,14 @@ func (r *SwiftSnapshotReconciler) handlePendingLocal(
 	}
 	srcURL = "file://" + srcURL
 
-	// Generate idempotent action-id: snapshot-name + resourceVersion.
-	// swiftletd treats repeated action-ids as no-ops.
-	actionID := snap.Name + "-" + snap.ResourceVersion
+	// Generate stable action-id: snapshot-name + first 8 chars of UID.
+	// UID is immutable for the lifetime of the SwiftSnapshot; using it
+	// (instead of ResourceVersion) means handleCapturingLocal can
+	// re-derive the same id on later reconciles even though
+	// ResourceVersion bumps every time the controller writes status.
+	// swiftletd treats repeated action-ids as no-ops, so the launcher
+	// only processes the capture once.
+	actionID := capturingActionID(snap)
 
 	args := captureArgs{
 		DestinationURL:      srcURL,
@@ -216,7 +221,7 @@ func (r *SwiftSnapshotReconciler) handleCapturingLocal(
 	}
 
 	annotations := pod.GetAnnotations()
-	expectedID := snap.Name + "-" + snap.ResourceVersion
+	expectedID := capturingActionID(snap)
 	statusID := annotations[annoStatusID]
 	statusVal := annotations[annoStatus]
 	statusDetail := annotations[annoStatusDetail]
@@ -313,6 +318,31 @@ func (r *SwiftSnapshotReconciler) patchPodActionAnnotations(
 // here because the action constants logically live with the
 // snapshot controller.
 var _ = []string{verbResume, verbPrepare}
+
+// capturingActionID returns a stable per-SwiftSnapshot action-id used
+// to drive (and later observe) the launcher pod's snapshot-action
+// annotations.
+//
+// Stable across status updates: derived from snap.Name and snap.UID,
+// both of which are immutable for the lifetime of the resource.
+// The original implementation used snap.ResourceVersion which mutates
+// on every status write — handlePendingLocal would send id=N, the
+// status update bumped resourceVersion to N+2, handleCapturingLocal
+// would compute expectedID=N+2 and never match the launcher's mirror
+// (still pinned to N). Tier B captures got stuck in Capturing until
+// the wall-clock deadline tripped them to Failed.
+//
+// First 8 chars of the UID are sufficient — UIDs are random UUIDs,
+// collisions on the first 8 hex chars across concurrent SwiftSnapshots
+// in the same namespace are not a concern (and the resource Name is a
+// uniqueness prefix anyway).
+func capturingActionID(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	uid := string(snap.UID)
+	if len(uid) > 8 {
+		uid = uid[:8]
+	}
+	return snap.Name + "-" + uid
+}
 
 // captureDeadlineExceeded returns (true, deadlineSeconds) when the
 // SwiftSnapshot has been in a non-terminal state past its deadline.

--- a/internal/controller/swiftsnapshot/local_test.go
+++ b/internal/controller/swiftsnapshot/local_test.go
@@ -13,14 +13,19 @@ import (
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
 )
 
+// fakeUID is a deterministic UID for test fixtures. The action-id
+// helper takes the first 8 chars, so the expected action-id for any
+// makeLocalSnap("name", ...) is "name-deadbeef".
+const fakeUID = "deadbeef-1234-5678-9abc-def012345678"
+
 // makeLocalSnap returns a Phase-2 local-backend SwiftSnapshot with a
 // single explicit hostPath under the operator-controlled prefix.
 func makeLocalSnap(name, ns, guestName string) *snapshotv1alpha1.SwiftSnapshot {
 	return &snapshotv1alpha1.SwiftSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            name,
-			Namespace:       ns,
-			ResourceVersion: "42",
+			Name:      name,
+			Namespace: ns,
+			UID:       fakeUID,
 		},
 		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
 			GuestRef: snapshotv1alpha1.SwiftSnapshotGuestRef{Name: guestName},
@@ -74,7 +79,7 @@ func TestLocal_Pending_AdvancesToCapturing_AndWritesActionAnnotations(t *testing
 	if p.Annotations[annoAction] != verbCapture {
 		t.Errorf("pod annotation %s = %q, want %q", annoAction, p.Annotations[annoAction], verbCapture)
 	}
-	wantID := "snap1-42"
+	wantID := "snap1-deadbeef"
 	if p.Annotations[annoActionID] != wantID {
 		t.Errorf("pod annotation %s = %q, want %q", annoActionID, p.Annotations[annoActionID], wantID)
 	}
@@ -161,7 +166,7 @@ func TestLocal_Capturing_StatusReady_FinalizesWithPauseWindow(t *testing.T) {
 	guest := makeGuest("default", "g1")
 	pod := makeLauncherPod("default", "g1", "boba")
 	pod.Annotations = map[string]string{
-		annoStatusID:      "snap1-42",
+		annoStatusID:      "snap1-deadbeef",
 		annoStatus:        "ready",
 		annoStatusDetail:  "captured to file:///x (1234ms pause window, resumed)",
 		annoPauseWindowMs: "1234",
@@ -191,7 +196,7 @@ func TestLocal_Capturing_StatusFailed_TransitionsToFailed(t *testing.T) {
 	guest := makeGuest("default", "g1")
 	pod := makeLauncherPod("default", "g1", "boba")
 	pod.Annotations = map[string]string{
-		annoStatusID:     "snap1-42",
+		annoStatusID:     "snap1-deadbeef",
 		annoStatus:       "failed",
 		annoStatusDetail: "snapshot: VM not in Paused state",
 	}
@@ -214,7 +219,7 @@ func TestLocal_Capturing_StatusRejected_TransitionsToFailed(t *testing.T) {
 	guest := makeGuest("default", "g1")
 	pod := makeLauncherPod("default", "g1", "boba")
 	pod.Annotations = map[string]string{
-		annoStatusID:     "snap1-42",
+		annoStatusID:     "snap1-deadbeef",
 		annoStatus:       "rejected",
 		annoStatusDetail: "rejected: action snap0-9 already in flight",
 	}
@@ -260,7 +265,7 @@ func TestLocal_Capturing_DeadlineExceeded_TransitionsToFailed(t *testing.T) {
 	guest := makeGuest("default", "g1")
 	pod := makeLauncherPod("default", "g1", "boba")
 	pod.Annotations = map[string]string{
-		annoStatusID: "snap1-42",
+		annoStatusID: "snap1-deadbeef",
 		annoStatus:   "running",
 	}
 
@@ -289,7 +294,7 @@ func TestLocal_Capturing_AnnotationOverride_ExtendsDeadline(t *testing.T) {
 	guest := makeGuest("default", "g1")
 	pod := makeLauncherPod("default", "g1", "boba")
 	pod.Annotations = map[string]string{
-		annoStatusID: "snap1-42",
+		annoStatusID: "snap1-deadbeef",
 		annoStatus:   "running",
 	}
 


### PR DESCRIPTION
The Tier B controllers (SwiftSnapshot capture and SwiftRestore resume) drove the launcher pod's snapshot-action lifecycle with an action-id derived from <Name>-<ResourceVersion>. ResourceVersion mutates on every status write — the controller's own status updates during Capturing/Resuming bumped it. Net effect:

  1. handlePendingLocal sends action-id="<name>-N", launcher accepts.
  2. Controller's status update bumps ResourceVersion to N+2.
  3. handleCapturingLocal recomputes expectedID="<name>-N+2".
  4. Launcher mirrors status-id="<name>-N" (the original).
  5. expectedID != statusID → stays in Capturing.
  6. ~10 minutes later the wall-clock deadline trips it to Failed.

This is exactly what the round-trip e2e was hitting against the freshly-deployed cluster: the launcher reported snapshot-status=ready within ~4 seconds, but the SwiftSnapshot stayed in Capturing because the controller's expected action-id had drifted past the launcher's mirror.

Fix: derive the action-id from <Name>-<UID[:8]>. UID is immutable for the lifetime of a Kubernetes resource, so handlePendingLocal and handleCapturingLocal compute the same value, and the launcher's mirror matches indefinitely.

Same bug in internal/controller/swiftrestore/local.go's handleResumingLocal — fixed in lockstep.

Tests:
  - swiftsnapshot fixtures updated to set a deterministic UID and drop ResourceVersion. All test assertions on the action-id string updated to the new "<name>-deadbeef" form.
  - go test ./... green; cargo fmt/check clean.