### PR TITLE
fix(swiftmigration): rationalize per-operation validation, bundle Bug C

### DIFF
--- a/internal/controller/swiftmigration/controller_test.go
+++ b/internal/controller/swiftmigration/controller_test.go
@@ -2,6 +2,7 @@ package swiftmigration
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -226,6 +227,89 @@ func TestReconcile_TerminalPhase_StaleFinalizer_RemovesIt(t *testing.T) {
 	}
 	if counter.patches != priorPatches {
 		t.Errorf("second reconcile on terminal+finalizer-absent should issue zero further Patch calls; got %d new", counter.patches-priorPatches)
+	}
+}
+
+// TestReconcile_InFlight_GuestDisappeared_DrivesToFailed — Bug C
+// regression at the controller level. An in-flight (Validating)
+// SwiftMigration whose source SwiftGuest has been deleted mid-flight
+// must be driven to Failed, not trapped in a non-terminal phase.
+// The companion webhook test (TestValidateUpdate_InFlight_NoClusterState)
+// proves the metadata patches the controller issues here are admitted;
+// this test proves the controller's state machine actually uses that
+// permission to drive cleanup.
+//
+// Flow:
+//
+//  1. Reconcile #1: phase=Validating, source guest absent.
+//     - ensureFinalizer adds finalizer (idempotent, no-op if already there).
+//     - handleValidating returns errMsg "source SwiftGuest no longer exists".
+//     - dispatchResult sets phase=Failed and persists status.
+//  2. Reconcile #2: phase=Failed, finalizer still present.
+//     - Terminal-phase short-circuit drops the finalizer and returns.
+//  3. Reconcile #3 (idempotent check): phase=Failed, finalizer absent.
+//     - Zero API roundtrips.
+//
+// Pre-fix the live cluster trapped this scenario: the validating
+// webhook rejected ensureFinalizer's metadata patch on every reconcile
+// because it tried to validate cluster state against a missing source
+// guest. The controller couldn't make forward progress; the migration
+// stayed Validating forever.
+func TestReconcile_InFlight_GuestDisappeared_DrivesToFailed(t *testing.T) {
+	scheme := testScheme(t)
+	mig := newMigration("m", "default")
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
+	// Source SwiftGuest intentionally absent — operator deleted it
+	// mid-migration.
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig).
+		WithStatusSubresource(mig).
+		Build()
+	r := &SwiftMigrationReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	key := client.ObjectKey{Name: "m", Namespace: "default"}
+
+	// Reconcile #1: should drive Validating → Failed.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile #1: %v", err)
+	}
+	var got migrationv1alpha1.SwiftMigration
+	if err := c.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("Get after #1: %v", err)
+	}
+	if got.Status.Phase != migrationv1alpha1.SwiftMigrationPhaseFailed {
+		t.Errorf("phase after Reconcile #1 = %q, want Failed", got.Status.Phase)
+	}
+	if got.Status.FailureMessage == "" || !strings.Contains(got.Status.FailureMessage, "no longer exists") {
+		t.Errorf("FailureMessage = %q, want mention of missing source guest", got.Status.FailureMessage)
+	}
+	if !hasFinalizer(&got) {
+		t.Error("finalizer should still be present after Reconcile #1 (transition to Failed)")
+	}
+
+	// Reconcile #2: terminal phase → drop finalizer.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile #2: %v", err)
+	}
+	if err := c.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("Get after #2: %v", err)
+	}
+	if hasFinalizer(&got) {
+		t.Errorf("finalizer should be removed after Reconcile #2; got %v", got.Finalizers)
+	}
+
+	// Reconcile #3 (idempotent): zero work expected.
+	counter := &patchCountingClient{Client: c}
+	r.Client = counter
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile #3: %v", err)
+	}
+	if counter.patches != 0 {
+		t.Errorf("Reconcile #3 on Failed+finalizer-absent should issue zero patches; got %d", counter.patches)
 	}
 }
 

--- a/internal/webhook/swiftmigration/validator.go
+++ b/internal/webhook/swiftmigration/validator.go
@@ -74,6 +74,36 @@ type Validator struct {
 	Client client.Client
 }
 
+// Per-operation validation discipline.
+//
+// Admission webhooks fire on every operation that touches the resource.
+// A "validate everything every time" default is the bug pattern that
+// produced this PR's three defects:
+//
+//   - Bug A (HIGH): finalizer-removal patches issued during DELETE flow
+//     hit ValidateUpdate; cluster-state validation tripped on a missing
+//     source SwiftGuest. Result: SwiftMigration could not be deleted
+//     via any normal kubectl operation.
+//   - Bug B (MEDIUM): finalizer-removal patches on terminal-phase
+//     migrations (Completed/Failed/Cancelled) hit the same
+//     cluster-state validation, rejected because source==target post-
+//     cutover. Result: stale completed migrations re-reconciled forever.
+//   - Bug C (MEDIUM): in-flight migrations (Pending/Validating/Preparing)
+//     whose source guest was deleted mid-flight hit the same rejection
+//     on every metadata patch (finalizer add, status flips that bring
+//     the controller back through ensureFinalizer). Result: trapped
+//     in-flight migrations the controller couldn't fail-and-clean-up.
+//
+// The discipline is "default to explicit": each operation enumerates
+// what validation fires and why. Future SwiftMigration phases (live
+// mode, drain integration) and other webhooks in this codebase should
+// follow the same pattern.
+
+// ValidateCreate runs full validation: spec shape AND cluster state.
+// CREATE is the submission point — when the operator's intent first
+// hits the API server. This is the right place to gate on cluster-
+// state matching that intent (source guest exists, target node Ready,
+// no conflicting in-flight migration, etc).
 func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	mig, ok := obj.(*migrationv1alpha1.SwiftMigration)
 	if !ok {
@@ -82,6 +112,29 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 	return v.validate(ctx, mig)
 }
 
+// ValidateUpdate runs spec immutability + spec shape ONLY.
+// Cluster-state validation is intentionally skipped because:
+//
+//  1. Spec immutability (enforced below) means the spec on UPDATE is
+//     byte-identical to the spec admitted at CREATE — and CREATE
+//     already validated cluster-state. Re-validating against currently-
+//     evolving cluster state cannot detect new spec problems (none
+//     exist) and only blocks legitimate metadata churn.
+//  2. Cluster-state changes between CREATE and UPDATE — source guest
+//     deleted, target node moved, source==target after cutover — are
+//     the controller's domain to detect and react to (mark migration
+//     Failed, drive cleanup), not the webhook's domain to gate. The
+//     webhook gating those state changes turns transient cluster
+//     conditions into stuck resources.
+//  3. UPDATE patches in this codebase are exclusively controller-
+//     issued: finalizer add/remove, annotation flips. Status changes
+//     don't reach this webhook (we don't subscribe to the status
+//     subresource). All controller-issued patches need to succeed
+//     idempotently for the controller to make forward progress.
+//
+// validateShape is kept as a defense-in-depth (cheap, no-op on an
+// already-validated unchanged spec) but cluster-state lookups are
+// skipped wholesale.
 func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	mig, ok := newObj.(*migrationv1alpha1.SwiftMigration)
 	if !ok {
@@ -94,13 +147,25 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	if !specsEqual(&oldMig.Spec, &mig.Spec) {
 		return nil, fmt.Errorf("SwiftMigration spec is immutable after creation; create a new SwiftMigration to retry with different inputs")
 	}
-	return v.validate(ctx, mig)
+	return nil, validateShape(mig)
 }
 
+// ValidateDelete is a pass-through. Deletion is always permitted at
+// the webhook layer — the controller's finalizer cleanup is the gate
+// that ensures cleanup runs before the resource is removed from
+// storage.
 func (v *Validator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
+// validate runs the full validation suite (shape + cluster state).
+// Called from ValidateCreate ONLY. ValidateUpdate intentionally does
+// not call this — see ValidateUpdate's doc comment for the rationale.
+//
+// Defense-in-depth: should a future caller re-route an UPDATE through
+// this function, the per-operation discipline is undermined. Reviewers
+// should reject any such change unless the corresponding rationale is
+// updated explicitly.
 func (v *Validator) validate(ctx context.Context, mig *migrationv1alpha1.SwiftMigration) (admission.Warnings, error) {
 	if err := validateShape(mig); err != nil {
 		return nil, err
@@ -108,37 +173,15 @@ func (v *Validator) validate(ctx context.Context, mig *migrationv1alpha1.SwiftMi
 	if v.Client == nil {
 		return nil, nil
 	}
-	// Skip cluster-state validation on UPDATE patches against migrations
-	// that are either being deleted or already in a terminal phase.
-	//
-	// Both cases produce metadata-only patches (finalizer removal) issued
-	// by the controller after the migration's outcome is decided. There's
-	// nothing left to gate, and re-running validateClusterState here can
-	// reject the patch on conditions that were valid at submission time
-	// but no longer hold (source SwiftGuest deleted, source==target after
-	// cutover succeeded). That rejection traps the resource: the
-	// finalizer can't be removed, which means the SwiftMigration can't
-	// be deleted via any normal kubectl operation, and stale completed
-	// migrations re-reconcile in a tight loop because each finalizer-
-	// removal patch fails admission.
-	//
-	// The shared pattern is "treat terminal states as terminal": once a
-	// resource is being deleted or has reached a terminal phase, spec
-	// validation against current cluster state has no value, only cost.
-	// Future SwiftMigration phases (live, drain integration) should
-	// preserve this discipline.
-	if mig.DeletionTimestamp != nil {
-		return nil, nil
-	}
-	if isTerminalPhase(mig.Status.Phase) {
-		return nil, nil
-	}
 	return v.validateClusterState(ctx, mig)
 }
 
 // isTerminalPhase returns true for SwiftMigration phases where the
-// outcome has been decided. Mirrors the controller's terminal-phase
-// short-circuit; the two must remain in sync.
+// outcome has been decided. The webhook does not consult this helper
+// directly anymore (per-operation discipline obviates the need), but
+// the controller's Reconcile short-circuit does, and tests in this
+// package lock in the canonical phase set so the controller's
+// duplicated copy can be cross-checked against it.
 func isTerminalPhase(phase migrationv1alpha1.SwiftMigrationPhase) bool {
 	switch phase {
 	case migrationv1alpha1.SwiftMigrationPhaseCompleted,

--- a/internal/webhook/swiftmigration/validator_test.go
+++ b/internal/webhook/swiftmigration/validator_test.go
@@ -636,25 +636,39 @@ func TestValidateUpdate_NoSpecChange(t *testing.T) {
 	}
 }
 
-// --- Terminal-state pass-through (Bug A + Bug B fix) ---
+// --- Per-operation validation discipline (Bug A + B + C fix) ---
 //
-// Background: in the deployed cluster, finalizer-removal patches issued
-// by the controller after a migration finished were rejected by this
-// webhook because the source SwiftGuest had moved to the destination
-// node (or had been deleted entirely). That trapped completed and
-// being-deleted migrations: the finalizer could not be removed, so
-// the SwiftMigration object could not be cleaned up via any normal
-// kubectl operation. The fix is to skip cluster-state validation
-// when the migration is terminal or being deleted — there's nothing
-// left to gate on metadata-only patches.
+// Background: this PR rationalizes admission validation to fire only
+// where it adds value. ValidateCreate runs full cluster-state checks
+// (the submission gate). ValidateUpdate runs spec immutability + spec
+// shape, never cluster-state. Cluster-state changes between CREATE
+// and UPDATE are the controller's domain — webhook re-validation
+// turns transient cluster conditions into stuck resources.
+//
+// The three bugs that motivated this design:
+//
+//   - Bug A (HIGH): operator deletes source SwiftGuest, then deletes
+//     SwiftMigration. removeFinalizer patch hits ValidateUpdate; old
+//     code ran cluster-state and rejected on missing guest. Result:
+//     SwiftMigration could not be deleted via any kubectl operation.
+//   - Bug B (MEDIUM): completed SwiftMigrations stuck reconciling.
+//     Watch fan-out enqueues every active migration; removeFinalizer
+//     patch hit ValidateUpdate; cluster-state rejected because
+//     source==target post-cutover. Retry storm forever.
+//   - Bug C (MEDIUM): in-flight (Pending/Validating/Preparing)
+//     migration whose source guest disappeared mid-flight had its
+//     ensureFinalizer patch rejected on every reconcile. Trapped
+//     in a non-terminal phase the controller couldn't fail-and-clean.
+//
+// All three share root cause: validation logic firing on every
+// operation without discriminating between submission (gate value)
+// and metadata churn (no value, real cost).
 
-// TestValidateUpdate_DeletionTimestamp_SkipsClusterState verifies that
-// an UPDATE patch on a SwiftMigration with deletionTimestamp set is
-// admitted even when the source SwiftGuest has been deleted. Mirrors
-// the headline bug: operator deletes the SwiftGuest, then deletes the
-// SwiftMigration; the controller's removeFinalizer Patch must not be
-// rejected. Source guest is intentionally absent from the fake client.
-func TestValidateUpdate_DeletionTimestamp_SkipsClusterState(t *testing.T) {
+// TestValidateUpdate_DeletionTimestamp_NoClusterState — Bug A
+// regression. SwiftMigration with deletionTimestamp set + source
+// guest absent. The controller's removeFinalizer patch shape must
+// pass admission.
+func TestValidateUpdate_DeletionTimestamp_NoClusterState(t *testing.T) {
 	scheme := migrationScheme(t)
 	// No source SwiftGuest in the cluster.
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -665,27 +679,20 @@ func TestValidateUpdate_DeletionTimestamp_SkipsClusterState(t *testing.T) {
 	now := metav1.Now()
 	old.DeletionTimestamp = &now
 	old.Finalizers = []string{"migration.kubeswift.io/cleanup"}
-
-	// Same-spec update with finalizer removed (the controller's
-	// removeFinalizer patch shape).
 	new := old.DeepCopy()
 	new.Finalizers = nil
 
 	if _, err := v.ValidateUpdate(context.Background(), old, new); err != nil {
-		t.Errorf("ValidateUpdate on deleting SwiftMigration should skip cluster-state validation; got %v", err)
+		t.Errorf("ValidateUpdate on deleting SwiftMigration should not run cluster-state; got %v", err)
 	}
 }
 
-// TestValidateUpdate_TerminalPhase_SkipsClusterState verifies that an
-// UPDATE patch on a Completed SwiftMigration is admitted even when
-// the source SwiftGuest now sits on what used to be the target node.
-// Pre-fix this rejected with "spec.target.nodeName equals SwiftGuest's
-// current node" because the migration had finished and the guest had
-// moved to boba — the very condition the webhook was designed to
-// reject at submission.
-func TestValidateUpdate_TerminalPhase_SkipsClusterState(t *testing.T) {
+// TestValidateUpdate_TerminalPhase_NoClusterState — Bug B regression.
+// Parameterized over all three terminal phases. Source guest exists
+// on what was the migration's target — exact post-cutover scenario
+// the live cluster hit.
+func TestValidateUpdate_TerminalPhase_NoClusterState(t *testing.T) {
 	scheme := migrationScheme(t)
-	// Source guest exists but lives on the target node now (post-cutover).
 	guest := newSwiftGuest("guest", "default")
 	guest.Status.NodeName = "miles" // matches mig.Spec.Target.NodeName
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
@@ -703,19 +710,25 @@ func TestValidateUpdate_TerminalPhase_SkipsClusterState(t *testing.T) {
 			new := old.DeepCopy()
 			new.Finalizers = nil
 			if _, err := v.ValidateUpdate(context.Background(), old, new); err != nil {
-				t.Errorf("ValidateUpdate on phase=%s SwiftMigration should skip cluster-state validation; got %v", phase, err)
+				t.Errorf("ValidateUpdate on phase=%s should not run cluster-state; got %v", phase, err)
 			}
 		})
 	}
 }
 
-// TestValidateUpdate_NonTerminalPhase_StillValidates verifies the skip
-// is scoped: a SwiftMigration in flight (Validating/Preparing/etc.)
-// still runs cluster-state validation. Otherwise the skip would
-// silently disable webhook gating mid-migration.
-func TestValidateUpdate_NonTerminalPhase_StillValidates(t *testing.T) {
+// TestValidateUpdate_InFlight_NoClusterState — Bug C regression.
+// Mid-flight (Pending/Validating/Preparing/StopAndCopy/Resuming)
+// migration whose source SwiftGuest was deleted mid-migration.
+// The controller's ensureFinalizer / annotation-flip metadata
+// patches must pass admission so the controller can drive the
+// migration to Failed and clean up.
+//
+// Pre-fix this was rejected with "source SwiftGuest 'guest' not
+// found" on every metadata patch, trapping the migration in a
+// non-terminal phase that no kubectl could untangle.
+func TestValidateUpdate_InFlight_NoClusterState(t *testing.T) {
 	scheme := migrationScheme(t)
-	// No source guest — would normally reject.
+	// Source guest deleted mid-migration — absent from the fake client.
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	v := &Validator{Client: c}
 
@@ -731,12 +744,51 @@ func TestValidateUpdate_NonTerminalPhase_StillValidates(t *testing.T) {
 			old := newSwiftMigration("m", "default")
 			old.Status.Phase = phase
 			new := old.DeepCopy()
-			new.ObjectMeta.Annotations = map[string]string{"x": "y"}
-			_, err := v.ValidateUpdate(context.Background(), old, new)
-			if err == nil || !strings.Contains(err.Error(), "not found") {
-				t.Errorf("ValidateUpdate on non-terminal phase=%s should still validate cluster-state; got %v", phase, err)
+			new.ObjectMeta.Annotations = map[string]string{"controller-touch": "1"}
+			if _, err := v.ValidateUpdate(context.Background(), old, new); err != nil {
+				t.Errorf("ValidateUpdate on phase=%s with metadata-only change should not run cluster-state; got %v", phase, err)
 			}
 		})
+	}
+}
+
+// TestValidateUpdate_StillEnforcesShape verifies the per-operation
+// discipline is "skip cluster-state on UPDATE", NOT "skip all
+// validation on UPDATE". Spec immutability is still enforced (a
+// dedicated test exists for that — TestValidateUpdate_SpecImmutable),
+// and spec shape is still validated as defense-in-depth in case a
+// future patch path bypasses immutability.
+func TestValidateUpdate_StillEnforcesShape(t *testing.T) {
+	scheme := migrationScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	v := &Validator{Client: c}
+
+	old := newSwiftMigration("m", "default")
+	// Construct an old with valid spec, then a new with invalid spec
+	// that ALSO mutates spec — the immutability check fires first.
+	// To test shape-on-update, we need both old and new to have the
+	// same invalid spec (so immutability passes) so shape is reached.
+	old.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
+	new := old.DeepCopy()
+	if _, err := v.ValidateUpdate(context.Background(), old, new); err == nil || !strings.Contains(err.Error(), "live") {
+		t.Errorf("ValidateUpdate must still enforce shape on UPDATE; got %v", err)
+	}
+}
+
+// TestValidateCreate_RunsClusterState verifies CREATE retains full
+// validation. The submission point is when cluster-state gating adds
+// value (operator's intent first hits the API server). Anti-regression
+// against accidentally extending the per-operation skip to CREATE.
+func TestValidateCreate_RunsClusterState(t *testing.T) {
+	scheme := migrationScheme(t)
+	// No source guest — CREATE must reject.
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	v := &Validator{Client: c}
+
+	mig := newSwiftMigration("m", "default")
+	_, err := v.ValidateCreate(context.Background(), mig)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("ValidateCreate must run cluster-state validation; got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #25. The first fix added per-bug guards in the webhook's ` validate() ` (DeletionTimestamp, terminal-phase). Code review surfaced a third bug in the same family that warranted bundling: the cleaner shape is a per-operation design rule that subsumes all three.

## Pattern flagged for future phases

These bugs share a common root: validation logic that fires on every operation without considering whether each operation is one where validation adds value vs. blocks legitimate work.

- **Bug A** (HIGH, fixed in #25): webhook designed for CREATE/UPDATE applied to DELETE-finalizer-flow without intent.
- **Bug B** (MEDIUM, fixed in #25): reconciler designed for active transitions reconciled terminal states without explicit exclusion.
- **Bug C** (MEDIUM, fixed here): webhook re-validating on metadata patches against cluster state that had legitimately drifted post-CREATE — trapping in-flight migrations whose source guest was deleted mid-flight in non-terminal phases the controller couldn't fail-and-clean-up.

Phase 2/3/4 implementations should explicitly enumerate which operations validation fires on, and document the rationale for each. **Default-to-everything is the bug pattern; default-to-explicit is the discipline.**

## What changed

### Webhook (` validator.go `)

- ` ValidateCreate `: full validation (shape + cluster state). The submission point is the right place to gate cluster-state.
- ` ValidateUpdate `: spec immutability + spec shape ONLY. Cluster-state is intentionally skipped because (a) immutability guarantees the spec is unchanged from CREATE-time validation, and (b) cluster-state changes between CREATE and UPDATE are the controller's domain, not the webhook's.
- ` ValidateDelete `: pass-through (already was; no change).
- The previous per-bug guards in ` validate() ` (DeletionTimestamp, terminal-phase) are removed as unreachable — UPDATE no longer routes through ` validate() `, and CREATE-time resources have neither set.
- ` isTerminalPhase ` helper kept (controller's mirror copy still uses it; webhook tests cross-check the canonical phase set).

### Tests

Renamed/restructured to reflect the broader design rule:

- ` TestValidateUpdate_DeletionTimestamp_NoClusterState ` — Bug A regression (renamed).
- ` TestValidateUpdate_TerminalPhase_NoClusterState ` — Bug B regression (renamed).
- ` TestValidateUpdate_InFlight_NoClusterState ` — Bug C regression **(new)**. Mid-flight migration + missing source guest, parameterized over Pending/Validating/Preparing/StopAndCopy/Resuming.
- ` TestValidateUpdate_StillEnforcesShape ` — anti-regression: skip is "no cluster-state on UPDATE", NOT "no validation on UPDATE". Spec shape (and immutability) still enforced.
- ` TestValidateCreate_RunsClusterState ` — anti-regression: CREATE keeps full validation. Guards against accidentally extending the per-operation skip to CREATE.
- ` TestReconcile_InFlight_GuestDisappeared_DrivesToFailed ` — Bug C at the controller level. Three-step reconcile sequence: Validating → Failed → finalizer dropped → idempotent no-op.

## Test plan

- [x] All new and existing tests pass: ` go test ./internal/webhook/swiftmigration/... ./internal/controller/swiftmigration/... `
- [x] ` go test ./... ` clean
- [x] ` gofmt -s -l ` clean on tracked files
- [x] ` go vet ./... ` clean

## What this PR does NOT change

- Controller behavior is unchanged. The terminal-phase short-circuit and ` hasFinalizer ` helper from #25 remain in place.
- Spec immutability still enforced exactly as before.
- ` ValidateCreate `'s cluster-state validation (source guest exists, target node ready, GPU rejection, IPWillChange warning, etc.) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)