### PR TITLE
docs(snapshots): close Phase 2 with documented identity-regen limitation

### DIFF
--- a/config/samples/local-snapshots/swiftseedprofile-test.yaml
+++ b/config/samples/local-snapshots/swiftseedprofile-test.yaml
@@ -1,16 +1,27 @@
 # Combined SwiftSeedProfile for the Tier B local-snapshot e2e tests.
 #
 # Merges two concerns into one profile so the e2e scripts can SSH into
-# the guest *and* trigger the identity-regen bootcmd on clone:
+# the guest *and* run the identity-regen bootcmd ONCE THE GUEST REBOOTS:
 #
 # 1. The swiftctl ssh defaults (user "kubeswift", key id_ed25519)
 #    — same as config/samples/shared/swiftseedprofile-minimal.yaml.
-# 2. The clone-identity-regen bootcmd
+# 2. The identity-regen bootcmd
 #    — same as config/samples/seed-profiles/clone-identity-regen.yaml.
 #
-# The doc (docs/snapshots/identity-regeneration.md) explicitly suggests
-# merging the bootcmd into your existing seed profile; this sample
-# does exactly that for the tests' purposes.
+# IMPORTANT — bootcmd does NOT fire on snapshot resume:
+#
+# CH `--restore` resumes the captured guest state byte-for-byte. The
+# kernel does not re-init, systemd does not re-init, and cloud-init
+# does not re-run. The bootcmd below only executes on a fresh boot
+# (kernel cold-start), e.g. after `reboot` inside a clone or after
+# the guest is power-cycled.
+#
+# Phase 2 ships clones that share machine-id, hostname, SSH host keys,
+# and the guest-visible MAC with the source. To get unique identity on
+# a clone today, either reboot the clone after first resume, or run
+# the regen commands manually inside each clone. See
+# docs/snapshots/identity-regeneration.md and the
+# kubeswift_context.md "Snapshots Phase 2 — Known limitation" section.
 apiVersion: seed.kubeswift.io/v1alpha1
 kind: SwiftSeedProfile
 metadata:

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -1049,6 +1049,73 @@ swiftctl ssh gpu-test -- nvidia-smi
 | 43 | controller-manager-rbac.yaml | Missing pods/log permission (Bug 20 regression) | Add pods/log to ClusterRole | 881f731 |
 | 44 | Makefile | IMAGE_TAG defaulted to :latest which CI never pushes | Default to sha-$(git rev-parse --short HEAD) | 5ddf9af |
 
+### Completed (Snapshots Phase 2 — Tier B local-backend memory snapshots)
+- SwiftSnapshot CRD with `backend.type: local` for memory snapshots stored
+  on the source VM's node via hostPath (`/var/lib/kubeswift/snapshots/`)
+- SwiftRestore CRD with `targetGuest.name == source` (in-place) and
+  `!= source` (clone) paths, both wired through to the launcher pod
+  via `snapshot.kubeswift.io/active-restore` annotation set
+- swiftletd action loop (`rust/swiftletd/src/action.rs`) handles
+  pause/snapshot/resume via CH HTTP API with sentinel-guarded
+  destination wipe-and-recreate before `vm.snapshot`
+- snapshot-stager init container (`cmd/snapshot-stager/`) for clone
+  restores: sentinel-guarded copy, then config.json patches via
+  `internal/snapshot/configjson` (cmdline marker, MAC rewrite,
+  runtime_dir prefix substitution on disks[].path and serial.socket,
+  host_mac null for tap auto-discovery)
+- In-place restore validated end-to-end: tmpfs sentinel survives
+  kill+restore cycle (`test/snapshot/local-roundtrip-test.sh`)
+- Clone restore validated end-to-end: both clones reach `GuestRunning`
+  + `SwiftRestore Ready` with deterministic per-clone hypervisor MAC,
+  unique runtime_dir paths, deterministic seed.iso rebuild
+  (`test/snapshot/local-clone-identity-test.sh`)
+
+#### Known limitation: identity regeneration on clone resume
+
+CH `--restore` resumes the captured guest state byte-for-byte —
+**this is not a fresh boot**. The kernel does not re-init, systemd
+does not re-init, and cloud-init does not re-run. As a result:
+
+| Identity field | After clone resume |
+| --- | --- |
+| `/etc/machine-id` | Inherited from source |
+| `/etc/ssh/ssh_host_*_key*` | Inherited from source |
+| `hostname` | Inherited from source |
+| Guest-visible eth0 MAC | Inherited from source (cached in virtio-net driver state) |
+| Hypervisor `config.net[0].mac` | Rewritten per clone (visible to bridge fdb, but not to guest) |
+| Pod network namespace | Per-clone (Kubernetes-isolated, prevents cross-clone L2 collision) |
+
+Empirical evidence captured during Phase 2 e2e (commit `a40c17f`):
+all three guests (source, clone-a, clone-b) showed identical
+`machine-id`, SSH host fingerprint, hostname, and guest-side MAC.
+The hypervisor-layer MAC rewrite from the snapshot-stager patcher
+landed correctly in `config.json` but is not observed by the guest's
+virtio-net driver, whose MAC is cached in the snapshot's RAM image.
+
+Operators using clones must either:
+- Reboot each clone after first resume (cloud-init bootcmd then fires
+  normally; the existing `swiftseedprofile-test.yaml` bootcmd works
+  on fresh boots), or
+- Manually regenerate identity inside each clone (`systemd-machine-id-setup`,
+  `rm /etc/ssh/ssh_host_*_key*; ssh-keygen -A`, `hostnamectl set-hostname …`)
+
+Identity regeneration without reboot is targeted for a future phase
+via an in-guest agent communicating over vsock. The agent listens for
+a "clone activated" message from swiftletd post-resume and runs the
+regen sequence in-place.
+
+#### Snapshot bugs fixed during Phase 2 validation
+
+| # | Component | Bug | PR |
+|---|-----------|-----|-----|
+| 47 | swiftsnapshot/local.go | action-id changed across status patches (ResourceVersion-derived); launcher's mirrored status never matched | #14 |
+| 48 | swiftletd/action.rs | `vm.snapshot` failed with "Destination is not a directory" — controller didn't pre-create the snapshot dir | #12 |
+| 49 | swiftletd/action.rs | `vm.snapshot` failed with "File exists (os error 17)" — stale destination from prior partial attempt | #13 |
+| 50 | swiftguest pod builder + swiftletd/main.rs | seed.iso missing on restore-receive — Go-side BuildRestorePod omitted the seed mount AND Rust-side main.rs gated the seed.iso build on `!is_restore()` | #15 |
+| 51 | configjson + stager | Patcher targeted wrong layout (cfg["config"]) when CH 51.1 writes flat top-level | #16 |
+| 52 | configjson | `appendCloneMarker` crashed on `cmdline: null` (CH 51.1 disk boot) — type assertion expected string, got JSON nil | #17 |
+| 53 | swiftrestore/local.go | `handlePendingLocal` clone branch tripped TargetConflict against its own freshly-created SwiftGuest when reconcile re-entered with stale phase | #18 |
+
 ### Completed (Root Disk Resize During Image Import)
 - Import script now runs `qemu-img resize -f raw image.raw <target-bytes>` after qcow2-to-raw conversion
 - Target size is `spec.rootDisk.size` from the SwiftImage (same value used for the PVC)


### PR DESCRIPTION
## Summary
- Marks **Snapshots Phase 2** (Tier B local-backend memory snapshots) as Completed in `kubeswift_context.md` with the actual shipped scope and the bug-fix table from validation
- Annotates `config/samples/local-snapshots/swiftseedprofile-test.yaml` so operators reading it see the resume-vs-boot caveat at the source rather than expecting the bootcmd to fire on clone resume

This is the closure PR. The functional code shipped earlier in PRs #11–#18.

## What works (validated end-to-end)
- **Capture**: `vm.snapshot` against the running source, stored under `/var/lib/kubeswift/snapshots/<ns>-<name>` via hostPath
- **In-place restore**: tmpfs sentinel survives kill+restore (`test/snapshot/local-roundtrip-test.sh`). The captured RAM is loaded — proves CH `--restore` actually resumes rather than booting fresh
- **Clone restore**: both clones reach `GuestRunning` and `SwiftRestore Ready` (`test/snapshot/local-clone-identity-test.sh`). The `snapshot-stager` init container patches `config.json` correctly per clone:
  - `payload.cmdline`: marker installed
  - `disks[1].path`: source runtime_dir prefix → clone runtime_dir prefix
  - `serial.socket`: same prefix substitution
  - `net[0].mac`: rewritten to a deterministic per-clone value
  - `net[0].host_mac`: nulled so CH auto-discovers the clone tap MAC

## Known limitation: identity regeneration on clone resume

CH `--restore` resumes the captured guest state byte-for-byte. **This is not a fresh boot.** The kernel does not re-init, systemd does not re-init, and cloud-init does not re-run. The cmdline marker is set in `config.json` but the bootcmd that's supposed to grep `/proc/cmdline` for it never executes — there is no boot.

### Empirical evidence (captured post-`a40c17f`)

| Field | source | clone-a | clone-b |
| --- | --- | --- | --- |
| `machine-id` | `92da5b0c3da343f895a5972a1ba6b3d4` | `92da5b0c3da343f895a5972a1ba6b3d4` | `92da5b0c3da343f895a5972a1ba6b3d4` |
| SSH host fingerprint | `SHA256:YliOHl0+nyZmSGwzPKQGIMo2rrRxUXdO9Ohehkw61Z8` | `SHA256:YliOHl0+nyZmSGwzPKQGIMo2rrRxUXdO9Ohehkw61Z8` | `SHA256:YliOHl0+nyZmSGwzPKQGIMo2rrRxUXdO9Ohehkw61Z8` |
| hostname | `kubeswift-guest` | `kubeswift-guest` | `kubeswift-guest` |
| guest-visible eth0 MAC | `2e:84:b8:b2:d1:5d` | `2e:84:b8:b2:d1:5d` | `2e:84:b8:b2:d1:5d` |
| hypervisor `config.net[0].mac` | `2e:84:b8:b2:d1:5d` | `52:54:00:78:cd:4b` | `52:54:00:27:61:20` |

The stager rewrote `config.net[0].mac` correctly per clone (visible to the bridge fdb), but the guest-visible MAC on `ens3` matches the source's because the virtio-net driver's MAC is cached in the snapshot's RAM image. The "hypervisor-level fait accompli" framing in the original design doc is incorrect: the rewrite is invisible to the guest.

L2 collision is avoided in practice **only because each clone runs in its own pod's network namespace** (different bridges), not because of the MAC rewrite.

### Workarounds operators have today

- Reboot each clone after first resume — cloud-init bootcmd then fires on the cold-start kernel, regenerating `machine-id`, SSH host keys, and hostname
- Manually regenerate identity inside each clone via SSH:
  ```
  : > /etc/machine-id && systemd-machine-id-setup
  rm /etc/ssh/ssh_host_*_key* && ssh-keygen -A
  hostnamectl set-hostname <unique-name>
  systemctl reload-or-restart ssh
  ```

### Deferred work

Identity regeneration without reboot is targeted for a future phase via an **in-guest agent communicating over vsock**: swiftletd opens a vsock channel to the guest after resume, sends a "clone activated" message, and a one-shot service inside the guest (`kubeswift-clone-regen.service`) runs the regen sequence in-place and exits. This is the only design that satisfies "fast clone, unique identity, no reboot" given the resume-vs-boot constraint.

## Companion PRs
- A small follow-up will rewrite `docs/snapshots/identity-regeneration.md` to match the actual mechanism (the current doc text "CH boots the restored VM. /proc/cmdline carries the marker. cloud-init runs the bootcmd…" is wrong for the memory-snapshot path)

## Test plan
- [x] `make build` (Go)
- [x] `cargo build --release` (Rust)
- [x] `go test ./api/... ./cmd/... ./internal/...`
- [x] `cargo test`
- [x] `gofmt -l ./api ./cmd ./internal` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `bash test/snapshot/local-roundtrip-test.sh` — PASS (in-place sentinel survival)
- [x] `bash test/snapshot/local-clone-identity-test.sh --no-cleanup` — clones reach Running; identity collisions captured (this is the documented limitation, not a regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)