### PR TITLE
fix(snapshot): handle cmdline: null in appendCloneMarker

### DIFF
--- a/internal/snapshot/configjson/configjson.go
+++ b/internal/snapshot/configjson/configjson.go
@@ -185,10 +185,12 @@ func appendCloneMarker(cfg map[string]any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cmdlineRaw, ok := payload["cmdline"]
-	if !ok {
-		// No cmdline at all — that's unusual for CH but possible for
-		// initramfs-only boots. Set it directly to the marker.
+	cmdlineRaw, present := payload["cmdline"]
+	// CH 51.1 disk-boot snapshots emit `cmdline: null` — the field is
+	// present but the value is JSON null (the boot loader inside the
+	// guest sets the kernel cmdline, so CH has nothing to record).
+	// Treat that the same as a missing field: install the marker.
+	if !present || cmdlineRaw == nil {
 		payload["cmdline"] = CloneCmdlineMarker
 		return "set cmdline to " + CloneCmdlineMarker + " (no prior cmdline)", nil
 	}

--- a/internal/snapshot/configjson/configjson_test.go
+++ b/internal/snapshot/configjson/configjson_test.go
@@ -101,6 +101,30 @@ func TestPatch_AppendCloneMarker_Idempotent(t *testing.T) {
 	}
 }
 
+func TestPatch_AppendCloneMarker_ExplicitNullCmdline(t *testing.T) {
+	// CH 51.1 disk-boot snapshots write payload.cmdline = null (the
+	// field is present but the JSON value is null). The patcher must
+	// treat this as "no cmdline" and set the marker, not crash with a
+	// type assertion error.
+	cfg := map[string]any{
+		"payload": map[string]any{
+			"cmdline": nil,
+			"kernel":  "/usr/share/kubeswift-firmware/CLOUDHV.fd",
+		},
+	}
+	changes, err := Patch(cfg, PatchOptions{AppendCmdlineMarker: true})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Errorf("expected one change, got %v", changes)
+	}
+	got := cfg["payload"].(map[string]any)["cmdline"]
+	if got != CloneCmdlineMarker {
+		t.Errorf("cmdline = %v, want %q", got, CloneCmdlineMarker)
+	}
+}
+
 func TestPatch_AppendCloneMarker_NoCmdlineField(t *testing.T) {
 	cfg := map[string]any{
 		"config": map[string]any{


### PR DESCRIPTION
CH 51.1 disk-boot snapshots write payload.cmdline = null because GRUB inside the guest sets the kernel cmdline (CH has nothing to record). The patcher's existing path treated "key present, value nil" as a type assertion failure ("cmdline is <nil>, want string"), crashing the stager and bringing down every clone restore.

Treat key-present-with-nil-value the same as key-missing: install the marker. Existing "missing key" path is unchanged.

Discovered when the first clone identity-regen e2e against 6c64511 surfaced "snapshot-stager: patch config.json: config.payload.cmdline is <nil>, want string" in the init container logs.