### PR TITLE
fix(snapshot): patch config.json for Tier B clone restores

### DIFF
--- a/cmd/snapshot-stager/main.go
+++ b/cmd/snapshot-stager/main.go
@@ -56,6 +56,12 @@ func main() {
 		"append the kubeswift.clone=true marker to the kernel cmdline in config.json")
 	rewriteMACsCSV := flag.String("rewrite-macs", "",
 		"comma-separated MAC list, indexed by config.net[]; empty entries leave the source MAC unchanged")
+	rewriteRuntimeDirFrom := flag.String("rewrite-runtime-dir-from", "",
+		"source runtime_dir prefix (must end in '/') to substitute in disks[].path and serial.socket")
+	rewriteRuntimeDirTo := flag.String("rewrite-runtime-dir-to", "",
+		"target runtime_dir prefix (must end in '/'); empty disables prefix rewrite")
+	nullifyHostMAC := flag.Bool("nullify-host-mac", false,
+		"set net[].host_mac to null so CH auto-discovers the clone tap's host MAC instead of forcing the source value")
 	flag.Parse()
 
 	if *src == "" || *dst == "" {
@@ -63,13 +69,20 @@ func main() {
 		os.Exit(2)
 	}
 
-	if err := run(*src, *dst, *appendCmdlineMarker, parseMACsCSV(*rewriteMACsCSV)); err != nil {
+	opts := configjson.PatchOptions{
+		AppendCmdlineMarker:   *appendCmdlineMarker,
+		RewriteMACs:           parseMACsCSV(*rewriteMACsCSV),
+		RewriteRuntimeDirFrom: *rewriteRuntimeDirFrom,
+		RewriteRuntimeDirTo:   *rewriteRuntimeDirTo,
+		NullifyHostMAC:        *nullifyHostMAC,
+	}
+	if err := run(*src, *dst, opts); err != nil {
 		fmt.Fprintln(os.Stderr, "snapshot-stager:", err)
 		os.Exit(1)
 	}
 }
 
-func run(src, dst string, appendCmdlineMarker bool, rewriteMACs []string) error {
+func run(src, dst string, opts configjson.PatchOptions) error {
 	if _, err := os.Stat(src); err != nil {
 		return fmt.Errorf("source dir not accessible: %w", err)
 	}
@@ -96,16 +109,13 @@ func run(src, dst string, appendCmdlineMarker bool, rewriteMACs []string) error 
 		return fmt.Errorf("copy: %w", err)
 	}
 
-	if appendCmdlineMarker || len(rewriteMACs) > 0 {
+	if patchRequested(opts) {
 		fmt.Println("snapshot-stager: patching config.json")
 		cfg, err := configjson.Read(dst)
 		if err != nil {
 			return fmt.Errorf("read config.json: %w", err)
 		}
-		changes, err := configjson.Patch(cfg, configjson.PatchOptions{
-			AppendCmdlineMarker: appendCmdlineMarker,
-			RewriteMACs:         rewriteMACs,
-		})
+		changes, err := configjson.Patch(cfg, opts)
 		if err != nil {
 			return fmt.Errorf("patch config.json: %w", err)
 		}
@@ -124,6 +134,17 @@ func run(src, dst string, appendCmdlineMarker bool, rewriteMACs []string) error 
 	}
 	fmt.Println("snapshot-stager: complete")
 	return nil
+}
+
+// patchRequested reports whether any PatchOptions field is set, so we
+// can skip the read/write round-trip on config.json when the stager
+// only needs to copy the snapshot tree.
+func patchRequested(opts configjson.PatchOptions) bool {
+	return opts.AppendCmdlineMarker ||
+		len(opts.RewriteMACs) > 0 ||
+		opts.RewriteRuntimeDirFrom != "" ||
+		opts.RewriteRuntimeDirTo != "" ||
+		opts.NullifyHostMAC
 }
 
 // parseMACsCSV splits a comma-separated MAC list. Empty input produces

--- a/cmd/snapshot-stager/main_test.go
+++ b/cmd/snapshot-stager/main_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/projectbeskar/kubeswift/internal/snapshot/configjson"
 )
 
 // writeMockSnapshot creates a directory layout that resembles a CH
@@ -64,7 +66,10 @@ func TestRun_AppliesPatchesAndWritesSentinel(t *testing.T) {
 	dst := t.TempDir()
 	writeMockSnapshot(t, src, "console=ttyS0 root=/dev/vda", "52:54:00:01:01:01")
 
-	if err := run(src, dst, true, []string{"52:54:00:aa:bb:cc"}); err != nil {
+	if err := run(src, dst, configjson.PatchOptions{
+		AppendCmdlineMarker: true,
+		RewriteMACs:         []string{"52:54:00:aa:bb:cc"},
+	}); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 
@@ -115,7 +120,10 @@ func TestRun_SentinelPresentIsIdempotentNoOp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := run(src, dst, true, []string{"52:54:00:aa:bb:cc"}); err != nil {
+	if err := run(src, dst, configjson.PatchOptions{
+		AppendCmdlineMarker: true,
+		RewriteMACs:         []string{"52:54:00:aa:bb:cc"},
+	}); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 
@@ -147,7 +155,7 @@ func TestRun_PartialPriorRunIsWipedAndRetried(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := run(src, dst, false, nil); err != nil {
+	if err := run(src, dst, configjson.PatchOptions{}); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 
@@ -171,7 +179,7 @@ func TestRun_NoPatchesRequestedSkipsConfigJSONRewrite(t *testing.T) {
 	dst := t.TempDir()
 	writeMockSnapshot(t, src, "console=ttyS0", "52:54:00:11:22:33")
 
-	if err := run(src, dst, false, nil); err != nil {
+	if err := run(src, dst, configjson.PatchOptions{}); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 
@@ -190,9 +198,84 @@ func TestRun_NoPatchesRequestedSkipsConfigJSONRewrite(t *testing.T) {
 
 func TestRun_MissingSourceFails(t *testing.T) {
 	dst := t.TempDir()
-	err := run("/this/path/does/not/exist", dst, true, nil)
+	err := run("/this/path/does/not/exist", dst, configjson.PatchOptions{AppendCmdlineMarker: true})
 	if err == nil {
 		t.Fatal("expected error for missing source")
+	}
+}
+
+// TestRun_RewritesRuntimeDirAndNullifiesHostMAC mirrors the clone path
+// end-to-end through run() against a flat-layout config.json (real CH
+// 51.1 snapshot output): seed.iso disk path + serial.socket carry the
+// source pod's runtime_dir prefix; net[0].host_mac is populated. After
+// run completes, both paths are rewritten to the target prefix and the
+// host_mac is null. Mirrors what the clone restore-receive launcher
+// will see.
+func TestRun_RewritesRuntimeDirAndNullifiesHostMAC(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	from := "/var/lib/kubeswift/run/default-source/"
+	to := "/var/lib/kubeswift/run/default-clone-a/"
+	cfg := map[string]any{
+		"payload": map[string]any{"cmdline": "console=ttyS0"},
+		"disks": []any{
+			map[string]any{"id": "_disk0", "path": "/var/lib/kubeswift/disks/root/image.raw"},
+			map[string]any{"id": "_disk1", "path": from + "seed.iso"},
+		},
+		"net": []any{
+			map[string]any{
+				"id":       "_net0",
+				"mac":      "52:54:00:aa:bb:01",
+				"host_mac": "be:b2:1e:5e:38:40",
+			},
+		},
+		"serial": map[string]any{"socket": from + "serial.sock"},
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(filepath.Join(src, "config.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "state.json"), []byte("opaque"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "memory-ranges"), []byte("opaque"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := run(src, dst, configjson.PatchOptions{
+		RewriteRuntimeDirFrom: from,
+		RewriteRuntimeDirTo:   to,
+		NullifyHostMAC:        true,
+	}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	// Read back the patched config.json.
+	out, err := os.ReadFile(filepath.Join(dst, "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var patched map[string]any
+	if err := json.Unmarshal(out, &patched); err != nil {
+		t.Fatal(err)
+	}
+	disks := patched["disks"].([]any)
+	if got := disks[0].(map[string]any)["path"]; got != "/var/lib/kubeswift/disks/root/image.raw" {
+		t.Errorf("root disk path mutated: %v", got)
+	}
+	if got := disks[1].(map[string]any)["path"]; got != to+"seed.iso" {
+		t.Errorf("seed.iso path = %v, want %s", got, to+"seed.iso")
+	}
+	if got := patched["serial"].(map[string]any)["socket"]; got != to+"serial.sock" {
+		t.Errorf("serial.socket = %v, want %s", got, to+"serial.sock")
+	}
+	dev := patched["net"].([]any)[0].(map[string]any)
+	if dev["host_mac"] != nil {
+		t.Errorf("host_mac = %v, want nil", dev["host_mac"])
+	}
+	if dev["mac"] != "52:54:00:aa:bb:01" {
+		t.Errorf("guest mac mutated: %v", dev["mac"])
 	}
 }
 
@@ -230,7 +313,10 @@ func TestSentinelWrittenLast(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()
 	writeMockSnapshot(t, src, "console=ttyS0", "52:54:00:11:22:33")
-	if err := run(src, dst, true, []string{"52:54:00:aa:bb:cc"}); err != nil {
+	if err := run(src, dst, configjson.PatchOptions{
+		AppendCmdlineMarker: true,
+		RewriteMACs:         []string{"52:54:00:aa:bb:cc"},
+	}); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 	cfgInfo, err := os.Stat(filepath.Join(dst, "config.json"))

--- a/internal/controller/swiftguest/restore.go
+++ b/internal/controller/swiftguest/restore.go
@@ -89,6 +89,22 @@ const (
 	// host keys, and hostname on first wake (see
 	// docs/snapshots/identity-regeneration.md).
 	AnnotationRestoreAppendCmdlineMarker = "snapshot.kubeswift.io/restore-append-cmdline-marker"
+	// AnnotationRestoreRuntimeDirFromPrefix is the source pod's
+	// runtime_dir prefix that the stager must rewrite in
+	// disks[].path and serial.socket. Must end in "/". Empty disables
+	// the rewrite (in-place restores reuse the source's runtime_dir
+	// name and don't need the patch).
+	AnnotationRestoreRuntimeDirFromPrefix = "snapshot.kubeswift.io/restore-runtime-dir-from"
+	// AnnotationRestoreRuntimeDirToPrefix is the clone pod's runtime_dir
+	// prefix that source-runtime_dir paths must be rewritten to. Must
+	// end in "/".
+	AnnotationRestoreRuntimeDirToPrefix = "snapshot.kubeswift.io/restore-runtime-dir-to"
+	// AnnotationRestoreNullifyHostMAC, when "true", asks the stager to
+	// set net[].host_mac to null in config.json. Required for clones
+	// because CH on restore would otherwise force the clone tap's MAC
+	// to the source's saved value (cloud-hypervisor v51.1
+	// net_util/src/open_tap.rs sets the tap MAC when host_mac is Some).
+	AnnotationRestoreNullifyHostMAC = "snapshot.kubeswift.io/restore-nullify-host-mac"
 )
 
 // Restore mode values for AnnotationRestoreMode.
@@ -136,6 +152,16 @@ type RestoreParams struct {
 	// AppendCmdlineMarker asks the stager to mark the kernel cmdline
 	// for the in-guest identity-regeneration bootcmd.
 	AppendCmdlineMarker bool
+	// RuntimeDirFromPrefix is the source pod's runtime_dir prefix
+	// (must end in '/') that the stager substitutes in disks[].path
+	// and serial.socket. Empty disables the rewrite.
+	RuntimeDirFromPrefix string
+	// RuntimeDirToPrefix is the clone pod's runtime_dir prefix
+	// (must end in '/') that source paths are rewritten to.
+	RuntimeDirToPrefix string
+	// NullifyHostMAC asks the stager to set net[].host_mac to null in
+	// config.json. Required for clones (see configjson.PatchOptions).
+	NullifyHostMAC bool
 }
 
 // IsClone reports whether the restore must stage and patch the
@@ -367,6 +393,15 @@ func snapshotStagerInitContainer(params RestoreParams) corev1.Container {
 	if strings.TrimSpace(params.MACRewrites) != "" {
 		args = append(args, "--rewrite-macs", params.MACRewrites)
 	}
+	if params.RuntimeDirFromPrefix != "" && params.RuntimeDirToPrefix != "" {
+		args = append(args,
+			"--rewrite-runtime-dir-from", params.RuntimeDirFromPrefix,
+			"--rewrite-runtime-dir-to", params.RuntimeDirToPrefix,
+		)
+	}
+	if params.NullifyHostMAC {
+		args = append(args, "--nullify-host-mac=true")
+	}
 	return corev1.Container{
 		Name:            SnapshotStagerInitContainerName,
 		Image:           LauncherImage(),
@@ -406,10 +441,13 @@ func RestoreParamsFromAnnotations(annotations map[string]string) (RestoreParams,
 		mode = RestoreModeInPlace
 	}
 	return RestoreParams{
-		SnapshotPath:        annotations[AnnotationRestoreSnapshotPath],
-		NodeName:            annotations[AnnotationRestoreNodeName],
-		Mode:                mode,
-		MACRewrites:         annotations[AnnotationRestoreMACRewrites],
-		AppendCmdlineMarker: annotations[AnnotationRestoreAppendCmdlineMarker] == "true",
+		SnapshotPath:         annotations[AnnotationRestoreSnapshotPath],
+		NodeName:             annotations[AnnotationRestoreNodeName],
+		Mode:                 mode,
+		MACRewrites:          annotations[AnnotationRestoreMACRewrites],
+		AppendCmdlineMarker:  annotations[AnnotationRestoreAppendCmdlineMarker] == "true",
+		RuntimeDirFromPrefix: annotations[AnnotationRestoreRuntimeDirFromPrefix],
+		RuntimeDirToPrefix:   annotations[AnnotationRestoreRuntimeDirToPrefix],
+		NullifyHostMAC:       annotations[AnnotationRestoreNullifyHostMAC] == "true",
 	}, true
 }

--- a/internal/controller/swiftguest/restore_test.go
+++ b/internal/controller/swiftguest/restore_test.go
@@ -1,6 +1,7 @@
 package swiftguest
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -93,12 +94,15 @@ func TestRestoreParamsFromAnnotations_DefaultsModeToInPlace(t *testing.T) {
 
 func TestRestoreParamsFromAnnotations_PicksUpAllFields(t *testing.T) {
 	annos := map[string]string{
-		AnnotationActiveRestore:              "r1",
-		AnnotationRestoreSnapshotPath:        "/var/lib/kubeswift/snapshots/x",
-		AnnotationRestoreNodeName:            "n1",
-		AnnotationRestoreMode:                RestoreModeClone,
-		AnnotationRestoreMACRewrites:         "52:54:00:aa:bb:01",
-		AnnotationRestoreAppendCmdlineMarker: "true",
+		AnnotationActiveRestore:               "r1",
+		AnnotationRestoreSnapshotPath:         "/var/lib/kubeswift/snapshots/x",
+		AnnotationRestoreNodeName:             "n1",
+		AnnotationRestoreMode:                 RestoreModeClone,
+		AnnotationRestoreMACRewrites:          "52:54:00:aa:bb:01",
+		AnnotationRestoreAppendCmdlineMarker:  "true",
+		AnnotationRestoreRuntimeDirFromPrefix: "/var/lib/kubeswift/run/default-src/",
+		AnnotationRestoreRuntimeDirToPrefix:   "/var/lib/kubeswift/run/default-clone-a/",
+		AnnotationRestoreNullifyHostMAC:       "true",
 	}
 	p, ok := RestoreParamsFromAnnotations(annos)
 	if !ok {
@@ -119,8 +123,69 @@ func TestRestoreParamsFromAnnotations_PicksUpAllFields(t *testing.T) {
 	if !p.AppendCmdlineMarker {
 		t.Errorf("AppendCmdlineMarker = false, want true")
 	}
+	if p.RuntimeDirFromPrefix != "/var/lib/kubeswift/run/default-src/" {
+		t.Errorf("RuntimeDirFromPrefix = %q", p.RuntimeDirFromPrefix)
+	}
+	if p.RuntimeDirToPrefix != "/var/lib/kubeswift/run/default-clone-a/" {
+		t.Errorf("RuntimeDirToPrefix = %q", p.RuntimeDirToPrefix)
+	}
+	if !p.NullifyHostMAC {
+		t.Errorf("NullifyHostMAC = false, want true")
+	}
 	if got := p.InPodSnapshotPath(); got != RestoreStagingPath {
 		t.Errorf("InPodSnapshotPath() = %q, want %q", got, RestoreStagingPath)
+	}
+}
+
+func TestSnapshotStagerInitContainer_WiresCloneFlags(t *testing.T) {
+	// The clone-mode stager invocation must surface every patch option
+	// as a CLI flag. Missing any flag means the corresponding rewrite
+	// is silently skipped — the launcher would then bring CH up against
+	// stale source paths, which fails with "no such file or directory".
+	params := RestoreParams{
+		Mode:                 RestoreModeClone,
+		AppendCmdlineMarker:  true,
+		MACRewrites:          "52:54:00:de:ad:be",
+		RuntimeDirFromPrefix: "/var/lib/kubeswift/run/default-src/",
+		RuntimeDirToPrefix:   "/var/lib/kubeswift/run/default-clone-a/",
+		NullifyHostMAC:       true,
+	}
+	c := snapshotStagerInitContainer(params)
+	args := strings.Join(c.Args, " ")
+	wants := []string{
+		"--src",
+		"--dst",
+		"--append-cmdline-marker=true",
+		"--rewrite-macs 52:54:00:de:ad:be",
+		"--rewrite-runtime-dir-from /var/lib/kubeswift/run/default-src/",
+		"--rewrite-runtime-dir-to /var/lib/kubeswift/run/default-clone-a/",
+		"--nullify-host-mac=true",
+	}
+	for _, w := range wants {
+		if !strings.Contains(args, w) {
+			t.Errorf("stager args missing %q\n  got: %s", w, args)
+		}
+	}
+}
+
+func TestSnapshotStagerInitContainer_OmitsCloneFlagsWhenUnset(t *testing.T) {
+	// When the controller doesn't ask for a particular rewrite, the
+	// flag must be omitted (not passed empty) so the stager's
+	// patchRequested() short-circuit can skip the read/write of
+	// config.json entirely.
+	params := RestoreParams{Mode: RestoreModeClone}
+	c := snapshotStagerInitContainer(params)
+	args := strings.Join(c.Args, " ")
+	for _, flag := range []string{
+		"--append-cmdline-marker",
+		"--rewrite-macs",
+		"--rewrite-runtime-dir-from",
+		"--rewrite-runtime-dir-to",
+		"--nullify-host-mac",
+	} {
+		if strings.Contains(args, flag) {
+			t.Errorf("stager args should not include %q when unset; got: %s", flag, args)
+		}
 	}
 }
 

--- a/internal/controller/swiftrestore/local.go
+++ b/internal/controller/swiftrestore/local.go
@@ -514,8 +514,32 @@ func (r *SwiftRestoreReconciler) restoreAnnotations(
 		if regenIncludes(restore, snapshotv1alpha1.RegenMACAddresses) {
 			annos[swiftguestctrl.AnnotationRestoreMACRewrites] = computeMACRewrites(restore.Namespace, restore.Spec.TargetGuest.Name, source)
 		}
+		// Always set on clones — the snapshot's config.json bakes in
+		// the source pod's runtime_dir name (e.g.
+		// /var/lib/kubeswift/run/<source-ns>-<source>/seed.iso). The
+		// clone pod's runtime_dir has a different name, so CH
+		// --restore would fail to open those paths without the
+		// stager rewriting them.
+		annos[swiftguestctrl.AnnotationRestoreRuntimeDirFromPrefix] = runtimeDirPrefix(source.Namespace, source.Name)
+		annos[swiftguestctrl.AnnotationRestoreRuntimeDirToPrefix] = runtimeDirPrefix(restore.Namespace, restore.Spec.TargetGuest.Name)
+		// Always set on clones — CH otherwise forces the clone tap's
+		// host MAC to the saved source value, colliding on the bridge
+		// when both pods run on the same node.
+		annos[swiftguestctrl.AnnotationRestoreNullifyHostMAC] = "true"
 	}
 	return annos
+}
+
+// runtimeDirPrefix returns the per-pod runtime_dir prefix that the
+// snapshot-stager substitutes in disks[].path and serial.socket.
+// Mirrors swift-runtime's create_runtime_dir naming
+// (rust/swift-runtime/src/runtime_dir.rs): base is
+// /var/lib/kubeswift/run, the per-guest directory is "<ns>-<name>"
+// (slashes in guest_id become hyphens), trailing "/" is required so
+// the patcher's prefix match doesn't clip a longer name that happens
+// to start with a shorter one.
+func runtimeDirPrefix(namespace, name string) string {
+	return "/var/lib/kubeswift/run/" + namespace + "-" + name + "/"
 }
 
 // computeMACRewrites returns a CSV of new MACs indexed by NIC ordinal
@@ -667,12 +691,15 @@ func (r *SwiftRestoreReconciler) unstampGuestRestoreAnnotations(
 	patch := map[string]any{
 		"metadata": map[string]any{
 			"annotations": map[string]any{
-				swiftguestctrl.AnnotationActiveRestore:              nil,
-				swiftguestctrl.AnnotationRestoreSnapshotPath:        nil,
-				swiftguestctrl.AnnotationRestoreNodeName:            nil,
-				swiftguestctrl.AnnotationRestoreMode:                nil,
-				swiftguestctrl.AnnotationRestoreMACRewrites:         nil,
-				swiftguestctrl.AnnotationRestoreAppendCmdlineMarker: nil,
+				swiftguestctrl.AnnotationActiveRestore:               nil,
+				swiftguestctrl.AnnotationRestoreSnapshotPath:         nil,
+				swiftguestctrl.AnnotationRestoreNodeName:             nil,
+				swiftguestctrl.AnnotationRestoreMode:                 nil,
+				swiftguestctrl.AnnotationRestoreMACRewrites:          nil,
+				swiftguestctrl.AnnotationRestoreAppendCmdlineMarker:  nil,
+				swiftguestctrl.AnnotationRestoreRuntimeDirFromPrefix: nil,
+				swiftguestctrl.AnnotationRestoreRuntimeDirToPrefix:   nil,
+				swiftguestctrl.AnnotationRestoreNullifyHostMAC:       nil,
 			},
 		},
 	}

--- a/internal/controller/swiftrestore/local_test.go
+++ b/internal/controller/swiftrestore/local_test.go
@@ -7,6 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	swiftguestctrl "github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
 )
 
 // -------- Pure version-comparison tests --------
@@ -214,6 +216,110 @@ func TestIsTierBRestore(t *testing.T) {
 	}
 	if !IsTierBRestore(local) {
 		t.Errorf("local snapshot should be Tier B")
+	}
+}
+
+// -------- restoreAnnotations: clone-mode wiring --------
+
+func TestRestoreAnnotations_Clone_SetsRuntimeDirPrefixAndNullifyHostMAC(t *testing.T) {
+	r := &SwiftRestoreReconciler{}
+	restore := &snapshotv1alpha1.SwiftRestore{
+		ObjectMeta: metav1.ObjectMeta{Name: "rst1", Namespace: "default"},
+		Spec: snapshotv1alpha1.SwiftRestoreSpec{
+			TargetGuest: snapshotv1alpha1.SwiftRestoreTarget{Name: "clone-a"},
+			Identity: &snapshotv1alpha1.IdentityRegeneration{
+				Regenerate: []snapshotv1alpha1.IdentityRegenerationItem{
+					snapshotv1alpha1.RegenMACAddresses,
+					snapshotv1alpha1.RegenMachineID,
+					snapshotv1alpha1.RegenSSHHostKeys,
+					snapshotv1alpha1.RegenHostname,
+				},
+			},
+		},
+	}
+	snap := &snapshotv1alpha1.SwiftSnapshot{
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			Backend: snapshotv1alpha1.SwiftSnapshotBackend{
+				Type:  snapshotv1alpha1.SnapshotBackendLocal,
+				Local: &snapshotv1alpha1.LocalBackend{HostPath: "/var/lib/kubeswift/snapshots/default-snap1"},
+			},
+		},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{NodeName: "boba"},
+	}
+	source := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: "default"}}
+
+	annos := r.restoreAnnotations(restore, snap, source, false /* inPlace */)
+
+	wantFrom := "/var/lib/kubeswift/run/default-src/"
+	wantTo := "/var/lib/kubeswift/run/default-clone-a/"
+	if got := annos[swiftguestctrl.AnnotationRestoreRuntimeDirFromPrefix]; got != wantFrom {
+		t.Errorf("from prefix = %q, want %q", got, wantFrom)
+	}
+	if got := annos[swiftguestctrl.AnnotationRestoreRuntimeDirToPrefix]; got != wantTo {
+		t.Errorf("to prefix = %q, want %q", got, wantTo)
+	}
+	if got := annos[swiftguestctrl.AnnotationRestoreNullifyHostMAC]; got != "true" {
+		t.Errorf("nullify-host-mac = %q, want \"true\"", got)
+	}
+	if got := annos[swiftguestctrl.AnnotationRestoreMode]; got != swiftguestctrl.RestoreModeClone {
+		t.Errorf("mode = %q, want clone", got)
+	}
+}
+
+func TestRestoreAnnotations_InPlace_DoesNotSetCloneOnlyAnnotations(t *testing.T) {
+	// In-place restore reuses the source's runtime_dir name and does
+	// not need any of the clone-only patches. The fast path bypasses
+	// the stager entirely; setting these annotations would still
+	// trigger a stager pass on a future pod recreation, so they must
+	// be omitted.
+	r := &SwiftRestoreReconciler{}
+	restore := &snapshotv1alpha1.SwiftRestore{
+		ObjectMeta: metav1.ObjectMeta{Name: "rst1", Namespace: "default"},
+		Spec: snapshotv1alpha1.SwiftRestoreSpec{
+			TargetGuest: snapshotv1alpha1.SwiftRestoreTarget{Name: "src"},
+		},
+	}
+	snap := &snapshotv1alpha1.SwiftSnapshot{
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			Backend: snapshotv1alpha1.SwiftSnapshotBackend{
+				Type:  snapshotv1alpha1.SnapshotBackendLocal,
+				Local: &snapshotv1alpha1.LocalBackend{HostPath: "/var/lib/kubeswift/snapshots/default-snap1"},
+			},
+		},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{NodeName: "boba"},
+	}
+	source := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: "default"}}
+
+	annos := r.restoreAnnotations(restore, snap, source, true /* inPlace */)
+
+	for _, key := range []string{
+		swiftguestctrl.AnnotationRestoreRuntimeDirFromPrefix,
+		swiftguestctrl.AnnotationRestoreRuntimeDirToPrefix,
+		swiftguestctrl.AnnotationRestoreNullifyHostMAC,
+		swiftguestctrl.AnnotationRestoreMACRewrites,
+		swiftguestctrl.AnnotationRestoreAppendCmdlineMarker,
+	} {
+		if _, set := annos[key]; set {
+			t.Errorf("in-place restore set clone-only annotation %s = %q", key, annos[key])
+		}
+	}
+	if got := annos[swiftguestctrl.AnnotationRestoreMode]; got != swiftguestctrl.RestoreModeInPlace {
+		t.Errorf("mode = %q, want in-place", got)
+	}
+}
+
+func TestRuntimeDirPrefix_FormatMatchesSwiftRuntime(t *testing.T) {
+	// Format must match swift-runtime's create_runtime_dir naming
+	// (rust/swift-runtime/src/runtime_dir.rs:48): "<ns>-<name>" under
+	// /var/lib/kubeswift/run, with a trailing "/" so the patcher's
+	// prefix match doesn't clip a longer name.
+	got := runtimeDirPrefix("default", "guest1")
+	want := "/var/lib/kubeswift/run/default-guest1/"
+	if got != want {
+		t.Errorf("runtimeDirPrefix(\"default\", \"guest1\") = %q, want %q", got, want)
+	}
+	if !strings.HasSuffix(got, "/") {
+		t.Errorf("runtimeDirPrefix must end in '/' — patcher requires it")
 	}
 }
 

--- a/internal/snapshot/configjson/configjson.go
+++ b/internal/snapshot/configjson/configjson.go
@@ -55,9 +55,28 @@ const ConfigJSONFilename = "config.json"
 // runtimeintent.GenerateMAC(InterfaceMACSeed(targetNs, targetName,
 // ifaceName)). The patcher only writes them; the policy of "what is
 // the right MAC?" lives one layer up.
+//
+// RewriteRuntimeDirPrefix performs a prefix substitution on every
+// runtime_dir-shaped path in config.json (currently disks[].path and
+// serial.socket). For clone restores the launcher pod's runtime_dir
+// has a different name from the source's, so paths the source baked
+// into config.json (e.g. /var/lib/kubeswift/run/<source-ns>-<source>/seed.iso)
+// must be rewritten to point at the clone's runtime_dir. From and To
+// are the source and target prefix strings; both must end in "/" or
+// the patcher errors. Empty From or To skips this transformation.
+//
+// NullifyHostMAC sets net[N].host_mac to null on every virtio-net
+// device. CH's open_tap (cloud-hypervisor v51.1 net_util/src/open_tap.rs)
+// forces the tap MAC to the saved value when host_mac is Some, which
+// would make the clone's freshly-created tap take the source's host
+// MAC — colliding with the source if both pods run on the same node.
+// Nulling host_mac lets CH auto-discover the clone tap's MAC instead.
 type PatchOptions struct {
-	AppendCmdlineMarker bool
-	RewriteMACs         []string
+	AppendCmdlineMarker   bool
+	RewriteMACs           []string
+	RewriteRuntimeDirFrom string
+	RewriteRuntimeDirTo   string
+	NullifyHostMAC        bool
 }
 
 // Read returns the parsed config.json from the given snapshot
@@ -114,7 +133,37 @@ func Patch(cfg map[string]any, opts PatchOptions) ([]string, error) {
 		}
 		changes = append(changes, cs...)
 	}
+	if opts.RewriteRuntimeDirFrom != "" || opts.RewriteRuntimeDirTo != "" {
+		cs, err := rewriteRuntimeDirPrefix(cfg, opts.RewriteRuntimeDirFrom, opts.RewriteRuntimeDirTo)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, cs...)
+	}
+	if opts.NullifyHostMAC {
+		cs, err := nullifyHostMAC(cfg)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, cs...)
+	}
 	return changes, nil
+}
+
+// unwrapConfig returns the inner config map — either cfg["config"]
+// (when CH wraps the snapshot fields) or cfg itself (CH 51.1 writes
+// the snapshot config flat). Callers traverse from the returned map.
+//
+// Both layouts have been observed in the wild: CH's HTTP API returns
+// the wrapped form (vm.config response), whereas the snapshot file
+// CH writes via vm.snapshot is flat. The patcher must work against
+// the snapshot-file layout because it runs from the staging init
+// container before any HTTP API is up.
+func unwrapConfig(cfg map[string]any) map[string]any {
+	if inner, ok := cfg["config"].(map[string]any); ok {
+		return inner
+	}
+	return cfg
 }
 
 // appendCloneMarker adds CloneCmdlineMarker to the payload's cmdline
@@ -159,28 +208,18 @@ func appendCloneMarker(cfg map[string]any) (string, error) {
 	return "appended " + CloneCmdlineMarker + " to kernel cmdline", nil
 }
 
-// navigateToPayload returns the inner config.payload object. It exists
-// to centralize the "this is what CH's config.json looks like"
-// assumption — when CH bumps its config version this is the function
-// that needs updating, not every call site.
+// navigateToPayload returns the payload object containing the kernel
+// cmdline. Tolerates both layouts (wrapped under "config" or flat at
+// the top level) by going through unwrapConfig.
 func navigateToPayload(cfg map[string]any) (map[string]any, error) {
-	configRaw, ok := cfg["config"]
-	if !ok {
-		return nil, fmt.Errorf("config.json: top-level 'config' missing")
-	}
-	configMap, ok := configRaw.(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("config.json: top-level 'config' is %T, want object", configRaw)
-	}
+	configMap := unwrapConfig(cfg)
 	payloadRaw, ok := configMap["payload"]
 	if !ok {
-		// CH's config.json sometimes has "payload" inline at top level;
-		// allow either nesting.
-		return configMap, nil
+		return nil, fmt.Errorf("config.json: 'payload' missing")
 	}
 	payload, ok := payloadRaw.(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("config.json: config.payload is %T, want object", payloadRaw)
+		return nil, fmt.Errorf("config.json: payload is %T, want object", payloadRaw)
 	}
 	return payload, nil
 }
@@ -203,10 +242,7 @@ func navigateToPayload(cfg map[string]any) (map[string]any, error) {
 // in two places risks divergence. Bad input from a future caller
 // will surface as a CH startup error during restore-receive.
 func rewriteMACs(cfg map[string]any, macsByIndex []string) ([]string, error) {
-	configMap, ok := cfg["config"].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("config.json: top-level 'config' missing or not an object")
-	}
+	configMap := unwrapConfig(cfg)
 	netRaw, ok := configMap["net"]
 	if !ok {
 		// Source VM has no net devices — caller asked us to rewrite
@@ -241,6 +277,118 @@ func rewriteMACs(cfg map[string]any, macsByIndex []string) ([]string, error) {
 			ifaceID = fmt.Sprintf("net[%d]", i)
 		}
 		changes = append(changes, fmt.Sprintf("rewrote MAC on %s: %s -> %s", ifaceID, oldMAC, newMAC))
+	}
+	return changes, nil
+}
+
+// rewriteRuntimeDirPrefix replaces every occurrence of `from` with `to`
+// at the start of path-shaped fields in config.json that reference the
+// source pod's runtime_dir. Currently scoped to:
+//
+//   - disks[].path  (e.g. .../run/<source>/seed.iso → .../run/<clone>/seed.iso)
+//   - serial.socket (e.g. .../run/<source>/serial.sock → .../run/<clone>/serial.sock)
+//
+// disks[].path that does NOT start with `from` is left alone — the
+// root disk PVC ("/var/lib/kubeswift/disks/root/image.raw") is mounted
+// at the same in-pod path on every launcher pod and shouldn't be
+// rewritten.
+//
+// Both `from` and `to` must end in "/" so a substring match doesn't
+// accidentally clip e.g. "<source>" out of a path that happens to
+// contain the source name as part of a longer segment.
+func rewriteRuntimeDirPrefix(cfg map[string]any, from, to string) ([]string, error) {
+	if from == "" || to == "" {
+		return nil, fmt.Errorf("config.json: rewriteRuntimeDirPrefix requires non-empty from and to")
+	}
+	if !strings.HasSuffix(from, "/") || !strings.HasSuffix(to, "/") {
+		return nil, fmt.Errorf("config.json: rewriteRuntimeDirPrefix from/to must end in '/' (got %q -> %q)", from, to)
+	}
+	configMap := unwrapConfig(cfg)
+	var changes []string
+
+	// disks[].path
+	if disksRaw, ok := configMap["disks"]; ok && disksRaw != nil {
+		disks, ok := disksRaw.([]any)
+		if !ok {
+			return nil, fmt.Errorf("config.json: disks is %T, want array", disksRaw)
+		}
+		for i, d := range disks {
+			disk, ok := d.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("config.json: disks[%d] is %T, want object", i, d)
+			}
+			pathRaw, ok := disk["path"]
+			if !ok {
+				continue
+			}
+			oldPath, ok := pathRaw.(string)
+			if !ok {
+				return nil, fmt.Errorf("config.json: disks[%d].path is %T, want string", i, pathRaw)
+			}
+			if !strings.HasPrefix(oldPath, from) {
+				continue
+			}
+			newPath := to + strings.TrimPrefix(oldPath, from)
+			disk["path"] = newPath
+			diskID, _ := disk["id"].(string)
+			if diskID == "" {
+				diskID = fmt.Sprintf("disks[%d]", i)
+			}
+			changes = append(changes, fmt.Sprintf("rewrote %s.path: %s -> %s", diskID, oldPath, newPath))
+		}
+	}
+
+	// serial.socket
+	if serialRaw, ok := configMap["serial"]; ok && serialRaw != nil {
+		serial, ok := serialRaw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("config.json: serial is %T, want object", serialRaw)
+		}
+		if sockRaw, ok := serial["socket"]; ok && sockRaw != nil {
+			oldSock, ok := sockRaw.(string)
+			if !ok {
+				return nil, fmt.Errorf("config.json: serial.socket is %T, want string", sockRaw)
+			}
+			if strings.HasPrefix(oldSock, from) {
+				newSock := to + strings.TrimPrefix(oldSock, from)
+				serial["socket"] = newSock
+				changes = append(changes, fmt.Sprintf("rewrote serial.socket: %s -> %s", oldSock, newSock))
+			}
+		}
+	}
+
+	return changes, nil
+}
+
+// nullifyHostMAC sets net[].host_mac to nil on every virtio-net device.
+// CH's open_tap (cloud-hypervisor v51.1 net_util/src/open_tap.rs)
+// forces the tap MAC to the saved value when host_mac is Some, which
+// would force the clone's tap to take the source's host MAC. Nulling
+// it lets CH auto-discover the clone tap's MAC at restore time.
+func nullifyHostMAC(cfg map[string]any) ([]string, error) {
+	configMap := unwrapConfig(cfg)
+	netRaw, ok := configMap["net"]
+	if !ok || netRaw == nil {
+		return nil, nil
+	}
+	net, ok := netRaw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("config.json: net is %T, want array", netRaw)
+	}
+	var changes []string
+	for i, n := range net {
+		device, ok := n.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("config.json: net[%d] is %T, want object", i, n)
+		}
+		if hostRaw, present := device["host_mac"]; present && hostRaw != nil {
+			device["host_mac"] = nil
+			ifaceID, _ := device["id"].(string)
+			if ifaceID == "" {
+				ifaceID = fmt.Sprintf("net[%d]", i)
+			}
+			changes = append(changes, fmt.Sprintf("nulled host_mac on %s (was %v)", ifaceID, hostRaw))
+		}
 	}
 	return changes, nil
 }

--- a/internal/snapshot/configjson/configjson_test.go
+++ b/internal/snapshot/configjson/configjson_test.go
@@ -365,3 +365,222 @@ func TestPatch_RewriteMACs_AndCmdlineMarker_TogetherProducesBothChanges(t *testi
 		t.Errorf("expected 2 changes (cmdline + MAC), got %d: %v", len(changes), changes)
 	}
 }
+
+// -------- Flat-layout tests (real CH 51.1 snapshot output) --------
+//
+// CH's snapshot file is written flat (no top-level "config" wrapper);
+// the wrapped form only appears in the HTTP API response. The patcher
+// must work against the snapshot-file layout because it runs from the
+// staging init container before any HTTP API is up. These tests assert
+// the flat layout works without needing the wrapper.
+
+// flatConfigWithNet builds a flat-layout CH config.json as
+// produced by vm.snapshot in v51.1.
+func flatConfigWithNet(devices ...map[string]any) map[string]any {
+	netList := make([]any, len(devices))
+	for i, d := range devices {
+		netList[i] = d
+	}
+	return map[string]any{
+		"payload": map[string]any{"cmdline": "console=ttyS0"},
+		"net":     netList,
+	}
+}
+
+func TestPatch_FlatLayout_AppendCmdlineMarker(t *testing.T) {
+	cfg := map[string]any{
+		"payload": map[string]any{"cmdline": "console=ttyS0"},
+	}
+	changes, err := Patch(cfg, PatchOptions{AppendCmdlineMarker: true})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Errorf("expected one change, got %v", changes)
+	}
+	got := cfg["payload"].(map[string]any)["cmdline"]
+	want := "console=ttyS0 " + CloneCmdlineMarker
+	if got != want {
+		t.Errorf("cmdline = %q, want %q", got, want)
+	}
+}
+
+func TestPatch_FlatLayout_RewriteMACs(t *testing.T) {
+	cfg := flatConfigWithNet(map[string]any{"id": "_net0", "mac": "52:54:00:aa:bb:01"})
+	if _, err := Patch(cfg, PatchOptions{RewriteMACs: []string{"52:54:00:de:ad:be"}}); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	got := cfg["net"].([]any)[0].(map[string]any)["mac"]
+	if got != "52:54:00:de:ad:be" {
+		t.Errorf("MAC = %v, want rewritten", got)
+	}
+}
+
+// -------- RewriteRuntimeDirPrefix tests --------
+
+func TestPatch_RewriteRuntimeDirPrefix_DiskAndSerial(t *testing.T) {
+	from := "/var/lib/kubeswift/run/default-source/"
+	to := "/var/lib/kubeswift/run/default-clone-a/"
+	cfg := map[string]any{
+		"disks": []any{
+			// Root disk — same path on every pod, NOT under "from", must pass through.
+			map[string]any{"id": "_disk0", "path": "/var/lib/kubeswift/disks/root/image.raw"},
+			// Seed.iso — under source runtime_dir, MUST be rewritten.
+			map[string]any{"id": "_disk1", "path": from + "seed.iso"},
+		},
+		"serial": map[string]any{"socket": from + "serial.sock"},
+	}
+	changes, err := Patch(cfg, PatchOptions{
+		RewriteRuntimeDirFrom: from,
+		RewriteRuntimeDirTo:   to,
+	})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	if len(changes) != 2 {
+		t.Errorf("expected 2 changes (disks[1] + serial), got %d: %v", len(changes), changes)
+	}
+	rootPath := cfg["disks"].([]any)[0].(map[string]any)["path"]
+	if rootPath != "/var/lib/kubeswift/disks/root/image.raw" {
+		t.Errorf("root disk path mutated: %v", rootPath)
+	}
+	seedPath := cfg["disks"].([]any)[1].(map[string]any)["path"]
+	if seedPath != to+"seed.iso" {
+		t.Errorf("seed.iso path = %v, want rewritten to %s", seedPath, to+"seed.iso")
+	}
+	serialSock := cfg["serial"].(map[string]any)["socket"]
+	if serialSock != to+"serial.sock" {
+		t.Errorf("serial.socket = %v, want rewritten to %s", serialSock, to+"serial.sock")
+	}
+}
+
+func TestPatch_RewriteRuntimeDirPrefix_RequiresTrailingSlash(t *testing.T) {
+	cfg := map[string]any{
+		"disks":  []any{map[string]any{"id": "_disk0", "path": "/run/foo/seed.iso"}},
+		"serial": map[string]any{"socket": "/run/foo/serial.sock"},
+	}
+	_, err := Patch(cfg, PatchOptions{
+		RewriteRuntimeDirFrom: "/run/foo",
+		RewriteRuntimeDirTo:   "/run/bar/",
+	})
+	if err == nil || !strings.Contains(err.Error(), "trailing") &&
+		!strings.Contains(err.Error(), "must end in '/'") {
+		t.Errorf("expected trailing-slash error, got: %v", err)
+	}
+}
+
+func TestPatch_RewriteRuntimeDirPrefix_NoMatchingPaths_NoChanges(t *testing.T) {
+	cfg := map[string]any{
+		"disks":  []any{map[string]any{"id": "_disk0", "path": "/var/lib/kubeswift/disks/root/image.raw"}},
+		"serial": map[string]any{"socket": nil},
+	}
+	changes, err := Patch(cfg, PatchOptions{
+		RewriteRuntimeDirFrom: "/var/lib/kubeswift/run/default-source/",
+		RewriteRuntimeDirTo:   "/var/lib/kubeswift/run/default-clone-a/",
+	})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("expected no changes (no matching prefixes), got %v", changes)
+	}
+}
+
+// -------- NullifyHostMAC tests --------
+
+func TestPatch_NullifyHostMAC_OneDevice(t *testing.T) {
+	cfg := flatConfigWithNet(map[string]any{
+		"id":       "_net0",
+		"mac":      "52:54:00:aa:bb:01",
+		"host_mac": "be:b2:1e:5e:38:40",
+	})
+	changes, err := Patch(cfg, PatchOptions{NullifyHostMAC: true})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Errorf("expected one change, got %v", changes)
+	}
+	dev := cfg["net"].([]any)[0].(map[string]any)
+	if dev["host_mac"] != nil {
+		t.Errorf("host_mac = %v, want nil", dev["host_mac"])
+	}
+	// The guest-side MAC ("mac") must be untouched — only host_mac is nulled.
+	if dev["mac"] != "52:54:00:aa:bb:01" {
+		t.Errorf("mac mutated: %v", dev["mac"])
+	}
+}
+
+func TestPatch_NullifyHostMAC_AlreadyNull_NoChange(t *testing.T) {
+	cfg := flatConfigWithNet(map[string]any{
+		"id":       "_net0",
+		"mac":      "52:54:00:aa:bb:01",
+		"host_mac": nil,
+	})
+	changes, err := Patch(cfg, PatchOptions{NullifyHostMAC: true})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("expected no change (already null), got %v", changes)
+	}
+}
+
+// -------- End-to-end clone patch (all four together) --------
+
+func TestPatch_AllCloneOptionsTogether(t *testing.T) {
+	from := "/var/lib/kubeswift/run/default-source/"
+	to := "/var/lib/kubeswift/run/default-clone-a/"
+	cfg := map[string]any{
+		"payload": map[string]any{"cmdline": "console=ttyS0"},
+		"disks": []any{
+			map[string]any{"id": "_disk0", "path": "/var/lib/kubeswift/disks/root/image.raw"},
+			map[string]any{"id": "_disk1", "path": from + "seed.iso"},
+		},
+		"net": []any{
+			map[string]any{
+				"id":       "_net0",
+				"mac":      "52:54:00:aa:bb:01",
+				"host_mac": "be:b2:1e:5e:38:40",
+			},
+		},
+		"serial": map[string]any{"socket": from + "serial.sock"},
+	}
+	changes, err := Patch(cfg, PatchOptions{
+		AppendCmdlineMarker:   true,
+		RewriteMACs:           []string{"52:54:00:de:ad:be"},
+		RewriteRuntimeDirFrom: from,
+		RewriteRuntimeDirTo:   to,
+		NullifyHostMAC:        true,
+	})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	// Expected: cmdline + MAC + 2 path rewrites + host_mac null = 5 changes
+	if len(changes) != 5 {
+		t.Errorf("expected 5 changes, got %d: %v", len(changes), changes)
+	}
+	// Cmdline marker
+	if got := cfg["payload"].(map[string]any)["cmdline"]; got != "console=ttyS0 "+CloneCmdlineMarker {
+		t.Errorf("cmdline = %q", got)
+	}
+	// Disk paths
+	if got := cfg["disks"].([]any)[0].(map[string]any)["path"]; got != "/var/lib/kubeswift/disks/root/image.raw" {
+		t.Errorf("root disk path mutated: %v", got)
+	}
+	if got := cfg["disks"].([]any)[1].(map[string]any)["path"]; got != to+"seed.iso" {
+		t.Errorf("seed disk path = %v", got)
+	}
+	// Net device
+	dev := cfg["net"].([]any)[0].(map[string]any)
+	if dev["mac"] != "52:54:00:de:ad:be" {
+		t.Errorf("mac = %v", dev["mac"])
+	}
+	if dev["host_mac"] != nil {
+		t.Errorf("host_mac = %v, want nil", dev["host_mac"])
+	}
+	// Serial
+	if got := cfg["serial"].(map[string]any)["socket"]; got != to+"serial.sock" {
+		t.Errorf("serial.socket = %v", got)
+	}
+}


### PR DESCRIPTION
CH 51.1 writes the snapshot config.json flat (no top-level "config:" wrapper); the existing patcher targeted the wrapped form, so any clone restore would have failed before touching disks[].path or net[].mac. Fix the layout assumption and extend the patcher with two new options needed for clones:

- RewriteRuntimeDirPrefix substitutes the source pod's runtime_dir prefix in disks[].path and serial.socket. Required because the clone pod's runtime_dir name differs from the source's, and CH --restore refuses to open paths it can't see.
- NullifyHostMAC sets net[].host_mac to null. CH's open_tap forces the tap MAC to the saved value when host_mac is Some (cloud-hypervisor v51.1 net_util/src/open_tap.rs); leaving the source value in place would force the clone tap to take the source's host MAC, colliding when both pods land on the same node.

Wires the new options through stager CLI flags, restore.go annotations, and the SwiftRestore controller's clone-mode path. In-place restore is unaffected — those annotations are only set when the target name differs from the source or any identity regen is requested.