### PR TITLE
docs(w9): scope storage RWX+Block runtime path follow-up to PR #32

### DIFF
--- a/docs/design/storage-rwx-block-runtime.md
+++ b/docs/design/storage-rwx-block-runtime.md
@@ -1,0 +1,306 @@
+# Storage RWX+Block Runtime Path (W9 follow-up to PR #32)
+
+> Status: scoping doc — implementer briefing
+> Last updated: 2026-04-30
+> Predecessor: PR #32 — `docs/design/storage-access-mode.md`
+
+## Framing
+
+This is a **runtime-path gap revealed by the API-surface unblock**, not a
+PR #32 regression. PR #32's stated scope was "let operators declare
+`spec.storage.{accessMode, volumeMode, storageClassName}` on
+SwiftGuestClass + SwiftGuest." Every piece of that surface is shipped and
+validated:
+
+| | Validated |
+|---|---|
+| CRD admission accepts RWX+Block | ✓ |
+| Per-field merge of class + guest spec.storage | ✓ |
+| `status.storage` echo | ✓ |
+| `StorageReady=True` (Longhorn migratable=true class) | ✓ |
+| `StorageReady=False / LonghornNotMigratable` (missing param) | ✓ |
+| Per-guest clone PVC creation, RWX, longhorn-migratable | ✓ Bound |
+| W8 RBAC (StorageClass list,watch) | ✓ shipped |
+
+The post-merge cluster walkthrough then moved one step further along the
+SwiftGuest lifecycle and surfaced W9 at the rootdisk Copy Job step:
+
+> `Unable to attach or mount volumes ... volume dst has volumeMode Block,
+> but is specified in volumeMounts`
+
+The Copy Job mounts the destination as a filesystem path
+(`volumeMounts: /dst`) and runs `cp /src/image.raw /dst/image.raw`. With
+`volumeMode: Block`, the kubelet refuses the mount because Block PVCs
+are surfaced as raw devices via `volumeDevices`, not as filesystem
+paths via `volumeMounts`.
+
+This is the **same pattern the project has been working through**:
+
+| Layer | Reveals next layer's gap |
+|---|---|
+| Phase 1 offline migration | Phase 2's swiftletd plumbing requirements |
+| Phase 2 walkthrough | PR #32's API-surface need (storage access mode) |
+| PR #32 walkthrough | W9's runtime-path need (Block volumeMode end-to-end) |
+
+Each layer's completion exposes the next. W9 is not surprising; it is
+precisely the kind of finding the API-surface unblock was always going
+to make addressable. The job here is to land it cleanly, not to
+re-litigate the layering.
+
+## Goal
+
+`spec.storage.volumeMode: Block` SwiftGuests boot end-to-end, with the
+root disk surfaced as a raw block device through Cloud Hypervisor's
+`--disk path=/dev/...` argument, populated correctly from the source
+SwiftImage's PVC, and surviving cloud-init's first-boot resize.
+
+Acceptance criteria — when this lands:
+
+- [ ] SwiftGuest with `storage: {accessMode: ReadWriteMany, volumeMode:
+      Block, storageClassName: longhorn-migratable}` reaches `Phase=Running`
+- [ ] `status.network.primaryIP` populated (full guest boot)
+- [ ] Cloud-init `growpart` extends the partition + filesystem inside the
+      guest to the SwiftGuestClass `rootDisk.size` (40 Gi by default)
+- [ ] `swiftctl console` shows the guest at a login prompt; sentinel write
+      survives a pod restart (block device data persistence test)
+- [ ] No regression: existing Filesystem-mode guests (every existing
+      SwiftGuest uses RWO+Filesystem by default) continue to boot
+      identically — the Block path is opt-in via spec.storage
+
+## Scope (three components)
+
+### 1. Copy Job — `internal/controller/swiftguest/rootdisk.go`
+
+Today (`createCloneJob`):
+
+```go
+VolumeMounts: []corev1.VolumeMount{
+    {Name: "src", MountPath: "/src", ReadOnly: true},
+    {Name: "dst", MountPath: "/dst"},
+},
+script := `cp /src/image.raw /dst/image.raw
+qemu-img resize -f raw /dst/image.raw <size>
+sgdisk -e /dst/image.raw`
+```
+
+Required for Block destinations:
+
+```go
+// Block path: src as filesystem mount (still readable as raw file),
+// dst as raw device.
+VolumeMounts: []corev1.VolumeMount{
+    {Name: "src", MountPath: "/src", ReadOnly: true},
+},
+VolumeDevices: []corev1.VolumeDevice{
+    {Name: "dst", DevicePath: "/dev/dst-block"},
+},
+script := `qemu-img convert -f raw -O raw /src/image.raw /dev/dst-block
+sgdisk -e /dev/dst-block`
+```
+
+Decision rule on which path to take: read `rg.Storage.VolumeMode` from
+the resolved spec (already plumbed by PR #32). The existing `volumeMode`
+helper in PR #32 (`resolvedVolumeMode`) returns the resolved value;
+`createCloneJob` should branch on it. Keep the Filesystem path
+byte-identical to today's behaviour for backward compatibility — the
+Block path is purely additive.
+
+The qemu-img resize step is a no-op on block devices (a Longhorn
+Migratable PVC is provisioned at the requested size; you cannot resize
+a block device with qemu-img). `sgdisk -e` rewrites the GPT backup
+header at the device's last sector and works on block devices natively.
+
+Source image (`/src/image.raw`) is still a filesystem mount — the
+SwiftImage's import PVC is RWO+Filesystem (today's default; see Open
+question (a)). No source-side change unless (a)'s answer says so.
+
+Both paths end with `sync` and an "OK" log line so the Job's success
+condition stays the same.
+
+### 2. Launcher pod builder — `internal/controller/swiftguest/pod.go`
+
+Today the root disk is mounted at a filesystem path (e.g.
+`/var/lib/kubeswift/disks/root/`) via `volumeMounts`, and swiftletd
+generates `--disk path=/var/lib/kubeswift/disks/root/image.raw`. For
+Block destinations:
+
+- The pod's launcher container declares `volumeDevices` (e.g.
+  `{Name: "rootdisk", DevicePath: "/dev/kubeswift-root"}`)
+- The pod NO LONGER declares the corresponding `volumeMounts` entry
+  for the root disk (mutually exclusive)
+- The RuntimeIntent's `RootDisk.Path` is set to the device path
+  instead of the filesystem path
+
+Watch out: the Filesystem path also relies on the launcher's clone-grow-init
+init container running `qemu-img resize` + `sgdisk -e` against the
+filesystem-mounted PVC. For Block destinations:
+
+- The clone-grow-init container needs `volumeDevices` instead of
+  `volumeMounts` for the dst PVC
+- `qemu-img resize` is a no-op (see above); the init container's
+  contract is sgdisk-only on Block, or skipped entirely
+- The grow-init's existence today is for the snapshot path's expand-and-wait
+  contract; that constraint is independent of volumeMode
+
+### 3. swiftletd (Rust) — `rust/swiftletd/`, `rust/swift-ch-client/`
+
+The `RuntimeIntent.RootDisk.Path` field is consumed by swiftletd to
+produce the CH `--disk` argument. Today the path is a filesystem path
+ending in `image.raw`. For Block:
+
+- The path is a device path (`/dev/...`) inside the launcher pod
+- CH's `--disk path=/dev/...` is supported natively (CH treats the path
+  as an opaque file/device handle and opens it raw)
+- swiftletd's startup probes (e.g. checking the root disk size for
+  logging) need to handle device paths — `stat()` works on devices, but
+  some path-suffix-based logic (`.raw`/`.qcow2` detection) needs to be
+  Block-aware
+
+`swift-ch-client::config` already accepts arbitrary path strings via
+`DiskConfig.path`; verify no implicit `image.raw` suffix is appended
+anywhere in the spawn pipeline. The existing CH spawn rejects qcow2 at
+runtime (raw-only invariant); device paths are raw by construction so
+no new check needed.
+
+## Open scoping questions (must be answered as part of W9)
+
+These are NOT blockers for starting the work. They are scoping bounds
+the implementer needs in their head from day one — answering them is
+part of the W9 PR's deliverables, not a pre-requisite.
+
+### (a) qcow2 → raw SwiftImage import pipeline against Block-mode PVCs
+
+The SwiftImage import Job today downloads a qcow2 from
+`spec.source.http.url`, runs `qemu-img convert -f qcow2 -O raw` to a
+filesystem-mounted destination PVC. If the W9 follow-up only touches
+guest-side clone+launcher, the **import pipeline stays on
+Filesystem-mode PVCs** and the source SwiftImage continues to be
+Filesystem; the Copy Job's source mount is unchanged. This is the
+default assumption.
+
+But: should `SwiftImage.spec.storage` exist as a peer to
+`SwiftGuestClass.spec.storage`, allowing operators to import SwiftImages
+directly to Block-mode PVCs? Argument for: avoids a Filesystem→Block
+data hop on every clone. Argument against: scope creep; SwiftImage
+import semantics are independent of guest runtime semantics. **Default:
+defer SwiftImage.spec.storage to a future PR; W9 leaves the import
+pipeline on Filesystem.** Document the assumption in the W9 PR
+description so future operators know the import-class is fixed.
+
+### (b) Cloud-init `growpart` on Block-mode root disk inside the guest
+
+Cloud-init's `cloud-init-growpart` runs on first boot and extends the
+last partition to fill the disk, then runs `resize2fs`/`xfs_growfs` on
+the filesystem inside that partition. The disk is presented to the
+guest as `/dev/vda` regardless of host-side volumeMode (the host's
+Block vs Filesystem decision is invisible to the guest). The guest's
+view of `/dev/vda` is the same raw device either way.
+
+Expected: growpart works identically on Block-host-volumeMode guests as
+on Filesystem-host-volumeMode guests, because the host-side mode never
+crosses the virtio-blk boundary. The W9 PR must verify this empirically
+on the cluster — a successful boot of an Ubuntu Noble guest on
+RWX+Block must show `df` reporting the full 40 GiB after
+`cloud-init-growpart` runs. If empirical reality differs (e.g.
+Longhorn's Block-mode causes virtio-blk to surface a different
+geometry), document the deviation and decide whether to ship a
+workaround.
+
+### (c) `qemu-img resize` + `sgdisk -e` against Block targets
+
+`qemu-img resize` on a block device is a **no-op** — block devices have
+their size fixed at provision time by the storage layer. This is fine
+for Block-mode clones because the destination PVC is created at the
+SwiftGuestClass `rootDisk.size` directly (vs the Filesystem path where
+the destination PVC starts at the source-image size and is qemu-img
+resized to grow the file inside it).
+
+`sgdisk -e` rewrites the GPT backup header at the device's last sector.
+This works on block devices natively — sgdisk operates byte-level
+through the block device's standard read/write interface. Verify on
+the cluster.
+
+The W9 PR's clone Job script for Block:
+
+```
+qemu-img convert -f raw -O raw /src/image.raw /dev/dst-block
+sgdisk -e /dev/dst-block
+sync
+```
+
+vs the existing Filesystem script (preserved):
+
+```
+cp /src/image.raw /dst/image.raw
+qemu-img resize -f raw /dst/image.raw <size>
+sgdisk -e /dst/image.raw
+sync
+```
+
+The Block script is shorter — no resize step, no `cp` (qemu-img convert
+handles the bulk transfer atomically and supports sparse-aware writes).
+
+## Out of scope
+
+- **Other CSI drivers' Block support.** The storage architecture review
+  PR #32 deferred to picks up Ceph RBD, AWS EBS, etc. W9 validates on
+  Longhorn Migratable; other drivers' Block mode follows.
+- **F2 split-brain mitigation on RWX.** Cloud Hypervisor's
+  concurrent-write coordination behaviour on RWX disks is its own
+  design problem; W9 lands the Block runtime path independent of
+  whether the storage layer prevents split-brain. Phase 3 live
+  migration's StopAndCopy phase is where F2 mitigation lives.
+- **SwiftImage.spec.storage** for direct Block imports (see Open
+  question (a)).
+- **Snapshot path Block support.** PR #32 didn't validate the
+  cloneStrategy=snapshot path against Block destinations; the snapshot
+  path uses CSI dataSource + clone-grow-init. CSI dataSource probably
+  handles volumeMode transparently (it's a property of the destination
+  PVC's spec, not the dataSource). Verify in W9 testing; if it works,
+  document; if it doesn't, surface as W9.x.
+
+## Test plan
+
+**Unit tests:**
+
+- Block branch of `createCloneJob` produces correct VolumeDevices +
+  script (no `cp`, qemu-img convert + sgdisk -e + sync).
+- Filesystem branch unchanged (regression check).
+- Launcher pod builder produces VolumeDevices for Block storage and
+  VolumeMounts for Filesystem.
+
+**Integration tests on cluster (the missing-by-construction test from
+W5/W7/W8):**
+
+- Apply RWX+Block SwiftGuestClass + SwiftGuest on `longhorn-migratable`.
+- Verify `Phase=Running`, `status.network.primaryIP` populated.
+- `swiftctl console` shows login prompt.
+- Inside guest: `df -h /` reports ~40 GiB (cloud-init-growpart success).
+- Restart launcher pod; verify sentinel file in guest survives.
+- Apply RWO+Filesystem SwiftGuest in the same namespace; verify it
+  reaches Running unchanged (no Block-path regression on the default
+  configuration).
+
+**Test infrastructure:**
+
+This is the right place to land the operator-flow validation pattern
+from Tracked Follow-up #2. The test harness should run on a real
+cluster (k0s + Longhorn or equivalent), not a fake client. PR #22's
+e2e-on-cluster.yaml workflow is the right scaffolding; add a
+`test/storage/rwx-block-runtime.sh` that runs the steps above on
+path-touch trigger for `internal/controller/swiftguest/**`,
+`rust/swiftletd/**`, and `rust/swift-ch-client/**`.
+
+## References
+
+- PR #32 design doc: `docs/design/storage-access-mode.md`
+- PR #32 walkthrough findings: `kubeswift_context.md` § "PR #32
+  walkthrough findings (post-merge cluster validation)"
+- W7 (cached-client RBAC, same-shape lesson as W8): `kubeswift_context.md`
+  § "Phase 2 walkthrough resumption"
+- KubeVirt's Block-mode root disks (reference architecture): KubeVirt
+  uses `volumeMode: Block` for live-migratable VMIs by default and
+  passes the device through libvirt to QEMU as a raw disk
+- Longhorn Migratable RWX: requires `parameters.migratable: "true"` on
+  the StorageClass; volumeMode must be Block (see PR #32
+  `swiftguestclass-rwx-migratable.yaml` sample)

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -520,6 +520,48 @@ Pattern decision validated: do mini-walkthroughs between phases for live migrati
 
 What happens when SwiftImage's source PVC is deleted while a snapshot of it has bound clones. Deferred from Phase 0 spike for cluster safety. Phase 2 e2e covered some of this but not all. Should validate before Phase 3.
 
+### 6. Storage RWX+Block runtime path (W9 — follow-up to PR #32)
+
+PR #32 shipped the API-surface unblock for storage access mode selection.
+The post-merge cluster walkthrough confirmed every API-surface path is
+working (resolution, status echo, StorageReady condition, CRD admission)
+and surfaced W9: the runtime path doesn't yet support `volumeMode: Block`
+destinations.
+
+Three components need updates, plus three open scoping questions the
+walkthrough did not exercise. Detail in
+[`docs/design/storage-rwx-block-runtime.md`](docs/design/storage-rwx-block-runtime.md).
+
+Components:
+- Copy Job (`internal/controller/swiftguest/rootdisk.go::createCloneJob`):
+  use `volumeDevices` + raw-device write (`dd`/`qemu-img convert` to
+  `/dev/dst-block`) for Block destinations
+- Launcher pod builder
+  (`internal/controller/swiftguest/pod.go`): switch root-disk volume to
+  `volumeDevices` for Block destinations; pass the device path via
+  RuntimeIntent
+- swiftletd (Rust): accept block device path in
+  `runtimeintent::DiskIntent` and pass as `--disk path=/dev/...` to
+  Cloud Hypervisor
+
+Open scoping questions (must be answered as part of W9, not blockers):
+(a) does the qcow2→raw SwiftImage import pipeline work against
+Block-mode destination PVCs (`qemu-img convert -O raw` to `/dev/...`
+inside the import Job)?
+(b) does cloud-init `growpart` work on a Block-mode root disk inside the
+guest, or does the Block path produce a partition that cloud-init's
+filesystem-resize step can't extend?
+(c) does the existing `qemu-img resize` + `sgdisk -e` GPT-fix step work
+against Block targets, or does Block change the resize/sgdisk semantics
+(qemu-img resize on a block device is typically a no-op since size is
+fixed at provision time; sgdisk -e operates byte-level so should still
+work)?
+
+This is not a PR #32 regression. Same shape as Phase 1 → Phase 2 → PR
+#32: each shipped layer reveals what the next needs. The W5 pattern
+(spike scenarios under-constrain the design) restated yet again — this
+time at the API/runtime boundary.
+
 ---
 
 ## Phase 2 Decisions Resolved (live migration)
@@ -596,6 +638,70 @@ What it did NOT validate (blocked on W6):
 
 Pre-migration sentinel md5 captured anyway for any future re-run on this same source pod: `88d94a051ea2db180606535a4125784d` (sentinel `SPIKE-PHASE2-WT-1777503996`, written via serial console).
 
+### PR #32 walkthrough findings (post-merge cluster validation)
+
+After PR #32 (storage access mode CRD) merged + redeployed, the cluster
+validation exercise in `default` namespace surfaced two findings (W8, W9).
+The framing applies the now-recurring pattern: **each shipped layer reveals
+what the next layer needs**. Phase 1 (offline migration) revealed Phase 2's
+need (live migration plumbing). Phase 2 walkthrough revealed PR #32's need
+(API surface for storage access mode). PR #32 walkthrough now reveals W9
+(runtime-path support for Block volumeMode). W9 is **not a PR #32
+regression** — PR #32's stated scope was the API-surface unblock, and
+every piece of that surface is validated. W9 is the next phase the
+unblock makes addressable.
+
+- **W8 — controller-runtime cached client requires `list,watch` on
+  StorageClass.** PR #32's `checkStorageReady()` calls `r.Get` on
+  StorageClass to verify the Longhorn migratable parameter. Same shape as
+  W7 (rolebindings) and Phase 2 walkthrough W3 (RBAC gap): adding a
+  cached-client `r.Get` on a new resource type without granting
+  `list,watch` starves the reconcile queue ("Failed to watch
+  *v1.StorageClass" loop, no SwiftGuest reconciles fire). Unit tests
+  passed because fake-client doesn't use informers. **Fixed in commit
+  `8f5265e` on the PR #32 branch:** verbs extended to `get, list, watch`
+  in both `config/manager/controller-manager-rbac.yaml` and the Helm
+  chart. **Recurring lesson** (W7 + W8 are the same lesson): when adding
+  a `r.Get` on a new resource type from inside the controller-runtime
+  cached client, grant `list,watch` alongside `get`. Adds further weight
+  to Tracked Follow-up #2 (operator-flow validation pattern in test
+  infrastructure) — fake-client tests verify control-flow but not RBAC
+  sufficiency.
+
+- **W9 — runtime-path gap: Copy Job + launcher pod + swiftletd do not
+  yet support `volumeMode: Block` destinations.** With PR #32 shipped,
+  applying a SwiftGuest with `spec.storage.{accessMode: ReadWriteMany,
+  volumeMode: Block, storageClassName: longhorn-migratable}` resolves
+  correctly, populates `status.storage`, surfaces `StorageReady=True`,
+  and creates the per-guest clone PVC bound at 40Gi RWX on the migratable
+  Longhorn class. The gap surfaces **at the rootdisk Copy Job step**:
+  kubelet refuses with `volume dst has volumeMode Block, but is specified
+  in volumeMounts`. The Copy Job in
+  `internal/controller/swiftguest/rootdisk.go::createCloneJob` mounts the
+  destination as a filesystem path (`volumeMounts: /dst`) and runs
+  `cp /src/image.raw /dst/image.raw` — which only works on Filesystem-mode
+  PVCs. Block-mode PVCs need `volumeDevices` + raw-device write
+  (`dd`/`qemu-img convert` to `/dev/dst-block`). The launcher pod and
+  swiftletd have the analogous gap further along the path: both currently
+  mount the root PVC as a filesystem path and pass `--disk
+  path=/var/lib/.../image.raw` to Cloud Hypervisor; for Block they would
+  need `volumeDevices` and `--disk path=/dev/...`. **Disposition: defer
+  to a follow-up PR** scoped as "Storage RWX+Block runtime path."
+  Detail and scoping questions in
+  [`docs/design/storage-rwx-block-runtime.md`](docs/design/storage-rwx-block-runtime.md).
+  PR #32 ships and is complete on its API-surface scope; the runtime-path
+  follow-up uses the same surface.
+
+W8 + W9 are the **fourth and fifth** post-hoc walkthroughs in 9 days to
+surface a finding the spike-and-tests cycle did not catch (after snapshot
+F2, Phase 2 W3, Phase 2 W6). The W5 pattern continues to restate itself:
+unit tests with fake clients verify control-flow shape but not RBAC
+sufficiency or kubelet-mount-side semantics; spike scenarios validate
+simplified inputs and miss the operator's full-feature target shape. This
+is now durable signal for Tracked Follow-up #2 — the operator-flow
+validation pattern needs to land as part of the test infrastructure, not
+as the next phase's after-the-fact discovery.
+
 ---
 
 ## Bugs Fixed (Recent — Snapshot and Migration Phases)
@@ -613,6 +719,7 @@ Pre-migration sentinel md5 captured anyway for any future re-run on this same so
 | 59 | swiftguest/rbac.go (new) | swiftletd RBAC was per-namespace Role + manually-applied RoleBinding; silently broke IP discovery in non-default namespaces. Promoted to ClusterRole + controller-driven auto-bind. (Re-surface of snapshot walkthrough F2; W3 in Phase 2 walkthrough.) | PR #30 |
 | 60 | rust/swiftletd/src/lease.rs | Lease poller `return`-ed unconditionally after first patch attempt; transient 403 (W3 RBAC gap) killed the poller permanently. Only `return` on patch success now; retry on transient errors. (W4 in Phase 2 walkthrough.) | PR #30 |
 | 61 | api/swift/v1alpha1 + controller + webhook | Storage access mode CRD: SwiftGuestClass.spec.storage and SwiftGuest.spec.storage select accessMode/volumeMode/storageClassName for controller-created PVCs. CRD admission rejects RWX+Filesystem (Filesystem RWX is not live-migration-capable). SwiftMigration webhook gains forward-compat live-mode storage gate (recompute from spec, NOT read status — write-back-race avoidance). Defaults preserve current behaviour (RWO+Filesystem). Resolves W6 design contradiction at the API surface; storage architecture review owns the deeper questions (CSI driver matrix, F2 split-brain on RWX). | PR #32 |
+| 62 | rbac (controller-manager ClusterRole) | StorageClass `list,watch` verbs missing — controller-runtime's cached client opens an informer on every GETable resource; PR #32's `checkStorageReady`'s `r.Get` on StorageClass triggered "Failed to watch" loop, starving SwiftGuest reconcile queue. Fake-client unit tests passed (no informer). Same shape as W7 (rolebindings). (W8 in PR #32 walkthrough.) | PR #32 |
 
 ---
 
@@ -668,17 +775,29 @@ See dedicated section above. Three PRs: #24 initial implementation, #25 terminal
 
 Phase 2 deliverable surface complete: operators can manually demonstrate cross-node CH live migration via `make migration-phase2-manual SWIFTGUEST=<name> TARGET_NODE=<node>`. No controller integration (Phase 3); no mTLS (Phase 3); no drain integration (Phase 4).
 
-**2. Live Migration Phase 3 — live mode + mTLS**
+**2. Storage RWX+Block runtime path (W9 follow-up to PR #32)**
+- Copy Job in `rootdisk.go` uses `volumeDevices` + `dd`/`qemu-img convert` for Block destinations
+- Launcher pod builder mounts root PVC as block device when resolved
+  storage is `volumeMode: Block`; RuntimeIntent carries device path
+- swiftletd accepts block device path and passes `--disk path=/dev/...` to CH
+- Verify (a) import pipeline against Block PVCs, (b) cloud-init growpart on
+  Block root disks, (c) qemu-img resize + sgdisk -e against Block targets
+- Detail: `docs/design/storage-rwx-block-runtime.md`
+- Unblocks Phase 3 live migration on RWX+Block guests (KubeVirt-model storage)
+- Same-shape pattern as the API-surface unblock that revealed it: each
+  shipped layer surfaces the next layer's gap. NOT a PR #32 regression.
+
+**3. Live Migration Phase 3 — live mode + mTLS**
 - SwiftMigration controller gains live mode
 - mTLS sidecar for migration channel
 - Pre-copy convergence handling
 
-**3. Live Migration Phase 4 — drain integration via eviction webhook**
+**4. Live Migration Phase 4 — drain integration via eviction webhook**
 - `kubectl drain` triggers migration automatically
 - Independent value: drain integration with offline migration alone dramatically improves operator UX
 - Could jump sequence if operator demand for safe drain dominates
 
-**4. Live Migration Phase 5 — operational polish**
+**5. Live Migration Phase 5 — operational polish**
 - Prometheus metrics, dashboards, retention
 
 ### Snapshot Roadmap Continuation (deferred behind live migration)


### PR DESCRIPTION
## Summary

Documents the **runtime-path gap surfaced by the post-merge cluster walkthrough of PR #32**, frames it as the next layer in the project's recurring pattern (each shipped layer reveals what the next needs), and ships an implementer scoping doc the W9 follow-up PR can pick up day one.

W9 is **not a PR #32 regression**. PR #32's stated scope was the API-surface unblock — every piece of that surface is validated end-to-end on the cluster (CRD admission, per-field merge, status echo, StorageReady condition, RBAC, PVC creation). W9 is the runtime path the unblock makes addressable.

## Pattern this fits

| Layer | Reveals next layer's gap |
|---|---|
| Phase 1 offline migration | Phase 2's swiftletd plumbing |
| Phase 2 walkthrough | PR #32 (storage access mode API surface) |
| **PR #32 walkthrough** | **W9 (Block volumeMode end-to-end runtime)** |

Same shape as W5/W7/W8: spike scenarios validate simplified inputs and miss the operator's full-feature target shape; fake-client unit tests verify control-flow but not real-cluster runtime semantics. This is now durable signal for Tracked Follow-up #2 (operator-flow validation pattern in test infrastructure).

## What this PR ships

- **`docs/design/storage-rwx-block-runtime.md`** (new) — implementer scoping doc with:
  - Goal + acceptance criteria
  - Three-component scope (Copy Job, launcher pod builder, swiftletd) with code-level notes
  - Three open scoping questions (a/b/c) the walkthrough did not exercise — must be answered as part of W9, not blockers
  - Out of scope explicit list (other CSI drivers, F2 split-brain, SwiftImage.spec.storage)
  - Test plan including the operator-flow integration tests that should land alongside

- **`kubeswift_context.md`** updates:
  - New "PR #32 walkthrough findings (post-merge cluster validation)" subsection logging W8 (storageclasses RBAC — fixed inline in PR #32) and W9 (deferred follow-up)
  - W8 row in bug-fix table
  - Tracked Follow-up #6: Storage RWX+Block runtime path with three-component scope + scoping questions inline
  - Next Priorities reordered: PR #32 done → W9 → Live Migration Phase 3 (which depends on RWX+Block runtime for KubeVirt-style live migration)

## What was validated on cluster (drives the framing)

| | Result |
|---|---|
| CRD admission accepts RWX+Block | ✓ |
| Per-field merge of class + guest spec.storage | ✓ |
| `status.storage` echo (RWX, Block, longhorn-migratable) | ✓ |
| `StorageReady=True` (Longhorn migratable=true class) | ✓ |
| `StorageReady=False / LonghornNotMigratable` (missing param) | ✓ with operator-actionable remedy |
| Per-guest clone PVC bound RWX/Block on longhorn-migratable | ✓ |
| W8 RBAC (StorageClass list,watch) shipped | ✓ commit `8f5265e` |
| Clone Job runs against Block destination | ❌ W9 |

The W9 surface point: kubelet refuses the Copy Job's destination mount with `volume dst has volumeMode Block, but is specified in volumeMounts`. The Copy Job uses `volumeMounts` + `cp`, which only works on Filesystem-mode PVCs.

## What this PR does NOT do

- Implement W9. That's the follow-up PR's job; this is the scoping doc.
- Modify any code, CRDs, samples, or charts. Documentation only.
- Reopen PR #32. PR #32 is complete on its scope.

## Test plan

- [x] `kubeswift_context.md` renders correctly in markdown preview
- [x] Cross-references resolve (storage-access-mode.md, storage-rwx-block-runtime.md)
- [x] Numbering of Tracked Follow-ups + Next Priorities is consistent
- [x] Reviewer confirms the framing is right ("runtime-path gap revealed by API-surface unblock," not regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)