### PR TITLE
fix(snapshot): rebuild seed.iso on restore-receive (mount + Rust)

### DIFF
--- a/internal/controller/swiftguest/gpu.go
+++ b/internal/controller/swiftguest/gpu.go
@@ -275,7 +275,7 @@ func (r *SwiftGuestReconciler) buildPod(
 	// before the GPU branch and the two are mutually exclusive in
 	// practice.
 	if params, ok := RestoreParamsFromAnnotations(guest.Annotations); ok {
-		return BuildRestorePod(guest, rg, intentConfigMapName, rootDiskClone, params), nil
+		return BuildRestorePod(guest, rg, seedConfigMapName, intentConfigMapName, rootDiskClone, params), nil
 	}
 	if guest.Spec.GPUProfileRef != nil && guest.Status.GPU != nil {
 		// Load profile to get hugepages size for the pod spec.

--- a/internal/controller/swiftguest/restore.go
+++ b/internal/controller/swiftguest/restore.go
@@ -163,10 +163,21 @@ func (p RestoreParams) InPodSnapshotPath() string {
 // when the per-guest PVC already exists, but Phase 2 commit 10b
 // callers don't need to do it). For clones, rootDiskClone names the
 // freshly-cloned per-guest PVC that EnsureRootDiskClone produced.
+//
+// seedConfigMapName names the seed ConfigMap to mount when the source
+// guest had a seed profile. The snapshot's config.json references the
+// original seed.iso disk path; CH refuses to restore when that file is
+// missing, so the launcher rebuilds seed.iso (deterministically — the
+// bytes are the same as the original since the seed dir contents are
+// the same). For in-place restore the runtime_dir name matches the
+// source so the rebuilt path matches what config.json expects. For
+// clones the runtime_dir differs; clone restore relies on the
+// snapshot-stager + a future config.json disk-path patch (not in
+// commit 10b). Empty seedConfigMapName skips the seed mount.
 func BuildRestorePod(
 	guest *swiftv1alpha1.SwiftGuest,
 	rg *resolved.ResolvedGuest,
-	intentConfigMapName string,
+	seedConfigMapName, intentConfigMapName string,
 	rootDiskClone *RootDiskCloneResult,
 	params RestoreParams,
 ) *corev1.Pod {
@@ -234,12 +245,25 @@ func BuildRestorePod(
 			},
 		})
 	}
+	// Seed ConfigMap mount — required for restore-receive even though
+	// cloud-init has already run (the seed dir is baked into the
+	// snapshot's memory state). The snapshot's config.json still
+	// references the seed.iso disk path; CH on --restore re-opens
+	// every disk listed and refuses with "no such file or directory"
+	// when the file is missing. swiftletd reconstructs seed.iso
+	// deterministically from the seed ConfigMap before spawn_ch_restore.
+	if rg.HasSeed() && seedConfigMapName != "" {
+		AddSeedVolume(&volumes, seedConfigMapName)
+	}
 
 	mounts := []corev1.VolumeMount{
 		{Name: "run", MountPath: RunDirPath},
 		{Name: "root-disk", MountPath: DisksRootPath},
 		{Name: "runtime-intent", MountPath: IntentPath},
 		{Name: "dev-kvm", MountPath: "/dev/kvm"},
+	}
+	if rg.HasSeed() && seedConfigMapName != "" {
+		mounts = append(mounts, corev1.VolumeMount{Name: "seed", MountPath: SeedPath})
 	}
 	if params.IsClone() {
 		// In clone mode the launcher reads the staged+patched copy.

--- a/internal/controller/swiftguest/restore_test.go
+++ b/internal/controller/swiftguest/restore_test.go
@@ -149,7 +149,7 @@ func TestBuildRestorePod_InPlaceFastPath_NoStagerInitContainer(t *testing.T) {
 		Mode:         RestoreModeInPlace,
 	}
 
-	pod := BuildRestorePod(guest, rg, "g1-runtime-intent", nil, params)
+	pod := BuildRestorePod(guest, rg, "", "g1-runtime-intent", nil, params)
 
 	if pod.Name != "g1" {
 		t.Errorf("pod.Name = %q, want g1", pod.Name)
@@ -199,7 +199,7 @@ func TestBuildRestorePod_CloneAddsStagerAndStagingVolume(t *testing.T) {
 	}
 	clone := &RootDiskCloneResult{PVCName: "swiftguest-root-clone1"}
 
-	pod := BuildRestorePod(guest, rg, "g1-runtime-intent", clone, params)
+	pod := BuildRestorePod(guest, rg, "", "g1-runtime-intent", clone, params)
 
 	staging := findVolume(pod, snapshotStagingVolume)
 	if staging == nil {
@@ -260,20 +260,73 @@ func TestBuildRestorePod_CloneAddsStagerAndStagingVolume(t *testing.T) {
 	}
 }
 
-func TestBuildRestorePod_RestartPolicyNeverAndNoSeedVolume(t *testing.T) {
+func TestBuildRestorePod_RestartPolicyNever(t *testing.T) {
 	guest := minimalGuest()
 	rg := minimalResolved()
 	params := RestoreParams{Mode: RestoreModeInPlace, NodeName: "n1"}
 
-	pod := BuildRestorePod(guest, rg, "intent-cm", nil, params)
+	pod := BuildRestorePod(guest, rg, "", "intent-cm", nil, params)
 
 	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Errorf("RestartPolicy = %s, want Never", pod.Spec.RestartPolicy)
 	}
-	// Seed ConfigMap must NOT be mounted — the source VM's cloud-init
-	// state is baked into the snapshot's memory.
+}
+
+func TestBuildRestorePod_NoSeedMountWhenSourceHadNoSeed(t *testing.T) {
+	guest := minimalGuest()
+	rg := minimalResolved() // Seed is nil by default
+	params := RestoreParams{Mode: RestoreModeInPlace, NodeName: "n1"}
+
+	pod := BuildRestorePod(guest, rg, "", "intent-cm", nil, params)
+
 	if findVolume(pod, "seed") != nil {
-		t.Errorf("restore pod must not have seed volume — cloud-init state is in the snapshot")
+		t.Errorf("restore pod must not have seed volume when source has no seed")
+	}
+}
+
+func TestBuildRestorePod_SeedMountWhenSourceHadSeed(t *testing.T) {
+	// CH on --restore re-opens every disk listed in config.json,
+	// including the seed.iso. swiftletd reconstructs seed.iso
+	// deterministically from the seed dir before spawn_ch_restore;
+	// for that to work, the restore pod must mount the seed
+	// ConfigMap at the canonical SeedPath.
+	guest := minimalGuest()
+	rg := minimalResolved()
+	rg.Seed = &resolved.Seed{Datasource: "NoCloud"}
+	params := RestoreParams{Mode: RestoreModeInPlace, NodeName: "n1"}
+
+	pod := BuildRestorePod(guest, rg, "g1-seed", "intent-cm", nil, params)
+
+	seedVol := findVolume(pod, "seed")
+	if seedVol == nil {
+		t.Fatal("restore pod missing seed volume despite source having a seed")
+	}
+	if seedVol.ConfigMap == nil {
+		t.Fatal("seed volume must be a ConfigMap")
+	}
+	if seedVol.ConfigMap.Name != "g1-seed" {
+		t.Errorf("seed ConfigMap name = %q, want g1-seed", seedVol.ConfigMap.Name)
+	}
+	launcher := pod.Spec.Containers[0]
+	mount := findMount(&launcher, "seed")
+	if mount == nil || mount.MountPath != SeedPath {
+		t.Errorf("launcher missing seed mount or wrong path: %+v", mount)
+	}
+}
+
+func TestBuildRestorePod_SkipsSeedWhenConfigMapNameEmpty(t *testing.T) {
+	// Defensive: even if rg.HasSeed() is true, an empty
+	// seedConfigMapName means the controller didn't materialize
+	// the ConfigMap yet — better to skip the mount than break the
+	// pod with a missing ConfigMap reference.
+	guest := minimalGuest()
+	rg := minimalResolved()
+	rg.Seed = &resolved.Seed{Datasource: "NoCloud"}
+	params := RestoreParams{Mode: RestoreModeInPlace, NodeName: "n1"}
+
+	pod := BuildRestorePod(guest, rg, "", "intent-cm", nil, params)
+	if findVolume(pod, "seed") != nil {
+		t.Errorf("seed volume must not be added when seedConfigMapName is empty")
 	}
 }
 
@@ -283,7 +336,7 @@ func TestBuildRestorePod_NetworkInitOnlyWhenHasNetwork(t *testing.T) {
 	rg.Network = false
 
 	params := RestoreParams{Mode: RestoreModeInPlace, NodeName: "n1"}
-	pod := BuildRestorePod(guest, rg, "intent-cm", nil, params)
+	pod := BuildRestorePod(guest, rg, "", "intent-cm", nil, params)
 	for _, ic := range pod.Spec.InitContainers {
 		if ic.Name == "network-init" {
 			t.Errorf("network-init must not run when guest has no network")
@@ -291,7 +344,7 @@ func TestBuildRestorePod_NetworkInitOnlyWhenHasNetwork(t *testing.T) {
 	}
 
 	rg.Network = true
-	pod = BuildRestorePod(guest, rg, "intent-cm", nil, params)
+	pod = BuildRestorePod(guest, rg, "", "intent-cm", nil, params)
 	found := false
 	for _, ic := range pod.Spec.InitContainers {
 		if ic.Name == "network-init" {
@@ -309,7 +362,7 @@ func TestBuildRestorePod_StagerHasNoPrivilege(t *testing.T) {
 	rg := minimalResolved()
 	params := RestoreParams{Mode: RestoreModeClone, NodeName: "n1"}
 
-	pod := BuildRestorePod(guest, rg, "intent-cm", &RootDiskCloneResult{PVCName: "p"}, params)
+	pod := BuildRestorePod(guest, rg, "", "intent-cm", &RootDiskCloneResult{PVCName: "p"}, params)
 	stager := findInit(pod, SnapshotStagerInitContainerName)
 	if stager == nil {
 		t.Fatal("stager missing")

--- a/rust/swiftletd/src/main.rs
+++ b/rust/swiftletd/src/main.rs
@@ -99,15 +99,32 @@ fn main() {
                 };
             log::info!("runtime_dir path={}", runtime_dir.root().display());
 
-            // Restore-receive mode (Phase 2): the seed is baked into
-            // the snapshot's memory state — cloud-init already ran on
-            // the original VM. Skip seed.iso construction entirely.
+            // Seed.iso construction.
+            //
+            // Fresh boot: cloud-init reads the seed.iso at first wake to
+            // configure the VM. Required path.
+            //
+            // Restore-receive (Phase 2): cloud-init has already run, but
+            // CH on `--restore` re-opens every disk listed in the
+            // snapshot's config.json — and the snapshot's config.json
+            // still references the seed.iso disk path. CH bails with
+            // "no such file or directory" if the file is missing.
+            //
+            // The build is deterministic and idempotent, so we run it
+            // for both fresh boot and restore-receive whenever the
+            // intent carries a seed. For in-place restore, the
+            // runtime_dir name matches the source pod's, so the
+            // rebuilt seed.iso lands at the same path config.json
+            // expects. Clone restores have a different runtime_dir
+            // and need a config.json disk-path patch in addition
+            // (Phase 2 follow-up).
             if intent.is_restore() {
                 log::info!(
-                    "restore_receive_mode snapshot_path={} (skipping seed.iso)",
+                    "restore_receive_mode snapshot_path={}",
                     intent.restore_snapshot_path()
                 );
-            } else if intent.has_seed() && !intent.has_kernel() {
+            }
+            if intent.has_seed() && !intent.has_kernel() {
                 let configmap_path = Path::new(intent.seed_path());
                 let nocloud_output = runtime_dir.seed_dir();
                 if let Err(e) = swift_seed::build_nocloud_dir(configmap_path, &nocloud_output) {

--- a/test/snapshot/local-clone-identity-test.sh
+++ b/test/snapshot/local-clone-identity-test.sh
@@ -6,33 +6,47 @@
 # despite resuming from the same captured RAM. This is the contract
 # the SwiftRestore stager + in-guest cloud-init bootcmd implement.
 #
-# The seed profile (config/samples/seed-profiles/clone-identity-regen.yaml)
-# is applied to the source VM. When the controller patches the snapshot's
-# config.json with kubeswift.clone=true and per-clone MAC rewrites, the
-# stager init container materializes the patched copy in a pod-local
-# emptyDir; the in-guest bootcmd regenerates machine-id, SSH host keys,
-# and hostname on first wake.
+# The combined seed profile (config/samples/local-snapshots/
+# swiftseedprofile-test.yaml) is applied to the source VM. When the
+# controller patches the snapshot's config.json with kubeswift.clone=true
+# and per-clone MAC rewrites, the stager init container materializes the
+# patched copy in a pod-local emptyDir; the in-guest bootcmd regenerates
+# machine-id, SSH host keys, and hostname on first wake.
+#
+# This script also captures and reports clone-from-snapshot timings
+# (SwiftRestore -> launcher Running -> SwiftRestore Ready) so we get
+# a feel for the cost of the Tier B clone path on this cluster.
 #
 # Requires:
 #   - kubectl configured against a KubeSwift cluster.
 #   - Source VM image: ubuntu-noble (created on first run if missing).
+#   - SSH key for swiftctl-default user "kubeswift" (matches the
+#     ssh_authorized_keys baked into the test seed profile).
 
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-default}"
 NO_CLEANUP=false
 SAMPLES_DIR="$(cd "$(dirname "$0")/../../config/samples/local-snapshots" && pwd)"
+IDENTITY="${KUBESWIFT_TEST_IDENTITY:-${HOME}/.ssh/id_ed25519}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --no-cleanup) NO_CLEANUP=true; shift ;;
     --namespace)  NAMESPACE="$2"; shift 2 ;;
+    --identity)   IDENTITY="$2"; shift 2 ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
 done
 
+if [[ ! -r "$IDENTITY" ]]; then
+  echo "ERROR: SSH identity $IDENTITY not readable. Override with --identity or KUBESWIFT_TEST_IDENTITY." >&2
+  exit 2
+fi
+
 echo "=== KubeSwift Tier B clone-identity e2e ==="
 echo "Namespace: $NAMESPACE"
+echo "Identity:  $IDENTITY"
 echo ""
 
 cleanup() {
@@ -54,21 +68,37 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Helper: SSH into a guest and capture identity attributes.
-# Prints: machine-id sshfp hostname mac (space-separated).
-identity_of() {
-  local guest="$1"
-  swiftctl ssh -n "$NAMESPACE" "$guest" -- bash -c '
-    set -e
-    mid=$(cat /etc/machine-id 2>/dev/null || echo missing)
-    sshfp=$(ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null | awk "{print \$2}" || echo missing)
-    if [ "$sshfp" = "missing" ]; then
-      sshfp=$(ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub 2>/dev/null | awk "{print \$2}" || echo missing)
-    fi
-    hn=$(hostname 2>/dev/null || echo missing)
-    mac=$(cat /sys/class/net/eth0/address 2>/dev/null || echo missing)
-    echo "$mid $sshfp $hn $mac"
-  ' 2>/dev/null | tail -1
+# guest_exec — same pattern as local-roundtrip-test.sh: kubectl exec
+# into the launcher and run ssh from inside, with the host's identity
+# piped in and the remote command base64-encoded so quotes/newlines
+# survive the shell chain.
+guest_exec() {
+  local guest="$1"; shift
+  local cmd="$*"
+  local ip
+  ip=$(kubectl get swiftguest "$guest" -n "$NAMESPACE" -o jsonpath='{.status.network.primaryIP}' 2>/dev/null)
+  if [[ -z "$ip" ]]; then
+    echo "guest_exec: $guest has no primaryIP" >&2
+    return 1
+  fi
+  local cmd_b64
+  cmd_b64=$(printf '%s' "$cmd" | base64 -w0)
+  local launcher_script
+  launcher_script=$(cat <<LAUNCHER_EOF
+set -eu
+KEY=\$(mktemp); chmod 600 "\$KEY"
+cat > "\$KEY" <<'KUBESWIFT_TEST_KEY'
+$(cat "$IDENTITY")
+KUBESWIFT_TEST_KEY
+CMD=\$(printf %s '$cmd_b64' | base64 -d)
+RC=0
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectTimeout=5 -i "\$KEY" kubeswift@$ip "\$CMD" || RC=\$?
+rm -f "\$KEY"
+exit \$RC
+LAUNCHER_EOF
+)
+  printf '%s\n' "$launcher_script" \
+    | kubectl exec -n "$NAMESPACE" -i "$guest" -c launcher -- sh
 }
 
 wait_for_ssh() {
@@ -76,7 +106,7 @@ wait_for_ssh() {
   local timeout="${2:-180}"
   local elapsed=0
   while [[ $elapsed -lt $timeout ]]; do
-    if swiftctl ssh -n "$NAMESPACE" "$guest" -- true >/dev/null 2>&1; then
+    if guest_exec "$guest" true >/dev/null 2>&1; then
       return 0
     fi
     sleep 5
@@ -84,6 +114,17 @@ wait_for_ssh() {
   done
   return 1
 }
+
+# identity_of: run a fixed bash one-liner inside the guest and parse
+# four space-separated fields: machine-id sshfp hostname mac.
+identity_of() {
+  local guest="$1"
+  guest_exec "$guest" "bash -c 'mid=\$(cat /etc/machine-id 2>/dev/null || echo missing); sshfp=\$(ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null | awk \"{print \\\$2}\"); if [ -z \"\$sshfp\" ]; then sshfp=\$(ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub 2>/dev/null | awk \"{print \\\$2}\"); fi; [ -z \"\$sshfp\" ] && sshfp=missing; hn=\$(hostname 2>/dev/null || echo missing); mac=\$(cat /sys/class/net/eth0/address 2>/dev/null || echo missing); echo \"\$mid \$sshfp \$hn \$mac\"'" 2>/dev/null | tail -1
+}
+
+# epoch_now / elapsed_since: integer-second timing helpers.
+epoch_now() { date +%s; }
+elapsed_since() { echo $(($(epoch_now) - $1)); }
 
 # 1. Source VM with the combined seed profile (kubeswift user for
 #    swiftctl ssh + clone-identity-regen bootcmd).
@@ -130,18 +171,73 @@ kubectl wait --for=jsonpath='{.status.phase}'=Ready \
   swiftsnapshot/snapshot-local-mem -n "$NAMESPACE" --timeout=5m
 echo "  Snapshot Ready"
 
-# 3. Restore two clones with full identity regeneration.
+# 3. Restore two clones with full identity regeneration. Capture
+#    timing milestones for each clone so we can report wall-clock
+#    cost of the Tier B clone path.
 echo ""
 echo "--- Step 3: Create two clones (A and B) with identity.regenerate ---"
-kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/swiftrestore-clone-a.yaml" >/dev/null
-kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/swiftrestore-clone-b.yaml" >/dev/null
 
-echo "  Waiting for clone A Ready (5m)..."
-kubectl wait --for=jsonpath='{.status.phase}'=Ready \
-  swiftrestore/snapshot-local-clone-a -n "$NAMESPACE" --timeout=5m
-echo "  Waiting for clone B Ready (5m)..."
-kubectl wait --for=jsonpath='{.status.phase}'=Ready \
-  swiftrestore/snapshot-local-clone-b -n "$NAMESPACE" --timeout=5m
+declare -A T_RESTORE_CREATED T_GUEST_RUNNING T_RESTORE_READY T_SSH_REACHABLE T_SENTINEL_PRESENT
+
+# Wait helper for a SwiftRestore phase, returns the wall-clock seconds
+# elapsed from the wait start to the phase reaching the target value.
+wait_phase_match() {
+  local kind="$1" name="$2" target="$3" timeout="$4"
+  local elapsed=0
+  while [[ $elapsed -lt $timeout ]]; do
+    local cur
+    cur=$(kubectl get "$kind" "$name" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+    if [[ "$cur" == "$target" ]]; then
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  return 1
+}
+
+# Wait helper for a SwiftGuest condition (e.g. GuestRunning=True).
+wait_guest_running() {
+  local name="$1" timeout="$2"
+  local elapsed=0
+  while [[ $elapsed -lt $timeout ]]; do
+    local cur
+    cur=$(kubectl get swiftguest "$name" -n "$NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="GuestRunning")].status}' 2>/dev/null || echo "")
+    if [[ "$cur" == "True" ]]; then
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  return 1
+}
+
+for clone in snapshot-local-clone-a snapshot-local-clone-b; do
+  T_RESTORE_CREATED[$clone]=$(epoch_now)
+  echo "  [$clone] Apply SwiftRestore (clone path)"
+  kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/swiftrestore-${clone#snapshot-local-}.yaml" >/dev/null
+done
+
+# Track each milestone independently.
+for clone in snapshot-local-clone-a snapshot-local-clone-b; do
+  echo ""
+  echo "  [$clone] waiting for GuestRunning=True (CH socket bound, paused)..."
+  if ! wait_guest_running "$clone" 300; then
+    echo "    FAIL: $clone never reached GuestRunning=True"
+    exit 1
+  fi
+  T_GUEST_RUNNING[$clone]=$(epoch_now)
+  echo "    GuestRunning=True after $(($(epoch_now) - ${T_RESTORE_CREATED[$clone]}))s"
+
+  echo "  [$clone] waiting for SwiftRestore Ready (resume action mirrored)..."
+  if ! wait_phase_match swiftrestore "$clone" Ready 300; then
+    echo "    FAIL: $clone SwiftRestore never reached Ready"
+    kubectl describe swiftrestore "$clone" -n "$NAMESPACE" 2>&1 | tail -15 || true
+    exit 1
+  fi
+  T_RESTORE_READY[$clone]=$(epoch_now)
+  echo "    SwiftRestore Ready after $(($(epoch_now) - ${T_RESTORE_CREATED[$clone]}))s"
+done
 
 # Verify clone pods have the snapshot-stager init container.
 for clone in snapshot-local-clone-a snapshot-local-clone-b; do
@@ -151,20 +247,26 @@ for clone in snapshot-local-clone-a snapshot-local-clone-b; do
     exit 1
   fi
 done
+echo ""
 echo "  Both clones have snapshot-stager init container (clone path engaged)"
 
 # 4. Wait for first-boot identity regeneration in each clone.
 echo ""
 echo "--- Step 4: Wait for in-guest identity regeneration sentinel ---"
 for clone in snapshot-local-clone-a snapshot-local-clone-b; do
+  echo "  [$clone] waiting for SSH..."
   if ! wait_for_ssh "$clone" 180; then
-    echo "  FAIL: clone $clone SSH not reachable"
+    echo "    FAIL: clone $clone SSH not reachable"
     exit 1
   fi
+  T_SSH_REACHABLE[$clone]=$(epoch_now)
+  echo "    SSH reachable after $(($(epoch_now) - ${T_RESTORE_CREATED[$clone]}))s"
+
   # Wait up to 90s for /var/lib/kubeswift/.clone-regenerated to appear.
   for _ in $(seq 1 18); do
-    if swiftctl ssh -n "$NAMESPACE" "$clone" -- test -f /var/lib/kubeswift/.clone-regenerated 2>/dev/null; then
-      echo "  $clone: clone-regenerated sentinel present"
+    if guest_exec "$clone" "test -f /var/lib/kubeswift/.clone-regenerated" >/dev/null 2>&1; then
+      T_SENTINEL_PRESENT[$clone]=$(epoch_now)
+      echo "    clone-regenerated sentinel present after $(($(epoch_now) - ${T_RESTORE_CREATED[$clone]}))s"
       break
     fi
     sleep 5
@@ -180,8 +282,6 @@ echo "  Source: $SOURCE_IDENTITY"
 echo "  A:      $A_IDENTITY"
 echo "  B:      $B_IDENTITY"
 
-# Each entry is space-separated: machine-id sshfp hostname mac.
-# Pull the four fields and compare.
 read -r SRC_MID SRC_SSHFP SRC_HOST SRC_MAC <<< "$SOURCE_IDENTITY"
 read -r A_MID   A_SSHFP   A_HOST   A_MAC   <<< "$A_IDENTITY"
 read -r B_MID   B_SSHFP   B_HOST   B_MAC   <<< "$B_IDENTITY"
@@ -204,6 +304,22 @@ check_diff "mac (eth0)"  "$SRC_MAC"   "$A_MAC"   "$B_MAC"
 if [[ $fail -ne 0 ]]; then
   exit 1
 fi
+
+# 6. Timing summary — the user wants to know how long Tier B clone
+#    startup costs on this cluster. We report the wall-clock between
+#    SwiftRestore creation and each milestone, for each clone.
+echo ""
+echo "--- Timing summary (seconds since SwiftRestore creation) ---"
+printf "%-30s %12s %14s %16s %18s\n" "clone" "GuestRunning" "RestoreReady" "SSH-reachable" "regen-sentinel"
+for clone in snapshot-local-clone-a snapshot-local-clone-b; do
+  t0=${T_RESTORE_CREATED[$clone]}
+  gr="${T_GUEST_RUNNING[$clone]:-}"
+  rr="${T_RESTORE_READY[$clone]:-}"
+  sr="${T_SSH_REACHABLE[$clone]:-}"
+  sp="${T_SENTINEL_PRESENT[$clone]:-}"
+  fmt() { [[ -z "$1" ]] && echo "—" || echo "$(($1 - t0))s"; }
+  printf "%-30s %12s %14s %16s %18s\n" "$clone" "$(fmt "$gr")" "$(fmt "$rr")" "$(fmt "$sr")" "$(fmt "$sp")"
+done
 
 echo ""
 echo "=== Tier B clone-identity e2e PASS ==="


### PR DESCRIPTION
CH on `--restore` re-opens every disk listed in the snapshot's config.json — including the seed.iso disk. The restore launcher pod path was double-broken:

1. Go side (BuildRestorePod): the seed ConfigMap mount was omitted under the assumption "cloud-init is in memory, no need for the seed dir." Without the mount, swiftletd had nothing to rebuild seed.iso from even if it tried.

2. Rust side (swiftletd/src/main.rs): the seed.iso construction block was explicitly gated to skip when intent.is_restore() is true. So even with the seed dir mounted, swiftletd would log "skipping seed.iso" and proceed to spawn_ch_restore — which then bailed with:

      Cloud Hypervisor exited with the following chain of errors:
        0: Error restoring VM
        ...
        3: Cannot open disk path
        4: No such file or directory (os error 2)

Caught by code-reading main.rs before the second redeploy: the Go fix on its own would not have been enough, and we'd have rebuilt the image only to hit the same error from a different cause.

Fix:
  - BuildRestorePod mounts the seed ConfigMap at the canonical SeedPath when the source had a seed and a seed ConfigMap name is threaded through. Idempotent across in-place vs clone paths; existing tests cover the gate.
  - main.rs runs the seed.iso construction block whenever intent.has_seed() && !intent.has_kernel(), regardless of is_restore(). The build is deterministic — same seed dir bytes in, same seed.iso bytes out — so for in-place restore the rebuilt seed.iso matches the snapshot's config.json disk path byte-for-byte. CH on --restore opens it cleanly.

In-place restore: this fix completes the chain. CH gets a valid seed.iso at the expected runtime_dir path.

Clone restore: the runtime_dir name differs from the source's (e.g. /var/lib/kubeswift/run/default-snapshot-local-clone-a/ vs .../default-snapshot-local-source/), so the rebuilt seed.iso lands at a different path than config.json expects. CH will still bail at the same step. Clone restores need a config.json disk-path patcher in addition; that's a follow-up after the in-place path validates end-to-end.

Tests:
  - 3 new BuildRestorePod tests cover the seed-mount gate.
  - Existing TestBuildRestorePod_RestartPolicyNeverAndNoSeedVolume split: the "no seed volume ever" assertion was the bug.
  - 12/12 swiftguest tests pass; full go test ./... green; cargo build + cargo fmt --check + gofmt clean.