### PR TITLE
ci: wire snapshot/clone-strategy e2es into CI; audit + Make targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ on:
       - 'rust/**'
       - 'go.mod'
       - 'go.sum'
+      - 'test/**'
+      - 'Makefile'
       - '.github/workflows/**'
   pull_request:
     branches: [main]
@@ -30,6 +32,8 @@ on:
       - 'rust/**'
       - 'go.mod'
       - 'go.sum'
+      - 'test/**'
+      - 'Makefile'
       - '.github/workflows/**'
 
 jobs:
@@ -96,6 +100,26 @@ jobs:
             echo "Generated code is out of date. Run: make generate"
             exit 1
           fi
+
+  e2e-scripts:
+    name: E2E script syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Static check (bash -n) of every script under test/. Catches typos,
+      # unclosed quotes, syntax-level breakage on every PR. Does NOT run
+      # the scripts against a cluster — that's the workflow_dispatch
+      # `cluster-e2e` job in e2e-on-cluster.yaml.
+      #
+      # This job exists because the cluster-side e2e suite (snapshot-test,
+      # local-roundtrip-test, etc.) sits behind a path-touch trigger and
+      # is rare to invoke; if a script gets corrupted between runs no one
+      # notices until someone tries to run it manually. PR #21 surfaced
+      # the broader pattern: e2es exist, never run, bugs accumulate.
+      # bash -n on every PR keeps the suite from rotting silently.
+      - name: bash -n every test script
+        run: make verify-e2e-scripts
 
   swiftletd-image:
     name: swiftletd image

--- a/.github/workflows/e2e-on-cluster.yaml
+++ b/.github/workflows/e2e-on-cluster.yaml
@@ -1,0 +1,190 @@
+name: E2E (cluster)
+
+# Cluster-side end-to-end tests. Runs the existing test/ scripts against
+# a kind cluster with snapshot-capable CSI installed. These scripts boot
+# real Cloud-Hypervisor VMs and exercise the full SwiftSnapshot /
+# SwiftRestore lifecycle — they are what would have caught the Tier A
+# data-loss bug fixed in PR #21 had they been wired into CI.
+#
+# Initial scope (this commit):
+#   - workflow_dispatch (manual): maintainers can trigger ad hoc against
+#     a kind cluster on a hosted runner. The job is self-contained
+#     (kind setup, CSI driver install, KubeSwift deploy, e2e runs).
+#   - schedule (nightly): runs the same path overnight to surface
+#     regressions within 24 hours.
+#
+# NOT YET wired:
+#   - pull_request path-touch triggers. Hosted-runner KVM + cloud-image
+#     download per PR is heavy and the kind+CSI setup is new ground;
+#     stabilize the manual + nightly runs first, then add PR triggers
+#     in a follow-up. Path-touch on
+#     internal/controller/{swiftrestore,swiftguest,swiftsnapshot}/**
+#     and rust/** is the documented next step.
+#
+# See docs/testing/e2e-audit.md for the full e2e suite inventory.
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: "Which e2e to run (default: all)"
+        required: false
+        default: "all"
+        type: choice
+        options:
+          - all
+          - smoke
+          - snapshot
+          - clonestrategy
+          - local-roundtrip
+          - local-clone-identity
+  schedule:
+    # Daily at 04:00 UTC. Surface regressions before working hours
+    # without flooding the runner pool.
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  cluster-e2e:
+    name: Cluster e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      # KVM acceleration is required for Cloud Hypervisor to boot the
+      # real Ubuntu Noble cloud images the smoke-test and snapshot-test
+      # scripts use. GitHub-hosted ubuntu-latest runners have /dev/kvm
+      # available since 2024; verify it explicitly so the failure mode
+      # is "KVM unavailable" instead of an opaque CH crash.
+      - name: Verify KVM availability
+        run: |
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm is not present on this runner. Cluster e2e cannot run without KVM."
+            exit 1
+          fi
+          ls -l /dev/kvm
+
+      - name: Install kind
+        run: |
+          curl -fsSLo kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+          chmod +x kind
+          sudo mv kind /usr/local/bin/
+
+      - name: Create kind cluster
+        run: |
+          kind create cluster --name kubeswift-e2e --config - <<'EOF'
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+            - role: control-plane
+            - role: worker
+          EOF
+
+      # Snapshot CRDs (the snapshot-controller side; the host-path CSI
+      # driver below provides the storage-side implementation).
+      - name: Install snapshot CRDs
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.0.1/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.0.1/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.0.1/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+
+      - name: Install snapshot controller
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.0.1/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.0.1/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+          kubectl -n kube-system rollout status deploy/snapshot-controller --timeout=2m
+
+      # csi-driver-host-path is the reference snapshot-capable CSI
+      # driver. It's lightweight (no real backing storage), correct
+      # enough for snapshot semantics, and has a default
+      # VolumeSnapshotClass annotation so snapshot-test.sh's
+      # auto-detection finds it.
+      - name: Install csi-driver-host-path
+        run: |
+          git clone --depth=1 --branch v1.15.0 https://github.com/kubernetes-csi/csi-driver-host-path /tmp/csi-host-path
+          /tmp/csi-host-path/deploy/kubernetes-1.30/deploy.sh
+          kubectl apply -f /tmp/csi-host-path/examples/csi-storageclass.yaml
+          kubectl apply -f /tmp/csi-host-path/examples/csi-snapshotclass.yaml
+          # Mark the snapshot class default so snapshot-test.sh auto-detects it.
+          kubectl annotate volumesnapshotclass csi-hostpath-snapclass \
+            snapshot.storage.kubernetes.io/is-default-class=true
+
+      - name: Build and load images
+        run: |
+          make build-images
+          kind load docker-image \
+            ghcr.io/projectbeskar/kubeswift/controller-manager:dev \
+            ghcr.io/projectbeskar/kubeswift/swiftletd:dev \
+            ghcr.io/projectbeskar/kubeswift/gpu-discovery:dev \
+            --name kubeswift-e2e
+
+      - name: Deploy KubeSwift
+        run: |
+          make deploy
+          kubectl -n kubeswift-system rollout status deploy/controller-manager --timeout=5m
+
+      - name: Run e2e ${{ github.event.inputs.scenario || 'all' }}
+        run: |
+          set -euo pipefail
+          SCENARIO="${{ github.event.inputs.scenario || 'all' }}"
+          run_one() {
+            echo "::group::e2e: $1"
+            make "$1"
+            echo "::endgroup::"
+          }
+          case "$SCENARIO" in
+            smoke)               run_one smoke-test ;;
+            snapshot)            run_one snapshot-test ;;
+            clonestrategy)       run_one clonestrategy-test ;;
+            local-roundtrip)     run_one local-roundtrip-test ;;
+            local-clone-identity) run_one local-clone-identity-test ;;
+            all)
+              run_one snapshot-test
+              run_one clonestrategy-test
+              # The Tier B local-* scripts need a node with KVM AND
+              # /var/lib/kubeswift/snapshots/ writable hostPath. Both
+              # are present on kind workers; if a future runner image
+              # changes that, these scripts will fail loudly rather
+              # than silently.
+              run_one local-roundtrip-test
+              run_one local-clone-identity-test
+              # Smoke-test runs last because it's the heaviest (boots
+              # five guests across scenarios) and a failure earlier in
+              # the chain is more informative for debugging.
+              run_one smoke-test
+              ;;
+            *)
+              echo "::error::unknown scenario: $SCENARIO"
+              exit 2
+              ;;
+          esac
+
+      - name: Diagnostic dump on failure
+        if: failure()
+        run: |
+          echo "::group::cluster state"
+          kubectl get all -A
+          echo "::endgroup::"
+          echo "::group::events"
+          kubectl get events -A --sort-by=.lastTimestamp | tail -100
+          echo "::endgroup::"
+          echo "::group::controller-manager logs"
+          kubectl -n kubeswift-system logs deploy/controller-manager --tail=200 || true
+          echo "::endgroup::"
+          for guest in $(kubectl get pod -A -l 'swift.kubeswift.io/guest' -o name 2>/dev/null); do
+            echo "::group::launcher $guest"
+            kubectl logs $guest --tail=100 || true
+            echo "::endgroup::"
+          done
+
+      - name: Cleanup kind
+        if: always()
+        run: kind delete cluster --name kubeswift-e2e || true

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
 
 .PHONY: build build-go build-rust build-images build-controller-image build-swiftletd-image \
 	build-gpu-discovery-image generate deploy undeploy load-images smoke-test smoke-test-cleanup \
+	clonestrategy-test snapshot-test local-roundtrip-test local-clone-identity-test e2e-tests \
+	verify-e2e-scripts \
 	preflight help push-images package-chart push-chart release-dev release-rc release-stable print-version
 
 help:
@@ -43,6 +45,12 @@ help:
 	@echo "  load-images           Load built images into kind/minikube (local clusters)"
 	@echo "  smoke-test            Run boot smoke test (requires KubeSwift cluster)"
 	@echo "  smoke-test-cleanup    Remove smoke-test resources (SwiftGuest, SwiftImage, etc.) for re-runs"
+	@echo "  clonestrategy-test    Run cloneStrategy: snapshot e2e (requires snapshot-capable CSI)"
+	@echo "  snapshot-test         Run Tier A (CSI VolumeSnapshot) snapshot+restore e2e"
+	@echo "  local-roundtrip-test  Run Tier B (local hostPath) memory snapshot+in-place restore e2e"
+	@echo "  local-clone-identity-test  Run Tier B clone-identity-collision e2e"
+	@echo "  e2e-tests             Run every cluster-side e2e in sequence"
+	@echo "  verify-e2e-scripts    Static check (bash -n) of every e2e script (fast, no cluster)"
 	@echo "  preflight             Run worker-node readiness preflight (host checks only)"
 
 build: build-go build-rust
@@ -169,6 +177,44 @@ smoke-test:
 # Uses NAMESPACE (default: default). Run: make smoke-test-cleanup NAMESPACE=myns
 smoke-test-cleanup:
 	@test/smoke/boot-test.sh --cleanup-only
+
+# Tier A (csi-volume-snapshot) end-to-end: source guest, snapshot, restore,
+# verify the per-guest PVC carries dataSource and the restore-seeded label.
+# Caught the Tier A data-loss bug fixed in PR #21 — would have caught it
+# from the day SwiftRestore was added had it run in CI.
+snapshot-test:
+	@test/snapshot/snapshot-test.sh
+
+# cloneStrategy: snapshot end-to-end: SwiftImage with status.cloneSeed,
+# fast per-guest PVC clone via dataSource: VolumeSnapshot.
+clonestrategy-test:
+	@test/clonestrategy/clonestrategy-test.sh
+
+# Tier B (local hostPath) memory snapshot + in-place restore: tmpfs
+# sentinel survives the kill+restore cycle.
+local-roundtrip-test:
+	@test/snapshot/local-roundtrip-test.sh
+
+# Tier B clone restore: machine-id, hostname, SSH host keys, guest-side
+# MAC are documented to collide between source and clones (resume-vs-boot
+# limitation). The test asserts that the documented behavior is what
+# operators observe.
+local-clone-identity-test:
+	@test/snapshot/local-clone-identity-test.sh
+
+# Every cluster-side e2e in sequence. Each script accepts --no-cleanup;
+# this target opts out so the cluster is clean between scripts.
+e2e-tests: smoke-test snapshot-test clonestrategy-test local-roundtrip-test local-clone-identity-test
+
+# Fast static check: every e2e script parses (bash -n). Catches
+# typos / unclosed quotes without needing a cluster. Designed to run
+# on every PR.
+verify-e2e-scripts:
+	@set -e; for script in $$(find test -name '*.sh' -type f); do \
+		echo "  bash -n $$script"; \
+		bash -n "$$script" || { echo "FAIL: $$script has syntax errors"; exit 1; }; \
+	done; \
+	echo "  all e2e scripts parse"
 
 preflight:
 	@./scripts/kubeswift-preflight.sh

--- a/docs/testing/e2e-audit.md
+++ b/docs/testing/e2e-audit.md
@@ -1,0 +1,70 @@
+# End-to-End Test Audit
+
+> Audience: KubeSwift maintainers. Inventory of every cluster-side
+> e2e script, what it covers, and what runs it. Drives "what gets
+> into CI" decisions.
+
+## Why this exists
+
+The Tier A SwiftRestore data-loss bug fixed in PR #21 had been latent
+since the controller's first commit (`4e055a6`). The unit test suite
+passed because the fake-client unit test didn't exercise the
+SwiftGuest controller's orphan-delete race against the SwiftRestore-
+created PVC. The e2e test that **would** have caught the bug
+(`test/snapshot/snapshot-test.sh`, lines 184–196 assert the
+`restore-seeded` label and the `dataSource` on the per-guest PVC)
+existed in the repo but was never invoked by CI.
+
+That pattern — e2es exist, never run, bugs accumulate that the e2e
+would catch — is the underlying issue. This audit lists every e2e
+and exactly how it gets exercised.
+
+## Inventory
+
+| Script | Purpose | Make target | CI invocation | Bug coverage notes |
+|---|---|---|---|---|
+| `test/smoke/boot-test.sh` | End-to-end VM boot in five scenarios (disk-boot, kernel-boot, qemu-boot, gpu-alloc, multi-nic) | `make smoke-test`, `make smoke-test-cleanup` | `e2e-on-cluster.yaml` (manual + nightly) | Sole "does the cluster boot a VM" test. Catches integration breakage in image import, CH spawn, networking. |
+| `test/snapshot/snapshot-test.sh` | Tier A (csi-volume-snapshot) snapshot+restore. Asserts the restored PVC carries `restore-seeded` label and `dataSource: VolumeSnapshot`. | `make snapshot-test` | `e2e-on-cluster.yaml` (manual + nightly) | **Would have caught the Tier A data-loss bug fixed in PR #21** (the orphan-delete race). |
+| `test/snapshot/local-roundtrip-test.sh` | Tier B (local hostPath) memory snapshot + in-place restore. tmpfs sentinel survives the kill+restore cycle. | `make local-roundtrip-test` | `e2e-on-cluster.yaml` (manual + nightly) | Validates memory-state preservation: the headline Phase 2 promise. |
+| `test/snapshot/local-clone-identity-test.sh` | Tier B clone restore. Asserts the documented identity-collision behavior (machine-id, hostname, SSH host keys, guest-side MAC all match source). | `make local-clone-identity-test` | `e2e-on-cluster.yaml` (manual + nightly) | Pins the resume-vs-boot limitation. If a future change accidentally fixed the collision (e.g. by triggering a guest reboot post-restore), this test would surface it for re-evaluation. |
+| `test/clonestrategy/clonestrategy-test.sh` | `cloneStrategy: snapshot` SwiftImage path: status.cloneSeed populated, per-guest PVC clone via dataSource. | `make clonestrategy-test` | `e2e-on-cluster.yaml` (manual + nightly) | Validates the Phase 1 fast-clone path (independent of SwiftRestore). |
+
+## CI coverage strategy
+
+Two complementary jobs:
+
+### `ci.yaml` — `e2e-scripts` job (every PR)
+
+`make verify-e2e-scripts` runs `bash -n` against every script in `test/`. Catches typos, unclosed quotes, missing-EOF heredocs — anything that prevents the script from running. Cheap (no cluster), runs on every PR. Designed so e2es never silently rot between cluster runs.
+
+### `e2e-on-cluster.yaml` — cluster-side (manual + nightly)
+
+A new workflow that:
+
+1. Creates a kind cluster with snapshot CRDs + `csi-driver-host-path` (snapshot-capable reference CSI).
+2. Builds and loads KubeSwift images into kind.
+3. Deploys CRDs + controller-manager.
+4. Runs the selected e2e scripts.
+5. Dumps cluster state on failure (events, controller logs, launcher logs per guest).
+
+**Triggers today:** `workflow_dispatch` (manual) and `schedule` (nightly at 04:00 UTC).
+
+**Not yet wired:** `pull_request` path-touch on `internal/controller/{swiftrestore,swiftguest,swiftsnapshot}/**` and `rust/**`. Stabilizing the manual + nightly path first; add PR triggers once the workflow has a track record. The data-loss-class bug PR #21 fixed would be caught by the nightly run within 24 hours of merge — better than indefinite latency, worse than per-PR. Closing the gap is tracked.
+
+## Adding a new e2e
+
+1. Drop the script in `test/<area>/<name>-test.sh`. Make it idempotent and self-cleanup-friendly (`--no-cleanup` flag if it fits).
+2. Add a Make target to `Makefile` (look for the existing snapshot-test / clonestrategy-test entries to copy from).
+3. Add a row to the inventory table above with what it covers and the bug class it would have caught had it existed earlier.
+4. Add an entry to the `e2e-on-cluster.yaml` `scenario` choice list and the corresponding `case` branch in the run step.
+5. Verify locally: `make verify-e2e-scripts` (must pass), then run against a real cluster (the GHA workflow_dispatch is the lowest-friction way once the workflow is merged).
+
+## Non-goals
+
+- **kubeswift-tester / dedicated test cluster.** Out of scope for now. The kind-based e2e is good enough for catching regressions; production-shape testing is a separate exercise (real CSI drivers, multi-node networking, GPU hardware) that benefits from a different runner topology.
+- **End-to-end performance benchmarks.** The walkthrough captures pause-window-style timings as observations; a benchmarking suite would be a separate workflow.
+
+## History
+
+- PR #21: Tier A restore data-loss fix. Surfaced during operator walkthrough Scenario 1.
+- PR #22 (this PR): wires snapshot e2e into CI; introduces `e2e-on-cluster.yaml`; adds Make targets for every existing e2e; adds `verify-e2e-scripts` to the per-PR fast-feedback loop.


### PR DESCRIPTION
## Summary

Closes the test-discoverability gap that allowed PR #21's Tier A data-loss bug to remain latent since the SwiftRestore controller's first commit. The e2e that would have caught it (`test/snapshot/snapshot-test.sh`) existed but was never invoked. This PR fixes that pattern.

## What's added

### Make targets for every existing e2e
```
make snapshot-test            # Tier A snapshot+restore
make clonestrategy-test       # cloneStrategy: snapshot SwiftImage
make local-roundtrip-test     # Tier B memory snapshot+in-place
make local-clone-identity-test # Tier B clone identity
make e2e-tests                # all of the above + smoke-test
make verify-e2e-scripts       # bash -n every script (no cluster)
```

Before this PR, only `make smoke-test` existed; the others required operators to know the script path.

### `ci.yaml` — `e2e-scripts` job (every PR)

`make verify-e2e-scripts` runs `bash -n` against every script in `test/`. Catches typos/unclosed quotes/heredoc breakage on every PR without needing a cluster. Designed so e2es never silently rot between cluster runs.

Also extended the path-touch triggers to include `test/**` and `Makefile` so script edits are exercised.

### `e2e-on-cluster.yaml` — cluster-side workflow (manual + nightly)

New workflow that:
- Creates a kind cluster
- Installs snapshot CRDs + `csi-driver-host-path` (snapshot-capable reference CSI)
- Builds and loads KubeSwift images into kind
- Deploys CRDs + controller-manager
- Runs the selected e2e scripts (one chosen scenario or `all`)
- Dumps cluster state on failure (events, controller-manager logs, per-launcher logs)

**Triggers today:** `workflow_dispatch` (manual; choose scenario from a dropdown) and `schedule` (nightly at 04:00 UTC).

**Not yet wired:** `pull_request` path-touch on `internal/controller/{swiftrestore,swiftguest,swiftsnapshot}/**` and `rust/**`. Stabilizing manual + nightly first, then adding PR triggers — the PR #21-class bug would still be caught within 24h by the nightly. Closing the gap to per-PR is tracked in the audit doc as the documented next step.

### `docs/testing/e2e-audit.md`

Inventory of every e2e, what it covers, what bug class it would catch, and how to add a new one. Drives explicit "what gets into CI" decisions.

| Script | Make target | Bug class it catches |
|---|---|---|
| `smoke/boot-test.sh` | `smoke-test` | VM boot integration |
| `snapshot/snapshot-test.sh` | `snapshot-test` | **Tier A data-loss class — caught PR #21's bug** |
| `snapshot/local-roundtrip-test.sh` | `local-roundtrip-test` | Memory-state preservation |
| `snapshot/local-clone-identity-test.sh` | `local-clone-identity-test` | Resume-vs-boot regression detector |
| `clonestrategy/clonestrategy-test.sh` | `clonestrategy-test` | Phase 1 fast-clone path |

## Test plan
- [x] `make verify-e2e-scripts` passes locally (every script `bash -n` clean)
- [x] `make help` lists every new target
- [x] `gofmt -l` clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-on-cluster.yaml'))"` parses
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yaml'))"` parses
- [ ] After merge: trigger `e2e-on-cluster.yaml` via workflow_dispatch with scenario=snapshot to verify the kind+CSI+KubeSwift path works against the merged commit (this PR can't self-test the workflow because the workflow needs to be on `main` for `workflow_dispatch` to find it). The first manual run will surface any kind/CSI version mismatch; iterating after merge is expected.

## Companion to PR #21

PR #21 fixes the Tier A bug that surfaced this gap. This PR makes sure that bug class can't go undetected for as long again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)