### PR TITLE
fix(swiftmigration): handle terminal states correctly in webhook and reconciler

### DIFF
--- a/internal/controller/swiftmigration/controller.go
+++ b/internal/controller/swiftmigration/controller.go
@@ -104,15 +104,23 @@ func (r *SwiftMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Terminal phases: nothing more to do. Idempotency: re-reconcile
-	// of a Completed/Failed/Cancelled SwiftMigration is a no-op.
-	// Drop the finalizer in case it's still attached (cleanup runs
-	// on transition into the terminal phase, but a re-reconcile
-	// after a controller restart could observe the terminal state
-	// with the finalizer still present).
-	switch mig.Status.Phase {
-	case migrationv1alpha1.SwiftMigrationPhaseCompleted,
-		migrationv1alpha1.SwiftMigrationPhaseFailed,
-		migrationv1alpha1.SwiftMigrationPhaseCancelled:
+	// of a Completed/Failed/Cancelled SwiftMigration is a no-op. The
+	// SwiftMigration controller watches Pod and SwiftGuest events
+	// (SetupWithManager) and a single completed migration receives
+	// many spurious enqueues over its lifetime — anything past this
+	// point should be skipped on stale terminal-phase resources.
+	//
+	// Order: check phase first, then short-circuit immediately when
+	// no work is left. The finalizer-cleanup branch only runs when
+	// the finalizer is still present (e.g., after a controller crash
+	// between the terminal-phase patch and the finalizer-removal
+	// patch in dispatchResult/handleCancellation). Skipping the
+	// removeFinalizer call when the finalizer is already gone avoids
+	// an unnecessary API roundtrip on every spurious enqueue.
+	if isTerminalPhase(mig.Status.Phase) {
+		if !hasFinalizer(&mig) {
+			return ctrl.Result{}, nil
+		}
 		if err := r.removeFinalizer(ctx, &mig); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -225,6 +233,35 @@ func (r *SwiftMigrationReconciler) dispatchResult(
 // handleResuming is in resuming.go.
 
 // --- Helpers ---
+
+// isTerminalPhase returns true for SwiftMigration phases where the
+// outcome has been decided. Used by Reconcile's terminal-phase short-
+// circuit and (textually duplicated) by the validating webhook to
+// skip cluster-state validation on metadata-only patches against
+// already-decided migrations. Both copies must remain in sync; the
+// controller can't import the webhook (cycle) and the webhook only
+// imports api types.
+func isTerminalPhase(phase migrationv1alpha1.SwiftMigrationPhase) bool {
+	switch phase {
+	case migrationv1alpha1.SwiftMigrationPhaseCompleted,
+		migrationv1alpha1.SwiftMigrationPhaseFailed,
+		migrationv1alpha1.SwiftMigrationPhaseCancelled:
+		return true
+	}
+	return false
+}
+
+// hasFinalizer returns true when FinalizerName is attached to the
+// SwiftMigration. Used to skip the removeFinalizer roundtrip on the
+// terminal-phase short-circuit when there's nothing to remove.
+func hasFinalizer(mig *migrationv1alpha1.SwiftMigration) bool {
+	for _, f := range mig.Finalizers {
+		if f == FinalizerName {
+			return true
+		}
+	}
+	return false
+}
 
 // setPhase advances the SwiftMigration to phase p, leaving conditions
 // alone (callers set Ready/Compatible separately).

--- a/internal/controller/swiftmigration/controller_test.go
+++ b/internal/controller/swiftmigration/controller_test.go
@@ -127,6 +127,230 @@ func TestReconcile_TerminalPhase_NoOp(t *testing.T) {
 	}
 }
 
+// TestReconcile_TerminalPhase_NoFinalizer_NoPatch verifies the Bug B
+// refinement: a terminal-phase SwiftMigration without our finalizer
+// short-circuits with zero API roundtrips. Pod and SwiftGuest watches
+// fan out to every active migration in the namespace and a single
+// completed migration receives many spurious enqueues over its
+// lifetime — none of those should trigger a Patch.
+//
+// The fake client's countingClient wraps Patch to count invocations.
+// A no-op Reconcile is expected to issue zero Patch calls.
+func TestReconcile_TerminalPhase_NoFinalizer_NoPatch(t *testing.T) {
+	for _, phase := range []migrationv1alpha1.SwiftMigrationPhase{
+		migrationv1alpha1.SwiftMigrationPhaseCompleted,
+		migrationv1alpha1.SwiftMigrationPhaseFailed,
+		migrationv1alpha1.SwiftMigrationPhaseCancelled,
+	} {
+		t.Run(string(phase), func(t *testing.T) {
+			scheme := testScheme(t)
+			mig := newMigration("m", "default")
+			mig.Status.Phase = phase
+			// Finalizer already absent (cleanup ran on terminal-phase transition).
+
+			base := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(mig).
+				WithStatusSubresource(mig).
+				Build()
+			counter := &patchCountingClient{Client: base}
+
+			r := &SwiftMigrationReconciler{
+				Client:   counter,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
+			res, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: client.ObjectKey{Name: "m", Namespace: "default"},
+			})
+			if err != nil {
+				t.Fatalf("Reconcile returned err = %v", err)
+			}
+			if res.Requeue || res.RequeueAfter != 0 {
+				t.Errorf("Reconcile should be no-op; got %+v", res)
+			}
+			if counter.patches != 0 {
+				t.Errorf("Reconcile on terminal+finalizer-absent should issue zero Patch calls; got %d", counter.patches)
+			}
+		})
+	}
+}
+
+// TestReconcile_TerminalPhase_StaleFinalizer_RemovesIt verifies that
+// a terminal-phase SwiftMigration WITH the finalizer still attached
+// (e.g., after a controller crash between the terminal-phase status
+// write and the finalizer-removal patch) drops the finalizer on the
+// next reconcile. Idempotent: a second reconcile is a no-op.
+func TestReconcile_TerminalPhase_StaleFinalizer_RemovesIt(t *testing.T) {
+	scheme := testScheme(t)
+	mig := newMigration("m", "default")
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseCompleted
+	mig.Finalizers = []string{FinalizerName}
+
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig).
+		WithStatusSubresource(mig).
+		Build()
+	counter := &patchCountingClient{Client: base}
+
+	r := &SwiftMigrationReconciler{
+		Client:   counter,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: "m", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("Reconcile returned err = %v", err)
+	}
+
+	var got migrationv1alpha1.SwiftMigration
+	if err := base.Get(context.Background(), client.ObjectKey{Name: "m", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if hasFinalizer(&got) {
+		t.Errorf("finalizer should have been removed on terminal-phase reconcile; got %v", got.Finalizers)
+	}
+	if counter.patches != 1 {
+		t.Errorf("expected exactly 1 Patch call (finalizer removal); got %d", counter.patches)
+	}
+
+	// Second reconcile: now the finalizer is gone — must issue zero
+	// further Patches.
+	priorPatches := counter.patches
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: "m", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("second Reconcile returned err = %v", err)
+	}
+	if counter.patches != priorPatches {
+		t.Errorf("second reconcile on terminal+finalizer-absent should issue zero further Patch calls; got %d new", counter.patches-priorPatches)
+	}
+}
+
+// TestHasFinalizer covers the helper directly. Trivial but locks in
+// the exact finalizer string and rejects accidental case/whitespace
+// drift.
+func TestHasFinalizer(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		finalizers []string
+		want       bool
+	}{
+		{"absent", nil, false},
+		{"empty", []string{}, false},
+		{"present", []string{FinalizerName}, true},
+		{"present with siblings", []string{"other", FinalizerName, "yet-another"}, true},
+		{"only-siblings", []string{"other", "yet-another"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mig := &migrationv1alpha1.SwiftMigration{
+				ObjectMeta: metav1.ObjectMeta{Finalizers: tc.finalizers},
+			}
+			if got := hasFinalizer(mig); got != tc.want {
+				t.Errorf("hasFinalizer(%v) = %v, want %v", tc.finalizers, got, tc.want)
+			}
+		})
+	}
+}
+
+// patchCountingClient wraps client.Client and counts BOTH metadata and
+// status Patch invocations. Used by terminal-phase short-circuit tests
+// to assert exact API roundtrip counts. Counts both surfaces so a
+// future regression that adds a status patch on the short-circuit path
+// (e.g., bumping lastObservedAt on a stale completed migration) is
+// caught — counting only metadata patches would silently miss it.
+type patchCountingClient struct {
+	client.Client
+	patches int
+}
+
+func (p *patchCountingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	p.patches++
+	return p.Client.Patch(ctx, obj, patch, opts...)
+}
+
+func (p *patchCountingClient) Status() client.SubResourceWriter {
+	return &countingStatusWriter{inner: p.Client.Status(), parent: p}
+}
+
+type countingStatusWriter struct {
+	inner  client.SubResourceWriter
+	parent *patchCountingClient
+}
+
+func (c *countingStatusWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	return c.inner.Create(ctx, obj, subResource, opts...)
+}
+
+func (c *countingStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	c.parent.patches++
+	return c.inner.Update(ctx, obj, opts...)
+}
+
+func (c *countingStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	c.parent.patches++
+	return c.inner.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *countingStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	c.parent.patches++
+	return c.inner.Apply(ctx, obj, opts...)
+}
+
+// TestHandleCancellation_DeletedSourceGuest_RemovesFinalizer covers
+// the Bug A controller-side flow end-to-end against the in-process
+// fake client (the webhook isn't wired in, but the controller's
+// removeFinalizer Patch shape is the same one the live cluster
+// rejects pre-fix, so verifying the controller handles the
+// happy path correctly closes the round-trip the QA review
+// flagged as untested).
+//
+// Scenario: a mid-flight (Preparing) SwiftMigration is deleted by
+// the operator AFTER they've already deleted the source SwiftGuest.
+// handleCancellation runs cleanupSourceGuest (no-op, guest gone),
+// then removeFinalizer. Assert the finalizer is removed and no
+// error is returned.
+func TestHandleCancellation_DeletedSourceGuest_RemovesFinalizer(t *testing.T) {
+	scheme := testScheme(t)
+	mig := newMigration("m", "default")
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhasePreparing
+	mig.Finalizers = []string{FinalizerName}
+	now := metav1.Now()
+	mig.DeletionTimestamp = &now
+
+	// Source SwiftGuest intentionally absent.
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig).
+		WithStatusSubresource(mig).
+		Build()
+
+	r := &SwiftMigrationReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	if _, err := r.handleCancellation(context.Background(), mig); err != nil {
+		t.Fatalf("handleCancellation should succeed when source guest is missing; got %v", err)
+	}
+
+	// The fake client honors finalizer removal: once the last
+	// finalizer is dropped on a resource with DeletionTimestamp set,
+	// the resource is deleted. Verify by Get → IsNotFound.
+	var got migrationv1alpha1.SwiftMigration
+	getErr := c.Get(context.Background(), client.ObjectKey{Name: "m", Namespace: "default"}, &got)
+	if getErr == nil {
+		// Some fake-client versions retain the object — fall back to
+		// asserting the finalizer is gone.
+		if hasFinalizer(&got) {
+			t.Errorf("finalizer should have been removed; got %v", got.Finalizers)
+		}
+	}
+}
+
 // TestReconcile_NotFoundIsIgnored verifies that a Reconcile call for a
 // SwiftMigration that doesn't exist returns nil error (NotFound is the
 // expected race condition: deletion observed before the cache caught

--- a/internal/controller/swiftmigration/failure.go
+++ b/internal/controller/swiftmigration/failure.go
@@ -26,10 +26,8 @@ func (r *SwiftMigrationReconciler) ensureFinalizer(
 	ctx context.Context,
 	mig *migrationv1alpha1.SwiftMigration,
 ) error {
-	for _, f := range mig.Finalizers {
-		if f == FinalizerName {
-			return nil
-		}
+	if hasFinalizer(mig) {
+		return nil
 	}
 	patch := client.MergeFrom(mig.DeepCopy())
 	mig.Finalizers = append(mig.Finalizers, FinalizerName)
@@ -84,14 +82,7 @@ func (r *SwiftMigrationReconciler) handleCancellation(
 	mig *migrationv1alpha1.SwiftMigration,
 ) (ctrl.Result, error) {
 	// Idempotent: if our finalizer is already gone, nothing to do.
-	hasFinalizer := false
-	for _, f := range mig.Finalizers {
-		if f == FinalizerName {
-			hasFinalizer = true
-			break
-		}
-	}
-	if !hasFinalizer {
+	if !hasFinalizer(mig) {
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/webhook/swiftmigration/validator.go
+++ b/internal/webhook/swiftmigration/validator.go
@@ -108,7 +108,45 @@ func (v *Validator) validate(ctx context.Context, mig *migrationv1alpha1.SwiftMi
 	if v.Client == nil {
 		return nil, nil
 	}
+	// Skip cluster-state validation on UPDATE patches against migrations
+	// that are either being deleted or already in a terminal phase.
+	//
+	// Both cases produce metadata-only patches (finalizer removal) issued
+	// by the controller after the migration's outcome is decided. There's
+	// nothing left to gate, and re-running validateClusterState here can
+	// reject the patch on conditions that were valid at submission time
+	// but no longer hold (source SwiftGuest deleted, source==target after
+	// cutover succeeded). That rejection traps the resource: the
+	// finalizer can't be removed, which means the SwiftMigration can't
+	// be deleted via any normal kubectl operation, and stale completed
+	// migrations re-reconcile in a tight loop because each finalizer-
+	// removal patch fails admission.
+	//
+	// The shared pattern is "treat terminal states as terminal": once a
+	// resource is being deleted or has reached a terminal phase, spec
+	// validation against current cluster state has no value, only cost.
+	// Future SwiftMigration phases (live, drain integration) should
+	// preserve this discipline.
+	if mig.DeletionTimestamp != nil {
+		return nil, nil
+	}
+	if isTerminalPhase(mig.Status.Phase) {
+		return nil, nil
+	}
 	return v.validateClusterState(ctx, mig)
+}
+
+// isTerminalPhase returns true for SwiftMigration phases where the
+// outcome has been decided. Mirrors the controller's terminal-phase
+// short-circuit; the two must remain in sync.
+func isTerminalPhase(phase migrationv1alpha1.SwiftMigrationPhase) bool {
+	switch phase {
+	case migrationv1alpha1.SwiftMigrationPhaseCompleted,
+		migrationv1alpha1.SwiftMigrationPhaseFailed,
+		migrationv1alpha1.SwiftMigrationPhaseCancelled:
+		return true
+	}
+	return false
 }
 
 // validateShape covers rules that depend only on the SwiftMigration

--- a/internal/webhook/swiftmigration/validator_test.go
+++ b/internal/webhook/swiftmigration/validator_test.go
@@ -635,3 +635,134 @@ func TestValidateUpdate_NoSpecChange(t *testing.T) {
 		t.Errorf("ValidateUpdate with metadata-only change should accept; got %v", err)
 	}
 }
+
+// --- Terminal-state pass-through (Bug A + Bug B fix) ---
+//
+// Background: in the deployed cluster, finalizer-removal patches issued
+// by the controller after a migration finished were rejected by this
+// webhook because the source SwiftGuest had moved to the destination
+// node (or had been deleted entirely). That trapped completed and
+// being-deleted migrations: the finalizer could not be removed, so
+// the SwiftMigration object could not be cleaned up via any normal
+// kubectl operation. The fix is to skip cluster-state validation
+// when the migration is terminal or being deleted — there's nothing
+// left to gate on metadata-only patches.
+
+// TestValidateUpdate_DeletionTimestamp_SkipsClusterState verifies that
+// an UPDATE patch on a SwiftMigration with deletionTimestamp set is
+// admitted even when the source SwiftGuest has been deleted. Mirrors
+// the headline bug: operator deletes the SwiftGuest, then deletes the
+// SwiftMigration; the controller's removeFinalizer Patch must not be
+// rejected. Source guest is intentionally absent from the fake client.
+func TestValidateUpdate_DeletionTimestamp_SkipsClusterState(t *testing.T) {
+	scheme := migrationScheme(t)
+	// No source SwiftGuest in the cluster.
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	v := &Validator{Client: c}
+
+	old := newSwiftMigration("m", "default")
+	old.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseCompleted
+	now := metav1.Now()
+	old.DeletionTimestamp = &now
+	old.Finalizers = []string{"migration.kubeswift.io/cleanup"}
+
+	// Same-spec update with finalizer removed (the controller's
+	// removeFinalizer patch shape).
+	new := old.DeepCopy()
+	new.Finalizers = nil
+
+	if _, err := v.ValidateUpdate(context.Background(), old, new); err != nil {
+		t.Errorf("ValidateUpdate on deleting SwiftMigration should skip cluster-state validation; got %v", err)
+	}
+}
+
+// TestValidateUpdate_TerminalPhase_SkipsClusterState verifies that an
+// UPDATE patch on a Completed SwiftMigration is admitted even when
+// the source SwiftGuest now sits on what used to be the target node.
+// Pre-fix this rejected with "spec.target.nodeName equals SwiftGuest's
+// current node" because the migration had finished and the guest had
+// moved to boba — the very condition the webhook was designed to
+// reject at submission.
+func TestValidateUpdate_TerminalPhase_SkipsClusterState(t *testing.T) {
+	scheme := migrationScheme(t)
+	// Source guest exists but lives on the target node now (post-cutover).
+	guest := newSwiftGuest("guest", "default")
+	guest.Status.NodeName = "miles" // matches mig.Spec.Target.NodeName
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	v := &Validator{Client: c}
+
+	for _, phase := range []migrationv1alpha1.SwiftMigrationPhase{
+		migrationv1alpha1.SwiftMigrationPhaseCompleted,
+		migrationv1alpha1.SwiftMigrationPhaseFailed,
+		migrationv1alpha1.SwiftMigrationPhaseCancelled,
+	} {
+		t.Run(string(phase), func(t *testing.T) {
+			old := newSwiftMigration("m", "default")
+			old.Status.Phase = phase
+			old.Finalizers = []string{"migration.kubeswift.io/cleanup"}
+			new := old.DeepCopy()
+			new.Finalizers = nil
+			if _, err := v.ValidateUpdate(context.Background(), old, new); err != nil {
+				t.Errorf("ValidateUpdate on phase=%s SwiftMigration should skip cluster-state validation; got %v", phase, err)
+			}
+		})
+	}
+}
+
+// TestValidateUpdate_NonTerminalPhase_StillValidates verifies the skip
+// is scoped: a SwiftMigration in flight (Validating/Preparing/etc.)
+// still runs cluster-state validation. Otherwise the skip would
+// silently disable webhook gating mid-migration.
+func TestValidateUpdate_NonTerminalPhase_StillValidates(t *testing.T) {
+	scheme := migrationScheme(t)
+	// No source guest — would normally reject.
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	v := &Validator{Client: c}
+
+	for _, phase := range []migrationv1alpha1.SwiftMigrationPhase{
+		"",
+		migrationv1alpha1.SwiftMigrationPhasePending,
+		migrationv1alpha1.SwiftMigrationPhaseValidating,
+		migrationv1alpha1.SwiftMigrationPhasePreparing,
+		migrationv1alpha1.SwiftMigrationPhaseStopAndCopy,
+		migrationv1alpha1.SwiftMigrationPhaseResuming,
+	} {
+		t.Run(string(phase), func(t *testing.T) {
+			old := newSwiftMigration("m", "default")
+			old.Status.Phase = phase
+			new := old.DeepCopy()
+			new.ObjectMeta.Annotations = map[string]string{"x": "y"}
+			_, err := v.ValidateUpdate(context.Background(), old, new)
+			if err == nil || !strings.Contains(err.Error(), "not found") {
+				t.Errorf("ValidateUpdate on non-terminal phase=%s should still validate cluster-state; got %v", phase, err)
+			}
+		})
+	}
+}
+
+// TestIsTerminalPhase covers the helper directly to lock in the set of
+// phases treated as terminal. Adding a new terminal phase in a future
+// release must be reflected here AND in the controller's mirror copy.
+func TestIsTerminalPhase(t *testing.T) {
+	for _, tc := range []struct {
+		phase migrationv1alpha1.SwiftMigrationPhase
+		want  bool
+	}{
+		{migrationv1alpha1.SwiftMigrationPhaseCompleted, true},
+		{migrationv1alpha1.SwiftMigrationPhaseFailed, true},
+		{migrationv1alpha1.SwiftMigrationPhaseCancelled, true},
+		{migrationv1alpha1.SwiftMigrationPhasePending, false},
+		{migrationv1alpha1.SwiftMigrationPhaseValidating, false},
+		{migrationv1alpha1.SwiftMigrationPhasePreparing, false},
+		{migrationv1alpha1.SwiftMigrationPhaseStopAndCopy, false},
+		{migrationv1alpha1.SwiftMigrationPhaseResuming, false},
+		{"", false},
+		{"future-phase", false},
+	} {
+		t.Run(string(tc.phase), func(t *testing.T) {
+			if got := isTerminalPhase(tc.phase); got != tc.want {
+				t.Errorf("isTerminalPhase(%q) = %v, want %v", tc.phase, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of live migration just merged (#24). A 30-60 minute operator-perspective headline-validation on the deployed cluster surfaced two defects that all unit, smoke, and CI tests passed cleanly. Both are post-cutover hygiene issues; neither blocks the headline path, but both hit operators in real use.

Both bugs trace to the same missing discipline: **treat terminal states as terminal**. Once a SwiftMigration is being deleted or has reached a terminal phase, spec validation against current cluster state has no value — only cost. Future SwiftMigration phase implementations (live mode, drain integration) should preserve this discipline.

### Bug A (HIGH) — SwiftMigration cannot be deleted after source SwiftGuest is gone

Operator deletes the source SwiftGuest, then deletes the SwiftMigration. The controller's ` removeFinalizer ` patch (metadata-only ` client.MergeFrom `) hits the validating webhook on UPDATE; ` validateClusterState ` rejects on the missing source guest. The SwiftMigration cannot be deleted via any normal kubectl operation. The only workaround pre-fix was to recreate a stub SwiftGuest with the same name to satisfy the webhook — not production-acceptable.

### Bug B (MEDIUM) — Completed SwiftMigrations stuck in reconcile retry loop

` SetupWithManager `'s Pod and SwiftGuest watches fan out to every active SwiftMigration in the namespace. Each spurious enqueue against a Completed migration eventually calls ` removeFinalizer `, whose Patch the webhook rejects because the source SwiftGuest moved to the target node post-cutover (` source == target `). Over weeks of cluster operation, N historical migrations means N controllers in retry loops continuously — real controller-budget burn, not just log pollution.

## Fixes

### Webhook (` internal/webhook/swiftmigration/validator.go `)

Added a short-circuit at the top of ` validate() `: when ` mig.DeletionTimestamp != nil ` OR ` isTerminalPhase(mig.Status.Phase) `, skip ` validateClusterState `. ` validateShape ` (immutability + spec syntax) still runs.

### Controller (` internal/controller/swiftmigration/controller.go `)

Tightened the existing terminal-phase branch in ` Reconcile ` to skip the ` removeFinalizer ` roundtrip when the finalizer is already absent. Saves an API call on every spurious watch enqueue against a fully-cleaned-up terminal migration.

New helpers:
- ` isTerminalPhase ` — textually duplicated from the webhook copy with sync-with-other-copy doc comments, mirroring the existing ` isDefaultNodeLocalNetworking ` precedent in this package (the controller can't import the webhook due to a cycle).
- ` hasFinalizer ` — also used to refactor inline checks in ` ensureFinalizer ` and ` handleCancellation ` for consistency.

## Test plan

- [x] ` TestValidateUpdate_DeletionTimestamp_SkipsClusterState ` — Bug A regression
- [x] ` TestValidateUpdate_TerminalPhase_SkipsClusterState ` — Bug B regression (parameterized over Completed/Failed/Cancelled)
- [x] ` TestValidateUpdate_NonTerminalPhase_StillValidates ` — anti-regression: skip is scoped, not blanket
- [x] ` TestIsTerminalPhase ` — locks in the exact terminal phase set, future-phase forward-compat
- [x] ` TestReconcile_TerminalPhase_NoFinalizer_NoPatch ` — zero Patch calls (metadata + status, both surfaces wrapped via ` patchCountingClient `) on terminal-phase short-circuit
- [x] ` TestReconcile_TerminalPhase_StaleFinalizer_RemovesIt ` — exactly 1 Patch on first reconcile, 0 on second (idempotent)
- [x] ` TestHandleCancellation_DeletedSourceGuest_RemovesFinalizer ` — controller-side Bug A end-to-end
- [x] ` TestHasFinalizer ` — helper coverage including siblings
- [x] ` go test ./... ` clean
- [x] ` gofmt -s -l ` clean
- [x] ` go vet ./... ` clean
- [x] qa-engineer review on test coverage (PASS-WITH-CONCERNS; the two actionable findings — handleCancellation untested + patchCountingClient not counting status writes — are both addressed in this PR)

## What this PR does NOT fix

- ` ensureFinalizer ` on a Pending/Validating SwiftMigration whose source SwiftGuest is deleted mid-flight will still trigger the webhook (correctly — ` validateClusterState ` rejecting on missing guest is the intended at-submission gate). The migration stays trapped in non-terminal phase. Out of scope here; rescuing those is a separate ticket on the migration controller's failure-driving discipline.

## Operator-flow lesson (worth carrying into Phase 2/3/4)

Headline operator-walkthrough on the deployed cluster caught both bugs in 30-60 minutes — neither was reachable from unit, smoke, or CI test surfaces. The bug class is "operator-flow correctness across the resource lifecycle in different deletion orders," not "implementation correctness." Future live-migration phases should bake in a brief mini-walkthrough between phase landings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)