### PR TITLE
fix(swiftletd): PR 1 hotfix #3 — W16 (receiver-mode GuestRunning post-receive)

### DIFF
--- a/rust/swiftletd/src/action.rs
+++ b/rust/swiftletd/src/action.rs
@@ -699,6 +699,24 @@ async fn dispatch_migration_receive(
             if let Some(ip) = &args.guest_ip {
                 propagate_guest_ip_annotation(ip).await;
             }
+            // W16: flip SwiftGuest's GuestRunning condition to True on
+            // the destination side. Without this, the controller's
+            // Resuming-live handler waits indefinitely for a signal
+            // that never arrives (the src-side swiftletd wrote
+            // GuestRunning=False/VmStopped at cutover step 1 when its
+            // CH exited; receiver-mode swiftletd never overwrites it
+            // because main.rs's on_socket_ready callback is skipped in
+            // receiver mode and the launcher's post-launch report path
+            // only fires when CH exits). Best-effort with the same
+            // posture as D3 — if the patch fails, the controller's
+            // spec.timeout is the floor.
+            //
+            // Reads the SwiftGuest name from the dst pod's
+            // swift.kubeswift.io/guest label (LabelGuestName from
+            // dst_pod.go); the SwiftGuest is named guest.Name throughout
+            // its lifetime (canonical pod is dst post-cutover, but the
+            // SwiftGuest CR's name is invariant).
+            report_guest_running_post_receive().await;
             Ok(ActionOutcome {
                 detail: Some(format!(
                     "received on {} ({}ms)",
@@ -906,6 +924,103 @@ async fn propagate_guest_ip_annotation(ip: &str) {
         Ok(_) => log::info!("d3_guest_ip_propagated ip={}", ip),
         Err(e) => log::warn!("d3_guest_ip_patch_failed: {}", e),
     }
+}
+
+/// W16: post-receive SwiftGuest GuestRunning condition flip on dst.
+///
+/// In receiver mode, main.rs skips the on_socket_ready callback (CH
+/// has no VM at socket-ready time; reporting "guest running" before
+/// receive_migration completes would be a lie). The post-launch
+/// report path in main.rs only fires when CH exits — which on a
+/// successful migration only happens when the guest itself shuts
+/// down, not at receive-completion time.
+///
+/// This helper closes the gap. Called from
+/// `dispatch_migration_receive`'s success branch, after the W1 gate
+/// confirmed CH state=Running with the migrated guest. It:
+///
+///   1. Reads `POD_NAMESPACE` / `POD_NAME` from env (downward API).
+///   2. Fetches the dst pod and reads `swift.kubeswift.io/guest`
+///      label to get the SwiftGuest's name (the canonical-pod name
+///      changed at cutover step 1, but the SwiftGuest CR name is
+///      invariant; dst pod construction in B2.2 preserves the
+///      guest label).
+///   3. Patches `SwiftGuest.status.conditions[GuestRunning] = True`
+///      via the same `report::report_guest_running` helper used by
+///      main.rs's on_socket_ready callback in non-receiver mode.
+///
+/// Best-effort like D3: any failure (kube client unavailable,
+/// missing env, missing label, API error) is logged but doesn't
+/// affect the migration outcome — the controller's spec.timeout is
+/// the floor for stall detection.
+async fn report_guest_running_post_receive() {
+    let (namespace, pod_name) = match (
+        std::env::var("POD_NAMESPACE").ok(),
+        std::env::var("POD_NAME").ok(),
+    ) {
+        (Some(ns), Some(name)) if !ns.is_empty() && !name.is_empty() => (ns, name),
+        _ => {
+            log::warn!("w16_guest_running_skipped reason=POD_NAMESPACE_or_POD_NAME_unset");
+            return;
+        }
+    };
+    let client = match crate::kube_client::create_client().await {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("w16_kube_client_unavailable: {}", e);
+            return;
+        }
+    };
+    // Fetch the dst pod to read the swift.kubeswift.io/guest label.
+    let pod_api: Api<k8s_openapi::api::core::v1::Pod> =
+        Api::namespaced(client.clone(), &namespace);
+    let pod = match pod_api.get(&pod_name).await {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!("w16_pod_get_failed: {}", e);
+            return;
+        }
+    };
+    let guest_name = match extract_guest_name_from_labels(pod.metadata.labels.as_ref()) {
+        Some(g) => g,
+        None => {
+            log::warn!("w16_guest_label_missing pod={}/{}", namespace, pod_name);
+            return;
+        }
+    };
+    match crate::report::report_guest_running(&client, &namespace, &guest_name, true, None).await {
+        Ok(()) => log::info!(
+            "w16_guest_running_reported guest={}/{}",
+            namespace,
+            guest_name
+        ),
+        Err(e) => log::warn!(
+            "w16_guest_running_patch_failed guest={}/{} err={}",
+            namespace,
+            guest_name,
+            e
+        ),
+    }
+}
+
+/// W16 helper: extract the SwiftGuest's name from a launcher pod's
+/// labels. Pure function (no I/O); unit-testable in isolation.
+///
+/// The label key (`swift.kubeswift.io/guest`) is set on the dst pod
+/// at construction time in B2.2's `mergeLabelsForDst`. The
+/// SwiftGuest CR's name is invariant through cutover (canonical pod
+/// changes; SwiftGuest CR doesn't), so this is the source of truth
+/// for "which SwiftGuest does this dst launcher pod represent."
+///
+/// Returns `None` if labels are absent, the key is missing, or the
+/// value is empty — caller logs and returns without patching.
+fn extract_guest_name_from_labels(
+    labels: Option<&std::collections::BTreeMap<String, String>>,
+) -> Option<String> {
+    labels
+        .and_then(|l| l.get("swift.kubeswift.io/guest"))
+        .filter(|v| !v.is_empty())
+        .cloned()
 }
 
 /// Sanitize a CH error string into a category. Defensive against
@@ -2769,6 +2884,55 @@ mod tests {
     // — unit-testing it would need a kube client mock and POD_*
     // env-var harness disproportionate to a 50-line reuse of the
     // lease.rs pattern.
+
+    // ─── W16 (Phase 3a PR 1 cluster walkthrough finding) ─────────────
+    //
+    // Cluster walkthrough surfaced that swiftletd-on-dst's receiver-mode
+    // never flips the SwiftGuest's GuestRunning condition to True after
+    // receive_migration completes successfully. The
+    // `report_guest_running_post_receive` helper added in
+    // `dispatch_migration_receive`'s success branch closes the gap.
+    //
+    // The kube-write path follows the same pattern as
+    // propagate_guest_ip_annotation (D3): real kube client +
+    // POD_NAMESPACE/POD_NAME env reads + best-effort patch. Cluster
+    // integration validates the side effect; unit-testing the kube
+    // write would need a kube-client mock harness disproportionate to
+    // the 30-line helper.
+    //
+    // The pure-function piece (label extraction) IS unit-testable:
+
+    #[test]
+    fn extract_guest_name_from_labels_returns_value_when_present() {
+        use std::collections::BTreeMap;
+        let mut labels = BTreeMap::new();
+        labels.insert("swift.kubeswift.io/guest".to_string(), "faas-s2".to_string());
+        labels.insert("kubeswift.io/migration".to_string(), "s2-mig".to_string());
+        assert_eq!(
+            extract_guest_name_from_labels(Some(&labels)),
+            Some("faas-s2".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_guest_name_from_labels_returns_none_when_missing() {
+        use std::collections::BTreeMap;
+        let labels = BTreeMap::new();
+        assert_eq!(extract_guest_name_from_labels(Some(&labels)), None);
+    }
+
+    #[test]
+    fn extract_guest_name_from_labels_returns_none_when_labels_absent() {
+        assert_eq!(extract_guest_name_from_labels(None), None);
+    }
+
+    #[test]
+    fn extract_guest_name_from_labels_returns_none_when_value_empty() {
+        use std::collections::BTreeMap;
+        let mut labels = BTreeMap::new();
+        labels.insert("swift.kubeswift.io/guest".to_string(), "".to_string());
+        assert_eq!(extract_guest_name_from_labels(Some(&labels)), None);
+    }
 
     #[test]
     fn migration_receive_args_parses_with_guest_ip() {

--- a/rust/swiftletd/src/action.rs
+++ b/rust/swiftletd/src/action.rs
@@ -972,8 +972,7 @@ async fn report_guest_running_post_receive() {
         }
     };
     // Fetch the dst pod to read the swift.kubeswift.io/guest label.
-    let pod_api: Api<k8s_openapi::api::core::v1::Pod> =
-        Api::namespaced(client.clone(), &namespace);
+    let pod_api: Api<k8s_openapi::api::core::v1::Pod> = Api::namespaced(client.clone(), &namespace);
     let pod = match pod_api.get(&pod_name).await {
         Ok(p) => p,
         Err(e) => {
@@ -2906,7 +2905,10 @@ mod tests {
     fn extract_guest_name_from_labels_returns_value_when_present() {
         use std::collections::BTreeMap;
         let mut labels = BTreeMap::new();
-        labels.insert("swift.kubeswift.io/guest".to_string(), "faas-s2".to_string());
+        labels.insert(
+            "swift.kubeswift.io/guest".to_string(),
+            "faas-s2".to_string(),
+        );
         labels.insert("kubeswift.io/migration".to_string(), "s2-mig".to_string());
         assert_eq!(
             extract_guest_name_from_labels(Some(&labels)),


### PR DESCRIPTION
# PR 1 hotfix #3: W16 — receiver-mode GuestRunning condition flip post-receive

Cluster walkthrough Scenario 2 (third iteration on image \`sha-4236252\`, post-W13/W14/W15) surfaced this **fourth consecutive finding-behind-a-finding**. With the controller-side bugs (W13, W14, W15) fixed, the data plane now succeeds end-to-end — but every migration ends \`Failed/Timeout\` because the SwiftGuest's \`GuestRunning\` condition never flips True on the destination side.

## Walkthrough excerpt — W16 discovery

\`\`\`
Migration timeline (Scenario 2):
  T+0s     StopAndCopy / 'transferring guest state'
  T+39s    StopAndCopy / 'cutover: completing'    <-- cutover crossed
  T+41s    Resuming    / 'waiting for guest health on destination'
  T+241s   STILL Resuming   <-- never advances
  T+300s   Failed (failureReason=Timeout, spec.timeout=5m exceeded)

dst pod swiftletd logs:
  [12:16:38] migration_role role=receiver
  [12:16:38] migration_receiver_mode
  [12:16:38] action_loop_started
  [12:16:38] dispatch_migration_receive id=s2-mig:recv:1
  [12:17:17] dispatch_migration_receive_complete state=Running elapsed_ms=38778  <-- success
  [12:17:17] d3_guest_ip_propagated ip=192.168.99.12                              <-- D3 fired
                                                                                  <-- logs END

dst pod state at failure:
  Phase: Running, IP: 10.244.213.48, Node: boba   <-- pod healthy
  guest-ip: 192.168.99.12                          <-- guest IP reachable
  migration-status: running                        <-- receive complete
  migration-pause-window-ms: 38778

SwiftGuest faas-s2 state:
  podRef: faas-s2-mig-81a5df                       <-- cutover crossed
  status.phase: Running                             <-- guest healthy on dst
  status.network.primaryIP: 192.168.99.12          <-- IP propagated
  conditions[GuestRunning]: False, reason=VmStopped, lastTransitionTime=12:17:17
                                                    ^^^ STALE from src cutover-time
\`\`\`

The src-side swiftletd wrote \`GuestRunning=False/VmStopped\` at cutover step 1 (its CH exited normally after \`vm.send-migration\` completed). That stale value sits on the SwiftGuest forever because **dst-side never overwrites it** — receiver-mode swiftletd doesn't transition into normal status-reporting mode after \`receive_migration\` completes.

## Root cause

[\`rust/swiftletd/src/main.rs\`](https://github.com/projectbeskar/kubeswift/blob/main/rust/swiftletd/src/main.rs) explicitly notes this gap in receiver-mode setup:

\`\`\`rust
// on_socket_ready: skipped in receiver mode. CH on a receiver pod
// has no VM at socket-ready time (it's an empty VMM awaiting
// receive-migration); reporting "guest running" here would be a
// lie. ... a future follow-up may add an
// on-migration-receive-success runtime report.
let on_socket_ready = if intent.is_migration_receiver() {
    None  // <-- never reports GuestRunning=True
} else { ... };
\`\`\`

Phase 2 PR-C deferred the runtime report. Phase 3a PR 1's \`Resuming-live\` handler relies on it via [\`isGuestRunningTrue\`](https://github.com/projectbeskar/kubeswift/blob/main/internal/controller/swiftmigration/resuming_live.go#L172). Without the flip, Resuming-live waits forever (until spec.timeout).

## Fix

In \`rust/swiftletd/src/action.rs\` \`dispatch_migration_receive\`'s success branch (after the W1 gate confirms CH state=Running and after D3's guest-ip propagation), call a new helper \`report_guest_running_post_receive\` that:

1. Reads \`POD_NAMESPACE\` / \`POD_NAME\` from env (downward API).
2. Fetches the dst pod and reads \`swift.kubeswift.io/guest\` label (the SwiftGuest CR name is invariant through cutover; canonical pod changes but SwiftGuest name doesn't).
3. Patches \`SwiftGuest.status.conditions[GuestRunning]=True\` via the existing \`report::report_guest_running\` helper (the same one main.rs's on_socket_ready callback uses in non-receiver mode).

Best-effort posture matches D3: any failure (kube client unavailable, missing env, missing label, API error) is logged but doesn't affect the migration outcome — controller's \`spec.timeout\` is the floor for stall detection.

## Sibling-issue audit (per operator instruction)

The operator's confirmation noted: \"while implementing W16's swiftletd fix, also do a careful read-through of the receiver-mode lifecycle to look for sibling issues.\"

Audit findings:

| Receiver-mode behavior | Status | Disposition |
|---|---|---|
| Lease poller skipped | Intentional per Phase 2 spike F2.5 (D3 already populates IP) | No change |
| on_socket_ready callback skipped | The W16 root cause — fixed via `report_guest_running_post_receive` | Fixed |
| runtime-pid annotation not written post-receive | Resuming-live does NOT gate on runtime-pid (only GuestRunning) | Not blocking; Phase 5 polish |
| serial-socket annotation not written post-receive | Same as runtime-pid — not blocking | Not blocking; Phase 5 polish |
| Pod-deletion cleanup | Same as non-receiver path (no special handling) | Not blocking |

No other BLOCKING issue surfaced in the audit. The runtime-pid + serial-socket annotations on dst are operator-visibility polish (\`swiftctl describe\` would show stale src-side values until a guest restart), not migration-completeness blockers. Tracking as Phase 5 backlog.

## Tests

\`extract_guest_name_from_labels_*\` (4 cases): pure-function label extraction tested in isolation:
- present → returns value
- missing key → returns None
- labels absent → returns None
- empty value → returns None

The kube-write path follows the same testing posture as D3's \`propagate_guest_ip_annotation\` (see action.rs:2868 comment): \"actual kube write is exercised by the cluster integration test...; unit-testing it would need a kube client mock and POD_* env-var harness disproportionate to a 50-line reuse of the lease.rs pattern.\"

\`cargo test -p swiftletd\` reports 81 passed (4 new W16 tests). Go test suite unchanged.

## Finding pattern: fourth finding-behind-a-finding

| Iter | Image | Finding | Layer | Blocker |
|---|---|---|---|---|
| 1 | sha-4cde589 | W13 (BLOCKING) | controller (Go) | src missing phase2 ack |
| 1 | sha-4cde589 | W14 (HIGH) | controller (Go) | rejected status not terminal |
| 2 | sha-ce68fa9 | W15 (BLOCKING) | controller (Go) | UID check uses canonicalPodName |
| 3 | sha-4236252 | W16 (BLOCKING) | **swiftletd (Rust)** | receiver-mode no post-receive lifecycle |

Each iteration's blocking bug hid the next. W16 specifically validates the Phase 2 walkthrough's W6 finding ([Phase 2 walkthrough](https://github.com/projectbeskar/kubeswift/blob/main/docs/design/live-migration-phase-2-walkthrough.md)): \"Receiver-mode launch branch (\`run_ch_receive\`) actually running in production\" was NOT validated end-to-end before this walkthrough. The Phase 2 manual demo's blockers (W3/W4 RBAC, W6 storage handoff) prevented disk-boot guests from completing receive_migration, so the post-receive lifecycle was never actually exercised pre-PR-1-merge.

## Test plan

- [x] \`cargo test -p swiftletd\` passes (81 tests; 4 new for W16)
- [x] \`cargo build --release -p swiftletd\` clean
- [x] \`go test ./...\` clean (no Go-side regression)
- [ ] Post-merge cluster walkthrough Scenario 1 + Scenario 2 re-run (fourth iteration) as the \"does anything work\" gate
- [ ] If Scenario 1 + Scenario 2 pass cleanly, walkthrough proceeds to Scenarios 3-9
- [ ] If another finding surfaces, stop and discuss

## Walkthrough log disposition

W16 will be documented as the fourth discovered finding alongside W13/W14/W15 in the Phase 3a cluster walkthrough log. The pattern observation (\"each iteration surfaced a new BLOCKING finding-behind-a-finding\") will be captured as the central operational insight of the walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)