### PR TITLE
fix(swiftrestore): clone-target self-conflict on re-entrant reconcile

### DIFF
--- a/internal/controller/swiftrestore/controller_test.go
+++ b/internal/controller/swiftrestore/controller_test.go
@@ -351,3 +351,10 @@ func reasonOrEmpty(c *metav1.Condition) string {
 	}
 	return c.Reason
 }
+
+func msgOrEmpty(c *metav1.Condition) string {
+	if c == nil {
+		return ""
+	}
+	return c.Message
+}

--- a/internal/controller/swiftrestore/local.go
+++ b/internal/controller/swiftrestore/local.go
@@ -74,6 +74,14 @@ const (
 	verbResume       = "resume"
 )
 
+// swiftRestoreOwnerLabel is set by the SwiftRestore controller on
+// every clone-target SwiftGuest it materializes. The handlePendingLocal
+// re-entrancy guard reads this label to distinguish "this SwiftGuest
+// is our own work from a prior reconcile" from "this SwiftGuest was
+// created by the user/another controller", which is the case
+// targetGuest.overwriteExisting protects against.
+const swiftRestoreOwnerLabel = "snapshot.kubeswift.io/swift-restore"
+
 // VersionCompatibility is the result of comparing snapshot's
 // HypervisorVersion to the current cluster CH version.
 type VersionCompatibility int
@@ -318,14 +326,24 @@ func (r *SwiftRestoreReconciler) handlePendingLocal(
 		// Clone: target SwiftGuest doesn't exist (or exists and
 		// OverwriteExisting=true). Create from source.Spec with the
 		// restore annotations stamped on metadata.
+		//
+		// Re-entrancy: a prior reconcile of this same SwiftRestore may
+		// have created the target already. Status updates from that
+		// reconcile can lag behind the SwiftGuest create in the cache,
+		// so a follow-up reconcile re-enters this function with phase
+		// still reading as Pending. Without the label check below, the
+		// controller would mark its own work as a TargetConflict.
 		var existing swiftv1alpha1.SwiftGuest
 		err := r.Get(ctx, client.ObjectKey{Name: restore.Spec.TargetGuest.Name, Namespace: restore.Namespace}, &existing)
-		if err == nil && !restore.Spec.TargetGuest.OverwriteExisting {
-			setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
-			setReadyCondition(status, metav1.ConditionFalse, ReasonTargetConflict,
-				"SwiftGuest "+restore.Spec.TargetGuest.Name+" already exists; "+
-					"set targetGuest.overwriteExisting=true to replace")
-			return true, 0, nil
+		if err == nil {
+			ownedByThisRestore := existing.Labels[swiftRestoreOwnerLabel] == restore.Name
+			if !ownedByThisRestore && !restore.Spec.TargetGuest.OverwriteExisting {
+				setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
+				setReadyCondition(status, metav1.ConditionFalse, ReasonTargetConflict,
+					"SwiftGuest "+restore.Spec.TargetGuest.Name+" already exists; "+
+						"set targetGuest.overwriteExisting=true to replace")
+				return true, 0, nil
+			}
 		}
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, 0, err
@@ -649,7 +667,7 @@ func (r *SwiftRestoreReconciler) ensureCloneTargetGuest(
 			Namespace:   restore.Namespace,
 			Annotations: annos,
 			Labels: map[string]string{
-				"snapshot.kubeswift.io/swift-restore": restore.Name,
+				swiftRestoreOwnerLabel: restore.Name,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(restore, swiftRestoreGVK),

--- a/internal/controller/swiftrestore/local_test.go
+++ b/internal/controller/swiftrestore/local_test.go
@@ -219,6 +219,94 @@ func TestIsTierBRestore(t *testing.T) {
 	}
 }
 
+// -------- handlePendingLocal: clone re-entrancy guard --------
+
+func TestLocal_Pending_Clone_ReentrantReconcileDoesNotConflict(t *testing.T) {
+	// Reproduces the failure mode that surfaced in the f41a310 e2e:
+	// a prior reconcile of this same SwiftRestore created the clone
+	// target and queued a status update to phase=Restoring, but the
+	// controller cache served stale phase=Pending while the new
+	// SwiftGuest was already visible. handlePendingLocal must
+	// recognize "this is our own work" via the swift-restore label
+	// and not fail with TargetConflict.
+	snap := makeLocalSnap("snap1", "default", "src", "/var/lib/kubeswift/snapshots/default-snap1", "v51.1")
+	snap.Status.Phase = snapshotv1alpha1.SwiftSnapshotPhaseReady
+	snap.Status.NodeName = "boba"
+	restore := makeRestore("restore-clone", "default", "snap1", "clone-a", true)
+	restore.Spec.Identity = &snapshotv1alpha1.IdentityRegeneration{
+		Regenerate: []snapshotv1alpha1.IdentityRegenerationItem{
+			snapshotv1alpha1.RegenMACAddresses,
+		},
+	}
+	source := makeSourceGuest("default", "src", "ubuntu-noble")
+
+	// Pre-existing clone-a SwiftGuest from the prior reconcile.
+	preExisting := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "clone-a",
+			Namespace: "default",
+			Labels: map[string]string{
+				swiftRestoreOwnerLabel: "restore-clone", // owned by THIS SwiftRestore
+			},
+		},
+		Spec: source.Spec,
+	}
+
+	r, c := newReconciler(t, snap, restore, source, preExisting)
+	r.CurrentHypervisorVersion = "v51.1"
+	reconcile(t, r, "restore-clone", "default")
+
+	got := get(t, c, "restore-clone", "default")
+	if got.Status.Phase == snapshotv1alpha1.SwiftRestorePhaseFailed {
+		cond := findReady(got)
+		t.Fatalf("re-entrant reconcile must not Fail; got phase=Failed reason=%s msg=%q",
+			reasonOrEmpty(cond), msgOrEmpty(cond))
+	}
+}
+
+func TestLocal_Pending_Clone_ExistingSwiftGuestNotOwnedByUs_StillConflicts(t *testing.T) {
+	// Counter-case: the user (or another controller) created a
+	// SwiftGuest with the target name. Without OverwriteExisting,
+	// this MUST still trip TargetConflict — we can't silently take
+	// over someone else's resource.
+	snap := makeLocalSnap("snap1", "default", "src", "/var/lib/kubeswift/snapshots/default-snap1", "v51.1")
+	snap.Status.Phase = snapshotv1alpha1.SwiftSnapshotPhaseReady
+	snap.Status.NodeName = "boba"
+	restore := makeRestore("restore-clone", "default", "snap1", "clone-a", true)
+	restore.Spec.Identity = &snapshotv1alpha1.IdentityRegeneration{
+		Regenerate: []snapshotv1alpha1.IdentityRegenerationItem{
+			snapshotv1alpha1.RegenMACAddresses,
+		},
+	}
+	source := makeSourceGuest("default", "src", "ubuntu-noble")
+
+	// Clone-a exists but with a DIFFERENT label value (owned by
+	// another SwiftRestore, or no label at all because user-created).
+	foreign := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "clone-a",
+			Namespace: "default",
+			Labels: map[string]string{
+				swiftRestoreOwnerLabel: "different-restore",
+			},
+		},
+		Spec: source.Spec,
+	}
+
+	r, c := newReconciler(t, snap, restore, source, foreign)
+	r.CurrentHypervisorVersion = "v51.1"
+	reconcile(t, r, "restore-clone", "default")
+
+	got := get(t, c, "restore-clone", "default")
+	if got.Status.Phase != snapshotv1alpha1.SwiftRestorePhaseFailed {
+		t.Fatalf("phase = %s, want Failed (foreign SwiftGuest)", got.Status.Phase)
+	}
+	cond := findReady(got)
+	if cond == nil || cond.Reason != ReasonTargetConflict {
+		t.Errorf("reason = %q, want TargetConflict", reasonOrEmpty(cond))
+	}
+}
+
 // -------- restoreAnnotations: clone-mode wiring --------
 
 func TestRestoreAnnotations_Clone_SetsRuntimeDirPrefixAndNullifyHostMAC(t *testing.T) {


### PR DESCRIPTION
handlePendingLocal's clone branch creates the target SwiftGuest, sets phase=Restoring, and returns. The status patch is committed after the function returns. A second reconcile triggered by the SwiftGuest creation event can fire before the cache observes the status patch, re-enters handlePendingLocal with phase still reading as Pending, sees the new SwiftGuest in the cache, and trips TargetConflict on its own work — leaving the SwiftRestore in Failed even though the clone is booting and reaches GuestRunning.

Fix: distinguish "we created this" from "user/another controller created this" via the swift-restore label that ensureCloneTargetGuest already stamps. Re-extract the inline label string into swiftRestoreOwnerLabel for symmetry with the new check site.

Discovered when the f41a310 e2e showed clone-a reaching GuestRunning=True at 102s, then SwiftRestore failing at the next reconcile with "SwiftGuest snapshot-local-clone-a already exists; set targetGuest.overwriteExisting=true to replace".