### PR TITLE
fix(swiftmigration): PR 1 hotfix #2 — W15 (UID check race with cutoverStep1)

### DIFF
--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -150,13 +150,38 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 		return phaseTransient(fmt.Errorf("get source guest: %w", err))
 	}
 
-	// Resolve src pod (the canonical pod pre-cutover; B2.3's helper
-	// returns guest.Name when status.podRef is nil/empty, which is
-	// the correct value here since B2.4's cutover hasn't run yet).
-	srcPodName := canonicalPodNameForGuest(&guest)
+	// Resolve src pod by guest.Name — NOT via canonicalPodName.
+	//
+	// W15 (cluster walkthrough finding): canonicalPodNameForGuest
+	// resolves to the dst pod name post-cutoverStep1 (which patches
+	// SwiftGuest.status.podRef.name = dst). cutoverStep1 issues two
+	// separate apiserver writes (SwiftGuest podRef + SwiftMigration
+	// status); the SwiftGuest patch fires the SwiftGuest informer
+	// watch and triggers a SwiftMigration reconcile. If that race-
+	// reconcile lands before the SwiftMigration status patch persists
+	// (or before the controller's persist completes from the original
+	// cutover-step-1 reconcile), the new reconcile reads:
+	//   - mig.Status.PhaseDetail = LiveSrcCompleted (stale; pre-cutover)
+	//   - guest.Status.PodRef.Name = dst (already swapped)
+	// shouldCheckSourcePodUID returns true (LiveSrcCompleted is in the
+	// pre-cutover vocabulary), and canonicalPodName resolves to dst.
+	// The Get fetches the dst pod, whose UID never matches
+	// status.SourcePodUID, so the UID check fires SourcePodReplaced on
+	// a perfectly healthy migration.
+	//
+	// The src pod is ALWAYS named guest.Name throughout its lifetime.
+	// Using guest.Name directly here makes the UID check race-free.
+	// canonicalPodName is the right abstraction for "the active
+	// canonical launcher pod" but wrong for "the original src pod
+	// whose UID we recorded at Validating".
+	//
+	// Same shape as the B3.2 fix in cutover.go::executeCutover, which
+	// also explicitly fetches src by guest.Name to bypass the same
+	// canonicalPodName-post-step-1 ambiguity. The fix didn't propagate
+	// to this outer site until W15 surfaced on cluster.
 	var srcPod corev1.Pod
 	srcPodPresent := true
-	if err := r.Get(ctx, client.ObjectKey{Name: srcPodName, Namespace: guest.Namespace}, &srcPod); err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Name: guest.Name, Namespace: guest.Namespace}, &srcPod); err != nil {
 		if apierrors.IsNotFound(err) {
 			srcPodPresent = false
 		} else {
@@ -314,7 +339,7 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 
 		if !srcPodPresent {
 			return phaseFailure(
-				fmt.Sprintf("source pod %q disappeared between pre-recv and pre-send", srcPodName),
+				fmt.Sprintf("source pod %q disappeared between pre-recv and pre-send", guest.Name),
 				migrationv1alpha1.FailureReasonSourcePodReplaced)
 		}
 		if dstPod.Status.PodIP == "" {
@@ -340,7 +365,7 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 			"issuing send action on source pod")
 		if r.Recorder != nil {
 			r.Recorder.Eventf(mig, corev1.EventTypeNormal, "SendIssued",
-				"wrote send-action on src pod %q (id=%s)", srcPodName, sendActionID(mig))
+				"wrote send-action on src pod %q (id=%s)", guest.Name, sendActionID(mig))
 		}
 		return phaseRequeue(stopAndCopyLivePollInterval)
 

--- a/internal/controller/swiftmigration/stopandcopy_live_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_live_test.go
@@ -591,6 +591,59 @@ func TestStopAndCopyLive_SrcPodGone_FailsWithSourcePodReplaced(t *testing.T) {
 	}
 }
 
+// W15 regression: when SwiftGuest.status.podRef.name has been patched
+// to the dst pod (post-cutoverStep1), the controller must NOT use
+// canonicalPodName to resolve src — that would fetch the dst pod and
+// false-positive the UID check.
+//
+// Cluster walkthrough surfaced this against PR 1 + W13/W14 hotfix
+// image (sha-ce68fa9): cutoverStep1 issues two separate apiserver
+// writes (SwiftGuest podRef + SwiftMigration status); the SwiftGuest
+// patch fires the SwiftGuest informer watch, triggering a race-
+// reconcile that reads stale phaseDetail (LiveSrcCompleted = pre-
+// cutover) and a fresh guest with podRef = dst. canonicalPodName
+// resolves to dst, the Get fetches the dst pod, and the UID check
+// false-fires SourcePodReplaced.
+//
+// Fix: src-pod fetch uses guest.Name (the original src pod name)
+// regardless of canonicalPodName state. The UID check is specifically
+// about the original src pod, not the canonical launcher pod.
+func TestStopAndCopyLive_PostCutoverStep1_RaceReconcile_DoesNotFalseFireUIDCheck_W15(t *testing.T) {
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-A")
+	mig.Status.RecvAttempts = 1
+	mig.Status.SendAttempts = 1
+	// Race state: cutoverStep1 has patched SwiftGuest podRef but the
+	// SwiftMigration status patch hasn't persisted yet. Phase still
+	// StopAndCopy, phaseDetail still LiveSrcCompleted (pre-cutover
+	// vocabulary; shouldCheckSourcePodUID returns true).
+	mig.Status.PhaseDetail = migrationv1alpha1.PhaseDetailLiveSrcCompleted
+	guest.Status.PodRef = &corev1.ObjectReference{
+		Name:      "guest-mig-abcdef", // matches dst pod name
+		Namespace: guest.Namespace,
+	}
+	// src pod still exists with original UID (cutoverStep2 hasn't run);
+	// dst pod has different UID. canonicalPodName would resolve to
+	// dst-name and fetch dst (UID mismatch → false-fire). guest.Name
+	// resolves to src-name and fetches src (UID match → no fire).
+	src.UID = "uid-A"
+	dst.UID = "uid-DST" // distinct from src
+	stamp(src, migrationActionVerbSend, sendActionID(mig),
+		migrationStatusComplete, sendActionID(mig), "ok")
+
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason == migrationv1alpha1.FailureReasonSourcePodReplaced {
+		t.Errorf("UID check false-fired SourcePodReplaced; W15 regression. msg=%q",
+			res.FailureMsg)
+	}
+	// Healthy outcome: cutover-in-progress short-circuit fires;
+	// executeCutover dispatches step 2 (delete src) since podRef-done
+	// + cutoverStep1At unset means cutoverStep1Timestamp recovery path,
+	// or step 2 if CutoverStep1At was set via fixture. Either way,
+	// no SourcePodReplaced.
+}
+
 func TestStopAndCopyLive_DefensiveGuard_NotLiveMode(t *testing.T) {
 	r := &SwiftMigrationReconciler{}
 	mig := &migrationv1alpha1.SwiftMigration{


### PR DESCRIPTION
# PR 1 hotfix #2: W15 — UID check race with cutoverStep1

Cluster walkthrough re-run against the W13/W14 hotfix image (\`sha-ce68fa9\`) surfaced a finding-behind-a-finding. With W13's stuck-at-send-pending fixed, Scenario 1 progressed all the way through cutover step 1 (\`cutoverStep1At\` populated, SwiftGuest podRef advanced to dst), then false-failed with \`failureReason=SourcePodReplaced\` at \`phaseDetail: 'cutover: completing'\` on a perfectly healthy migration.

## Walkthrough excerpt — W15 discovery

\`\`\`
T+0s     Pending
T+3s     StopAndCopy / 'transferring guest state'
T+42s    Failed

cutoverStep1At: 2026-05-03T11:48:09Z   <-- cutover step 1 succeeded
phase: Failed
phaseDetail: 'cutover: completing'
failureReason: SourcePodReplaced
failureMessage: source pod for SwiftGuest "faas-s1" was replaced
                (UID changed from "68100a7c-73bb-40e0-8637-4304755ad6a9"
                to "52bafad8-60a2-41d8-a644-df155ead2083")
\`\`\`

But:

\`\`\`
$ kubectl -n mig-wt get pod faas-s1-mig-e5a450 -o jsonpath='{.metadata.uid}'
52bafad8-60a2-41d8-a644-df155ead2083    <-- the "replaced" UID is the DST pod's UID

$ kubectl -n mig-wt get swiftguest faas-s1 -o jsonpath='{.status.podRef.name}'
faas-s1-mig-e5a450                       <-- guest.podRef advanced to dst (cutoverStep1)
\`\`\`

The \"replaced\" UID is the destination pod's UID, not a recreated source pod's UID. The UID check fetched the dst pod and compared its UID against \`status.SourcePodUID\` (the original src pod UID).

## Root cause

[\`stopandcopy_live.go:156\`](https://github.com/projectbeskar/kubeswift/blob/main/internal/controller/swiftmigration/stopandcopy_live.go#L156) used \`canonicalPodNameForGuest(&guest)\` to fetch the src pod for the UID check. Post-cutoverStep1, \`canonicalPodName\` follows \`guest.Status.PodRef.Name\` and resolves to the **dst pod name**.

cutoverStep1 issues two separate apiserver writes:
1. SwiftGuest.status.podRef.name = dst (cluster-of-truth signal)
2. SwiftMigration.status.cutoverStep1At + phaseDetail = DeleteSrc

The SwiftGuest patch fires the SwiftGuest informer watch, triggering a SwiftMigration reconcile via \`guestToMigrations\`. If that race-reconcile lands before the SwiftMigration status patch persists, the new reconcile reads:

- \`mig.Status.PhaseDetail\` = \`LiveSrcCompleted\` (stale; pre-cutover vocabulary)
- \`guest.Status.PodRef.Name\` = dst (already swapped)

\`shouldCheckSourcePodUID\` returns true (LiveSrcCompleted IS in the pre-cutover vocabulary). canonicalPodName resolves to dst-pod-name. The \`r.Get\` fetches the **dst pod**. UID check compares dst-pod-UID against \`status.SourcePodUID\` (which was the original src-pod UID) → false-fires SourcePodReplaced.

## Same shape as B3.2's fix

The B3.2 cutover handler had the **same canonicalPodName-post-step-1 ambiguity**, caught by the selectiveFailingClient test surface and fixed in commit \`420b075\` by explicitly fetching src by \`guest.Name\` inside \`executeCutover\`. The fix didn't propagate to the **outer** stopandcopy_live.go site because no unit test exercised the specific sequence: cutoverStep1-podRef-patch + race-reconcile + UID-check, all in the same reconcile invocation.

## Fix

\`\`\`go
- // Resolve src pod (the canonical pod pre-cutover; B2.3's helper
- // returns guest.Name when status.podRef is nil/empty, which is
- // the correct value here since B2.4's cutover hasn't run yet).
- srcPodName := canonicalPodNameForGuest(&guest)
+ // Resolve src pod by guest.Name — NOT via canonicalPodName.
+ // [W15 race window explained in code comment]
+ //
+ // The src pod is ALWAYS named guest.Name throughout its lifetime.
+ // Using guest.Name directly here makes the UID check race-free.
\`\`\`

\`canonicalPodName\` is the right abstraction for \"the active canonical launcher pod\" but wrong for \"the original src pod whose UID we recorded at Validating\". The src pod's name is invariant (= \`guest.Name\`) for its entire lifetime, regardless of cutover state.

## Test

\`TestStopAndCopyLive_PostCutoverStep1_RaceReconcile_DoesNotFalseFireUIDCheck_W15\`:

Fixture pre-sets the race state — \`guest.Status.PodRef.Name\` = dst-name (cutoverStep1 SwiftGuest patch landed), \`mig.Status.PhaseDetail\` = LiveSrcCompleted (SwiftMigration status patch hasn't persisted yet), src.UID and dst.UID distinct. Without the fix, UID check resolves src to dst-pod and fires false SourcePodReplaced. With fix, src is fetched by guest.Name, UID matches, the race-reconcile is benign and the cutover-in-progress short-circuit proceeds normally.

## Finding pattern: finding-behind-a-finding twice in two iterations

| Iteration | Findings | Root cause |
|---|---|---|
| 1 (PR 1 baseline, sha-4cde589) | W13 (BLOCKING), W14 (HIGH) | src pod missing phase2 ack; rejected status not recognized |
| 2 (W13/W14 hotfix, sha-ce68fa9) | W15 (BLOCKING) | UID check uses canonicalPodName which resolves to dst post-step-1 |

Each iteration's blocking bug hid the next finding. This pattern reinforces the W5 lesson: cluster integration validates the implementation against real-world behavior in ways unit tests cannot. The B0 selectiveFailingClient infrastructure caught the canonicalPodName ambiguity in cutover.go (B3.2 fix) but not in this outer site because no test exercised the specific race-reconcile sequence.

The walkthrough discipline (\"fix and continue on clean baseline\" over \"manual workaround\" or \"defer to follow-up PR\") continues to be the right call: each iteration surfaces a new blocking bug that would otherwise stay latent.

## Test plan

- [x] Unit tests pass (\`go test ./...\`)
- [x] \`go vet\` clean
- [x] \`gofmt\` clean
- [ ] Post-merge cluster walkthrough Scenario 1 re-run (third attempt) as the \"does anything work\" gate
- [ ] If Scenario 1 passes cleanly, walkthrough proceeds to Scenarios 2-9
- [ ] If Scenario 1 surfaces another finding, stop and discuss

## Walkthrough log disposition

W15 will be documented as the third discovered finding in the Phase 3a cluster walkthrough log alongside W13/W14. The log will show: \"Scenario 1 iteration 2 surfaced W15, fixed via this hotfix PR, walkthrough resumed against fixed image, Scenarios 1-10 results.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)