### PR TITLE
fix(swiftmigration): Phase 3a PR 1 follow-up — W17/W18/W19/W21

### DIFF
--- a/docs/migration/phase-3a.md
+++ b/docs/migration/phase-3a.md
@@ -100,38 +100,79 @@ resolved mode is recorded in `status.mode`.
 > **DO NOT use `kubectl delete pod --grace-period=0 --force` on
 > the destination pod.**
 
-Force-deleting the destination pod produces a slow-failure
-path: the source CH's `vm.send-migration` call is synchronous
-in `swift-ch-client`, so when the destination disappears
-abruptly, the source side can take up to ~127 seconds (kernel
-TCP retransmit timeout) to unwind. The migration eventually
-transitions to Failed via `spec.timeout` (5 minute default),
-but operators may perceive it as stuck during the unwind
-window. The source pod's swiftletd logs show
-`send_migration: connection reset` only after the kernel
-gives up retransmitting.
+Force-deleting the destination pod produces a fast-failure
+path on the controller side, but the source-side TCP unwind
+remains slow internally. **Empirical timing from PR #46
+walkthrough Scenario 5** (force-delete dst on
+`kubectl delete pod <dst> --grace-period=0 --force`):
 
-`spec.cancelRequested: true` triggers a clean cancel through
-the controller's cancel handler:
+- **T+0s**: SwiftMigration transitions to Failed with
+  `failureReason=PodTerminated` and message `"destination pod
+  <name> disappeared during StopAndCopy"`. The controller's
+  outer dst-pod-NotFound check fires immediately on the
+  apiserver's pod-deletion event.
+
+- **Up to ~127s** (background, no operator-visible signal):
+  source CH's `vm.send-migration` call is synchronous in
+  `swift-ch-client` and TCP-retransmits to a peer that no
+  longer exists. The src pod's `migration-status: running`
+  annotation lingers throughout this window (cosmetic; the
+  SwiftMigration is already terminally Failed). Once the
+  kernel gives up retransmitting (~127s default), the src
+  swiftletd writes `migration-status: failed` with detail
+  `send_migration: connection reset`. The SwiftMigration is
+  unaffected by this late status write.
+
+The behavior is **better than this doc previously described**
+(the prior narrative claimed ~127s slow-failure of the
+SwiftMigration phase itself; cluster reality is fast
+PodTerminated at T+0s). The src-side TCP unwind is internal
+state that doesn't surface as user-visible delay.
+
+`spec.cancelRequested: true` triggers a controller-side cancel
+flow:
 
 1. Controller writes the cancel action annotation on the
    destination pod with the cancel ID.
 2. swiftletd-on-dst's D1 cancel handler verifies the
    destination CH PID, SIGKILLs the destination CH process.
-3. Source CH's TCP send unwinds within sub-seconds (TCP RST
-   from the dst kernel).
+3. Source CH's TCP send unwinds (TCP RST from the dst kernel).
 4. Source swiftletd writes `migration-status=failed` with
    detail `cancelled` and the cancel action ID.
 5. Controller observes the terminal status and transitions
    the SwiftMigration to Cancelled.
 
-End-to-end: cancellation completes within a few seconds in
-the typical case, vs ~127 seconds for the force-delete path.
+**Empirical timing from PR #46 walkthrough Scenario 7**
+(`spec.cancelRequested=true` mid-StopAndCopy/transferring):
+**~27 seconds end-to-end**. This is faster than the force-
+delete path (T+0 controller-side, ~127s src-internal unwind)
+because the controller's 30s cancel-ack budget triggers a
+fallback (force-delete dst pod) when swiftletd's D1 ack
+doesn't arrive in time. D1 itself is blocked while
+`dispatch_migration_receive` holds the action loop's current-
+thread runtime — Phase 2 spike F2.4 finding. The fallback
+delivers a clean Cancelled phase with `failureReason=Cancelled`
+and message `"destination pod force-deleted; swiftletd cancel
+ack timed out (30s budget)"`.
 
-This W12 limitation will be resolved in Phase 3b when
-`swift-ch-client` is refactored to async I/O (cancellable
-network calls). Until then, `spec.cancelRequested` is the
-supported cancellation mechanism.
+**Why prefer `spec.cancelRequested` despite the 30s fallback?**
+
+- It surfaces a clean `Cancelled` phase (not Failed), with
+  `failureReason=Cancelled` for operator-readable audit trail.
+- It's the supported, documented mechanism — operators
+  shouldn't reach for `kubectl delete --force` as a debugging
+  tool.
+- The post-cutover behavior is correct: cancel-after-cutover
+  sets a `CancelIgnored` condition and lets the migration
+  complete normally (operators don't risk destroying an
+  already-migrated guest).
+
+The W12 (action-loop blocking) and W20 (fallback fires
+because D1 doesn't dispatch in time) limitations both resolve
+in Phase 3b when `swift-ch-client` is refactored to async I/O
+(cancellable network calls). At that point, D1 will fire
+within sub-seconds and `spec.cancelRequested` cancellation
+will land in "few seconds" range.
 
 To cancel:
 

--- a/internal/controller/swiftmigration/cutover.go
+++ b/internal/controller/swiftmigration/cutover.go
@@ -241,17 +241,38 @@ func (r *SwiftMigrationReconciler) cutoverStep1(
 	return r.cutoverStep1Timestamp(ctx, status)
 }
 
-// cutoverStep1Timestamp stamps status.CutoverStep1At = now(). Called
-// from cutoverStep1 (after SwiftGuest patch succeeded) and from the
-// dispatcher when deriveCutoverStep returns cutoverStep1TimestampOnly
-// (recovery from leader-handover-between-the-two-patches).
+// cutoverStep1Timestamp stamps status.CutoverStep1At = now() AND
+// writes the PodRefSwapped=True condition. Called from cutoverStep1
+// (after SwiftGuest patch succeeded) and from the dispatcher when
+// deriveCutoverStep returns cutoverStep1TimestampOnly (recovery from
+// leader-handover-between-the-two-patches).
 //
 // The status update happens via the in-memory `status` pointer the
 // dispatchResult will persist. We don't issue a separate Patch here
 // because dispatchResult's persist() handles the SwiftMigration
 // status diff at the end of every reconcile invocation. This means
-// a transient-fail-on-persist will leave the timestamp unset and
-// the next reconcile re-runs cutoverStep1TimestampOnly cleanly.
+// a transient-fail-on-persist will leave the timestamp + condition
+// unset and the next reconcile re-runs cutoverStep1TimestampOnly
+// cleanly (idempotent: `if CutoverStep1At == nil` short-circuits the
+// timestamp write; setCondition's same-value short-circuit handles
+// the condition).
+//
+// W21 (PR #46 cluster walkthrough): the PodRefSwapped condition is
+// the safety gate against data-loss in cancel-post-cutover (cancel
+// during the narrow Resuming window where the dst pod IS the live
+// migrated guest; without the gate, transitionCancelLive would
+// destroy the just-migrated guest). The architect's Q3.3(c)
+// decision was that PodRefSwapped is DERIVED from cluster state
+// (guest.Status.PodRef.Name == dstName) on every cutover-substate
+// reconcile — derivation remains primary for state-machine logic
+// (the cutover-in-progress short-circuit in stopandcopy_live reads
+// directly from guest.status.podRef). The explicit write here is
+// ADDITIONAL DEFENSE so that downstream call-sites that read the
+// SwiftMigration's Conditions list (isPostCutover, honorCancel,
+// shouldCheckSourcePodUID) get a consistent signal even when the
+// SwiftGuest informer cache lags by a reconcile. **Do not remove
+// the derivation; do not remove this explicit write — both are
+// load-bearing.**
 func (r *SwiftMigrationReconciler) cutoverStep1Timestamp(
 	ctx context.Context,
 	status *migrationv1alpha1.SwiftMigrationStatus,
@@ -260,6 +281,11 @@ func (r *SwiftMigrationReconciler) cutoverStep1Timestamp(
 		now := metav1.Now()
 		status.CutoverStep1At = &now
 	}
+	setCondition(status,
+		migrationv1alpha1.SwiftMigrationConditionPodRefSwapped,
+		metav1.ConditionTrue,
+		migrationv1alpha1.ReasonCutoverStep1Complete,
+		"cutover step 1 complete: SwiftGuest.status.podRef.name patched to destination pod")
 	setPhaseDetail(status, migrationv1alpha1.PhaseDetailLiveCutoverDeleteSrc)
 	// Requeue so the next reconcile observes step 1 done and
 	// proceeds to step 2. Short interval — no external state to

--- a/internal/controller/swiftmigration/cutover_test.go
+++ b/internal/controller/swiftmigration/cutover_test.go
@@ -172,6 +172,96 @@ func TestCutover_Step1PartialCompletion_TimestampOnlyRetry(t *testing.T) {
 	}
 }
 
+// W21 (PR #46 walkthrough): cutoverStep1Timestamp must write BOTH
+// status.CutoverStep1At AND the PodRefSwapped=True condition. The
+// condition is the safety gate for cancel-post-cutover; without it,
+// cancel during the narrow Resuming window would route through the
+// pre-cutover code path and destroy the just-migrated guest.
+func TestCutover_Step1WritesPodRefSwappedCondition_W21(t *testing.T) {
+	mig, guest, src, dst := cutoverFixture(t)
+	scheme := testScheme(t)
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest, src, dst).
+		WithStatusSubresource(mig, guest).
+		Build()
+	r := &SwiftMigrationReconciler{Client: base, Scheme: scheme, Recorder: record.NewFakeRecorder(20)}
+
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.Err != nil || res.FailureMsg != "" {
+		t.Fatalf("unexpected failure: err=%v msg=%q", res.Err, res.FailureMsg)
+	}
+
+	// Both signals must be set on the in-memory status (persisted by
+	// dispatchResult at the end of the reconcile).
+	if status.CutoverStep1At == nil {
+		t.Errorf("CutoverStep1At should be stamped after cutoverStep1")
+	}
+	var podRefSwapped *metav1.Condition
+	for i := range status.Conditions {
+		c := &status.Conditions[i]
+		if c.Type == migrationv1alpha1.SwiftMigrationConditionPodRefSwapped {
+			podRefSwapped = c
+			break
+		}
+	}
+	if podRefSwapped == nil {
+		t.Fatalf("PodRefSwapped condition not written; W21 regression")
+	}
+	if podRefSwapped.Status != metav1.ConditionTrue {
+		t.Errorf("PodRefSwapped status: want True, got %q", podRefSwapped.Status)
+	}
+	if podRefSwapped.Reason != migrationv1alpha1.ReasonCutoverStep1Complete {
+		t.Errorf("PodRefSwapped reason: want %q, got %q",
+			migrationv1alpha1.ReasonCutoverStep1Complete, podRefSwapped.Reason)
+	}
+
+	// isPostCutover() reads the Conditions list — verify the gate
+	// flips True so downstream call-sites (honorCancel,
+	// shouldCheckSourcePodUID) see the post-cutover signal.
+	migWithStatus := mig.DeepCopy()
+	migWithStatus.Status = *status
+	if !isPostCutover(migWithStatus) {
+		t.Errorf("isPostCutover should return true after W21 condition write")
+	}
+}
+
+// W21 idempotency: cutoverStep1TimestampOnly recovery branch (when
+// SwiftGuest patch landed but timestamp persist failed) must also
+// write the condition, AND must be idempotent when re-fired.
+func TestCutover_Step1TimestampOnly_WritesPodRefSwappedCondition_W21(t *testing.T) {
+	mig, guest, src, dst := cutoverFixture(t)
+	guest.Status.PodRef = &corev1.ObjectReference{Name: "guest-mig-abcdef", Namespace: "default"}
+	// CutoverStep1At nil → cutoverStep1TimestampOnly path
+
+	scheme := testScheme(t)
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest, src, dst).
+		WithStatusSubresource(mig, guest).
+		Build()
+	r := &SwiftMigrationReconciler{Client: base, Scheme: scheme, Recorder: record.NewFakeRecorder(20)}
+
+	status := mig.Status.DeepCopy()
+	_ = r.handleStopAndCopyLive(context.Background(), mig, status)
+
+	if status.CutoverStep1At == nil {
+		t.Errorf("CutoverStep1At should be stamped on timestamp-only retry")
+	}
+	var found bool
+	for _, c := range status.Conditions {
+		if c.Type == migrationv1alpha1.SwiftMigrationConditionPodRefSwapped &&
+			c.Status == metav1.ConditionTrue {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("PodRefSwapped=True must be written on timestamp-only path too; W21 regression")
+	}
+}
+
 // TestCutover_Step2RetryInPlace: src pod Delete fails → next reconcile
 // observes step 1 done + src exists → retries Delete.
 func TestCutover_Step2RetryInPlace_DeleteFails(t *testing.T) {

--- a/internal/controller/swiftmigration/failure.go
+++ b/internal/controller/swiftmigration/failure.go
@@ -161,15 +161,31 @@ func (r *SwiftMigrationReconciler) cleanupSourceGuest(
 
 // onTerminalPhase performs cleanup when the SwiftMigration transitions
 // to Failed (the dispatchResult path) so the source guest doesn't get
-// left annotated and stopped. Called from Reconcile after persist().
+// left annotated and stopped, AND so a pre-cutover-created dst pod
+// (live mode) doesn't leak (W17).
 //
 // Mirrors handleCancellation's pre/post-cutover split. The Completed
-// phase already clears the annotation in Resuming (commit 9); this
-// helper covers the Failed case across all phases.
+// phase already clears the annotation in Resuming; this helper covers
+// the Failed case across all phases.
 //
-// Idempotent: skips when the SwiftMigration's annotation isn't on
-// the source guest (cleanup ran on a previous reconcile, or the
-// failure was Validating-phase before any patches).
+// Pre/post-cutover detection is mode-aware:
+//   - offline: SwiftGuest.spec.nodeName patched at cutover, so check
+//     guest.Spec.NodeName == status.DestinationNode (existing
+//     heuristic, unchanged).
+//   - live (Phase 3a): cutover patches guest.STATUS.podRef.name and
+//     writes the PodRefSwapped condition (W21). Use isPostCutover()
+//     which reads the condition — same gate as honorCancel and
+//     shouldCheckSourcePodUID for consistency.
+//
+// W17 (PR #46 Scenario 3): on pre-cutover Failed in LIVE mode, also
+// delete the destination pod the controller created in Preparing-live.
+// Without this, the dst pod leaks (resource consumption + UX confusion).
+// Best-effort retry-in-place: a transient Delete failure surfaces as
+// the function's error return, which triggers controller-runtime
+// reconcile retry (controller.go:299 propagates the error).
+//
+// Idempotent: cleanupSourceGuest skips when the annotation isn't ours;
+// dst pod Delete returns NotFound on second attempt (success).
 func (r *SwiftMigrationReconciler) onTerminalPhase(
 	ctx context.Context,
 	mig *migrationv1alpha1.SwiftMigration,
@@ -178,22 +194,72 @@ func (r *SwiftMigrationReconciler) onTerminalPhase(
 	if status.Phase != migrationv1alpha1.SwiftMigrationPhaseFailed {
 		return nil
 	}
+
 	postCutover := false
-	// Use the same heuristic as handleCancellation, but consult the
-	// PRE-failure phase: status.Phase has already been set to Failed
-	// by dispatchResult, so we can't distinguish Validating-failure
-	// from StopAndCopy-failure by status.Phase alone. The destination
-	// node patch is only issued in StopAndCopy; check the SwiftGuest
-	// directly to decide whether the cutover happened.
-	var guest swiftv1alpha1.SwiftGuest
-	if err := r.Get(ctx, client.ObjectKey{Name: mig.Spec.GuestRef.Name, Namespace: mig.Namespace}, &guest); err != nil {
+	if status.Mode == migrationv1alpha1.SwiftMigrationModeLive {
+		// Live mode: PodRefSwapped condition is the authoritative
+		// post-cutover signal (post-W21 it's always written at
+		// cutoverStep1).
+		postCutover = isPostCutover(mig)
+	} else {
+		// Offline mode: check guest.Spec.NodeName patch.
+		var guest swiftv1alpha1.SwiftGuest
+		if err := r.Get(ctx, client.ObjectKey{Name: mig.Spec.GuestRef.Name, Namespace: mig.Namespace}, &guest); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if guest.Spec.NodeName == status.DestinationNode && status.DestinationNode != "" {
+			postCutover = true
+		}
+	}
+
+	if err := r.cleanupSourceGuest(ctx, mig, !postCutover); err != nil {
+		return err
+	}
+
+	// W17: pre-cutover Failed in live mode → delete the dst pod that
+	// Preparing-live created. Post-cutover Failed leaves the dst pod
+	// in place because it IS the canonical guest at that point
+	// (the migration crossed the cutover commit point).
+	if !postCutover && status.Mode == migrationv1alpha1.SwiftMigrationModeLive {
+		if err := r.cleanupDstPod(ctx, mig, status); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cleanupDstPod deletes the destination pod created during Preparing-
+// live. Best-effort: NotFound is success (idempotent re-fire); other
+// errors surface and trigger reconcile retry.
+//
+// status.destinationPodRef.name is the load-bearing input — it's set
+// in Preparing-live B2.2 when the controller successfully Creates the
+// dst pod. If the field is empty (Validating-phase failure, or
+// Preparing failed before Create), there's nothing to clean up.
+func (r *SwiftMigrationReconciler) cleanupDstPod(
+	ctx context.Context,
+	mig *migrationv1alpha1.SwiftMigration,
+	status *migrationv1alpha1.SwiftMigrationStatus,
+) error {
+	if status.DestinationPodRef == nil || status.DestinationPodRef.Name == "" {
+		return nil
+	}
+	pod := &corev1.Pod{}
+	pod.Name = status.DestinationPodRef.Name
+	pod.Namespace = mig.Namespace
+	if err := r.Delete(ctx, pod); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return fmt.Errorf("delete destination pod %q: %w", pod.Name, err)
 	}
-	if guest.Spec.NodeName == status.DestinationNode && status.DestinationNode != "" {
-		postCutover = true
+	if r.Recorder != nil {
+		r.Recorder.Eventf(mig, corev1.EventTypeNormal, "DestinationPodCleanedUp",
+			"deleted destination pod %q after pre-cutover Failed", pod.Name)
 	}
-	return r.cleanupSourceGuest(ctx, mig, !postCutover)
+	return nil
 }

--- a/internal/controller/swiftmigration/failure_test.go
+++ b/internal/controller/swiftmigration/failure_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -260,5 +263,170 @@ func TestOnTerminalPhase_FailedPreCutover_RestoresRunPolicy(t *testing.T) {
 	}
 	if got.Spec.RunPolicy != swiftv1alpha1.RunPolicyRunning {
 		t.Errorf("pre-cutover Failed: runPolicy = %q, want Running (restored)", got.Spec.RunPolicy)
+	}
+}
+
+// W17 (PR #46 Scenario 3): pre-cutover Failed in live mode must
+// delete the destination pod the controller created during
+// Preparing-live. Without the cleanup, dst pod leaks.
+func TestOnTerminalPhase_FailedPreCutoverLive_DeletesDstPod_W17(t *testing.T) {
+	scheme := preparingScheme(t)
+	guest := newGuestForValidating("guest", "default", "class-default")
+	guest.Status.NodeName = "miles"
+	guest.Annotations = map[string]string{
+		migrationv1alpha1.AnnotationMigrationInProgress: "m",
+	}
+	mig := newMigration("m", "default")
+	dstPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guest-mig-abcdef",
+			Namespace: "default",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest, dstPod).
+		WithStatusSubresource(mig).
+		Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	status := &migrationv1alpha1.SwiftMigrationStatus{
+		Phase:           migrationv1alpha1.SwiftMigrationPhaseFailed,
+		Mode:            migrationv1alpha1.SwiftMigrationModeLive,
+		SourceNode:      "miles",
+		DestinationNode: "boba",
+		DestinationPodRef: &migrationv1alpha1.SwiftMigrationPodRef{
+			Name: "guest-mig-abcdef",
+		},
+		// No PodRefSwapped condition → pre-cutover.
+	}
+
+	if err := r.onTerminalPhase(context.Background(), mig, status); err != nil {
+		t.Fatalf("onTerminalPhase returned err = %v", err)
+	}
+
+	var got corev1.Pod
+	err := c.Get(context.Background(),
+		client.ObjectKey{Name: "guest-mig-abcdef", Namespace: "default"}, &got)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("dst pod should be deleted post-W17 cleanup; got err=%v", err)
+	}
+}
+
+// W17 negative case: post-cutover Failed in live mode must NOT
+// delete the dst pod (it IS the canonical guest at that point).
+func TestOnTerminalPhase_FailedPostCutoverLive_PreservesDstPod_W17(t *testing.T) {
+	scheme := preparingScheme(t)
+	guest := newGuestForValidating("guest", "default", "class-default")
+	guest.Annotations = map[string]string{
+		migrationv1alpha1.AnnotationMigrationInProgress: "m",
+	}
+	mig := newMigration("m", "default")
+	// Post-cutover: PodRefSwapped=True
+	mig.Status.Conditions = []metav1.Condition{{
+		Type:               migrationv1alpha1.SwiftMigrationConditionPodRefSwapped,
+		Status:             metav1.ConditionTrue,
+		Reason:             migrationv1alpha1.ReasonCutoverStep1Complete,
+		LastTransitionTime: metav1.Now(),
+		Message:            "cutover step 1 complete",
+	}}
+	dstPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guest-mig-abcdef",
+			Namespace: "default",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest, dstPod).
+		WithStatusSubresource(mig).
+		Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	status := &migrationv1alpha1.SwiftMigrationStatus{
+		Phase:      migrationv1alpha1.SwiftMigrationPhaseFailed,
+		Mode:       migrationv1alpha1.SwiftMigrationModeLive,
+		SourceNode: "miles",
+		Conditions: mig.Status.Conditions,
+		DestinationPodRef: &migrationv1alpha1.SwiftMigrationPodRef{
+			Name: "guest-mig-abcdef",
+		},
+	}
+
+	if err := r.onTerminalPhase(context.Background(), mig, status); err != nil {
+		t.Fatalf("onTerminalPhase returned err = %v", err)
+	}
+
+	var got corev1.Pod
+	if err := c.Get(context.Background(),
+		client.ObjectKey{Name: "guest-mig-abcdef", Namespace: "default"}, &got); err != nil {
+		t.Errorf("dst pod must NOT be deleted post-cutover; W17 must respect post-cutover gate. err=%v", err)
+	}
+}
+
+// W17 retry-in-place: if dst pod Delete fails (transient apiserver
+// error), onTerminalPhase returns the error and controller-runtime
+// retries on the next reconcile.
+func TestOnTerminalPhase_DstPodDeleteFails_ReturnsErrorForRetry_W17(t *testing.T) {
+	scheme := preparingScheme(t)
+	guest := newGuestForValidating("guest", "default", "class-default")
+	guest.Annotations = map[string]string{
+		migrationv1alpha1.AnnotationMigrationInProgress: "m",
+	}
+	mig := newMigration("m", "default")
+	dstPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guest-mig-abcdef",
+			Namespace: "default",
+		},
+	}
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest, dstPod).
+		WithStatusSubresource(mig).
+		Build()
+	c := newSelectiveFailingClient(base)
+	c.FailNext(typeKeyOf(&corev1.Pod{}), VerbDelete, 1,
+		apierrors.NewServerTimeout(schema.GroupResource{Resource: "pods"}, "delete", 1))
+
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+	status := &migrationv1alpha1.SwiftMigrationStatus{
+		Phase: migrationv1alpha1.SwiftMigrationPhaseFailed,
+		Mode:  migrationv1alpha1.SwiftMigrationModeLive,
+		DestinationPodRef: &migrationv1alpha1.SwiftMigrationPodRef{
+			Name: "guest-mig-abcdef",
+		},
+	}
+
+	err := r.onTerminalPhase(context.Background(), mig, status)
+	if err == nil {
+		t.Errorf("expected transient err for retry-in-place; got nil")
+	}
+}
+
+// W17: dst pod cleanup is a no-op when status.DestinationPodRef is
+// empty (Validating-phase failure before any pod was created).
+func TestOnTerminalPhase_NoDstPodRef_NoOpCleanup_W17(t *testing.T) {
+	scheme := preparingScheme(t)
+	guest := newGuestForValidating("guest", "default", "class-default")
+	guest.Annotations = map[string]string{
+		migrationv1alpha1.AnnotationMigrationInProgress: "m",
+	}
+	mig := newMigration("m", "default")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest).
+		WithStatusSubresource(mig).
+		Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	status := &migrationv1alpha1.SwiftMigrationStatus{
+		Phase: migrationv1alpha1.SwiftMigrationPhaseFailed,
+		Mode:  migrationv1alpha1.SwiftMigrationModeLive,
+		// DestinationPodRef nil — Validating-phase failure
+	}
+
+	if err := r.onTerminalPhase(context.Background(), mig, status); err != nil {
+		t.Errorf("onTerminalPhase should succeed when no dst pod was created; got err=%v", err)
 	}
 }

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -406,9 +406,24 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 		if srcArg != nil {
 			detail = srcArg.Annotations[AnnotationMigrationStatusDtl]
 		}
+		// W18 (PR #46 Scenario 4): when dst pod is being K8s-
+		// terminated mid-StopAndCopy, src CH's vm.send-migration
+		// errors out with a generic CH error (e.g.,
+		// "send_migration: internal_server_error") because the TCP
+		// peer disappeared. The src-side detail string by itself
+		// can't distinguish "dst terminated" from "any other src
+		// failure", so classifyFailureFromDetail defaults to Other.
+		// §4.7 design intent: dst-K8s-termination should map to
+		// PodTerminated. Use dst pod state to disambiguate: if
+		// dst has DeletionTimestamp set (graceful termination in
+		// progress), override the classification.
+		reason := classifyFailureFromDetail(detail)
+		if dstPod.DeletionTimestamp != nil {
+			reason = migrationv1alpha1.FailureReasonPodTerminated
+		}
 		return phaseFailure(
 			fmt.Sprintf("source reported migration failure: %s", normalizeStatusDetail(detail)),
-			classifyFailureFromDetail(detail))
+			reason)
 
 	case substateDstRejected:
 		// W14: dst's swiftletd refused the receive-action via decide().

--- a/internal/controller/swiftmigration/stopandcopy_live_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_live_test.go
@@ -285,6 +285,59 @@ func TestStopAndCopyLive_PreRecv_PatchesSrcPodWithLabelAndAck_W13(t *testing.T) 
 	}
 }
 
+// W18 (PR #46 Scenario 4): when dst pod is being K8s-terminated mid-
+// StopAndCopy, src CH errors with generic detail. Without a dst-state
+// check, classifyFailureFromDetail defaults to Other; §4.7 says
+// PodTerminated. The fix overrides classification when
+// dst.DeletionTimestamp is set.
+func TestStopAndCopyLive_SrcFailed_DstTerminating_MapsToPodTerminated_W18(t *testing.T) {
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
+	mig.Status.RecvAttempts = 1
+	mig.Status.SendAttempts = 1
+	stamp(src, migrationActionVerbSend, sendActionID(mig),
+		MigrationStatusFailed, sendActionID(mig),
+		"send_migration: internal_server_error")
+	// dst pod is K8s-terminating: DeletionTimestamp set.
+	now := metav1.Now()
+	dst.DeletionTimestamp = &now
+	dst.Finalizers = []string{"kubernetes.io/grace-period"} // required for fake client to honor DeletionTimestamp
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason != migrationv1alpha1.FailureReasonPodTerminated {
+		t.Errorf("FailureReason: want PodTerminated (W18 override), got %q",
+			res.FailureReason)
+	}
+	if !strings.Contains(res.FailureMsg, "source reported migration failure") {
+		t.Errorf("FailureMsg should still describe src-failed; got %q", res.FailureMsg)
+	}
+	if !strings.Contains(res.FailureMsg, "send_migration: internal_server_error") {
+		t.Errorf("FailureMsg should preserve src detail; got %q", res.FailureMsg)
+	}
+}
+
+// W18 negative case: when dst is healthy (no DeletionTimestamp), the
+// existing classifier behavior is preserved (generic src failure →
+// Other, not PodTerminated).
+func TestStopAndCopyLive_SrcFailed_DstHealthy_PreservesOther_W18(t *testing.T) {
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
+	mig.Status.RecvAttempts = 1
+	mig.Status.SendAttempts = 1
+	stamp(src, migrationActionVerbSend, sendActionID(mig),
+		MigrationStatusFailed, sendActionID(mig),
+		"send_migration: internal_server_error")
+	// dst pod healthy — no DeletionTimestamp.
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason != migrationv1alpha1.FailureReasonOther {
+		t.Errorf("FailureReason: want Other (W18 preserves classifier when dst healthy), got %q",
+			res.FailureReason)
+	}
+}
+
 // W14: deriveSubstate must recognise migration-status=rejected on src
 // and dst as terminal sub-states. Without this, swiftletd's decide()
 // rejection (e.g., missing phase2 ack, action-id mismatch) leaves the


### PR DESCRIPTION
# Phase 3a PR 1 follow-up: W17/W18/W19/W21

Addresses the four non-blocking findings from [PR #46](https://github.com/projectbeskar/kubeswift/pull/46)'s cluster walkthrough as a single coherent unit. Four commits, four findings.

## Commits

| Commit | Finding | Severity | Locus |
|---|---|---|---|
| `c02a095` | W21 | HIGH | `cutover.go::cutoverStep1Timestamp` |
| `0b9e765` | W18 | HIGH | `stopandcopy_live.go::substateSrcFailed` branch |
| `0975ab3` | W17 | MEDIUM | `failure.go::onTerminalPhase` + new `cleanupDstPod` |
| `6b49e55` | W19 | LOW (docs) | `docs/migration/phase-3a.md` W12 section |

W20 deferred to Phase 3b (same blocker as W12: `swift-ch-client` needs async refactor).

## W21 — Write `PodRefSwapped=True` at cutoverStep1

**Root cause:** `SwiftMigrationConditionPodRefSwapped` was defined in API types and read by `isPostCutover()` (in `source_pod_uid.go` and `cancel_live.go`) but never written by any controller code path. Consequences:

1. **CancelIgnored condition never fires** for cancel-post-cutover — design intent unmet.
2. **Data-loss potential in narrow Resuming window:** cancel during Resuming routes through the pre-cutover path → `transitionCancelLive` writes cancel-action on the dst pod (which IS the live migrated guest at that point) → swiftletd SIGKILLs dst CH → migrated guest destroyed.

Same root cause as W15. PR #44's `canonicalPodName → guest.Name` fix mitigated W15 symptomatically; W21 closes the underlying gate.

**Fix:** write `PodRefSwapped=True` with `reason=CutoverStep1Complete` in `cutoverStep1Timestamp`, alongside the `CutoverStep1At` stamp. Single SwiftMigration status patch via `dispatchResult.persist()`.

**Q3.3(c) preservation:** Architect decision was that `PodRefSwapped` is DERIVED from cluster state (`guest.Status.PodRef.Name == dstName`). Derivation remains primary for state-machine logic — the cutover-in-progress short-circuit in `stopandcopy_live` still reads directly from `guest.status.podRef`. The explicit condition write is **additional defense** so downstream call-sites reading the SwiftMigration's Conditions list (`isPostCutover`, `honorCancel`, `shouldCheckSourcePodUID`) get a consistent signal even when the SwiftGuest informer cache lags by a reconcile. Code comment at the fix site explicitly notes both are load-bearing.

**Tests:** `TestCutover_Step1WritesPodRefSwappedCondition_W21`, `TestCutover_Step1TimestampOnly_WritesPodRefSwappedCondition_W21`.

## W18 — Classify dst-K8s-terminated as PodTerminated

**Root cause:** when dst pod is K8s-terminated (graceful `kubectl delete --grace-period=N`) mid-StopAndCopy, src CH errors with generic detail (`"send_migration: internal_server_error"`) because TCP peer disappeared. `classifyFailureFromDetail` defaults to `Other`. Per §4.7 design intent, this case should map to `PodTerminated`.

**Fix:** in the `substateSrcFailed` branch, after running the classifier, check `dstPod.DeletionTimestamp`. If set (graceful termination in progress), override the classification to `PodTerminated`. The src-side detail string is preserved in `failureMessage` for operator diagnosis.

Negative case preserved: when dst is healthy (no DeletionTimestamp), classifier behavior is unchanged — generic src failures still map to `Other`.

This W18 fix is for the **graceful-termination window** where dst exists but is being torn down. Force-delete (Scenario 5) is caught earlier by the controller's outer `dstPodPresent` check, which already maps to `PodTerminated`.

**Tests:** `TestStopAndCopyLive_SrcFailed_DstTerminating_MapsToPodTerminated_W18`, `TestStopAndCopyLive_SrcFailed_DstHealthy_PreservesOther_W18`.

## W17 — Clean up dst pod on pre-cutover Failed

**Root cause:** `cleanupSourceGuest` only removes the migration-in-progress annotation and restores runPolicy. It does NOT delete the dst pod the controller created in Preparing-live. Per design §2.3 ("pre-cutover failure case is the only one that explicitly deletes a pod the controller created") this is a real bug — resource leak + UX confusion.

Two pieces:

1. **Mode-aware postCutover detection** in `onTerminalPhase`. Existing heuristic (`guest.Spec.NodeName == status.DestinationNode`) is offline-specific — Phase 3a live mode never patches `guest.Spec.NodeName`. Branch on `status.Mode`:
   - **live**: use `isPostCutover(mig)` (reads `PodRefSwapped`, post-W21 always written)
   - **offline**: keep existing nodeName check
   
   This was a latent bug — post-cutover Failed in live mode was incorrectly treated as pre-cutover, which would have restored `runPolicy=Running` on a SwiftGuest whose canonical pod is the dst (creating a confused state).

2. **`cleanupDstPod` helper** that deletes the dst pod via `status.DestinationPodRef.Name`. NotFound is success (idempotent). Transient errors propagate, triggering controller-runtime reconcile retry per the load-bearing rule.

Cleanup fires only on (live mode) AND (pre-cutover Failed). Post-cutover Failed in live mode leaves the dst pod in place — it IS the canonical guest at that point.

**Tests:** `TestOnTerminalPhase_FailedPreCutoverLive_DeletesDstPod_W17`, `TestOnTerminalPhase_FailedPostCutoverLive_PreservesDstPod_W17`, `TestOnTerminalPhase_DstPodDeleteFails_ReturnsErrorForRetry_W17`, `TestOnTerminalPhase_NoDstPodRef_NoOpCleanup_W17`.

## W19 — phase-3a.md W12 narrative empirical timing

**Root cause:** `docs/migration/phase-3a.md` W12 section was based on design-doc estimates. Cluster walkthrough captured contradicting empirical timing.

**Update:** rewrote the W12 section with the walkthrough's actual numbers:

- **Scenario 5 (force-delete dst):** prior narrative claimed ~127s slow-failure of the SwiftMigration. Reality: T+0s Failed/PodTerminated fires from controller's outer dst-pod-NotFound check. The ~127s TCP unwind happens internally on src (cosmetic stale annotation) but doesn't affect SwiftMigration phase.
- **Scenario 7 (spec.cancelRequested):** prior narrative claimed "few seconds" via D1 fast-path. Reality: ~27s end-to-end via fallback path because D1 is blocked by synchronous `dispatch_migration_receive` (Phase 2 spike F2.4). Functionally correct (Cancelled phase) but slower than claimed.

Added "why prefer spec.cancelRequested despite the 30s fallback" subsection so operators don't conclude "force-delete is fine."

Both W12 and W20 noted as Phase 3b resolution scope (`swift-ch-client` async refactor).

## Test plan

- [x] `go test ./...` passes (existing tests + 8 new tests across W17/W18/W21)
- [x] `go vet` clean
- [x] `gofmt` clean
- [x] Phase 1 offline behavior unchanged (W17's mode-aware switch preserves the existing offline heuristic)
- [ ] Post-merge cluster re-walkthrough on affected scenarios (S3, S4, S8) validates fixes empirically — operator-driven separate session
- [ ] If re-walkthrough clean: PR 2 (SwiftGuest migration-awareness + swiftctl) is the next major work

## Notes on PR scope

- No new CRD fields, no new annotation keys, no new RBAC.
- No swiftletd changes (W20 is the only swiftletd-side concern; deferred to Phase 3b).
- Phase 1 offline path unchanged — all four fixes are in live-mode-specific code paths or mode-aware branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)