### PR TITLE
fix(rbac): add storageclasses list,watch verbs (W8 follow-up to PR #32)

### DIFF
--- a/charts/kubeswift/templates/controller-manager/rbac.yaml
+++ b/charts/kubeswift/templates/controller-manager/rbac.yaml
@@ -105,6 +105,17 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
+  # storage.k8s.io StorageClass — read-only. The SwiftGuest controller's
+  # checkStorageReady (PR #32) inspects the resolved StorageClass to
+  # verify the Longhorn migratable parameter for RWX+Block guests.
+  # list+watch are required because controller-runtime's cached client
+  # opens an informer on every GETable resource — same pattern as W7
+  # for rolebindings; without list+watch the informer cache fails to
+  # sync and every reconcile that touches the cached client blocks
+  # indefinitely. PR #32 W8 follow-up.
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
   # rbac.authorization.k8s.io RoleBindings — the SwiftGuest controller
   # creates a per-namespace RoleBinding that binds the
   # `kubeswift-swiftletd-reporter` ClusterRole to the workload

--- a/config/manager/controller-manager-rbac.yaml
+++ b/config/manager/controller-manager-rbac.yaml
@@ -98,6 +98,18 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
+  # storage.k8s.io StorageClass — read-only. The SwiftGuest controller's
+  # checkStorageReady (PR #32) inspects the resolved StorageClass to
+  # verify the Longhorn migratable parameter for RWX+Block guests.
+  # list+watch are required because controller-runtime's cached client
+  # opens an informer on every GETable resource — same pattern as W7
+  # for rolebindings; without list+watch the informer cache fails to
+  # sync ("Failed to watch *v1.StorageClass" loop) and every reconcile
+  # that touches the cached client blocks indefinitely. PR #32 W8
+  # follow-up.
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
   # Leader election (controller-runtime uses coordination.k8s.io/leases)
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]


### PR DESCRIPTION
PR #32's checkStorageReady() in internal/controller/swiftguest/storage.go calls r.Get on a StorageClass to verify the Longhorn migratable parameter. Controller-runtime's default cached client opens an informer on every GETable resource — and informers require list+watch, not just get.

Without these verbs, the cache-sync loop emits "Failed to watch *v1.StorageClass: storageclasses.storage.k8s.io is forbidden" repeatedly and the SwiftGuest controller's reconcile queue is starved (every reconcile that touches the cached client blocks indefinitely).

Same shape as Phase 2 walkthrough finding W7 (rolebindings list,watch gap from PR #30): unit tests with the fake client passed because the fake client doesn't use informers; the gap surfaces only on a real cluster. Recurring lesson — when adding a r.Get on a new resource type, grant list,watch alongside get.

Verified on cluster: after applying this fix and bouncing the controller-manager, SwiftGuest with spec.storage RWX+Block reconciles correctly, status.storage echoes the resolved spec, and StorageReady condition surfaces LonghornNotMigratable when the chosen Longhorn class lacks parameters.migratable=true.