### PR TITLE
fix(swiftimage): set allow-volume-mode-change on cloneSeed VSC (W9.x / #37)

### DIFF
--- a/charts/kubeswift/templates/controller-manager/rbac.yaml
+++ b/charts/kubeswift/templates/controller-manager/rbac.yaml
@@ -90,6 +90,15 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
+  # snapshot.storage.k8s.io VolumeSnapshotContents — get,patch only.
+  # The CSI external-snapshotter owns VSC creation/deletion. The
+  # SwiftImage controller patches the
+  # snapshot.storage.kubernetes.io/allow-volume-mode-change annotation
+  # on the cloneSeed VSC after binding (W9.x / issue #37). list,watch
+  # required by controller-runtime's cached client.
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list", "watch", "patch"]
   # SwiftMigration (migration.kubeswift.io). Phase 1 controller patches
   # SwiftGuest spec fields (runPolicy + nodeName) using the existing
   # swift.kubeswift.io/swiftguests grant; no additional grant needed

--- a/config/manager/controller-manager-rbac.yaml
+++ b/config/manager/controller-manager-rbac.yaml
@@ -65,6 +65,22 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
+  # snapshot.storage.k8s.io VolumeSnapshotContents — get,patch only.
+  # The CSI external-snapshotter owns VSC creation/deletion (the
+  # controller never creates or deletes VSCs). The SwiftImage
+  # controller patches the
+  # snapshot.storage.kubernetes.io/allow-volume-mode-change annotation
+  # on the cloneSeed VSC after the snapshotter binds it (W9.x / issue
+  # #37) so RWX+Block guests can clone from a Filesystem-mode source
+  # snapshot. Without these verbs the patch fails 403 and snapshot+
+  # Block guests never reach Running.
+  #
+  # list,watch are required by controller-runtime's cached client (the
+  # informer cache opens a watch on every GETable resource — same
+  # pattern as W7 rolebindings, W8 storageclasses).
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list", "watch", "patch"]
   # Core resources
   - apiGroups: [""]
     resources: ["nodes"]

--- a/internal/controller/swiftimage/snapshot.go
+++ b/internal/controller/swiftimage/snapshot.go
@@ -30,6 +30,28 @@ const (
 	ReasonSnapshotting   = "Snapshotting"
 	ReasonSnapshotReady  = "SnapshotReady"
 	ReasonSnapshotFailed = "SnapshotFailed"
+
+	// AllowVolumeModeChangeAnnotation is the CSI external-snapshotter
+	// annotation that permits a clone PVC to use a volumeMode different
+	// from the source VolumeSnapshot's volumeMode. Without it, the
+	// snapshotter rejects clones that change Filesystem→Block (or vice
+	// versa) at PVC provisioning time.
+	//
+	// W9.x — issue #37. The SwiftImage import PVC is RWO+Filesystem on
+	// Longhorn (the default); a SwiftGuest with spec.storage.volumeMode:
+	// Block clones from this seed via dataSource: VolumeSnapshot. Without
+	// this annotation on the VolumeSnapshotContent, Longhorn's CSI
+	// provisioner refuses with "modifies the mode of the source volume
+	// but does not have permission to do so."
+	//
+	// The annotation must be on the VolumeSnapshotContent, NOT on the
+	// VolumeSnapshot — the snapshotter's clone-mode check reads the
+	// VSC, and there is no automatic propagation from VS to VSC. We
+	// patch the VSC after the snapshotter binds it (status
+	// .boundVolumeSnapshotContentName is populated). The annotation is
+	// no-op when destination volumeMode matches source, so it's safe
+	// (and idempotent) to set unconditionally on every cloneSeed VSC.
+	AllowVolumeModeChangeAnnotation = "snapshot.storage.kubernetes.io/allow-volume-mode-change"
 )
 
 // CloneSeedSnapshotName returns the deterministic VolumeSnapshot name for
@@ -97,11 +119,74 @@ func (r *SwiftImageReconciler) EnsureCloneSeed(ctx context.Context, img *imagev1
 		return false, sourceSizeBytes, fmt.Errorf("get clone-seed snapshot: %w", err)
 	}
 
+	// Snapshot exists. Ensure the allow-volume-mode-change annotation
+	// is set on the bound VolumeSnapshotContent before the snapshot is
+	// used as a dataSource for any clone PVC (W9.x / issue #37).
+	//
+	// Sequence: snapshotter binds VSC first (status.boundVolumeSnapshotContentName
+	// populated), then drives ReadyToUse=true. We patch in between so
+	// the annotation is in place by the time any SwiftGuest's clone PVC
+	// references the snapshot. If the binding hasn't happened yet,
+	// this is a no-op and we requeue with the readyToUse check below.
+	if err := r.ensureAllowVolumeModeChange(ctx, &snap); err != nil {
+		return false, sourceSizeBytes, fmt.Errorf("ensure allow-volume-mode-change annotation: %w", err)
+	}
+
 	// Snapshot exists. Check readiness.
 	if snap.Status == nil || snap.Status.ReadyToUse == nil || !*snap.Status.ReadyToUse {
 		return false, sourceSizeBytes, nil
 	}
 	return true, sourceSizeBytes, nil
+}
+
+// ensureAllowVolumeModeChange patches the VolumeSnapshotContent bound to
+// the given VolumeSnapshot with
+// snapshot.storage.kubernetes.io/allow-volume-mode-change: "true" so that
+// clone PVCs may differ in volumeMode from the source. No-op when the
+// VSC has not been bound yet (snapshotter hasn't created it) or when the
+// annotation already carries the expected value.
+//
+// Idempotent: returns nil whenever the annotation is in the desired
+// state, including the not-yet-bound case (caller's outer loop requeues
+// via the ReadyToUse check).
+//
+// Permissions required (controller-manager ClusterRole):
+//   - snapshot.storage.k8s.io/volumesnapshotcontents: get, patch
+//
+// Without these the patch fails with 403 Forbidden; the controller
+// surfaces the error and the next reconcile retries. See PR #35
+// walkthrough W11 finding for the failure mode this prevents.
+func (r *SwiftImageReconciler) ensureAllowVolumeModeChange(ctx context.Context, snap *volumesnapshotv1.VolumeSnapshot) error {
+	if snap.Status == nil || snap.Status.BoundVolumeSnapshotContentName == nil {
+		// Snapshotter has not created the VSC yet; the next reconcile
+		// loop will re-check.
+		return nil
+	}
+	vscName := *snap.Status.BoundVolumeSnapshotContentName
+	if vscName == "" {
+		return nil
+	}
+	var vsc volumesnapshotv1.VolumeSnapshotContent
+	if err := r.Get(ctx, client.ObjectKey{Name: vscName}, &vsc); err != nil {
+		if errors.IsNotFound(err) {
+			// VSC referenced by status but not yet visible to the cache;
+			// retry on next reconcile.
+			return nil
+		}
+		return fmt.Errorf("get VolumeSnapshotContent %q: %w", vscName, err)
+	}
+	if vsc.Annotations[AllowVolumeModeChangeAnnotation] == "true" {
+		return nil
+	}
+	patch := client.MergeFrom(vsc.DeepCopy())
+	if vsc.Annotations == nil {
+		vsc.Annotations = map[string]string{}
+	}
+	vsc.Annotations[AllowVolumeModeChangeAnnotation] = "true"
+	if err := r.Patch(ctx, &vsc, patch); err != nil {
+		return fmt.Errorf("patch VolumeSnapshotContent %q with %s=true: %w", vscName, AllowVolumeModeChangeAnnotation, err)
+	}
+	return nil
 }
 
 // createCloneSeedSnapshot creates a VolumeSnapshot of the SwiftImage's

--- a/internal/controller/swiftimage/snapshot_w9x_test.go
+++ b/internal/controller/swiftimage/snapshot_w9x_test.go
@@ -1,0 +1,198 @@
+package swiftimage
+
+import (
+	"context"
+	"testing"
+
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// W9.x — issue #37. The CSI external-snapshotter requires the
+// `snapshot.storage.kubernetes.io/allow-volume-mode-change: "true"`
+// annotation on the VolumeSnapshotContent (not the VolumeSnapshot)
+// when a clone PVC's volumeMode differs from the source's. Without
+// this, RWX+Block SwiftGuests cloning from a Filesystem-mode SwiftImage
+// snapshot (the default — the SwiftImage import PVC is RWO+Filesystem)
+// fail at PVC provisioning.
+//
+// The SwiftImage controller's EnsureCloneSeed patches the bound VSC
+// with the annotation after the snapshotter creates it. These tests
+// pin three contracts:
+//
+//  1. Pre-bind no-op: when status.boundVolumeSnapshotContentName is
+//     not yet populated, ensureAllowVolumeModeChange returns nil
+//     without error and without touching state. The next reconcile
+//     loop retries.
+//  2. Post-bind annotation set: when the VSC exists, the annotation
+//     is patched to "true". Idempotent — re-running on an already-
+//     annotated VSC is a no-op.
+//  3. VSC missing: when status names a VSC that does not exist (CSI
+//     race between status update and VSC visibility in the cache),
+//     ensureAllowVolumeModeChange returns nil for retry rather than
+//     surfacing a hard error.
+
+func newReconciler(t *testing.T, objs ...client.Object) *SwiftImageReconciler {
+	t.Helper()
+	scheme := finalizerScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &SwiftImageReconciler{Client: c, Scheme: scheme}
+}
+
+// TestEnsureAllowVolumeModeChange_NotYetBound is the pre-bind contract.
+// The snapshotter has not yet created the VSC; the controller must not
+// error out — the next reconcile loop will pick up the binding.
+func TestEnsureAllowVolumeModeChange_NotYetBound(t *testing.T) {
+	r := newReconciler(t)
+	snap := &volumesnapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "img-clone-seed", Namespace: "default"},
+		// Status either nil or with BoundVolumeSnapshotContentName=nil:
+		// the snapshotter has not bound a VSC yet.
+		Status: nil,
+	}
+	if err := r.ensureAllowVolumeModeChange(context.Background(), snap); err != nil {
+		t.Fatalf("nil status should be a no-op; got err=%v", err)
+	}
+
+	snap.Status = &volumesnapshotv1.VolumeSnapshotStatus{}
+	if err := r.ensureAllowVolumeModeChange(context.Background(), snap); err != nil {
+		t.Fatalf("empty status should be a no-op; got err=%v", err)
+	}
+
+	emptyName := ""
+	snap.Status.BoundVolumeSnapshotContentName = &emptyName
+	if err := r.ensureAllowVolumeModeChange(context.Background(), snap); err != nil {
+		t.Fatalf("empty BoundVolumeSnapshotContentName should be a no-op; got err=%v", err)
+	}
+}
+
+// TestEnsureAllowVolumeModeChange_PatchesUnannotatedVSC is the headline
+// contract. After the snapshotter binds a VSC, the controller patches
+// it with the annotation. This is the fix for W9.x / issue #37.
+func TestEnsureAllowVolumeModeChange_PatchesUnannotatedVSC(t *testing.T) {
+	vscName := "snapcontent-9290f326"
+	vsc := &volumesnapshotv1.VolumeSnapshotContent{
+		ObjectMeta: metav1.ObjectMeta{Name: vscName},
+	}
+	r := newReconciler(t, vsc)
+
+	snap := &volumesnapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "img-clone-seed", Namespace: "default"},
+		Status: &volumesnapshotv1.VolumeSnapshotStatus{
+			BoundVolumeSnapshotContentName: ptr.To(vscName),
+		},
+	}
+	if err := r.ensureAllowVolumeModeChange(context.Background(), snap); err != nil {
+		t.Fatalf("ensureAllowVolumeModeChange: %v", err)
+	}
+
+	var got volumesnapshotv1.VolumeSnapshotContent
+	if err := r.Get(context.Background(), client.ObjectKey{Name: vscName}, &got); err != nil {
+		t.Fatalf("get VSC: %v", err)
+	}
+	if got.Annotations[AllowVolumeModeChangeAnnotation] != "true" {
+		t.Errorf("annotation %s = %q, want true; full annotations=%v",
+			AllowVolumeModeChangeAnnotation, got.Annotations[AllowVolumeModeChangeAnnotation], got.Annotations)
+	}
+}
+
+// TestEnsureAllowVolumeModeChange_IdempotentOnAnnotatedVSC verifies that
+// re-running on an already-annotated VSC is a no-op: no error, no state
+// change. EnsureCloneSeed runs on every reconcile, so this path will be
+// hit many times for a single SwiftImage; it must not churn.
+func TestEnsureAllowVolumeModeChange_IdempotentOnAnnotatedVSC(t *testing.T) {
+	vscName := "snapcontent-already-set"
+	vsc := &volumesnapshotv1.VolumeSnapshotContent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: vscName,
+			Annotations: map[string]string{
+				AllowVolumeModeChangeAnnotation:  "true",
+				"unrelated.example.com/leave-me": "alone",
+			},
+		},
+	}
+	r := newReconciler(t, vsc)
+
+	snap := &volumesnapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "img-clone-seed", Namespace: "default"},
+		Status: &volumesnapshotv1.VolumeSnapshotStatus{
+			BoundVolumeSnapshotContentName: ptr.To(vscName),
+		},
+	}
+	if err := r.ensureAllowVolumeModeChange(context.Background(), snap); err != nil {
+		t.Fatalf("ensureAllowVolumeModeChange (idempotent run): %v", err)
+	}
+
+	var got volumesnapshotv1.VolumeSnapshotContent
+	if err := r.Get(context.Background(), client.ObjectKey{Name: vscName}, &got); err != nil {
+		t.Fatalf("get VSC: %v", err)
+	}
+	if got.Annotations[AllowVolumeModeChangeAnnotation] != "true" {
+		t.Errorf("annotation lost: %q", got.Annotations[AllowVolumeModeChangeAnnotation])
+	}
+	if got.Annotations["unrelated.example.com/leave-me"] != "alone" {
+		t.Errorf("unrelated annotation altered: %q", got.Annotations["unrelated.example.com/leave-me"])
+	}
+}
+
+// TestEnsureAllowVolumeModeChange_VSCNotFoundIsNoOp covers the CSI race
+// where status.boundVolumeSnapshotContentName has been set but the VSC
+// is not yet visible to the controller's cached client. The controller
+// must not surface this as a hard error — the next reconcile will see
+// the VSC and patch it.
+func TestEnsureAllowVolumeModeChange_VSCNotFoundIsNoOp(t *testing.T) {
+	r := newReconciler(t)
+	snap := &volumesnapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "img-clone-seed", Namespace: "default"},
+		Status: &volumesnapshotv1.VolumeSnapshotStatus{
+			BoundVolumeSnapshotContentName: ptr.To("snapcontent-not-yet-cached"),
+		},
+	}
+	if err := r.ensureAllowVolumeModeChange(context.Background(), snap); err != nil {
+		t.Fatalf("VSC NotFound should be a no-op (retry on next reconcile); got err=%v", err)
+	}
+}
+
+// TestEnsureAllowVolumeModeChange_PreservesExistingAnnotations confirms
+// the patch only adds the W9.x annotation; any other annotations on the
+// VSC (e.g. snapshotter-internal annotations) are preserved.
+func TestEnsureAllowVolumeModeChange_PreservesExistingAnnotations(t *testing.T) {
+	vscName := "snapcontent-with-other-annotations"
+	vsc := &volumesnapshotv1.VolumeSnapshotContent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: vscName,
+			Annotations: map[string]string{
+				"snapshot.storage.kubernetes.io/deletion-secret-name":      "secret",
+				"snapshot.storage.kubernetes.io/deletion-secret-namespace": "kube-system",
+			},
+		},
+	}
+	r := newReconciler(t, vsc)
+
+	snap := &volumesnapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "img-clone-seed", Namespace: "default"},
+		Status: &volumesnapshotv1.VolumeSnapshotStatus{
+			BoundVolumeSnapshotContentName: ptr.To(vscName),
+		},
+	}
+	if err := r.ensureAllowVolumeModeChange(context.Background(), snap); err != nil {
+		t.Fatalf("ensureAllowVolumeModeChange: %v", err)
+	}
+
+	var got volumesnapshotv1.VolumeSnapshotContent
+	if err := r.Get(context.Background(), client.ObjectKey{Name: vscName}, &got); err != nil {
+		t.Fatalf("get VSC: %v", err)
+	}
+	if got.Annotations[AllowVolumeModeChangeAnnotation] != "true" {
+		t.Errorf("W9.x annotation missing post-patch")
+	}
+	if got.Annotations["snapshot.storage.kubernetes.io/deletion-secret-name"] != "secret" {
+		t.Errorf("deletion-secret-name annotation lost")
+	}
+	if got.Annotations["snapshot.storage.kubernetes.io/deletion-secret-namespace"] != "kube-system" {
+		t.Errorf("deletion-secret-namespace annotation lost")
+	}
+}

--- a/test/storage/w9x-snapshot-block.sh
+++ b/test/storage/w9x-snapshot-block.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+#
+# W9.x cluster integration test (issue #37).
+#
+# Verifies that a SwiftImage with cloneStrategy=snapshot can be cloned
+# into a Block-mode destination PVC by a SwiftGuest declaring
+# spec.storage.{accessMode: ReadWriteMany, volumeMode: Block,
+# storageClassName: longhorn-migratable}. Without the fix, the CSI
+# external-snapshotter rejects the clone PVC with the
+# allow-volume-mode-change error captured in PR #35 walkthrough W11.
+#
+# A/B REPRODUCTION PATTERN
+# ------------------------
+#
+# This script does NOT rebuild the controller. It expects the operator
+# to redeploy with the W9.x fix BEFORE running the validate phase. The
+# reproduce phase establishes the failure baseline against the OLD
+# image; the validate phase confirms the fix works under the NEW image.
+#
+# Use:
+#   ./w9x-snapshot-block.sh reproduce   # apply manifests; expect PVC ProvisioningFailed
+#   # operator: deploy NEW controller image with the W9.x fix
+#   ./w9x-snapshot-block.sh validate    # expect PVC bound + SwiftGuest Running
+#   ./w9x-snapshot-block.sh w10check    # bundled W10 verification
+#   ./w9x-snapshot-block.sh cleanup     # tear down test resources
+#
+# Or run the full sequence with manual redeploy in the middle:
+#   ./w9x-snapshot-block.sh reproduce
+#   # ... rebuild + redeploy controller ...
+#   ./w9x-snapshot-block.sh validate
+#   ./w9x-snapshot-block.sh w10check
+#   ./w9x-snapshot-block.sh cleanup
+#
+# Prerequisites:
+#   - KUBECONFIG pointing at a cluster with Longhorn (default class)
+#   - StorageClass `longhorn-migratable` with parameters.migratable=true
+#   - VolumeSnapshotClass `longhorn-snapshot` (Longhorn default)
+#   - SwiftSeedProfile `minimal` in `default` namespace
+#
+# Operator workaround until W9.x ships: use cloneStrategy=copy for any
+# RWX+Block guest. This script proves the snapshot path works post-fix.
+
+set -euo pipefail
+
+NS="${NS:-default}"
+SWIFTIMAGE="${SWIFTIMAGE:-w9x-noble-snap}"
+SWIFTGUESTCLASS="${SWIFTGUESTCLASS:-w9x-live-migratable}"
+SWIFTGUEST="${SWIFTGUEST:-w9x-rwx-snap-test}"
+FS_GUEST="${FS_GUEST:-w9x-fs-baseline}"  # for the W10 check
+TIMEOUT_SECS="${TIMEOUT_SECS:-600}"
+
+cmd="${1:-help}"
+
+ensure_prereqs() {
+    kubectl get sc longhorn-migratable >/dev/null \
+        || { echo "ERROR: StorageClass longhorn-migratable not found"; exit 1; }
+    [ "$(kubectl get sc longhorn-migratable -o jsonpath='{.parameters.migratable}')" = "true" ] \
+        || { echo "ERROR: longhorn-migratable.parameters.migratable != true"; exit 1; }
+    kubectl get volumesnapshotclass longhorn-snapshot >/dev/null \
+        || { echo "ERROR: VolumeSnapshotClass longhorn-snapshot not found"; exit 1; }
+    kubectl -n "$NS" get swiftseedprofile minimal >/dev/null \
+        || { echo "ERROR: SwiftSeedProfile minimal not found in ns=$NS"; exit 1; }
+    echo "OK: prerequisites present"
+}
+
+apply_manifests() {
+    cat <<EOF | kubectl apply -f -
+apiVersion: image.kubeswift.io/v1alpha1
+kind: SwiftImage
+metadata:
+  name: $SWIFTIMAGE
+  namespace: $NS
+spec:
+  format: qcow2
+  cloneStrategy: snapshot
+  volumeSnapshotClassName: longhorn-snapshot
+  rootDisk:
+    size: "10Gi"
+  source:
+    http:
+      url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+---
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestClass
+metadata:
+  name: $SWIFTGUESTCLASS
+spec:
+  cpu: "2"
+  memory: "4Gi"
+  rootDisk:
+    size: "40Gi"
+    format: raw
+  storage:
+    accessMode: ReadWriteMany
+    volumeMode: Block
+    storageClassName: longhorn-migratable
+---
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: $SWIFTGUEST
+  namespace: $NS
+spec:
+  imageRef:
+    name: $SWIFTIMAGE
+  guestClassRef:
+    name: $SWIFTGUESTCLASS
+  seedProfileRef:
+    name: minimal
+  runPolicy: Running
+EOF
+}
+
+wait_for_swiftimage_ready() {
+    echo "waiting for SwiftImage $SWIFTIMAGE to become Ready (cloneSeed populated)..."
+    local deadline=$(( $(date +%s) + TIMEOUT_SECS ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        local phase
+        phase=$(kubectl -n "$NS" get swiftimage "$SWIFTIMAGE" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+        local seed
+        seed=$(kubectl -n "$NS" get swiftimage "$SWIFTIMAGE" -o jsonpath='{.status.cloneSeed.name}' 2>/dev/null || true)
+        echo "  swiftimage=$phase cloneSeed=$seed"
+        [ "$phase" = "Ready" ] && [ -n "$seed" ] && return 0
+        sleep 15
+    done
+    echo "TIMEOUT waiting for SwiftImage Ready"
+    return 1
+}
+
+reproduce() {
+    echo "=== W9.x REPRODUCE phase ==="
+    echo "Goal: apply snapshot+Block manifests; PVC should fail with"
+    echo "      allow-volume-mode-change error (PROVES the bug exists)."
+    echo "Run this AGAINST THE OLD CONTROLLER IMAGE (pre-W9.x)."
+    echo ""
+
+    ensure_prereqs
+    apply_manifests
+    wait_for_swiftimage_ready
+
+    echo ""
+    echo "Waiting up to 90s for PVC ProvisioningFailed event..."
+    local pvc="swiftguest-root-$SWIFTGUEST"
+    local deadline=$(( $(date +%s) + 90 ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        if kubectl -n "$NS" get events --field-selector involvedObject.name="$pvc" \
+                -o json 2>/dev/null | grep -q 'allow-volume-mode-change'; then
+            echo ""
+            echo "=== EXPECTED FAILURE OBSERVED ==="
+            kubectl -n "$NS" get events --field-selector involvedObject.name="$pvc" \
+                --sort-by=.lastTimestamp 2>&1 | grep -i 'allow-volume-mode-change\|ProvisioningFailed' | tail -5
+            echo ""
+            echo "Reproduction successful. Now redeploy with the W9.x fix and run:"
+            echo "    $0 validate"
+            return 0
+        fi
+        sleep 5
+    done
+    echo "WARNING: did not observe the expected allow-volume-mode-change error within 90s."
+    echo "Possible causes: (a) cluster already has the fix deployed; (b) a different"
+    echo "CSI driver is in use; (c) Longhorn version differs. Inspect events:"
+    kubectl -n "$NS" get events --field-selector involvedObject.name="$pvc" --sort-by=.lastTimestamp
+    return 1
+}
+
+validate() {
+    echo "=== W9.x VALIDATE phase ==="
+    echo "Goal: with the fix deployed, the snapshot+Block guest reaches Phase=Running."
+    echo "Run this AFTER redeploying the controller image with the W9.x fix."
+    echo ""
+
+    # Re-apply ensures the manifests are in a sane state even if reproduce
+    # was skipped or partially completed. Apply is idempotent.
+    apply_manifests
+    wait_for_swiftimage_ready
+
+    # The fix patches the VSC annotation post-bind. Existing PVC may be in
+    # ProvisioningFailed state from the reproduce phase; deletion + re-creation
+    # picks up the now-annotated VSC.
+    local pvc="swiftguest-root-$SWIFTGUEST"
+    if kubectl -n "$NS" get pvc "$pvc" >/dev/null 2>&1; then
+        local pvc_phase
+        pvc_phase=$(kubectl -n "$NS" get pvc "$pvc" -o jsonpath='{.status.phase}')
+        if [ "$pvc_phase" != "Bound" ]; then
+            echo "PVC $pvc is in phase=$pvc_phase (likely ProvisioningFailed from reproduce);"
+            echo "deleting so the controller recreates with the now-annotated VSC."
+            kubectl -n "$NS" delete pvc "$pvc" --wait=false || true
+            sleep 5
+        fi
+    fi
+
+    echo "Waiting for SwiftGuest $SWIFTGUEST to reach Phase=Running with primaryIP..."
+    local deadline=$(( $(date +%s) + TIMEOUT_SECS ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        local phase ip
+        phase=$(kubectl -n "$NS" get swiftguest "$SWIFTGUEST" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+        ip=$(kubectl -n "$NS" get swiftguest "$SWIFTGUEST" -o jsonpath='{.status.network.primaryIP}' 2>/dev/null || true)
+        echo "  guest=$phase ip=$ip"
+        if [ "$phase" = "Running" ] && [ -n "$ip" ]; then
+            echo ""
+            echo "=== W9.x FIX VALIDATED ==="
+            local vsc
+            vsc=$(kubectl -n "$NS" get volumesnapshot "${SWIFTIMAGE}-clone-seed" \
+                -o jsonpath='{.status.boundVolumeSnapshotContentName}')
+            local annot
+            annot=$(kubectl get volumesnapshotcontent "$vsc" \
+                -o jsonpath='{.metadata.annotations.snapshot\.storage\.kubernetes\.io/allow-volume-mode-change}')
+            echo "VolumeSnapshotContent: $vsc"
+            echo "allow-volume-mode-change annotation: $annot (expected: true)"
+            kubectl -n "$NS" get pvc "$pvc" -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,ACCESS:.spec.accessModes,VOLUMEMODE:.spec.volumeMode,CLASS:.spec.storageClassName
+            return 0
+        fi
+        sleep 15
+    done
+    echo "TIMEOUT waiting for SwiftGuest Running"
+    kubectl -n "$NS" get events --field-selector involvedObject.name="$pvc" --sort-by=.lastTimestamp | tail -10
+    return 1
+}
+
+w10check() {
+    echo "=== W10 verification (binary decision rule) ==="
+    echo "Per PR #35 walkthrough W10: the launcher logs of Block-mode guests show"
+    echo "two boot-time CH 'Request check failed: ... ReadOnly' WARNs at sector 0."
+    echo "Open question: does this happen on Filesystem-mode guests too?"
+    echo ""
+    echo "Method: deploy a Filesystem-mode guest, count ReadOnly WARNs in launcher logs."
+    echo ""
+
+    cat <<EOF | kubectl apply -f -
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestClass
+metadata:
+  name: w9x-fs-baseline
+spec:
+  cpu: "2"
+  memory: "2Gi"
+  rootDisk:
+    size: "10Gi"
+    format: raw
+---
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: $FS_GUEST
+  namespace: $NS
+spec:
+  imageRef:
+    name: $SWIFTIMAGE  # snapshot SwiftImage from the validate phase
+  guestClassRef:
+    name: w9x-fs-baseline
+  seedProfileRef:
+    name: minimal
+  runPolicy: Running
+EOF
+
+    echo "Waiting for $FS_GUEST to reach Running..."
+    local deadline=$(( $(date +%s) + TIMEOUT_SECS ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        local phase ip
+        phase=$(kubectl -n "$NS" get swiftguest "$FS_GUEST" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+        ip=$(kubectl -n "$NS" get swiftguest "$FS_GUEST" -o jsonpath='{.status.network.primaryIP}' 2>/dev/null || true)
+        if [ "$phase" = "Running" ] && [ -n "$ip" ]; then break; fi
+        sleep 15
+    done
+
+    # Give CH a few seconds to log boot messages.
+    sleep 20
+
+    local count
+    count=$(kubectl -n "$NS" logs "$FS_GUEST" -c launcher 2>/dev/null | grep -c 'ReadOnly' || echo 0)
+    echo ""
+    echo "=== W10 decision ==="
+    echo "Filesystem-mode guest $FS_GUEST launcher log 'ReadOnly' WARN count: $count"
+    if [ "$count" -eq 0 ]; then
+        echo ""
+        echo "DECISION: W10 is BLOCK-SPECIFIC."
+        echo "Action: file W10 as a separate GitHub issue with full launcher log"
+        echo "        evidence (kubectl -n $NS logs <block-guest-pod> -c launcher | grep ReadOnly)"
+        echo "        and CH version (cloud-hypervisor v51.1). Cross-link to PR #35."
+    else
+        echo ""
+        echo "DECISION: W10 is GENERIC CH BOOT NOISE."
+        echo "Action: close W10 as wontfix with a one-line note in kubeswift_context.md"
+        echo "        under PR #32 walkthrough findings: 'W10 — boot-time CH ReadOnly WARN"
+        echo "        appears on both Block and Filesystem guests; generic CH v51.1 diagnostic"
+        echo "        noise; no functional impact; closed as wontfix.'"
+    fi
+}
+
+cleanup() {
+    echo "=== cleanup ==="
+    kubectl -n "$NS" delete swiftguest "$SWIFTGUEST" "$FS_GUEST" --wait=false 2>/dev/null || true
+    kubectl delete swiftguestclass "$SWIFTGUESTCLASS" w9x-fs-baseline --wait=false 2>/dev/null || true
+    kubectl -n "$NS" delete swiftimage "$SWIFTIMAGE" --wait=false 2>/dev/null || true
+    echo "queued for deletion. PVCs will be GC'd via finalizer chain."
+}
+
+case "$cmd" in
+    reproduce) reproduce ;;
+    validate)  validate ;;
+    w10check)  w10check ;;
+    cleanup)   cleanup ;;
+    help|*)
+        cat <<EOF
+W9.x cluster integration test (Issue #37).
+
+Usage:
+  $0 reproduce   # apply manifests; expect PVC ProvisioningFailed pre-fix
+  $0 validate    # post-redeploy; expect PVC bound + SwiftGuest Running
+  $0 w10check    # bundled W10 binary-decision verification
+  $0 cleanup     # tear down test resources
+
+Env overrides:
+  NS=$NS
+  SWIFTIMAGE=$SWIFTIMAGE
+  SWIFTGUESTCLASS=$SWIFTGUESTCLASS
+  SWIFTGUEST=$SWIFTGUEST
+  FS_GUEST=$FS_GUEST
+  TIMEOUT_SECS=$TIMEOUT_SECS
+
+The script does NOT redeploy the controller — that is the operator's
+responsibility between reproduce and validate. The A/B contrast (failure
+pre-fix vs success post-fix) is the load-bearing piece per PR #35
+walkthrough's binding scope addition.
+EOF
+        ;;
+esac


### PR DESCRIPTION
## Summary

Resolves #37. Surfaced during the [PR #35 (W9 runtime path) cluster mini-walkthrough](https://github.com/projectbeskar/kubeswift/pull/35#issuecomment-4355730487).

W9 ships RWX+Block end-to-end via `cloneStrategy: copy` (validated end-to-end). The `cloneStrategy: snapshot` path fails at PVC provisioning because the CSI external-snapshotter requires the `snapshot.storage.kubernetes.io/allow-volume-mode-change: \"true\"` annotation on the **VolumeSnapshotContent** (not the VolumeSnapshot — there is no automatic propagation) when destination volumeMode differs from source.

The SwiftImage import PVC is RWO+Filesystem on Longhorn (the project default). RWX+Block destinations need the annotation set so the clone PVC can use Block volumeMode against a Filesystem-mode source snapshot.

## Section 1 — Failure reproduction (pre-fix)

```bash
# OLD controller image (pre-W9.x)
./test/storage/w9x-snapshot-block.sh reproduce
```

Expected output:
```
=== EXPECTED FAILURE OBSERVED ===
... ProvisioningFailed ... failed to provision volume with StorageClass \"longhorn-migratable\":
    error getting handle for DataSource Type VolumeSnapshot by Name w9x-noble-snap-clone-seed:
    requested volume default/swiftguest-root-w9x-rwx-snap-test modifies the mode of the source
    volume but does not have permission to do so.
    snapshot.storage.kubernetes.io/allow-volume-mode-change annotation is not present on
    snapshotcontent snapcontent-...
```

This proves the bug exists in the pre-fix controller.

## Section 2 — The fix (code change summary)

**SwiftImage controller** (`internal/controller/swiftimage/snapshot.go`): `EnsureCloneSeed` gains `ensureAllowVolumeModeChange`, called between the snapshot-exists check and the ReadyToUse check. Sequence: snapshotter binds VSC first (`status.boundVolumeSnapshotContentName` populated), then drives ReadyToUse=true. The patch fires on the binding event, before any clone PVC tries to use the snapshot.

- Pre-bind no-op: status doesn't yet name a VSC → return nil, retry next reconcile
- Idempotent: already-annotated VSC → cheap Get, no patch; existing unrelated annotations preserved
- VSC-not-found is a no-op (CSI race between status populate and cache visibility)

**RBAC additions** (both `config/manager/controller-manager-rbac.yaml` and the Helm chart):
```yaml
- apiGroups: [\"snapshot.storage.k8s.io\"]
  resources: [\"volumesnapshotcontents\"]
  verbs: [\"get\", \"list\", \"watch\", \"patch\"]
```
`list,watch` required by controller-runtime's cached client (same pattern as W7 rolebindings, W8 storageclasses). `patch` is the actual write the fix performs.

The annotation is no-op when destination volumeMode matches source, so it's safe (and idempotent) to set unconditionally on every cloneSeed VSC.

## Section 3 — Re-validation (post-fix)

```bash
# NEW controller image (with W9.x fix) deployed
./test/storage/w9x-snapshot-block.sh validate
```

Expected output (operator fills in actual evidence after running on cluster):
```
=== W9.x FIX VALIDATED ===
VolumeSnapshotContent: snapcontent-XXX
allow-volume-mode-change annotation: true (expected: true)
NAME                              PHASE   ACCESS              VOLUMEMODE   CLASS
swiftguest-root-w9x-rwx-snap-test Bound   [ReadWriteMany]     Block        longhorn-migratable
```

```
guest=Running ip=10.244.125.X
```

## Section 4 — W10 verification result block (operator fills in post-merge)

Per the binding decision rule from PR #35 walkthrough:
```bash
./test/storage/w9x-snapshot-block.sh w10check
```

The script applies a Filesystem-mode guest, waits for boot, then runs:
```
kubectl -n default logs <fs-guest-pod> -c launcher | grep -c 'ReadOnly'
```

**Operator: paste the count + decision here:**

```
ReadOnly WARN count on Filesystem-mode guest:  ___
DECISION:  [ ] Block-specific → file W10 separately   [ ] Generic CH noise → close W10 as wontfix
```

Either outcome closes the W10 question. The script prints the decision rule and which action to take based on the count.

## Section 5 — Cross-references

- Issue #37 — W9.x scope
- PR #35 — W9 (Block runtime path, merged 2026-04-30)
- PR #36 — W9 walkthrough log + W10/W9.x narrative
- `kubeswift_context.md` — Tracked Follow-up #6 (W9 SHIPPED) + #7 (W9.x — this PR)
- `docs/design/storage-rwx-block-runtime.md` — original W9 scoping (historical)

## Section 6 — `make smoke-test` regression gate

W9.x touches the SwiftImage controller's snapshot-creation path. Smoke-test scenarios use `cloneStrategy: copy` (the project default) — the new code path runs only on `cloneStrategy: snapshot`, so smoke-test serves as a regression gate for the existing copy-strategy paths.

**Local smoke-test status (running in background as PR was opened):**

```
=== KubeSwift smoke test ===
Namespace: default
--- Scenario: disk-boot (Cloud Hypervisor + Ubuntu Noble) ---
SwiftImage ubuntu-noble Ready ✓
SwiftGuest sample → Running [in flight at PR-open time]
```

I'll comment with full smoke-test output when it completes. The disk-boot scenario covers the SwiftImage Ready → SwiftGuest Running path that exercises the SwiftImage controller's reconcile loop (without exercising the new `ensureAllowVolumeModeChange` path, since the smoke SwiftImage uses `cloneStrategy: copy`).

## Test plan

- [x] `go test ./...` clean (5 new tests in `snapshot_w9x_test.go`, all pass; existing tests unchanged)
- [x] `cargo test --workspace` clean (130/130; no Rust changes in W9.x)
- [x] `gofmt`, `go vet`, `cargo fmt --check` clean
- [x] CRD generation no-op (no API changes)
- [x] Cluster integration script `test/storage/w9x-snapshot-block.sh` authored with A/B reproduction + W10 binary check
- [ ] Cluster validation (operator): `reproduce` → redeploy → `validate` → `w10check` → `cleanup`
- [ ] Smoke-test in-flight at PR open; results posted as a comment

## Out of scope

- Other CSI drivers' Block support (Ceph RBD, EBS, etc.)
- `SwiftImage.spec.storage` for direct Block imports
- Any change to PR #35's runtime path (W9 ships as-is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)