### PR TITLE
fix(swiftmigration): PR 1 hotfix — W13 + W14 (Phase 3a live migration unblock)

### DIFF
--- a/internal/controller/swiftmigration/cancel_live.go
+++ b/internal/controller/swiftmigration/cancel_live.go
@@ -29,6 +29,20 @@ const (
 	MigrationActionCancel         = "cancel"
 	MigrationStatusFailed         = "failed"
 	MigrationStatusFailedCancelDt = "cancelled" // expected substring in status-detail
+
+	// MigrationStatusRejected is swiftletd's status for an action it
+	// refused to execute (Phase 2 PR-B's decide() rejection path —
+	// e.g., missing phase2-ack annotation, namespace mismatch, action-id
+	// mismatch). Distinct from "failed" (action ran and errored) per
+	// rust/swiftletd/src/action.rs's StatusKind::Rejected vs
+	// StatusKind::Failed.
+	//
+	// Phase 3a's controller treats rejected with matching action-id as
+	// terminal: surface as a fast Failed transition with the rejection
+	// detail preserved in failureMessage. Without this recognition the
+	// migration stalls at substateSendPending/substateRecvPending until
+	// spec.timeout (W14, surfaced during PR 1 cluster walkthrough).
+	MigrationStatusRejected = "rejected"
 )
 
 // cancelAckTimeout is the upper bound for waiting on D1's cancel-ack

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -385,6 +385,29 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 			fmt.Sprintf("source reported migration failure: %s", normalizeStatusDetail(detail)),
 			classifyFailureFromDetail(detail))
 
+	case substateDstRejected:
+		// W14: dst's swiftletd refused the receive-action via decide().
+		// Detail carries the rejection reason (e.g.,
+		// phase2_plaintext_ack_missing, action-id mismatch). Surface as
+		// FailureReasonOther with the detail preserved — operator-
+		// readable failureMessage is the load-bearing artifact for
+		// diagnosis since rejection reasons are open-ended.
+		detail := dstPod.Annotations[AnnotationMigrationStatusDtl]
+		return phaseFailure(
+			fmt.Sprintf("destination rejected migration action: %s", normalizeStatusDetail(detail)),
+			migrationv1alpha1.FailureReasonOther)
+
+	case substateSrcRejected:
+		// W14: src's swiftletd refused the send-action via decide().
+		// See substateDstRejected for rationale.
+		detail := ""
+		if srcArg != nil {
+			detail = srcArg.Annotations[AnnotationMigrationStatusDtl]
+		}
+		return phaseFailure(
+			fmt.Sprintf("source rejected migration action: %s", normalizeStatusDetail(detail)),
+			migrationv1alpha1.FailureReasonOther)
+
 	default:
 		// deriveSubstate is exhaustive; this branch is unreachable
 		// unless a future sub-state is added without updating the

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -236,21 +236,36 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 
 	switch sub {
 	case substatePreRecv:
-		// Patch src pod with migration-name label per architect F-3:
-		// makes src observable via the same labeled-pod watch the
-		// manager registers for dst. Idempotent — skips patch if the
-		// label is already present (leader-handover safe). Without
-		// this, controller observability of src migration-status
-		// transitions falls back to the 30s SyncPeriod (defense-in-
-		// depth), adding up to 30s latency to state advances.
-		if srcPodPresent && srcPod.Labels[LabelMigrationName] != mig.Name {
-			labelPatch := client.MergeFrom(srcPod.DeepCopy())
+		// Patch src pod with the migration-name label (architect F-3,
+		// informer observability) AND the Phase 2 plaintext-ack
+		// annotation (W13: swiftletd's decide() rejects send actions
+		// on pods missing the ack with status=rejected; without this
+		// patch the migration would stall at substateSendPending until
+		// spec.timeout). Both writes are idempotent at the apiserver
+		// layer (same-value MergeFrom is a no-op patch); skip-when-
+		// present is a small optimisation that also makes leader-
+		// handover behaviour observable in tests. dst pod gets the
+		// ack at construction time in B2.2's mergeAnnotationsForDst;
+		// src pod is the existing SwiftGuest launcher pod which
+		// predates the migration, so the controller must add it.
+		needLabelPatch := srcPodPresent && srcPod.Labels[LabelMigrationName] != mig.Name
+		needAckPatch := srcPodPresent && srcPod.Annotations[AnnotationMigrationPhase2Ack] != AnnotationMigrationPhase2AckValue
+		if needLabelPatch || needAckPatch {
+			patch := client.MergeFrom(srcPod.DeepCopy())
 			if srcPod.Labels == nil {
 				srcPod.Labels = map[string]string{}
 			}
-			srcPod.Labels[LabelMigrationName] = mig.Name
-			if err := r.Patch(ctx, &srcPod, labelPatch); err != nil {
-				return phaseTransient(fmt.Errorf("label src pod for informer observability: %w", err))
+			if srcPod.Annotations == nil {
+				srcPod.Annotations = map[string]string{}
+			}
+			if needLabelPatch {
+				srcPod.Labels[LabelMigrationName] = mig.Name
+			}
+			if needAckPatch {
+				srcPod.Annotations[AnnotationMigrationPhase2Ack] = AnnotationMigrationPhase2AckValue
+			}
+			if err := r.Patch(ctx, &srcPod, patch); err != nil {
+				return phaseTransient(fmt.Errorf("patch src pod (label + phase2 ack) at StopAndCopy entry: %w", err))
 			}
 		}
 

--- a/internal/controller/swiftmigration/stopandcopy_live_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_live_test.go
@@ -243,6 +243,78 @@ func TestStopAndCopyLive_PreRecv_WritesReceiveAction(t *testing.T) {
 	}
 }
 
+// W13 regression: substatePreRecv must patch src pod with BOTH the
+// migration-name label (informer observability per architect F-3) AND
+// the Phase 2 plaintext-ack annotation. Without the ack, swiftletd's
+// decide() rejects the send-action with status=rejected and the
+// migration stalls at substateSendPending until spec.timeout.
+//
+// Cluster walkthrough surfaced this against PR 1's merged image
+// (sha-4cde589): src pod's migration-status annotation went to
+// "rejected" with detail "phase2_plaintext_ack_missing"; controller
+// stayed at substateSendPending; spec.timeout fired ~5min later.
+func TestStopAndCopyLive_PreRecv_PatchesSrcPodWithLabelAndAck_W13(t *testing.T) {
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
+	// Confirm src pod starts WITHOUT the ack — fixture realism.
+	if src.Annotations[AnnotationMigrationPhase2Ack] != "" {
+		t.Fatalf("fixture invalid: src pod should not pre-set ack")
+	}
+	if src.Labels[LabelMigrationName] != "" {
+		t.Fatalf("fixture invalid: src pod should not pre-set migration label")
+	}
+
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.Err != nil || res.FailureMsg != "" {
+		t.Fatalf("unexpected failure: err=%v msg=%q", res.Err, res.FailureMsg)
+	}
+
+	var got corev1.Pod
+	if err := r.Get(context.Background(), key(src), &got); err != nil {
+		t.Fatalf("re-get src: %v", err)
+	}
+	if got.Labels[LabelMigrationName] != mig.Name {
+		t.Errorf("src migration-name label: want %q, got %q",
+			mig.Name, got.Labels[LabelMigrationName])
+	}
+	if got.Annotations[AnnotationMigrationPhase2Ack] != AnnotationMigrationPhase2AckValue {
+		t.Errorf("src phase2-ack annotation: want %q, got %q",
+			AnnotationMigrationPhase2AckValue,
+			got.Annotations[AnnotationMigrationPhase2Ack])
+	}
+}
+
+// W13 idempotency: re-running the handler when src pod already has
+// the label + ack must not re-patch (verified via ResourceVersion
+// stability across reconciles).
+func TestStopAndCopyLive_PreRecv_W13Idempotent(t *testing.T) {
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
+	if src.Labels == nil {
+		src.Labels = map[string]string{}
+	}
+	if src.Annotations == nil {
+		src.Annotations = map[string]string{}
+	}
+	src.Labels[LabelMigrationName] = mig.Name
+	src.Annotations[AnnotationMigrationPhase2Ack] = AnnotationMigrationPhase2AckValue
+
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+	var pre corev1.Pod
+	_ = r.Get(context.Background(), key(src), &pre)
+	preRV := pre.ResourceVersion
+
+	status := mig.Status.DeepCopy()
+	_ = r.handleStopAndCopyLive(context.Background(), mig, status)
+
+	var post corev1.Pod
+	_ = r.Get(context.Background(), key(src), &post)
+	if post.ResourceVersion != preRV {
+		t.Errorf("src pod ResourceVersion changed; W13 patch should be a no-op when label+ack already present (pre=%q post=%q)",
+			preRV, post.ResourceVersion)
+	}
+}
+
 func TestStopAndCopyLive_RecvPending_RequeuesWithDetail(t *testing.T) {
 	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
 	mig.Status.RecvAttempts = 1

--- a/internal/controller/swiftmigration/stopandcopy_live_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_live_test.go
@@ -285,6 +285,75 @@ func TestStopAndCopyLive_PreRecv_PatchesSrcPodWithLabelAndAck_W13(t *testing.T) 
 	}
 }
 
+// W14: deriveSubstate must recognise migration-status=rejected on src
+// and dst as terminal sub-states. Without this, swiftletd's decide()
+// rejection (e.g., missing phase2 ack, action-id mismatch) leaves the
+// migration parked at substateSendPending/substateRecvPending until
+// spec.timeout — operators see Timeout when the real cause is the
+// rejection detail.
+func TestDeriveSubstate_SrcRejected_W14(t *testing.T) {
+	mig, _, src, dst := stopAndCopyFixture(t, "uid-1")
+	stamp(src, migrationActionVerbSend, sendActionID(mig),
+		MigrationStatusRejected, sendActionID(mig),
+		"phase2_plaintext_ack_missing")
+	if got := deriveSubstate(mig, src, dst); got != substateSrcRejected {
+		t.Errorf("substate: want src-rejected, got %v", got)
+	}
+}
+
+func TestDeriveSubstate_DstRejected_W14(t *testing.T) {
+	mig, _, src, dst := stopAndCopyFixture(t, "uid-1")
+	stamp(dst, migrationActionVerbReceive, recvActionID(mig),
+		MigrationStatusRejected, recvActionID(mig),
+		"phase2_plaintext_ack_missing")
+	if got := deriveSubstate(mig, src, dst); got != substateDstRejected {
+		t.Errorf("substate: want dst-rejected, got %v", got)
+	}
+}
+
+func TestStopAndCopyLive_SrcRejected_FailsWithOther_W14(t *testing.T) {
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
+	mig.Status.RecvAttempts = 1
+	mig.Status.SendAttempts = 1
+	stamp(src, migrationActionVerbSend, sendActionID(mig),
+		MigrationStatusRejected, sendActionID(mig),
+		"phase2_plaintext_ack_missing")
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason != migrationv1alpha1.FailureReasonOther {
+		t.Errorf("FailureReason: want Other, got %q", res.FailureReason)
+	}
+	if !strings.Contains(res.FailureMsg, "source rejected migration action") {
+		t.Errorf("FailureMsg: want src-rejected message, got %q", res.FailureMsg)
+	}
+	if !strings.Contains(res.FailureMsg, "phase2_plaintext_ack_missing") {
+		t.Errorf("FailureMsg should preserve rejection detail; got %q", res.FailureMsg)
+	}
+}
+
+func TestStopAndCopyLive_DstRejected_FailsWithOther_W14(t *testing.T) {
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
+	mig.Status.RecvAttempts = 1
+	stamp(dst, migrationActionVerbReceive, recvActionID(mig),
+		MigrationStatusRejected, recvActionID(mig),
+		"phase2_plaintext_ack_missing")
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason != migrationv1alpha1.FailureReasonOther {
+		t.Errorf("FailureReason: want Other, got %q", res.FailureReason)
+	}
+	if !strings.Contains(res.FailureMsg, "destination rejected migration action") {
+		t.Errorf("FailureMsg: want dst-rejected message, got %q", res.FailureMsg)
+	}
+	if !strings.Contains(res.FailureMsg, "phase2_plaintext_ack_missing") {
+		t.Errorf("FailureMsg should preserve rejection detail; got %q", res.FailureMsg)
+	}
+}
+
 // W13 idempotency: re-running the handler when src pod already has
 // the label + ack must not re-patch (verified via ResourceVersion
 // stability across reconciles).

--- a/internal/controller/swiftmigration/stopandcopy_substate.go
+++ b/internal/controller/swiftmigration/stopandcopy_substate.go
@@ -69,6 +69,17 @@ const (
 	// CH-internal errors, network failures during send. Per F4 the
 	// controller maps the FailureReason based on detail string.
 	substateSrcFailed
+	// substateDstRejected is "dst pod reported migration-status=
+	// rejected with matching $RECV_ID." swiftletd's decide() refused
+	// the receive-action (e.g., missing phase2-ack — addressed by W13
+	// for happy-path; namespace mismatch; action-id mismatch). Without
+	// W14's recognition the migration would stall at substateRecvPending
+	// until spec.timeout.
+	substateDstRejected
+	// substateSrcRejected is the src-side equivalent — swiftletd
+	// refused the send-action with status=rejected. Same default
+	// rationale as substateDstRejected.
+	substateSrcRejected
 )
 
 // String returns the design-doc sub-state name for diagnostic logging
@@ -90,6 +101,10 @@ func (s stopAndCopySubstate) String() string {
 		return "dst-failed"
 	case substateSrcFailed:
 		return "src-failed"
+	case substateDstRejected:
+		return "dst-rejected"
+	case substateSrcRejected:
+		return "src-rejected"
 	default:
 		return fmt.Sprintf("unknown(%d)", int(s))
 	}
@@ -188,6 +203,11 @@ func deriveSubstate(mig *migrationv1alpha1.SwiftMigration, src, dst *corev1.Pod)
 	if podStatusMatches(src, MigrationStatusFailed, sid) {
 		return substateSrcFailed
 	}
+	// Src-side rejected (W14): swiftletd's decide() refused the send-
+	// action. Terminal — fast-fail rather than wait for spec.timeout.
+	if podStatusMatches(src, MigrationStatusRejected, sid) {
+		return substateSrcRejected
+	}
 
 	// Dst-side terminal: failed (D2 watchdog or CH receive error).
 	// We do NOT check dst-side "running" here as a terminal state —
@@ -195,6 +215,11 @@ func deriveSubstate(mig *migrationv1alpha1.SwiftMigration, src, dst *corev1.Pod)
 	// is src=complete; dst=running is intermediate.
 	if podStatusMatches(dst, MigrationStatusFailed, rid) {
 		return substateDstFailed
+	}
+	// Dst-side rejected (W14): swiftletd-on-dst refused the receive-
+	// action. Terminal — same rationale as src-side.
+	if podStatusMatches(dst, MigrationStatusRejected, rid) {
+		return substateDstRejected
 	}
 
 	// Send-action acknowledged on src (action-id matches $SEND_ID):


### PR DESCRIPTION
# PR 1 hotfix: W13 + W14 — Phase 3a live migration unblock

Cluster walkthrough of merged PR #42 (image \`sha-4cde589\`) surfaced two findings during Scenario 1 (happy-path kernel-boot live migration). Both block every Phase 3a live migration in production-equivalent shape, so this hotfix lands before the cluster walkthrough resumes.

## Walkthrough excerpt — finding discovery

\`\`\`
T+0s  phase=Pending  detail=''
T+10s  phase=StopAndCopy  detail='transferring guest state'
T+30s  phase=StopAndCopy  detail='transferring guest state'
...
T+147s  phase=StopAndCopy  detail='transferring guest state'   <-- stuck

src pod migration annotations:
  kubeswift.io/migration-action: send
  kubeswift.io/migration-action-id: s1-mig:send:1
  kubeswift.io/migration-status: rejected                       <-- W13 + W14
  kubeswift.io/migration-status-detail: phase2_plaintext_ack_missing
  kubeswift.io/migration-status-id: s1-mig:send:1
  (no kubeswift.io/migration-phase2-unsafe-plaintext annotation)

dst pod migration annotations:
  kubeswift.io/migration-phase2-unsafe-plaintext: ack           <-- present on dst
  kubeswift.io/migration-status: running
\`\`\`

After manually patching src with the ack annotation, swiftletd-on-src re-evaluated and the send action **succeeded**: \`migration-status: complete\`, detail \`sent to tcp:10.244.213.41:6789 (38158ms)\` — matches the Phase 3a spike Q1 baseline (~38s migration body for kernel-boot 4Gi guest). But the SwiftMigration had already crossed the 5m \`spec.timeout\` window, so phase=Failed with failureReason=Timeout.

## W13 (BLOCKING) — Controller does not patch src pod with \`migration-phase2-unsafe-plaintext: ack\`

**Root cause:** \`internal/controller/swiftmigration/stopandcopy_live.go\` substatePreRecv branch patches src pod with the \`kubeswift.io/migration\` label only (Group C / df74bf8 architect F-3 informer observability). The dst pod gets the ack at construction time via B2.2's \`mergeAnnotationsForDst\`/\`AnnotationMigrationPhase2Ack\`, but the src pod is the existing SwiftGuest launcher pod which predates the migration entirely. Phase 2's manual-demo design assumed both pods were operator-set with the ack; Phase 3a's controller automated dst but missed src.

**Fix:** Single MergeFrom patches src with both label AND ack annotation. Idempotent at the apiserver layer (same-value patch is a no-op); skip-when-present optimisation makes leader-handover behaviour observable in tests.

**Commit:** \`efc08fd\`

**Tests:**
- \`TestStopAndCopyLive_PreRecv_PatchesSrcPodWithLabelAndAck_W13\` — verify src pod gets both label AND ack on first reconcile
- \`TestStopAndCopyLive_PreRecv_W13Idempotent\` — ResourceVersion stable when label+ack already present

## W14 (HIGH) — \`deriveSubstate\` does not recognise \`migration-status=rejected\` as terminal

**Root cause:** \`stopandcopy_substate.go\`'s \`deriveSubstate\` only matched \`complete\` (success) and \`failed\` (action ran but errored). swiftletd's \`decide()\` writes \`StatusKind::Rejected\` for refused actions (phase2-ack missing, action-id mismatch, namespace not allowed, etc.) — semantically distinct from Failed (action attempted) and Complete (success). The controller's substate machine treated rejected as non-terminal, leaving the migration parked at substateSendPending/substateRecvPending until \`spec.timeout\` fired ~5min later. Operators saw \`failureReason=Timeout\` when the real cause was \`phase2_plaintext_ack_missing\` (or any other future rejection reason).

**Fix:**
- Add \`MigrationStatusRejected = "rejected"\` constant
- Add \`substateSrcRejected\` / \`substateDstRejected\` enum values
- \`deriveSubstate\` checks rejected (with matching \$RECV_ID/\$SEND_ID) BEFORE the action-pending checks
- Handler maps both rejection sub-states to \`phaseFailure\` with \`FailureReasonOther\` + \"source/destination rejected migration action: <detail>\" message; raw rejection detail preserved in \`failureMessage\` for operator diagnosis

**Commit:** \`1d256b9\`

**Tests:**
- \`TestDeriveSubstate_{Src,Dst}Rejected_W14\` — pure-derivation coverage
- \`TestStopAndCopyLive_{Src,Dst}Rejected_FailsWithOther_W14\` — handler produces phaseFailure with detail preserved

## Finding-behind-a-finding

W14 surfaced because W13's missing phase2 ack triggered the rejection code path. Without W13's failure mode firing, W14's rejected-status-not-recognised would have stayed latent until some other rejection reason occurred in production (e.g., a future namespace-mismatch finding from a different feature, or operator misconfiguration of the ack annotation).

This is exactly why Option 1 (\"fix and continue on clean baseline\") was chosen over fixing only the immediately-blocking finding. Fixing only W13 would have left W14 latent; fixing both ensures the next rejection reason — whatever it is — surfaces with a useful \`failureReason\` instead of \`Timeout\`.

## Test plan

- [x] Unit tests pass (\`go test ./...\`)
- [x] \`go vet\` clean
- [x] \`gofmt\` clean
- [ ] Post-merge cluster walkthrough Scenario 1 re-run as the \"does anything work\" gate (operator-driven; see commit \`df74bf8\` walkthrough notes)
- [ ] If Scenario 1 passes cleanly, walkthrough proceeds to Scenarios 2-9
- [ ] If Scenario 1 surfaces another finding, stop and discuss

## Walkthrough log disposition

W13 + W14 will be documented as discovered findings in the Phase 3a cluster walkthrough log (lands as \`docs/migration/phase-3a-cluster-validation.md\` after walkthrough completes). The log will show: \"Scenario 1 surfaced W13 + W14, fixed via this hotfix PR, walkthrough resumed against fixed image, Scenarios 1-10 results.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)