### PR TITLE
fix(swiftguest): orphan check deletes restore-seeded PVCs (Tier A data loss)

### DIFF
--- a/internal/controller/swiftguest/rootdisk.go
+++ b/internal/controller/swiftguest/rootdisk.go
@@ -140,19 +140,14 @@ func (r *SwiftGuestReconciler) ensureRootDiskCloneFromCopy(
 	}
 
 	if pvcExists {
-		if !metav1.IsControlledBy(&existingPVC, guest) {
-			if err := r.Delete(ctx, &existingPVC); err != nil && !errors.IsNotFound(err) {
-				return nil, err
-			}
-			if jobExists {
-				_ = r.Delete(ctx, &existingJob)
-			}
-			return nil, fmt.Errorf("deleted orphaned clone PVC %s, will recreate", cloneName)
-		}
 		// Restore-seeded PVCs are pre-populated from a VolumeSnapshot by
-		// SwiftRestore. Skip the Copy Job entirely — its cp from the source
-		// SwiftImage's PVC would overwrite the restore data. Wait for Bound,
-		// then hand the PVC straight to the launcher pod.
+		// SwiftRestore. They carry RestoreSeededLabel=true and are owned
+		// by the SwiftRestore (not by this SwiftGuest), which means the
+		// orphan check below would otherwise delete the snapshot data.
+		// Check the label FIRST and short-circuit before the orphan
+		// branch fires. Skip the Copy Job entirely — its cp from the
+		// source SwiftImage's PVC would overwrite the restore data.
+		// Wait for Bound, then hand the PVC straight to the launcher pod.
 		if existingPVC.Labels[RestoreSeededLabel] == "true" {
 			if existingPVC.Status.Phase != corev1.ClaimBound {
 				return nil, fmt.Errorf("restore-seeded PVC %s not yet Bound (phase=%s)", cloneName, existingPVC.Status.Phase)
@@ -163,6 +158,15 @@ func (r *SwiftGuestReconciler) ensureRootDiskCloneFromCopy(
 				_ = r.Delete(ctx, &existingJob)
 			}
 			return &RootDiskCloneResult{PVCName: cloneName, NeedsGrowInit: false}, nil
+		}
+		if !metav1.IsControlledBy(&existingPVC, guest) {
+			if err := r.Delete(ctx, &existingPVC); err != nil && !errors.IsNotFound(err) {
+				return nil, err
+			}
+			if jobExists {
+				_ = r.Delete(ctx, &existingJob)
+			}
+			return nil, fmt.Errorf("deleted orphaned clone PVC %s, will recreate", cloneName)
 		}
 		if jobExists {
 			if isJobComplete(&existingJob) {

--- a/internal/controller/swiftguest/rootdisk_test.go
+++ b/internal/controller/swiftguest/rootdisk_test.go
@@ -30,6 +30,129 @@ func rootdiskScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
+// TestEnsureRootDiskClone_RestoreSeededOwnedByRestoreNotDeleted is the
+// regression test for the Tier A restore data-loss bug fixed in this
+// commit. SwiftRestore creates the per-guest PVC with controller-ref =
+// SwiftRestore (not = SwiftGuest), so the orphan check
+// `!IsControlledBy(pvc, guest)` is true. Before the fix, the orphan
+// branch fired first and the PVC was deleted before the
+// RestoreSeededLabel short-circuit had a chance to run; the SwiftGuest
+// controller then created a fresh PVC and ran the Copy Job from the
+// source SwiftImage, silently destroying the restore. The fix reorders
+// the checks so the label is consulted first.
+//
+// Operator-visible symptom of the bug: SwiftRestore reaches Ready, the
+// restored SwiftGuest reaches Running, sentinels written before the
+// snapshot are missing, machine-id is regenerated. Backup-and-restore
+// produces a fresh boot, not a restore.
+func TestEnsureRootDiskClone_RestoreSeededOwnedByRestoreNotDeleted(t *testing.T) {
+	scheme := rootdiskScheme(t)
+
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "target-vm",
+			Namespace: "default",
+			UID:       "guest-uid",
+		},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef:      &corev1.LocalObjectReference{Name: "ubuntu"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "default"},
+		},
+	}
+	cloneName := RootDiskCloneName(guest.Name)
+
+	// Owner-ref points at a different controller (a SwiftRestore in
+	// production; we use a non-existent placeholder GVK here so the
+	// fake client doesn't need the snapshot scheme registered).
+	otherController := true
+	apiGroup := "snapshot.storage.k8s.io"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cloneName,
+			Namespace: guest.Namespace,
+			Labels: map[string]string{
+				RestoreSeededLabel: "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "snapshot.kubeswift.io/v1alpha1",
+					Kind:       "SwiftRestore",
+					Name:       "the-restore",
+					UID:        "restore-uid",
+					Controller: &otherController,
+				},
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSource: &corev1.TypedLocalObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     "VolumeSnapshot",
+				Name:     "vs1",
+			},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("40Gi")},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+	srcPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "src-image", Namespace: guest.Namespace},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("40Gi")},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(guest, pvc, srcPVC).
+		Build()
+
+	r := &SwiftGuestReconciler{Client: c, Scheme: scheme}
+	rg := &resolved.ResolvedGuest{
+		PreparedImage: resolved.PreparedImage{PVCName: "src-image"},
+		RootDisk:      resolved.RootDisk{Size: resource.MustParse("40Gi")},
+	}
+
+	res, err := r.EnsureRootDiskClone(context.Background(), guest, rg)
+	if err != nil {
+		t.Fatalf("EnsureRootDiskClone returned err = %v, want nil (restore-seeded must pass even when not controlled by guest)", err)
+	}
+	if res == nil || res.PVCName != cloneName {
+		t.Fatalf("result = %+v, want PVCName=%s", res, cloneName)
+	}
+	if res.NeedsGrowInit {
+		t.Errorf("NeedsGrowInit = true, want false")
+	}
+
+	// Most important assertion: PVC was NOT deleted by the orphan
+	// check. Before the fix, the PVC would be gone from the fake
+	// client at this point.
+	var got corev1.PersistentVolumeClaim
+	if err := c.Get(context.Background(), client.ObjectKey{Name: cloneName, Namespace: guest.Namespace}, &got); err != nil {
+		t.Fatalf("restore-seeded PVC was deleted by orphan check: %v", err)
+	}
+	if got.Spec.DataSource == nil || got.Spec.DataSource.Name != "vs1" {
+		t.Errorf("PVC dataSource = %v, want VolumeSnapshot/vs1 (the orphan branch may have replaced the PVC)", got.Spec.DataSource)
+	}
+	if got.Labels[RestoreSeededLabel] != "true" {
+		t.Errorf("PVC label %s missing — PVC was likely replaced", RestoreSeededLabel)
+	}
+
+	// Second assertion: NO Copy Job was created for the restore-seeded
+	// PVC. Its presence would mean the controller is about to overwrite
+	// the snapshot data with a cp from the source SwiftImage.
+	var jobs batchv1.JobList
+	if err := c.List(context.Background(), &jobs, client.InNamespace(guest.Namespace)); err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	for _, j := range jobs.Items {
+		if j.Name == CloneJobName(guest.Name) {
+			t.Errorf("Copy Job %s was created — restore-seeded path must skip it", j.Name)
+		}
+	}
+}
+
 // TestEnsureRootDiskClone_RestoreSeededSkipsCopyJob verifies that a PVC
 // labelled RestoreSeededLabel=true short-circuits the Copy Job path. This
 // is the contract SwiftRestore relies on — without it, the controller


### PR DESCRIPTION
## Summary

Tier A SwiftRestore is silently broken: SwiftRestore reaches `Ready`, the restored SwiftGuest reaches `Running`, but the disk content is a fresh SwiftImage boot rather than the snapshot. Sentinels written before snapshot are missing; machine-id is regenerated. The contract documented in [`docs/snapshots/csi-snapshots.md`](docs/snapshots/csi-snapshots.md) — backup-and-restore — produces a fresh boot, not a restore.

The bug has existed since [`4e055a6`](https://github.com/projectbeskar/kubeswift/commit/4e055a6) (`feat: add SwiftRestore controller`). It surfaced during the operator-perspective walkthrough Scenario 1.

## Root cause

`EnsureRootDiskClone` in [internal/controller/swiftguest/rootdisk.go](internal/controller/swiftguest/rootdisk.go) had:

```go
if pvcExists {
    if !metav1.IsControlledBy(&existingPVC, guest) {       // line 143 — fires
        r.Delete(ctx, &existingPVC)
        return nil, fmt.Errorf("deleted orphaned clone PVC %s, will recreate", cloneName)
    }
    if existingPVC.Labels[RestoreSeededLabel] == "true" {  // line 156 — unreachable
        ...
```

SwiftRestore creates the per-guest PVC owned by the **SwiftRestore** (not by the SwiftGuest), with `dataSource: VolumeSnapshot` and `swift.kubeswift.io/restore-seeded=true`. The orphan check fires first because `IsControlledBy(pvc, guest)` is false — the snapshot-seeded PVC is deleted before the `RestoreSeededLabel` short-circuit at line 156 runs. The SwiftGuest controller then creates a fresh PVC owned by itself (no dataSource) and runs the Copy Job from the source SwiftImage, overwriting the restored disk data.

Verified on cluster: `swiftguest-root-s1-restored.metadata.ownerReferences[0].kind = SwiftGuest` (the recreated PVC), no `restore-seeded` label, no `dataSource`. The Copy Job ran. Sentinel data lost.

## Fix

Reorder the two checks. `RestoreSeededLabel` is consulted first; labelled PVCs are accepted as authoritative regardless of controller-ref. The orphan-delete still fires for genuinely orphaned PVCs (no label) so the existing protection against stale clones from prior reconciles is preserved.

## Phase 2 NOT affected

Phase 2 clone restore intentionally uses the SwiftImage Copy Job for the root disk (memory snapshots don't capture disk state — see [docs/snapshots/local-snapshots.md](docs/snapshots/local-snapshots.md) "Disk caveat — clone-mode root disk"). It never creates a snapshot-seeded PVC, so it doesn't hit the orphan-delete. Phase 2 in-place restore reuses the source's existing PVC. Bug isolated to Phase 1 / Tier A.

## Why neither test caught it

| Test | What it checks | Why it missed |
|------|---------------|---------------|
| `TestRestore_HappyPath_CreatesPVCAndGuest` (unit) | Asserts ensureRestorePVC creates PVC with label and dataSource | Fake client has no SwiftGuest controller running concurrently — orphan-delete race never fires |
| `test/snapshot/snapshot-test.sh` (e2e) | Asserts restore-seeded label and dataSource on the per-guest PVC after restore | **Not wired into CI** — only `go test ./...` and `cargo test` run |

Wiring `snapshot-test.sh` into CI is the immediate next PR.

## Regression test added

`TestEnsureRootDiskClone_RestoreSeededOwnedByRestoreNotDeleted` recreates the production layout (PVC owned by a non-SwiftGuest controller, RestoreSeededLabel=true, Status.Phase=Bound) and asserts:

1. `EnsureRootDiskClone` returns the PVC unchanged
2. The PVC is not deleted by the orphan check
3. The dataSource and label are preserved
4. No Copy Job is created

Verified: this test FAILS against the unfixed code with `deleted orphaned clone PVC swiftguest-root-target-vm, will recreate` and PASSES with the fix applied.

## Test plan
- [x] `go build ./...`
- [x] `go test ./api/... ./cmd/... ./internal/...` — all packages green
- [x] `gofmt -l ./api ./cmd ./internal` — clean
- [x] `go vet ./api/... ./cmd/... ./internal/...` — clean
- [x] New regression test `TestEnsureRootDiskClone_RestoreSeededOwnedByRestoreNotDeleted` passes
- [x] Verified the new test FAILS without the fix (bug coverage)
- [x] Existing test `TestEnsureRootDiskClone_RestoreSeededSkipsCopyJob` still passes
- [ ] After merge + deploy: walkthrough Scenario 1 will re-run as the operator-flow validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)