### PR TITLE
feat(storage): Block volumeMode runtime path end-to-end (W9 follow-up to PR #32)

### DIFF
--- a/internal/controller/swiftguest/constants.go
+++ b/internal/controller/swiftguest/constants.go
@@ -40,6 +40,24 @@ const (
 	IntentFile    = "runtime-intent.json"
 	RunDirPath    = "/var/lib/kubeswift/run"
 
+	// DiskRootDevicePath is the in-pod device path for a Block-mode
+	// root disk (W9 — runtime path for spec.storage.volumeMode: Block).
+	// Cloud Hypervisor's --disk path=<value> opens this path opaquely;
+	// for Block-mode PVCs, the path resolves to a raw block device
+	// surfaced via VolumeDevices, not a filesystem-mounted file.
+	//
+	// Distinct from DisksRootPath (the Filesystem mount): the two are
+	// mutually exclusive on the same volume by Kubernetes contract
+	// (VolumeMounts and VolumeDevices cannot share a volume name —
+	// kubelet rejects with "volume X has volumeMode Block, but is
+	// specified in volumeMounts", which was the W9 surface point).
+	//
+	// Brand prefix is deliberate: /dev/kubeswift-root is unambiguous
+	// in pod logs, swiftletd diagnostics, and CH --disk arg dumps. We
+	// avoid /dev/vda* / /dev/sd* (kernel-managed virtio/SCSI) and
+	// /dev/disk/by-* (udev-reserved-feeling) per architect Q3 review.
+	DiskRootDevicePath = "/dev/kubeswift-root"
+
 	// SnapshotsHostPath is the on-node directory Cloud Hypervisor writes
 	// Tier B snapshot directories into (config.json, state.json, memory-
 	// ranges) when the SwiftSnapshot controller drives a vm.snapshot

--- a/internal/controller/swiftguest/gpu.go
+++ b/internal/controller/swiftguest/gpu.go
@@ -423,7 +423,8 @@ func BuildGPUDiskBootPod(
 
 	// Standard launcher mounts.
 	var mounts []corev1.VolumeMount
-	AddVolumeMounts(&mounts, rg.HasSeed())
+	var volumeDevices []corev1.VolumeDevice
+	AddVolumeMounts(&mounts, &volumeDevices, rg, rg.HasSeed())
 	mounts = append(mounts, corev1.VolumeMount{Name: "dev-vfio", MountPath: "/dev/vfio"})
 	if hugepages != "" {
 		mounts = append(mounts, corev1.VolumeMount{Name: "hugepages", MountPath: "/dev/hugepages"})
@@ -465,7 +466,7 @@ func BuildGPUDiskBootPod(
 
 	var initContainers []corev1.Container
 	if rootDiskClone != nil && rootDiskClone.NeedsGrowInit {
-		initContainers = append(initContainers, cloneGrowInitContainer(rootDiskClone.TargetSizeBytes))
+		initContainers = append(initContainers, cloneGrowInitContainer(rg, rootDiskClone.TargetSizeBytes))
 	}
 	initContainers = append(initContainers, gpuInitContainer)
 	if rg.HasNetwork() {
@@ -526,8 +527,9 @@ func BuildGPUDiskBootPod(
 							},
 						},
 					},
-					Resources:    resources,
-					VolumeMounts: mounts,
+					Resources:     resources,
+					VolumeMounts:  mounts,
+					VolumeDevices: volumeDevices,
 				},
 			},
 			Volumes: volumes,

--- a/internal/controller/swiftguest/pod.go
+++ b/internal/controller/swiftguest/pod.go
@@ -303,7 +303,8 @@ func buildDiskBootPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGues
 	}
 
 	var mounts []corev1.VolumeMount
-	AddVolumeMounts(&mounts, rg.HasSeed())
+	var volumeDevices []corev1.VolumeDevice
+	AddVolumeMounts(&mounts, &volumeDevices, rg, rg.HasSeed())
 	if rg.HasDataDisk() {
 		mounts = append(mounts, corev1.VolumeMount{Name: "data-disk", MountPath: DisksDataPath})
 	}
@@ -327,7 +328,7 @@ func buildDiskBootPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGues
 
 	var initContainers []corev1.Container
 	if rootDiskClone != nil && rootDiskClone.NeedsGrowInit {
-		initContainers = append(initContainers, cloneGrowInitContainer(rootDiskClone.TargetSizeBytes))
+		initContainers = append(initContainers, cloneGrowInitContainer(rg, rootDiskClone.TargetSizeBytes))
 	}
 	if rg.HasNetwork() {
 		initContainers = append(initContainers, networkInitContainer())
@@ -377,8 +378,9 @@ func buildDiskBootPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGues
 							},
 						},
 					},
-					Resources:    resources,
-					VolumeMounts: mounts,
+					Resources:     resources,
+					VolumeMounts:  mounts,
+					VolumeDevices: volumeDevices,
 				},
 			},
 			Volumes: volumes,
@@ -394,13 +396,51 @@ func VolumeMountPaths() (imagePath, seedPath, intentDir string) {
 	return DisksRootPath, SeedPath, IntentPath
 }
 
-// AddVolumeMounts adds the standard volume mounts to a container.
-// Caller must ensure volumes exist for image, seed (if present), intent, and dev-kvm.
-func AddVolumeMounts(mounts *[]corev1.VolumeMount, hasSeed bool) {
-	imagePath, seedPath, intentDir := VolumeMountPaths()
+// rootDiskMount returns the launcher-pod root-disk mount surface for
+// the resolved storage spec (W9 — runtime path for volumeMode: Block).
+// Filesystem mode returns a non-nil VolumeMount; Block mode returns a
+// non-nil VolumeDevice. Exactly one is non-nil. Callers append to the
+// appropriate list.
+//
+// The two are mutually exclusive on the same volume name by Kubernetes
+// contract — kubelet rejects with "volume X has volumeMode Block, but
+// is specified in volumeMounts" (the W9 surface point that triggered
+// this whole follow-up). Centralising the branch here means the four
+// call sites (launcher container in pod.go and gpu.go;
+// cloneGrowInitContainer; restore-receive launcher in restore.go)
+// share one source of truth.
+//
+// The same helper serves the launcher container, clone-grow-init, and
+// restore-receive launcher because all three use the same volume name
+// ("root-disk") and the same path constants — the architect (W9 Q1
+// review) confirmed a single helper covers the four call sites without
+// per-site differentiation.
+func rootDiskMount(rg *resolved.ResolvedGuest) (*corev1.VolumeMount, *corev1.VolumeDevice) {
+	if rg.Storage.VolumeMode == "Block" {
+		return nil, &corev1.VolumeDevice{Name: "root-disk", DevicePath: DiskRootDevicePath}
+	}
+	return &corev1.VolumeMount{Name: "root-disk", MountPath: DisksRootPath}, nil
+}
+
+// AddVolumeMounts adds the standard volume mounts (and, for Block-mode
+// guests, the root-disk volume device) to a container.
+//
+// Caller must ensure volumes exist for image, seed (if present),
+// intent, and dev-kvm. The W9 signature change adds the devices slice
+// and rg parameter so the helper can place the root-disk surface on
+// the correct list. Pre-W9 callers passed (mounts, hasSeed); W9
+// callers pass (mounts, devices, rg, hasSeed).
+func AddVolumeMounts(mounts *[]corev1.VolumeMount, devices *[]corev1.VolumeDevice, rg *resolved.ResolvedGuest, hasSeed bool) {
+	_, seedPath, intentDir := VolumeMountPaths()
 	*mounts = append(*mounts,
 		corev1.VolumeMount{Name: "run", MountPath: RunDirPath},
-		corev1.VolumeMount{Name: "root-disk", MountPath: imagePath},
+	)
+	if mount, device := rootDiskMount(rg); mount != nil {
+		*mounts = append(*mounts, *mount)
+	} else if device != nil && devices != nil {
+		*devices = append(*devices, *device)
+	}
+	*mounts = append(*mounts,
 		corev1.VolumeMount{Name: "runtime-intent", MountPath: intentDir},
 		corev1.VolumeMount{Name: "dev-kvm", MountPath: "/dev/kvm"},
 	)

--- a/internal/controller/swiftguest/pod_block_test.go
+++ b/internal/controller/swiftguest/pod_block_test.go
@@ -1,0 +1,396 @@
+package swiftguest
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/resolved"
+	"github.com/projectbeskar/kubeswift/internal/runtimeintent"
+)
+
+// W9 Component 2 tests for the launcher pod builder + clone-grow-init
+// Block path. Coverage:
+//
+//  1. rootDiskMount helper: Filesystem returns VolumeMount only, Block
+//     returns VolumeDevice only. Centralised source of truth.
+//  2. AddVolumeMounts: branches root-disk on rg.Storage.VolumeMode;
+//     other volumes (run, runtime-intent, dev-kvm, seed) unchanged.
+//  3. cloneGrowInitContainer: Filesystem byte-identical script + mount,
+//     Block uses VolumeDevices + sgdisk-only script (no qemu-img resize).
+//  4. BuildPod end-to-end: Block guest produces a launcher container
+//     with VolumeDevices for root-disk and no /var/lib/kubeswift/disks/root
+//     filesystem mount for that volume.
+//  5. Mixed Block-root + Filesystem-data (architect Q4): launcher
+//     container has both VolumeDevices + VolumeMounts with no overlap.
+//  6. Constant agreement: controller-side and runtimeintent-side
+//     DiskRootDevicePath constants must be byte-identical (cross-package
+//     contract; the two packages can't share constants without a cycle).
+
+func TestRootDiskMount_FilesystemReturnsVolumeMountOnly(t *testing.T) {
+	rg := &resolved.ResolvedGuest{Storage: resolved.Storage{VolumeMode: "Filesystem"}}
+	mount, device := rootDiskMount(rg)
+	if mount == nil {
+		t.Fatal("Filesystem mode should return non-nil VolumeMount")
+	}
+	if device != nil {
+		t.Errorf("Filesystem mode should return nil VolumeDevice; got %+v", device)
+	}
+	if mount.Name != "root-disk" || mount.MountPath != DisksRootPath {
+		t.Errorf("VolumeMount = %+v, want {root-disk, %s}", mount, DisksRootPath)
+	}
+}
+
+func TestRootDiskMount_BlockReturnsVolumeDeviceOnly(t *testing.T) {
+	rg := &resolved.ResolvedGuest{Storage: resolved.Storage{VolumeMode: "Block"}}
+	mount, device := rootDiskMount(rg)
+	if mount != nil {
+		t.Errorf("Block mode should return nil VolumeMount; got %+v", mount)
+	}
+	if device == nil {
+		t.Fatal("Block mode should return non-nil VolumeDevice")
+	}
+	if device.Name != "root-disk" || device.DevicePath != DiskRootDevicePath {
+		t.Errorf("VolumeDevice = %+v, want {root-disk, %s}", device, DiskRootDevicePath)
+	}
+}
+
+func TestRootDiskMount_EmptyVolumeModeDefaultsToFilesystem(t *testing.T) {
+	// Pre-W9 SwiftGuests have no spec.storage; resolution defaults to
+	// Filesystem, but the resolved struct may pass through empty in
+	// edge cases (e.g. partial resolution during cluster restore).
+	// Treat empty as Filesystem to match the kubelet's default behaviour.
+	rg := &resolved.ResolvedGuest{Storage: resolved.Storage{}}
+	mount, device := rootDiskMount(rg)
+	if mount == nil || device != nil {
+		t.Errorf("empty VolumeMode should resolve to Filesystem (mount=%+v device=%+v)", mount, device)
+	}
+}
+
+// TestAddVolumeMounts_FilesystemUnchanged is the regression gate for
+// the launcher container's mount surface. Pre-W9 callers got 4 mounts
+// (run, root-disk, runtime-intent, dev-kvm) plus optionally seed, with
+// no VolumeDevices. The W9 signature changed but Filesystem-mode
+// callers must still get the same 4-or-5 mounts and zero VolumeDevices.
+func TestAddVolumeMounts_FilesystemUnchanged(t *testing.T) {
+	rg := &resolved.ResolvedGuest{Storage: resolved.Storage{VolumeMode: "Filesystem"}}
+
+	t.Run("no seed", func(t *testing.T) {
+		var mounts []corev1.VolumeMount
+		var devices []corev1.VolumeDevice
+		AddVolumeMounts(&mounts, &devices, rg, false)
+		assertMountNames(t, mounts, []string{"run", "root-disk", "runtime-intent", "dev-kvm"})
+		if len(devices) != 0 {
+			t.Errorf("Filesystem-mode AddVolumeMounts should produce zero VolumeDevices; got %v", devices)
+		}
+		// root-disk must mount at the filesystem path, not the device path.
+		for _, m := range mounts {
+			if m.Name == "root-disk" {
+				if m.MountPath != DisksRootPath {
+					t.Errorf("root-disk MountPath = %q, want %q", m.MountPath, DisksRootPath)
+				}
+				if m.MountPath == DiskRootDevicePath {
+					t.Errorf("root-disk Filesystem mount must NOT be the device path")
+				}
+			}
+		}
+	})
+
+	t.Run("with seed", func(t *testing.T) {
+		var mounts []corev1.VolumeMount
+		var devices []corev1.VolumeDevice
+		AddVolumeMounts(&mounts, &devices, rg, true)
+		assertMountNames(t, mounts, []string{"run", "root-disk", "runtime-intent", "dev-kvm", "seed"})
+		if len(devices) != 0 {
+			t.Errorf("Filesystem-mode AddVolumeMounts should produce zero VolumeDevices; got %v", devices)
+		}
+	})
+}
+
+// TestAddVolumeMounts_BlockUsesVolumeDevices is the forward contract.
+// Block destinations get root-disk on the VolumeDevices list (DevicePath
+// = /dev/kubeswift-root) and NOT on VolumeMounts. Other mounts (run,
+// runtime-intent, dev-kvm, seed) are unchanged.
+func TestAddVolumeMounts_BlockUsesVolumeDevices(t *testing.T) {
+	rg := &resolved.ResolvedGuest{Storage: resolved.Storage{VolumeMode: "Block"}}
+
+	t.Run("no seed", func(t *testing.T) {
+		var mounts []corev1.VolumeMount
+		var devices []corev1.VolumeDevice
+		AddVolumeMounts(&mounts, &devices, rg, false)
+		// root-disk is NOT in VolumeMounts.
+		assertMountNames(t, mounts, []string{"run", "runtime-intent", "dev-kvm"})
+		// root-disk IS in VolumeDevices.
+		if len(devices) != 1 {
+			t.Fatalf("VolumeDevices = %d, want 1 (root-disk)", len(devices))
+		}
+		if devices[0].Name != "root-disk" || devices[0].DevicePath != DiskRootDevicePath {
+			t.Errorf("VolumeDevice = %+v, want {root-disk, %s}", devices[0], DiskRootDevicePath)
+		}
+	})
+
+	t.Run("with seed", func(t *testing.T) {
+		var mounts []corev1.VolumeMount
+		var devices []corev1.VolumeDevice
+		AddVolumeMounts(&mounts, &devices, rg, true)
+		assertMountNames(t, mounts, []string{"run", "runtime-intent", "dev-kvm", "seed"})
+		if len(devices) != 1 {
+			t.Errorf("VolumeDevices = %d, want 1 (root-disk)", len(devices))
+		}
+	})
+}
+
+// TestCloneGrowInit_FilesystemUnchanged is the regression gate for the
+// clone-grow-init init container. Filesystem path is byte-identical to
+// pre-W9: qemu-img resize + sgdisk -e, with the volume mounted at the
+// filesystem path. No VolumeDevices.
+func TestCloneGrowInit_FilesystemUnchanged(t *testing.T) {
+	rg := &resolved.ResolvedGuest{Storage: resolved.Storage{VolumeMode: "Filesystem"}}
+	c := cloneGrowInitContainer(rg, 42949672960) // 40 GiB
+
+	if len(c.VolumeMounts) != 1 || c.VolumeMounts[0].Name != "root-disk" || c.VolumeMounts[0].MountPath != DisksRootPath {
+		t.Errorf("Filesystem clone-grow-init VolumeMounts = %+v, want [{root-disk, %s}]", c.VolumeMounts, DisksRootPath)
+	}
+	if len(c.VolumeDevices) != 0 {
+		t.Errorf("Filesystem clone-grow-init must have zero VolumeDevices; got %v", c.VolumeDevices)
+	}
+	script := strings.Join(c.Command, " ")
+	for _, want := range []string{"qemu-img resize -f raw " + DisksRootPath + "/image.raw", "sgdisk -e " + DisksRootPath + "/image.raw"} {
+		if !strings.Contains(script, want) {
+			t.Errorf("Filesystem clone-grow-init script missing %q; got:\n%s", want, script)
+		}
+	}
+	if strings.Contains(script, DiskRootDevicePath) {
+		t.Errorf("Filesystem clone-grow-init script must NOT reference %s; got:\n%s", DiskRootDevicePath, script)
+	}
+}
+
+// TestCloneGrowInit_BlockUsesVolumeDevicesAndSkipsResize is the forward
+// contract: Block-mode clone-grow-init uses VolumeDevices for root-disk,
+// runs sgdisk -e on the device path, and DOES NOT run qemu-img resize
+// (no-op on block devices, scoping doc decision (c)).
+func TestCloneGrowInit_BlockUsesVolumeDevicesAndSkipsResize(t *testing.T) {
+	rg := &resolved.ResolvedGuest{Storage: resolved.Storage{VolumeMode: "Block"}}
+	c := cloneGrowInitContainer(rg, 42949672960)
+
+	if len(c.VolumeMounts) != 0 {
+		t.Errorf("Block clone-grow-init must have zero VolumeMounts; got %v", c.VolumeMounts)
+	}
+	if len(c.VolumeDevices) != 1 || c.VolumeDevices[0].Name != "root-disk" || c.VolumeDevices[0].DevicePath != DiskRootDevicePath {
+		t.Errorf("Block clone-grow-init VolumeDevices = %+v, want [{root-disk, %s}]", c.VolumeDevices, DiskRootDevicePath)
+	}
+	script := strings.Join(c.Command, " ")
+	if !strings.Contains(script, "sgdisk -e "+DiskRootDevicePath) {
+		t.Errorf("Block clone-grow-init script must run sgdisk -e %s; got:\n%s", DiskRootDevicePath, script)
+	}
+	// qemu-img resize is a no-op on block devices and is skipped per
+	// scoping doc decision (c). If a future commit adds it back as a
+	// no-op, this test fails; reviewers should reject the change unless
+	// the no-op is justified.
+	if strings.Contains(script, "qemu-img resize") {
+		t.Errorf("Block clone-grow-init script must NOT include qemu-img resize (no-op on block devices); got:\n%s", script)
+	}
+}
+
+// TestBuildPod_BlockGuestUsesVolumeDevices is the end-to-end pod-spec
+// contract: a SwiftGuest with spec.storage.volumeMode=Block produces a
+// launcher pod whose launcher container has VolumeDevices[root-disk]
+// at /dev/kubeswift-root, and zero root-disk VolumeMounts. Kubelet
+// would otherwise refuse the pod with the W9 error message.
+func TestBuildPod_BlockGuestUsesVolumeDevices(t *testing.T) {
+	guest := newDiskBootGuest("block-vm")
+	rg := newDiskBootResolved("block-vm", "default", resolved.Storage{
+		AccessMode: "ReadWriteMany",
+		VolumeMode: "Block",
+	})
+	pod := BuildPod(guest, rg, "block-vm-seed", "block-vm-runtime-intent", nil)
+	launcher := pod.Spec.Containers[0]
+
+	for _, m := range launcher.VolumeMounts {
+		if m.Name == "root-disk" {
+			t.Errorf("Block-mode launcher must NOT have root-disk VolumeMount; got %+v", m)
+		}
+	}
+	foundDevice := false
+	for _, d := range launcher.VolumeDevices {
+		if d.Name == "root-disk" {
+			foundDevice = true
+			if d.DevicePath != DiskRootDevicePath {
+				t.Errorf("root-disk VolumeDevice DevicePath = %q, want %q", d.DevicePath, DiskRootDevicePath)
+			}
+		}
+	}
+	if !foundDevice {
+		t.Errorf("Block-mode launcher must have a root-disk VolumeDevice; got mounts=%v devices=%v", launcher.VolumeMounts, launcher.VolumeDevices)
+	}
+
+	// No-overlap invariant: same volume name appears at most once across
+	// mounts and devices for the launcher container. This is the
+	// kubelet-side contract that surfaced as W9.
+	assertNoVolumeNameOverlap(t, launcher)
+}
+
+// TestBuildPod_BlockRootWithFilesystemDataDisk locks in architect Q4:
+// a guest with Block-mode root + Filesystem-mode dataDisk produces a
+// launcher container with both VolumeDevices (root) and VolumeMounts
+// (data), no overlap. This is the cross-feature compose case the
+// architect specifically asked for a unit test on.
+func TestBuildPod_BlockRootWithFilesystemDataDisk(t *testing.T) {
+	guest := newDiskBootGuest("mixed-vm")
+	guest.Spec.DataDiskRef = &corev1.LocalObjectReference{Name: "data-img"}
+	rg := newDiskBootResolved("mixed-vm", "default", resolved.Storage{
+		AccessMode: "ReadWriteMany",
+		VolumeMode: "Block",
+	})
+	rg.DataDisk = &resolved.PreparedImage{Path: "/var/lib/kubeswift/disks/data/image.raw", PVCName: "data-pvc", Ready: true}
+	pod := BuildPod(guest, rg, "mixed-vm-seed", "mixed-vm-runtime-intent", nil)
+	launcher := pod.Spec.Containers[0]
+
+	// Root-disk on VolumeDevices.
+	hasRootDevice := false
+	for _, d := range launcher.VolumeDevices {
+		if d.Name == "root-disk" && d.DevicePath == DiskRootDevicePath {
+			hasRootDevice = true
+		}
+	}
+	if !hasRootDevice {
+		t.Errorf("expected root-disk VolumeDevice at %s; got %v", DiskRootDevicePath, launcher.VolumeDevices)
+	}
+
+	// Data-disk on VolumeMounts (Filesystem-mode dataDisk PVC, independent
+	// of root-disk volumeMode per PR #32 scope: spec.storage applies to
+	// controller-created PVCs only — DataDiskRefs are referenced PVCs
+	// with their own volumeMode set elsewhere).
+	hasDataMount := false
+	for _, m := range launcher.VolumeMounts {
+		if m.Name == "data-disk" && m.MountPath == DisksDataPath {
+			hasDataMount = true
+		}
+	}
+	if !hasDataMount {
+		t.Errorf("expected data-disk VolumeMount at %s; got %v", DisksDataPath, launcher.VolumeMounts)
+	}
+
+	assertNoVolumeNameOverlap(t, launcher)
+}
+
+// TestBuildPod_FilesystemGuestRegression confirms the default path is
+// byte-identical to pre-W9: launcher has VolumeMounts including
+// root-disk at the filesystem path, zero root-disk VolumeDevices.
+// Existing TestBuildPod_* tests in pod_test.go also exercise this; this
+// adds an explicit Block-vs-Filesystem A/B contrast.
+func TestBuildPod_FilesystemGuestRegression(t *testing.T) {
+	guest := newDiskBootGuest("fs-vm")
+	rg := newDiskBootResolved("fs-vm", "default", resolved.Storage{
+		AccessMode: "ReadWriteOnce",
+		VolumeMode: "Filesystem",
+	})
+	pod := BuildPod(guest, rg, "fs-vm-seed", "fs-vm-runtime-intent", nil)
+	launcher := pod.Spec.Containers[0]
+
+	hasRootMount := false
+	for _, m := range launcher.VolumeMounts {
+		if m.Name == "root-disk" && m.MountPath == DisksRootPath {
+			hasRootMount = true
+		}
+	}
+	if !hasRootMount {
+		t.Errorf("Filesystem-mode launcher must have root-disk VolumeMount at %s; got %v", DisksRootPath, launcher.VolumeMounts)
+	}
+	for _, d := range launcher.VolumeDevices {
+		if d.Name == "root-disk" {
+			t.Errorf("Filesystem-mode launcher must NOT have root-disk VolumeDevice; got %+v", d)
+		}
+	}
+	assertNoVolumeNameOverlap(t, launcher)
+}
+
+// TestDiskRootDevicePath_AgreesAcrossPackages locks in the cross-package
+// constant invariant. The runtimeintent package and the swiftguest
+// controller package each define DiskRootDevicePath because they
+// cannot import each other (controller imports runtimeintent, never
+// the other way around). Drift between the two is a runtime hazard:
+// the launcher pod would attach the device at one path while
+// swiftletd (which reads the runtimeintent constant via the JSON
+// payload's RootDisk.Path) tells CH to open it at the other.
+func TestDiskRootDevicePath_AgreesAcrossPackages(t *testing.T) {
+	if DiskRootDevicePath != runtimeintent.DiskRootDevicePath {
+		t.Errorf("DiskRootDevicePath drift: controller=%q runtimeintent=%q",
+			DiskRootDevicePath, runtimeintent.DiskRootDevicePath)
+	}
+}
+
+// --- helpers ---
+
+func newDiskBootGuest(name string) *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID("guest-uid-" + name),
+		},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef:      &corev1.LocalObjectReference{Name: "ubuntu"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "default"},
+		},
+	}
+}
+
+func newDiskBootResolved(name, namespace string, storage resolved.Storage) *resolved.ResolvedGuest {
+	return &resolved.ResolvedGuest{
+		Meta:      resolved.Meta{Name: name, Namespace: namespace, UID: types.UID("guest-uid-" + name)},
+		Resources: resolved.Resources{CPU: 2, Memory: 2048},
+		RootDisk:  resolved.RootDisk{Size: resource.MustParse("40Gi"), Format: "raw"},
+		PreparedImage: resolved.PreparedImage{
+			PVCName: "swiftguest-root-" + name,
+			Format:  "raw",
+			Size:    10737418240,
+			Ready:   true,
+		},
+		Lifecycle: resolved.Lifecycle{RunPolicy: "Running"},
+		Network:   true,
+		Storage:   storage,
+	}
+}
+
+func assertMountNames(t *testing.T, mounts []corev1.VolumeMount, want []string) {
+	t.Helper()
+	got := make([]string, 0, len(mounts))
+	for _, m := range mounts {
+		got = append(got, m.Name)
+	}
+	if !sameStringSlice(got, want) {
+		t.Errorf("mount names = %v, want %v", got, want)
+	}
+}
+
+func sameStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func assertNoVolumeNameOverlap(t *testing.T, c corev1.Container) {
+	t.Helper()
+	seen := map[string]string{}
+	for _, m := range c.VolumeMounts {
+		seen[m.Name] = "VolumeMount"
+	}
+	for _, d := range c.VolumeDevices {
+		if existing, ok := seen[d.Name]; ok {
+			t.Errorf("volume %q appears as %s and VolumeDevice — kubelet rejects this", d.Name, existing)
+		}
+		seen[d.Name] = "VolumeDevice"
+	}
+}

--- a/internal/controller/swiftguest/restore.go
+++ b/internal/controller/swiftguest/restore.go
@@ -282,12 +282,24 @@ func BuildRestorePod(
 		AddSeedVolume(&volumes, seedConfigMapName)
 	}
 
+	// W9 — root-disk surface depends on resolved storage volumeMode. The
+	// restore-receive launcher pod has the same kubelet contract as the
+	// regular launcher: VolumeMounts and VolumeDevices cannot share a
+	// volume name. Channel through rootDiskMount so the same source-of-
+	// truth covers all five call sites.
 	mounts := []corev1.VolumeMount{
 		{Name: "run", MountPath: RunDirPath},
-		{Name: "root-disk", MountPath: DisksRootPath},
-		{Name: "runtime-intent", MountPath: IntentPath},
-		{Name: "dev-kvm", MountPath: "/dev/kvm"},
 	}
+	var volumeDevices []corev1.VolumeDevice
+	if mount, device := rootDiskMount(rg); mount != nil {
+		mounts = append(mounts, *mount)
+	} else if device != nil {
+		volumeDevices = append(volumeDevices, *device)
+	}
+	mounts = append(mounts,
+		corev1.VolumeMount{Name: "runtime-intent", MountPath: IntentPath},
+		corev1.VolumeMount{Name: "dev-kvm", MountPath: "/dev/kvm"},
+	)
 	if rg.HasSeed() && seedConfigMapName != "" {
 		mounts = append(mounts, corev1.VolumeMount{Name: "seed", MountPath: SeedPath})
 	}
@@ -368,8 +380,9 @@ func BuildRestorePod(
 							},
 						},
 					},
-					Resources:    resources,
-					VolumeMounts: mounts,
+					Resources:     resources,
+					VolumeMounts:  mounts,
+					VolumeDevices: volumeDevices,
 				},
 			},
 			Volumes: volumes,

--- a/internal/controller/swiftguest/rootdisk.go
+++ b/internal/controller/swiftguest/rootdisk.go
@@ -187,7 +187,7 @@ func (r *SwiftGuestReconciler) ensureRootDiskCloneFromCopy(
 			}
 			return nil, fmt.Errorf("clone Job %s in progress", jobName)
 		}
-		if err := r.createCloneJob(ctx, guest, jobName, sourcePVC, cloneName, targetSize); err != nil {
+		if err := r.createCloneJob(ctx, guest, rg, jobName, sourcePVC, cloneName, targetSize); err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf("clone Job %s created, waiting for completion", jobName)
@@ -380,22 +380,89 @@ func (r *SwiftGuestReconciler) ensureRootDiskCloneFromSnapshot(
 	}, nil
 }
 
+// CloneJobBlockDevicePath is the in-Job device path for a Block-mode
+// destination PVC. Only meaningful inside the Copy Job's pod namespace —
+// the launcher pod uses its own constant (DiskRootDevicePath in pod.go).
+// The two are deliberately distinct: Copy Job device naming is internal
+// to a one-shot Job and need not align with the launcher's branding.
+const CloneJobBlockDevicePath = "/dev/dst-block"
+
+// createCloneJob creates the per-guest root-disk Copy Job. Branches on
+// the resolved storage volumeMode (PR #32 surface):
+//
+//   - Filesystem (default): byte-identical to pre-W9 behaviour. Mounts
+//     the destination PVC as a filesystem path and runs
+//     `cp + qemu-img resize + sgdisk -e + sync`.
+//   - Block: mounts the destination PVC via VolumeDevices as a raw block
+//     device and runs `qemu-img convert + sgdisk -e + sync`. No
+//     `qemu-img resize` (no-op on block devices: size is fixed at PVC
+//     provision time by the storage layer; including it as a no-op
+//     invites future confusion). No `cp` (cp can't write to a raw
+//     device; qemu-img convert handles the bulk transfer atomically and
+//     supports sparse-aware writes).
+//
+// The source PVC mount is unchanged (read-only filesystem mount) for
+// both branches — SwiftImage import PVCs stay on Filesystem per W9
+// scoping question (a)'s default. SwiftImage.spec.storage for direct
+// Block imports is deferred.
 func (r *SwiftGuestReconciler) createCloneJob(
 	ctx context.Context,
 	guest *swiftv1alpha1.SwiftGuest,
+	rg *resolved.ResolvedGuest,
 	jobName, sourcePVC, clonePVC string,
 	targetSize resource.Quantity,
 ) error {
 	targetBytes := targetSize.Value()
+	isBlock := rg.Storage.VolumeMode == "Block"
 
-	script := fmt.Sprintf(`set -e
+	var script string
+	var volumeMounts []corev1.VolumeMount
+	var volumeDevices []corev1.VolumeDevice
+
+	if isBlock {
+		// Block destination. qemu-img convert writes the raw image to
+		// the block device atomically. sgdisk -e operates byte-level
+		// through the block device's standard read/write interface,
+		// which works natively on block devices (W9 scoping question
+		// (c) — verified on cluster). No qemu-img resize: block devices
+		// are pre-sized at the PVC's requested capacity by the storage
+		// layer, so resize would be a no-op and including it would
+		// invite future confusion about whether the resize step was
+		// load-bearing.
+		script = fmt.Sprintf(`set -e
+echo "Cloning root disk from %s to %s (%d bytes, Block mode -> %s)"
+apt-get update -qq && apt-get install -y -qq qemu-utils gdisk >/dev/null 2>&1
+qemu-img convert -f raw -O raw /src/image.raw %s
+sgdisk -e %s
+sync
+echo "Clone complete (Block mode)"`,
+			sourcePVC, clonePVC, targetBytes, CloneJobBlockDevicePath,
+			CloneJobBlockDevicePath, CloneJobBlockDevicePath)
+		volumeMounts = []corev1.VolumeMount{
+			{Name: "src", MountPath: "/src", ReadOnly: true},
+		}
+		volumeDevices = []corev1.VolumeDevice{
+			{Name: "dst", DevicePath: CloneJobBlockDevicePath},
+		}
+	} else {
+		// Filesystem destination — byte-identical to pre-W9 behaviour.
+		// Reviewers: this branch is the regression contract; any change
+		// that alters the rendered Job for Filesystem-mode guests is a
+		// regression and the smoke test will catch it.
+		script = fmt.Sprintf(`set -e
 echo "Cloning root disk from %s to %s (%d bytes)"
 cp /src/image.raw /dst/image.raw
 apt-get update -qq && apt-get install -y -qq qemu-utils gdisk >/dev/null 2>&1
 qemu-img resize -f raw /dst/image.raw %d
 sgdisk -e /dst/image.raw
 sync
-echo "Clone complete: $(stat -c %%s /dst/image.raw) bytes"`, sourcePVC, clonePVC, targetBytes, targetBytes)
+echo "Clone complete: $(stat -c %%s /dst/image.raw) bytes"`,
+			sourcePVC, clonePVC, targetBytes, targetBytes)
+		volumeMounts = []corev1.VolumeMount{
+			{Name: "src", MountPath: "/src", ReadOnly: true},
+			{Name: "dst", MountPath: "/dst"},
+		}
+	}
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -415,13 +482,11 @@ echo "Clone complete: $(stat -c %%s /dst/image.raw) bytes"`, sourcePVC, clonePVC
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,
 					Containers: []corev1.Container{{
-						Name:    "clone",
-						Image:   CloneJobImage,
-						Command: []string{"/bin/sh", "-c", script},
-						VolumeMounts: []corev1.VolumeMount{
-							{Name: "src", MountPath: "/src", ReadOnly: true},
-							{Name: "dst", MountPath: "/dst"},
-						},
+						Name:          "clone",
+						Image:         CloneJobImage,
+						Command:       []string{"/bin/sh", "-c", script},
+						VolumeMounts:  volumeMounts,
+						VolumeDevices: volumeDevices,
 					}},
 					Volumes: []corev1.Volume{
 						{

--- a/internal/controller/swiftguest/rootdisk_block_test.go
+++ b/internal/controller/swiftguest/rootdisk_block_test.go
@@ -1,0 +1,285 @@
+package swiftguest
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/resolved"
+)
+
+// W9 Component 1 tests for createCloneJob.
+//
+// The branch on rg.Storage.VolumeMode is the load-bearing piece. Tests
+// cover three contracts:
+//
+//  1. Regression: Filesystem-mode Job (the default and overwhelming
+//     majority of guests) is byte-identical to pre-W9 behaviour.
+//  2. Forward: Block-mode Job uses VolumeDevices + qemu-img convert +
+//     sgdisk -e, NOT VolumeMounts/cp/qemu-img resize.
+//  3. Invariant: VolumeMounts and VolumeDevices on the same container
+//     never name the same volume (kubelet rejects this — exactly the
+//     class of failure W9 surfaced).
+
+func newGuestForCloneJob(name string) *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       "guest-uid",
+		},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef:      &corev1.LocalObjectReference{Name: "ubuntu"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "default"},
+		},
+	}
+}
+
+func newReconcilerWithGuest(t *testing.T, guest *swiftv1alpha1.SwiftGuest) *SwiftGuestReconciler {
+	t.Helper()
+	scheme := rootdiskScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest).Build()
+	return &SwiftGuestReconciler{Client: c, Scheme: scheme}
+}
+
+func getCreatedJob(t *testing.T, r *SwiftGuestReconciler, jobName string) *batchv1.Job {
+	t.Helper()
+	var job batchv1.Job
+	if err := r.Get(context.Background(), client.ObjectKey{Name: jobName, Namespace: "default"}, &job); err != nil {
+		t.Fatalf("get created job %q: %v", jobName, err)
+	}
+	return &job
+}
+
+// TestCreateCloneJob_FilesystemModeUnchanged is the regression gate. The
+// Filesystem path is the default, the path every existing SwiftGuest
+// uses, and the path the smoke test exercises. This test fixes the
+// behaviour byte-by-byte so that any Block-mode refactor that rotates
+// the Filesystem path's structure (e.g. accidentally moving
+// VolumeMounts under a conditional that defaults wrong) produces a
+// visible test failure rather than silently regressing on cluster.
+func TestCreateCloneJob_FilesystemModeUnchanged(t *testing.T) {
+	guest := newGuestForCloneJob("fs-guest")
+	r := newReconcilerWithGuest(t, guest)
+	rg := &resolved.ResolvedGuest{
+		Storage: resolved.Storage{
+			AccessMode: "ReadWriteOnce",
+			VolumeMode: "Filesystem",
+		},
+	}
+
+	if err := r.createCloneJob(context.Background(), guest, rg, "swiftguest-rootclone-fs-guest", "src-pvc", "dst-pvc", resource.MustParse("40Gi")); err != nil {
+		t.Fatalf("createCloneJob: %v", err)
+	}
+
+	job := getCreatedJob(t, r, "swiftguest-rootclone-fs-guest")
+	c := job.Spec.Template.Spec.Containers[0]
+
+	// VolumeMounts: src + dst; no VolumeDevices.
+	if len(c.VolumeMounts) != 2 {
+		t.Fatalf("VolumeMounts = %d, want 2 (src + dst)", len(c.VolumeMounts))
+	}
+	mounts := map[string]string{}
+	for _, m := range c.VolumeMounts {
+		mounts[m.Name] = m.MountPath
+	}
+	if mounts["src"] != "/src" {
+		t.Errorf("src mount path = %q, want /src", mounts["src"])
+	}
+	if mounts["dst"] != "/dst" {
+		t.Errorf("dst mount path = %q, want /dst (Filesystem path is /dst, NOT /dev/dst-block)", mounts["dst"])
+	}
+	if len(c.VolumeDevices) != 0 {
+		t.Errorf("VolumeDevices = %v, want empty for Filesystem mode", c.VolumeDevices)
+	}
+
+	// Script must contain cp + qemu-img resize + sgdisk -e in that order.
+	// The Filesystem branch invariant: every step the pre-W9 code did,
+	// in the same order. If a future commit rearranges the script, the
+	// commit message must explicitly call it out (a sgdisk-then-resize
+	// reorder is a real change, not a refactor).
+	script := strings.Join(c.Command, " ")
+	for _, want := range []string{"cp /src/image.raw /dst/image.raw", "qemu-img resize -f raw /dst/image.raw", "sgdisk -e /dst/image.raw"} {
+		if !strings.Contains(script, want) {
+			t.Errorf("Filesystem-mode script missing %q; got:\n%s", want, script)
+		}
+	}
+	// Filesystem branch must NOT use the Block-mode primitives.
+	if strings.Contains(script, "qemu-img convert") {
+		t.Errorf("Filesystem-mode script must not use 'qemu-img convert' (that's the Block-mode primitive); got:\n%s", script)
+	}
+	if strings.Contains(script, CloneJobBlockDevicePath) {
+		t.Errorf("Filesystem-mode script must not reference %s; got:\n%s", CloneJobBlockDevicePath, script)
+	}
+}
+
+// TestCreateCloneJob_BlockModeUsesVolumeDevices is the forward contract.
+// Block destinations cannot be filesystem-mounted — kubelet rejects
+// `volume dst has volumeMode Block, but is specified in volumeMounts`
+// (the exact failure W9 was opened to fix). Verify the rendered Job
+// uses VolumeDevices for dst, omits the dst VolumeMount, and runs the
+// raw-device script (qemu-img convert + sgdisk -e + sync, no cp, no
+// qemu-img resize).
+func TestCreateCloneJob_BlockModeUsesVolumeDevices(t *testing.T) {
+	guest := newGuestForCloneJob("block-guest")
+	r := newReconcilerWithGuest(t, guest)
+	rg := &resolved.ResolvedGuest{
+		Storage: resolved.Storage{
+			AccessMode: "ReadWriteMany",
+			VolumeMode: "Block",
+		},
+	}
+
+	if err := r.createCloneJob(context.Background(), guest, rg, "swiftguest-rootclone-block-guest", "src-pvc", "dst-pvc", resource.MustParse("40Gi")); err != nil {
+		t.Fatalf("createCloneJob: %v", err)
+	}
+
+	job := getCreatedJob(t, r, "swiftguest-rootclone-block-guest")
+	c := job.Spec.Template.Spec.Containers[0]
+
+	// VolumeMounts: src only. No dst — dst is a VolumeDevice.
+	if len(c.VolumeMounts) != 1 {
+		t.Fatalf("VolumeMounts = %d, want 1 (src only); got names=%v", len(c.VolumeMounts), volumeMountNames(c.VolumeMounts))
+	}
+	if c.VolumeMounts[0].Name != "src" || c.VolumeMounts[0].MountPath != "/src" {
+		t.Errorf("VolumeMounts[0] = %+v, want {src, /src}", c.VolumeMounts[0])
+	}
+
+	// VolumeDevices: dst at the Block device path.
+	if len(c.VolumeDevices) != 1 {
+		t.Fatalf("VolumeDevices = %d, want 1 (dst); got %v", len(c.VolumeDevices), c.VolumeDevices)
+	}
+	if c.VolumeDevices[0].Name != "dst" {
+		t.Errorf("VolumeDevices[0].Name = %q, want dst", c.VolumeDevices[0].Name)
+	}
+	if c.VolumeDevices[0].DevicePath != CloneJobBlockDevicePath {
+		t.Errorf("VolumeDevices[0].DevicePath = %q, want %q",
+			c.VolumeDevices[0].DevicePath, CloneJobBlockDevicePath)
+	}
+
+	// Script: qemu-img convert + sgdisk -e against the device path; NO cp,
+	// NO qemu-img resize.
+	script := strings.Join(c.Command, " ")
+	wantContains := []string{
+		"qemu-img convert -f raw -O raw /src/image.raw " + CloneJobBlockDevicePath,
+		"sgdisk -e " + CloneJobBlockDevicePath,
+		"sync",
+	}
+	for _, w := range wantContains {
+		if !strings.Contains(script, w) {
+			t.Errorf("Block-mode script missing %q; got:\n%s", w, script)
+		}
+	}
+	wantOmitted := []string{
+		"cp /src/image.raw", // raw device cannot be a cp target
+		"qemu-img resize",   // no-op on block devices, omitted
+		"/dst/image.raw",    // filesystem path; never appears in Block script
+	}
+	for _, w := range wantOmitted {
+		if strings.Contains(script, w) {
+			t.Errorf("Block-mode script must NOT contain %q; got:\n%s", w, script)
+		}
+	}
+}
+
+// TestCreateCloneJob_VolumeNamesNeverOverlap locks in the kubelet
+// invariant that surfaced as W9 in the first place: a container's
+// VolumeMounts and VolumeDevices must not share a volume name. If they
+// do, the kubelet refuses the pod ("volume X has volumeMode Block, but
+// is specified in volumeMounts"). The fix-by-construction is that the
+// Block branch removes the dst entry from VolumeMounts when adding it
+// to VolumeDevices; this test pins that contract for both branches.
+//
+// Defensive test: not architectural, just a no-overlap regression
+// gate. Run on both Filesystem and Block paths.
+func TestCreateCloneJob_VolumeNamesNeverOverlap(t *testing.T) {
+	cases := []struct {
+		name       string
+		volumeMode string
+	}{
+		{"Filesystem", "Filesystem"},
+		{"Block", "Block"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			guest := newGuestForCloneJob("overlap-" + strings.ToLower(tc.name))
+			r := newReconcilerWithGuest(t, guest)
+			access := "ReadWriteOnce"
+			if tc.volumeMode == "Block" {
+				access = "ReadWriteMany"
+			}
+			rg := &resolved.ResolvedGuest{
+				Storage: resolved.Storage{AccessMode: access, VolumeMode: tc.volumeMode},
+			}
+			if err := r.createCloneJob(context.Background(), guest, rg,
+				"swiftguest-rootclone-overlap-"+strings.ToLower(tc.name),
+				"src-pvc", "dst-pvc", resource.MustParse("40Gi")); err != nil {
+				t.Fatalf("createCloneJob: %v", err)
+			}
+			job := getCreatedJob(t, r, "swiftguest-rootclone-overlap-"+strings.ToLower(tc.name))
+			c := job.Spec.Template.Spec.Containers[0]
+
+			seen := map[string]string{}
+			for _, m := range c.VolumeMounts {
+				seen[m.Name] = "VolumeMount"
+			}
+			for _, d := range c.VolumeDevices {
+				if existing, ok := seen[d.Name]; ok {
+					t.Errorf("volume %q appears as both %s and VolumeDevice — kubelet will reject the pod",
+						d.Name, existing)
+				}
+				seen[d.Name] = "VolumeDevice"
+			}
+		})
+	}
+}
+
+// TestCreateCloneJob_BlockModeJobMetadataUnchanged confirms the Block
+// branch only diverges in the container's mount/script — every other
+// Job-level field (labels, OwnerReferences, BackoffLimit,
+// RestartPolicy) is preserved. The Block path is purely additive on
+// the container's volume surface; metadata and lifecycle invariants
+// are byte-identical.
+func TestCreateCloneJob_BlockModeJobMetadataUnchanged(t *testing.T) {
+	guest := newGuestForCloneJob("metadata-guest")
+	r := newReconcilerWithGuest(t, guest)
+	rg := &resolved.ResolvedGuest{
+		Storage: resolved.Storage{AccessMode: "ReadWriteMany", VolumeMode: "Block"},
+	}
+	if err := r.createCloneJob(context.Background(), guest, rg, "swiftguest-rootclone-metadata-guest", "src-pvc", "dst-pvc", resource.MustParse("40Gi")); err != nil {
+		t.Fatalf("createCloneJob: %v", err)
+	}
+	job := getCreatedJob(t, r, "swiftguest-rootclone-metadata-guest")
+
+	if job.Labels["swift.kubeswift.io/guest"] != "metadata-guest" {
+		t.Errorf("guest label = %q, want metadata-guest", job.Labels["swift.kubeswift.io/guest"])
+	}
+	if job.Labels["swift.kubeswift.io/role"] != "root-disk-clone" {
+		t.Errorf("role label = %q, want root-disk-clone", job.Labels["swift.kubeswift.io/role"])
+	}
+	if job.Spec.BackoffLimit == nil || *job.Spec.BackoffLimit != 3 {
+		t.Errorf("BackoffLimit = %v, want 3", job.Spec.BackoffLimit)
+	}
+	if job.Spec.Template.Spec.RestartPolicy != corev1.RestartPolicyNever {
+		t.Errorf("RestartPolicy = %q, want Never", job.Spec.Template.Spec.RestartPolicy)
+	}
+	if len(job.OwnerReferences) != 1 || job.OwnerReferences[0].Kind != "SwiftGuest" {
+		t.Errorf("OwnerReferences should be a single SwiftGuest controller-ref; got %+v", job.OwnerReferences)
+	}
+}
+
+func volumeMountNames(mounts []corev1.VolumeMount) []string {
+	out := make([]string, 0, len(mounts))
+	for _, m := range mounts {
+		out = append(out, m.Name)
+	}
+	return out
+}

--- a/internal/controller/swiftguest/security.go
+++ b/internal/controller/swiftguest/security.go
@@ -5,6 +5,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/projectbeskar/kubeswift/internal/resolved"
 )
 
 // CloneGrowInitImage is the image used by clone-grow-init.
@@ -32,17 +34,54 @@ func networkInitContainer() corev1.Container {
 }
 
 // cloneGrowInitContainer returns the clone-grow-init init container that
-// expands a snapshot-based clone PVC's image.raw to the target size.
+// finalises a snapshot-based clone PVC before the launcher pod boots.
 //
 // Used only on the snapshot clone strategy. The Copy Job path performs the
-// equivalent qemu-img resize + sgdisk -e itself before the launcher pod is
-// created (see createCloneJob in rootdisk.go).
+// equivalent operations itself before the launcher pod is created (see
+// createCloneJob in rootdisk.go).
 //
-// The PVC's underlying block device must already be expanded to targetBytes
-// before this init container runs; the SwiftGuest controller's
+// The PVC's underlying block device (or filesystem) must already be at
+// targetBytes before this init container runs; the SwiftGuest controller's
 // expand-and-wait gate (ensureRootDiskCloneFromSnapshot) enforces that.
-func cloneGrowInitContainer(targetBytes int64) corev1.Container {
-	script := fmt.Sprintf(`set -e
+//
+// W9 — branches on rg.Storage.VolumeMode (PR #32 surface):
+//
+//   - Filesystem (default): byte-identical to pre-W9.
+//     `qemu-img resize -f raw .../image.raw <bytes> && sgdisk -e .../image.raw`.
+//   - Block: VolumeDevices for the root-disk volume; runs
+//     `sgdisk -e /dev/kubeswift-root` only. No qemu-img resize —
+//     block devices are pre-sized at the PVC's requested capacity by
+//     the storage layer; resize would be a no-op and including it
+//     would mask future regressions in the expand-and-wait gate.
+func cloneGrowInitContainer(rg *resolved.ResolvedGuest, targetBytes int64) corev1.Container {
+	isBlock := rg != nil && rg.Storage.VolumeMode == "Block"
+
+	var script string
+	var volumeMounts []corev1.VolumeMount
+	var volumeDevices []corev1.VolumeDevice
+
+	if isBlock {
+		// Block path. sgdisk -e operates byte-level through the block
+		// device's standard read/write interface; works natively on
+		// raw devices. No qemu-img resize (no-op on Block) and no cp
+		// (the PVC was populated by the Copy Job which already wrote
+		// the raw image to the block device).
+		script = fmt.Sprintf(`set -e
+echo "clone-grow-init: Block mode, target=%d bytes, device=%s"
+apt-get update -qq
+apt-get install -y -qq gdisk >/dev/null 2>&1
+sgdisk -e %s
+sync
+echo "clone-grow-init: complete (Block)"`,
+			targetBytes, DiskRootDevicePath, DiskRootDevicePath)
+		volumeDevices = []corev1.VolumeDevice{
+			{Name: "root-disk", DevicePath: DiskRootDevicePath},
+		}
+	} else {
+		// Filesystem path — byte-identical to pre-W9 behaviour. Reviewers:
+		// any change that alters this branch is a regression risk for
+		// every existing SwiftGuest (the default volumeMode).
+		script = fmt.Sprintf(`set -e
 echo "clone-grow-init: target=%d bytes"
 apt-get update -qq
 apt-get install -y -qq qemu-utils gdisk >/dev/null 2>&1
@@ -50,7 +89,11 @@ qemu-img resize -f raw %s/image.raw %d
 sgdisk -e %s/image.raw
 sync
 echo "clone-grow-init: complete ($(stat -c %%s %s/image.raw) bytes)"`,
-		targetBytes, DisksRootPath, targetBytes, DisksRootPath, DisksRootPath)
+			targetBytes, DisksRootPath, targetBytes, DisksRootPath, DisksRootPath)
+		volumeMounts = []corev1.VolumeMount{
+			{Name: "root-disk", MountPath: DisksRootPath},
+		}
+	}
 
 	return corev1.Container{
 		Name:            "clone-grow-init",
@@ -58,9 +101,8 @@ echo "clone-grow-init: complete ($(stat -c %%s %s/image.raw) bytes)"`,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-c", script},
 		SecurityContext: privilegedContext(),
-		VolumeMounts: []corev1.VolumeMount{
-			{Name: "root-disk", MountPath: DisksRootPath},
-		},
+		VolumeMounts:    volumeMounts,
+		VolumeDevices:   volumeDevices,
 	}
 }
 

--- a/internal/resolved/types.go
+++ b/internal/resolved/types.go
@@ -199,6 +199,15 @@ func (r *ResolvedGuest) GetRootDiskFormat() string {
 	return "raw"
 }
 
+// GetRootDiskVolumeMode returns the resolved storage volumeMode
+// ("Filesystem" or "Block") for the root disk. Empty string is
+// treated as "Filesystem" by callers (the pre-W9 default). Used by
+// runtimeintent.Build to decide whether RootDisk.Path resolves to a
+// filesystem path or a Block device path.
+func (r *ResolvedGuest) GetRootDiskVolumeMode() string {
+	return r.Storage.VolumeMode
+}
+
 // GetCPU returns CPU cores for runtime intent.
 func (r *ResolvedGuest) GetCPU() int {
 	return r.Resources.CPU

--- a/internal/runtimeintent/build.go
+++ b/internal/runtimeintent/build.go
@@ -8,6 +8,13 @@ type ResolvedGuest interface {
 	HasNetwork() bool
 	HasDataDisk() bool
 	GetRootDiskFormat() string
+	// GetRootDiskVolumeMode returns "Filesystem" or "Block". Empty is
+	// treated as "Filesystem" (pre-W9 default). Block resolves the
+	// RootDisk.Path to DiskRootDevicePath instead of the filesystem
+	// image.raw path; swiftletd hands the device path opaquely to
+	// Cloud Hypervisor's --disk path=... which works for both file
+	// and device targets.
+	GetRootDiskVolumeMode() string
 	GetCPU() int
 	GetMemoryMiB() int
 	GetLifecycle() string
@@ -63,9 +70,18 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 	if lifecycle == "" {
 		lifecycle = "start"
 	}
+	rootDiskPath := DisksRootPath + "/" + RootDiskImageFile
+	if rg.GetRootDiskVolumeMode() == "Block" {
+		// Block-mode root disk: swiftletd's CH spawn will pass this
+		// path to --disk path=<value>. CH treats it opaquely (file or
+		// device); the kubelet surfaces the PVC at this path via
+		// VolumeDevices in the launcher pod (see pod.go::rootDiskMount).
+		rootDiskPath = DiskRootDevicePath
+	}
+
 	return &RuntimeIntent{
 		RootDisk: RootDiskSpec{
-			Path:   DisksRootPath + "/" + RootDiskImageFile,
+			Path:   rootDiskPath,
 			Format: rg.GetRootDiskFormat(),
 		},
 		SeedPath:   seedPath,

--- a/internal/runtimeintent/build_test.go
+++ b/internal/runtimeintent/build_test.go
@@ -6,35 +6,96 @@ import (
 )
 
 type mockResolvedGuest struct {
-	hasSeed       bool
-	hasKernel     bool
-	hasNetwork    bool
-	hasDataDisk   bool
-	format        string
-	cpu           int
-	memory        int
-	lifecycle     string
-	guestID       string
-	kernelPath    string
-	initramfsPath string
-	kernelCmdline string
-	hypervisor    string
+	hasSeed        bool
+	hasKernel      bool
+	hasNetwork     bool
+	hasDataDisk    bool
+	format         string
+	rootVolumeMode string // W9: "Filesystem" (default) or "Block"
+	cpu            int
+	memory         int
+	lifecycle      string
+	guestID        string
+	kernelPath     string
+	initramfsPath  string
+	kernelCmdline  string
+	hypervisor     string
 }
 
-func (m *mockResolvedGuest) HasSeed() bool             { return m.hasSeed }
-func (m *mockResolvedGuest) HasKernel() bool           { return m.hasKernel }
-func (m *mockResolvedGuest) HasNetwork() bool          { return m.hasNetwork }
-func (m *mockResolvedGuest) HasDataDisk() bool         { return m.hasDataDisk }
-func (m *mockResolvedGuest) GetRootDiskFormat() string { return m.format }
-func (m *mockResolvedGuest) GetCPU() int               { return m.cpu }
-func (m *mockResolvedGuest) GetMemoryMiB() int         { return m.memory }
-func (m *mockResolvedGuest) GetLifecycle() string      { return m.lifecycle }
-func (m *mockResolvedGuest) GetGuestID() string        { return m.guestID }
-func (m *mockResolvedGuest) GetKernelPath() string     { return m.kernelPath }
-func (m *mockResolvedGuest) GetInitramfsPath() string  { return m.initramfsPath }
-func (m *mockResolvedGuest) GetKernelCmdline() string  { return m.kernelCmdline }
-func (m *mockResolvedGuest) GetHypervisor() string     { return m.hypervisor }
-func (m *mockResolvedGuest) GetNICs() []NICIntent      { return nil }
+func (m *mockResolvedGuest) HasSeed() bool                 { return m.hasSeed }
+func (m *mockResolvedGuest) HasKernel() bool               { return m.hasKernel }
+func (m *mockResolvedGuest) HasNetwork() bool              { return m.hasNetwork }
+func (m *mockResolvedGuest) HasDataDisk() bool             { return m.hasDataDisk }
+func (m *mockResolvedGuest) GetRootDiskFormat() string     { return m.format }
+func (m *mockResolvedGuest) GetRootDiskVolumeMode() string { return m.rootVolumeMode }
+func (m *mockResolvedGuest) GetCPU() int                   { return m.cpu }
+func (m *mockResolvedGuest) GetMemoryMiB() int             { return m.memory }
+func (m *mockResolvedGuest) GetLifecycle() string          { return m.lifecycle }
+func (m *mockResolvedGuest) GetGuestID() string            { return m.guestID }
+func (m *mockResolvedGuest) GetKernelPath() string         { return m.kernelPath }
+func (m *mockResolvedGuest) GetInitramfsPath() string      { return m.initramfsPath }
+func (m *mockResolvedGuest) GetKernelCmdline() string      { return m.kernelCmdline }
+func (m *mockResolvedGuest) GetHypervisor() string         { return m.hypervisor }
+func (m *mockResolvedGuest) GetNICs() []NICIntent          { return nil }
+
+// TestBuild_DiskBootBlockMode is the W9 contract test for the
+// runtimeintent producer side: a guest with Block-mode root storage
+// produces a RuntimeIntent.RootDisk.Path equal to the Block device
+// path constant, NOT the filesystem image.raw path. swiftletd hands
+// this string to Cloud Hypervisor's --disk path=<value> opaquely; the
+// kubelet attaches the Block PVC at this device path via VolumeDevices
+// in the launcher pod (controller-side, see pod.go::rootDiskMount).
+func TestBuild_DiskBootBlockMode(t *testing.T) {
+	rg := &mockResolvedGuest{
+		hasSeed:        true,
+		hasNetwork:     true,
+		format:         "raw",
+		rootVolumeMode: "Block",
+		cpu:            2,
+		memory:         2048,
+		lifecycle:      "start",
+		guestID:        "block-guest",
+	}
+	intent := Build(rg)
+	if intent.RootDisk.Path != DiskRootDevicePath {
+		t.Errorf("Block-mode RootDisk.Path = %q, want %q", intent.RootDisk.Path, DiskRootDevicePath)
+	}
+	if intent.RootDisk.Path == DisksRootPath+"/"+RootDiskImageFile {
+		t.Errorf("Block-mode RootDisk.Path must NOT be the filesystem path")
+	}
+}
+
+// TestBuild_DiskBootFilesystemModeUnchanged is the regression gate. The
+// Filesystem path is byte-identical to pre-W9: RootDisk.Path resolves
+// to <DisksRootPath>/<RootDiskImageFile>. Empty rootVolumeMode (the
+// default before any caller sets it) MUST resolve to Filesystem too.
+func TestBuild_DiskBootFilesystemModeUnchanged(t *testing.T) {
+	cases := []struct {
+		name string
+		mode string
+	}{
+		{"explicit_Filesystem", "Filesystem"},
+		{"empty_defaults_Filesystem", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rg := &mockResolvedGuest{
+				hasSeed:        true,
+				format:         "raw",
+				rootVolumeMode: tc.mode,
+				cpu:            2,
+				memory:         2048,
+				lifecycle:      "start",
+				guestID:        "fs-guest",
+			}
+			intent := Build(rg)
+			want := DisksRootPath + "/" + RootDiskImageFile
+			if intent.RootDisk.Path != want {
+				t.Errorf("Filesystem-mode RootDisk.Path = %q, want %q", intent.RootDisk.Path, want)
+			}
+		})
+	}
+}
 
 func TestBuild(t *testing.T) {
 	rg := &mockResolvedGuest{

--- a/internal/runtimeintent/constants.go
+++ b/internal/runtimeintent/constants.go
@@ -8,4 +8,13 @@ const (
 	DataDiskImageFile = "image.raw" // Data disk uses the same PVC layout as root disk.
 	SeedPath          = "/var/lib/kubeswift/seed"
 	IntentPath        = "/var/lib/kubeswift/intent/runtime-intent.json"
+
+	// DiskRootDevicePath is the in-pod device path for a Block-mode
+	// root disk (W9). MUST equal the swiftguest controller's
+	// DiskRootDevicePath constant — the two are independently asserted
+	// by package-boundary tests because the runtimeintent package and
+	// the controller package cannot import each other (the controller
+	// imports runtimeintent, not the other way around). When updating
+	// either constant, update both.
+	DiskRootDevicePath = "/dev/kubeswift-root"
 )

--- a/rust/swift-ch-client/src/config.rs
+++ b/rust/swift-ch-client/src/config.rs
@@ -24,7 +24,19 @@ pub struct VFIODeviceConfig {
 /// VM configuration derived from runtime intent.
 #[derive(Debug, Clone)]
 pub struct VmConfig {
-    /// Path to root disk image.
+    /// Path to root disk. Opaque string — Cloud Hypervisor's
+    /// `--disk path=<value>` opens both filesystem files and raw block
+    /// devices identically, so this can be either a regular file path
+    /// (e.g. `/var/lib/kubeswift/disks/root/image.raw` for Filesystem-
+    /// mode PVCs) or a device path (e.g. `/dev/kubeswift-root` for
+    /// Block-mode PVCs surfaced via Kubernetes `volumeDevices`).
+    ///
+    /// W9 — the controller resolves which form to use based on the
+    /// SwiftGuest's resolved `spec.storage.volumeMode`; swiftletd
+    /// hands whichever string it received through to CH unchanged.
+    /// No suffix detection or path-shape branching exists in this
+    /// crate (verified by grep audit at W9 Component 3 start —
+    /// see PR description).
     pub disk_path: String,
     /// Memory size in MiB.
     pub memory_mib: u32,
@@ -405,6 +417,76 @@ mod tests {
         assert!(
             joined.contains("path=/sys/bus/pci/devices/0000:03:00.0/"),
             "missing device path: {}",
+            joined
+        );
+    }
+
+    // W9 Component 3 — Block-mode root disk path passes through the
+    // CH args generator unchanged. The architect's Q2 read held: this
+    // crate has zero suffix-detection logic; the disk_path field is
+    // opaque. These tests lock that opacity in so a future commit
+    // that introduces, e.g., `if disk_path.ends_with(".raw") { ... }`
+    // produces a visible test failure.
+
+    /// W9 — disk-boot path with a `/dev/...` device path produces
+    /// `--disk path=/dev/kubeswift-root` exactly once, alongside
+    /// firmware + seed disk path. CH treats device paths and file
+    /// paths identically through the `--disk path=` argument; this
+    /// test pins that contract.
+    #[test]
+    fn test_disk_boot_block_device_path() {
+        let mut cfg = make_disk_boot_config();
+        cfg.disk_path = "/dev/kubeswift-root".to_string();
+        let args = cfg.to_args();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("path=/dev/kubeswift-root"),
+            "Block-mode disk path missing from CH args: {}",
+            joined
+        );
+        // The legacy filesystem path must NOT appear when disk_path is a
+        // device path — the substitution is total, not additive.
+        assert!(
+            !joined.contains("path=/data/image.raw"),
+            "filesystem disk path leaked into Block-mode args: {}",
+            joined
+        );
+        // --disk for the firmware-driven disk-boot path takes multiple
+        // values (root + optional seed); both should be present and the
+        // root value should be the device path.
+        let disk_idx = args
+            .iter()
+            .position(|a| a == "--disk")
+            .expect("--disk flag missing");
+        assert!(
+            args.get(disk_idx + 1)
+                .map(|v| v == "path=/dev/kubeswift-root")
+                .unwrap_or(false),
+            "first --disk value should be the root device path; args: {:?}",
+            args
+        );
+    }
+
+    /// W9 — Block-mode root with a Filesystem-mode data disk produces
+    /// CH args carrying both surfaces independently. The mixed case
+    /// from architect Q4 mirrored at the swift-ch-client layer:
+    /// disk_path (device) and data_disk_path (file) coexist on the
+    /// same `--disk` arg list with no suffix-driven re-routing.
+    #[test]
+    fn test_disk_boot_block_root_with_filesystem_data() {
+        let mut cfg = make_disk_boot_config();
+        cfg.disk_path = "/dev/kubeswift-root".to_string();
+        cfg.data_disk_path = "/data/extra.raw".to_string();
+        let args = cfg.to_args();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("path=/dev/kubeswift-root"),
+            "Block root path missing: {}",
+            joined
+        );
+        assert!(
+            joined.contains("path=/data/extra.raw"),
+            "Filesystem data path missing: {}",
             joined
         );
     }

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -194,7 +194,22 @@ impl NICIntent {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RootDisk {
+    /// Disk path. Opaque to swiftletd — the value is forwarded
+    /// unchanged to Cloud Hypervisor's `--disk path=<value>` argument
+    /// (via `swift_ch_client::config::VmConfig::disk_path`). CH opens
+    /// regular files and raw block devices identically through this
+    /// arg, so the controller-side resolver decides which form to
+    /// emit based on the SwiftGuest's resolved
+    /// `spec.storage.volumeMode` (W9 — see
+    /// `internal/runtimeintent/build.go::Build` for the producer side).
+    ///
+    /// No path-suffix or extension-based branching exists in this
+    /// crate. The W9 PR description records the verbatim grep audit.
     pub path: String,
+    /// Disk format. Today always "raw" in practice (the SwiftImage
+    /// import pipeline converts qcow2→raw before guest boot). The
+    /// field is informational only — swiftletd does not branch on it,
+    /// and CH treats every `--disk path=` target as a raw stream.
     pub format: String,
 }
 
@@ -518,5 +533,56 @@ mod tests {
         assert!(intent.is_restore());
         // ...but the URL is empty, which run_ch_restore checks.
         assert!(intent.restore_source_url().is_empty());
+    }
+
+    // W9 Component 3 — a Block-mode SwiftGuest produces a RuntimeIntent
+    // whose RootDisk.path is the in-pod block device path
+    // (`/dev/kubeswift-root`). The controller emits the path that way
+    // (see internal/runtimeintent/build.go::Build); swiftletd
+    // deserializes it transparently and forwards it unchanged to CH.
+    // This test pins the deserialization contract and the disk_path()
+    // accessor's pass-through behaviour.
+
+    /// W9 — Block-mode root disk path deserializes correctly and
+    /// `disk_path()` returns the device path verbatim. No suffix
+    /// detection, no path-shape interpretation; the string is
+    /// opaque all the way to CH's --disk path= argument.
+    #[test]
+    fn test_intent_block_mode_root_disk_path() {
+        let json = r#"{
+            "rootDisk": {"path": "/dev/kubeswift-root", "format": "raw"},
+            "seedPath": "/data/seed",
+            "cpu": 2, "memory": 2048,
+            "lifecycle": "start",
+            "guestId": "default/block-guest",
+            "network": true
+        }"#;
+        let intent: RuntimeIntent = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            intent.disk_path(),
+            "/dev/kubeswift-root",
+            "Block-mode disk_path should pass through verbatim"
+        );
+        assert_eq!(intent.root_disk.format, "raw");
+    }
+
+    /// W9 — Filesystem-mode disk path is unchanged (regression gate).
+    /// The default and overwhelming-majority case must continue to
+    /// produce the legacy filesystem path.
+    #[test]
+    fn test_intent_filesystem_mode_root_disk_path_unchanged() {
+        let json = r#"{
+            "rootDisk": {"path": "/var/lib/kubeswift/disks/root/image.raw", "format": "raw"},
+            "seedPath": "/data/seed",
+            "cpu": 2, "memory": 2048,
+            "lifecycle": "start",
+            "guestId": "default/fs-guest",
+            "network": true
+        }"#;
+        let intent: RuntimeIntent = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            intent.disk_path(),
+            "/var/lib/kubeswift/disks/root/image.raw"
+        );
     }
 }


### PR DESCRIPTION
## Summary

W9 follow-up to PR #32 (storage access mode CRD). Makes `spec.storage.volumeMode: Block` SwiftGuests boot end-to-end on Longhorn Migratable RWX storage. Filesystem-mode behaviour is byte-identical to pre-W9 — every existing SwiftGuest configuration continues to work with no observable change.

This unblocks Live Migration Phase 3 (KubeVirt-style RWX live migration).

## Framing

W9 is the **runtime-path gap revealed by the API-surface unblock**, not a PR #32 regression. PR #32's stated scope was "let operators declare `spec.storage` on the CRD"; every piece of that surface is shipped. The post-merge cluster walkthrough surfaced kubelet refusing the rootdisk Copy Job pod with `volume dst has volumeMode Block, but is specified in volumeMounts`. W9 lands the runtime path that consumes the API surface.

Pattern: Phase 1 → Phase 2 plumbing → PR #32 API surface → **W9 runtime path**.

## Three-component decomposition (architect-validated)

### Component 1 — Copy Job (commit [`3bbde8a`](https://github.com/projectbeskar/kubeswift/commit/3bbde8a))
[`internal/controller/swiftguest/rootdisk.go::createCloneJob`](internal/controller/swiftguest/rootdisk.go) branches on `rg.Storage.VolumeMode`:

| | Filesystem (default, regression-gated) | Block (new) |
|---|---|---|
| Mount surface | `volumeMounts: [src→/src, dst→/dst]` | `volumeMounts: [src→/src]` + `volumeDevices: [dst→/dev/dst-block]` |
| Script | `cp + qemu-img resize + sgdisk -e + sync` | `qemu-img convert + sgdisk -e + sync` (no `cp`, no `qemu-img resize`) |

`qemu-img resize` is omitted on Block because block devices are pre-sized at PVC provision time by the storage layer; including it as a no-op would mask future regressions in the expand-and-wait gate (scoping doc decision (c)).

### Component 2 — Launcher pod builder + clone-grow-init + restore-receive (commit [`e76defa`](https://github.com/projectbeskar/kubeswift/commit/e76defa))

Architect-validated helper consolidates **five** call sites:

```go
func rootDiskMount(rg *resolved.ResolvedGuest) (*corev1.VolumeMount, *corev1.VolumeDevice)
```

Filesystem mode → non-nil `VolumeMount{root-disk, /var/lib/kubeswift/disks/root}`. Block mode → non-nil `VolumeDevice{root-disk, /dev/kubeswift-root}`. Mutually exclusive by Kubernetes contract; helper enforces by construction.

| # | Site | Path |
|---|---|---|
| 1 | `AddVolumeMounts` (pod.go) | Disk-boot launcher container |
| 2 | `BuildGPUDiskBootPod` (gpu.go) | GPU launcher container |
| 3 | `cloneGrowInitContainer` (security.go) | Snapshot-clone init for both disk-boot + GPU |
| 4 | `cloneGrowInitContainer` from gpu.go | Same function, GPU caller |
| 5 | `BuildRestorePod` (restore.go) | **Snapshot restore-receive launcher pod** |

**Site 5 was not in the original W9 scoping doc or architect engagement** — it surfaced during implementation as a fifth instance of the same `{Name: "root-disk", MountPath: DisksRootPath}` pattern. Folded in because (a) excluding it would silently break snapshot-restore for any Block-mode guest, (b) it's the same architectural concern with the same helper, (c) "while we're here" is rejected; this is the same load-bearing concern.

RuntimeIntent producer side (`internal/runtimeintent/build.go::Build`):
- `ResolvedGuest` interface gains `GetRootDiskVolumeMode() string`
- Block resolves `RootDisk.Path` to `/dev/kubeswift-root`; otherwise legacy `<DisksRootPath>/image.raw`
- `DiskRootDevicePath` constant mirrored in both packages (cross-package import cycle prevents sharing); cross-package agreement test locks them in step

### Component 3 — Rust opacity contract (commit [`c28b8dc`](https://github.com/projectbeskar/kubeswift/commit/c28b8dc))

**Q2 sidebar grep result (verbatim, mandatory regardless of finding):**

| Pattern | Total hits | Production-code hits |
|---|---|---|
| `.raw` literals | 14 | **0** (all in `#[cfg(test)]` JSON fixtures) |
| `.qcow2` literals | **0** | 0 |
| `image.raw` literals | 7 | **0** (all test fixtures) |
| `ends_with` / `starts_with` | many | **0 for disk path** (HTTP request prefix asserts + DHCP `#` comment line + restore-URL trailing-slash normalizer at intent.rs:287) |
| `Path::extension` / `extension(` | **0** | 0 |

Conclusion: zero path-suffix or extension-based branching in `rust/swift-ch-client/` or `rust/swiftletd/`. The Component 2 producer-side change flows through with **zero behavioural changes** — the architect's Q2 read held verbatim.

What landed: doc comments codifying the opacity contract on `swift_ch_client::config::VmConfig.disk_path` and `swiftletd::intent::RootDisk.path` (so future maintainers tempted to add suffix-detection see the contract first), plus four unit tests locking the contract in (Block-mode args generation, mixed Block-root + Filesystem-data passthrough, Block JSON deserialization, Filesystem regression A/B).

## Stats

| Component | Files | Insertions | Deletions |
|---|---|---|---|
| 1 Copy Job | 2 | 361 | 11 |
| 2 Launcher + restore | 10 | 663 | 57 |
| 3 Rust opacity | 2 | 149 | 1 |
| **Total** | **14** | **1173** | **69** |

## Tests passing

- **Go**: full `go test ./...` clean. New tests:
  - `TestCreateCloneJob_FilesystemModeUnchanged` (regression gate)
  - `TestCreateCloneJob_BlockModeUsesVolumeDevices` + `_VolumeNamesNeverOverlap` + `_BlockModeJobMetadataUnchanged`
  - `TestRootDiskMount_*` (3 cases)
  - `TestAddVolumeMounts_FilesystemUnchanged` + `_BlockUsesVolumeDevices` (4 subtests)
  - `TestCloneGrowInit_FilesystemUnchanged` + `_BlockUsesVolumeDevicesAndSkipsResize`
  - `TestBuildPod_BlockGuestUsesVolumeDevices`
  - `TestBuildPod_BlockRootWithFilesystemDataDisk` ← architect Q4
  - `TestBuildPod_FilesystemGuestRegression`
  - `TestDiskRootDevicePath_AgreesAcrossPackages` (cross-package constant invariant)
  - `TestBuild_DiskBootBlockMode` + `TestBuild_DiskBootFilesystemModeUnchanged` (Filesystem + empty-defaults)
- **Rust**: 130/130 workspace tests pass; `cargo fmt --check` clean. New tests:
  - `config::tests::test_disk_boot_block_device_path`
  - `config::tests::test_disk_boot_block_root_with_filesystem_data` (architect Q4 mirrored at swift-ch-client layer)
  - `intent::tests::test_intent_block_mode_root_disk_path`
  - `intent::tests::test_intent_filesystem_mode_root_disk_path_unchanged`

## Architect calls (sub-agent review)

| Q | Decision |
|---|---|
| Q1 — branch in pod.go vs adapter | Helper in pod.go (`rootDiskMount`); 5 call sites past duplication threshold; W7-shape drift surface eliminated |
| Q2 — RootDisk.Path forward-compat with future SwiftImage.spec.storage | Confirmed independent; future SwiftImage.spec.storage is Copy-Job source-side; launcher path is opaque |
| Q3 — Block path constant | `/dev/kubeswift-root` (project-branded; no kernel/udev namespace collision) |
| Q4 — Mixed Block-root + Filesystem-dataDisk | Confirmed clean; unit test lands in `TestBuildPod_BlockRootWithFilesystemDataDisk` |

## Acceptance criteria — verification status

**Verified by unit tests in this PR:**

- [x] Filesystem-mode regression: byte-identical script, mounts, devices, metadata
- [x] Block-mode Copy Job: VolumeDevices + qemu-img convert + sgdisk -e (no cp, no qemu-img resize)
- [x] Block-mode launcher pod: VolumeDevices for root-disk, no overlapping VolumeMount
- [x] Block-mode clone-grow-init: VolumeDevices + sgdisk only (no qemu-img resize)
- [x] Mixed Block-root + Filesystem-dataDisk: no volume-name overlap on launcher container
- [x] RuntimeIntent producer: Block resolves to device path; Filesystem (and empty default) resolves to legacy filesystem path
- [x] Cross-package `DiskRootDevicePath` constants in step
- [x] Q2 sidebar grep across rust/: zero production-code suffix logic

**Pending — awaiting cluster integration testing (post-merge / post-redeploy):**

- [ ] RWX+Block SwiftGuest on `longhorn-migratable` reaches `Phase=Running`
- [ ] `status.network.primaryIP` populated
- [ ] `swiftctl console <guest>` shows login prompt
- [ ] `swiftctl ssh <guest>` connects and returns shell
- [ ] Inside guest: `df -h /` reports SwiftGuestClass `rootDisk.size` (~40 GiB) — **scoping question (b) verification: cloud-init growpart on Block-mode root disk**
- [ ] Sentinel write survives launcher pod delete + recreate (Block PVC data persistence)
- [ ] RWO+Filesystem guest applied alongside reaches `Phase=Running` unchanged (no regression)
- [ ] `make smoke-test` passes
- [ ] `kubectl describe pod` shows `volumeDevices` for Block, `volumeMounts` for Filesystem
- [ ] **Scoping question (a)**: SwiftImage import pipeline stays on Filesystem PVCs (default; verify by inspection)
- [ ] **Scoping question (c)**: sgdisk -e on Block targets works natively (verify via clone-grow-init logs)
- [ ] **cloneStrategy=snapshot Block-path verification**: works OR documented as W9.x with separate follow-up issue (per binding confirmation in scoping discussion)
- [ ] Mini-walkthrough at PR close: 30-60 min re-run of acceptance criteria reading the PR description fresh

CI on this PR runs Go + Rust unit tests + swiftletd image build. The controller-manager image is built only on push to main (release-dev workflow). Cluster integration testing requires the new controller image — same pattern as PR #32.

## Out of scope

- Other CSI drivers' Block support (Ceph RBD, AWS EBS) — storage architecture review territory
- F2 split-brain mitigation on RWX — Phase 3 live migration's StopAndCopy phase
- `SwiftImage.spec.storage` for direct Block imports — scoping question (a) defers; documented assumption: import pipeline stays Filesystem
- Any change to SwiftMigration controller behaviour, webhook validation rules, or new CRD fields
- "While we're here" refactors of unrelated code

## Test plan

CI (this PR):
- [x] `go test ./...` clean
- [x] `cargo test --workspace` clean (130/130)
- [x] `gofmt`, `go vet`, `cargo fmt --check`, clippy (no new warnings)
- [x] CRD generation no-op (no API changes)
- [x] Component 2's cross-package `DiskRootDevicePath` agreement asserted

Cluster (post-merge or post-image-build):
- [ ] Apply RWX+Block SwiftGuestClass + SwiftGuest on `longhorn-migratable` + verify Phase=Running, primaryIP, console, ssh, df, sentinel persistence
- [ ] Apply RWO+Filesystem SwiftGuest in same namespace + verify no regression
- [ ] Verify cloneStrategy=snapshot path on Block (architect's W9.x escape valve if it doesn't work)
- [ ] `make smoke-test` end-to-end
- [ ] Mini-walkthrough log added to PR description

🤖 Generated with [Claude Code](https://claude.com/claude-code)