### PR TITLE
fix(swiftletd): PR 1 hotfix #4 — W22 (suppress VmStopped on migration-send completion)

### DIFF
--- a/rust/swiftletd/src/action.rs
+++ b/rust/swiftletd/src/action.rs
@@ -67,7 +67,36 @@
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
+
+/// W22 (PR #46 follow-up cluster re-walkthrough): tracks whether a
+/// migration-send has completed cleanly. Set inside
+/// `dispatch_migration_send`'s success branch (after the W1 gate
+/// confirms CH is gone post-vm.send-migration); cleared never (the
+/// flag has process lifetime — once a swiftletd has done a successful
+/// send, its CH is irrevocably retired).
+///
+/// main.rs's post-launch report_running(VmStopped) path reads this
+/// flag and suppresses the GuestRunning=False write when it's set,
+/// avoiding the race against swiftletd-on-dst's W16 GuestRunning=True
+/// write. Without this, the two writes (both Patches on the same
+/// SwiftGuest condition) race on the apiserver: in S8's
+/// cancel-during-Resuming scenario, src's VmStopped landed last,
+/// stuck Resuming-live until spec.timeout.
+///
+/// Local-state-tracking-in-swiftletd-on-src per F2.4 (no
+/// controller→swiftletd command channel needed). Matches the D1
+/// pattern of tracking state via local primitives (D1 uses
+/// runtime_dir/ch.pid for the cancel handler).
+pub static MIGRATION_SEND_COMPLETED: AtomicBool = AtomicBool::new(false);
+
+/// Returns true if `dispatch_migration_send` has completed cleanly in
+/// this swiftletd process. main.rs uses this to decide whether to
+/// suppress the post-launch VmStopped report (W22).
+pub fn migration_send_completed_clean() -> bool {
+    MIGRATION_SEND_COMPLETED.load(Ordering::SeqCst)
+}
 
 use kube::api::{Api, Patch, PatchParams};
 use kube::Client;
@@ -607,8 +636,14 @@ async fn dispatch_migration_send(
         Err(_) => {
             // CH is gone — the expected outcome on success.
             let elapsed_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
+            // W22: mark migration-send as cleanly completed so main.rs's
+            // post-launch path suppresses the VmStopped write that
+            // would race the dst-side W16 GuestRunning=True write.
+            // Set BEFORE logging the success message so any future
+            // observer sees a consistent state.
+            MIGRATION_SEND_COMPLETED.store(true, Ordering::SeqCst);
             log::info!(
-                "dispatch_migration_send_complete id={} elapsed_ms={}",
+                "dispatch_migration_send_complete id={} elapsed_ms={} w22_send_completed_flag=set",
                 action.id,
                 elapsed_ms
             );
@@ -2900,6 +2935,56 @@ mod tests {
     // the 30-line helper.
     //
     // The pure-function piece (label extraction) IS unit-testable:
+
+    // ─── W22 (PR #46 follow-up cluster re-walkthrough) ──────────────
+    //
+    // Cluster re-walkthrough Scenario 8 surfaced a race between
+    // swiftletd-on-src's post-CH-exit VmStopped write and
+    // swiftletd-on-dst's W16 GuestRunning=True write. Both target the
+    // same SwiftGuest condition; last-write-wins. In S1 happy path
+    // dst typically wins (lucky timing); in S8 cancel-during-Resuming
+    // src wins because cancel-induced apiserver activity reorders
+    // things, leaving the SwiftGuest stuck at GuestRunning=False.
+    //
+    // The fix: when dispatch_migration_send completes cleanly (W1
+    // gate verifies CH is gone post-send), set
+    // MIGRATION_SEND_COMPLETED=true. main.rs's post-launch path
+    // checks the flag via migration_send_completed_clean() and
+    // suppresses the VmStopped report; dst's W16 write becomes the
+    // authoritative post-migration state.
+    //
+    // The full kube-write race is exercised by the cluster re-
+    // walkthrough; the unit-testable surface is the flag's
+    // behavior.
+
+    // Serialization: the static AtomicBool is process-wide, so tests
+    // that mutate it must serialize. Using #[serial_test] would add
+    // a dependency; for two tests we sequence via a small helper.
+
+    #[test]
+    fn migration_send_completed_clean_default_false() {
+        // The flag default is false. Don't mutate; just check the
+        // initial-state contract (other W22 tests reset the flag
+        // after their assertion).
+        // Note: if a prior test leaked state, this assertion catches
+        // the regression — the flag must not be set until a real
+        // dispatch_migration_send success.
+        // We can't unconditionally assert false here because test
+        // ordering is undefined; instead we test the helper as a
+        // pure read of the AtomicBool's current value, against an
+        // explicit set/clear in the same test.
+        // First: explicit clear, then read should be false.
+        MIGRATION_SEND_COMPLETED.store(false, Ordering::SeqCst);
+        assert!(!migration_send_completed_clean());
+    }
+
+    #[test]
+    fn migration_send_completed_clean_after_set_true() {
+        MIGRATION_SEND_COMPLETED.store(true, Ordering::SeqCst);
+        assert!(migration_send_completed_clean());
+        // Reset so other tests see the default.
+        MIGRATION_SEND_COMPLETED.store(false, Ordering::SeqCst);
+    }
 
     #[test]
     fn extract_guest_name_from_labels_returns_value_when_present() {

--- a/rust/swiftletd/src/main.rs
+++ b/rust/swiftletd/src/main.rs
@@ -320,8 +320,28 @@ fn main() {
             match result {
                 Ok((exit_status, _pid, _serial_socket_path)) => {
                     if exit_status.success() {
-                        log::info!("vm_stopped_gracefully");
-                        report_running(false, Some("VmStopped"));
+                        // W22 (PR #46 follow-up cluster re-walkthrough):
+                        // when CH exits cleanly because vm.send-migration
+                        // succeeded (src side of a live migration), the
+                        // guest is NOT stopped — it's running on the dst
+                        // pod. Writing GuestRunning=False/VmStopped here
+                        // races with swiftletd-on-dst's W16
+                        // GuestRunning=True write on the same SwiftGuest
+                        // condition; non-deterministic outcome leaves the
+                        // SwiftGuest stuck at GuestRunning=False.
+                        // action::migration_send_completed_clean() returns
+                        // true iff dispatch_migration_send hit its W1-gate
+                        // success path; suppress the VmStopped write so
+                        // dst's GuestRunning=True is the authoritative
+                        // post-migration state.
+                        if action::migration_send_completed_clean() {
+                            log::info!(
+                                "vm_exited_post_send_migration; skipping VmStopped report (W22)"
+                            );
+                        } else {
+                            log::info!("vm_stopped_gracefully");
+                            report_running(false, Some("VmStopped"));
+                        }
                     } else {
                         log::warn!("vm_exited_nonzero code={:?}", exit_status.code());
                         report_running(false, Some("VmFailed"));


### PR DESCRIPTION
# PR 1 hotfix #4: W22 — race between src VmStopped and dst GuestRunning=True

PR #46 follow-up cluster re-walkthrough surfaced a fifth finding-behind-a-finding while validating the W17/W18/W21 fixes from [PR #47](https://github.com/projectbeskar/kubeswift/pull/47). Scenario 8 (cancel-post-cutover with W21 fix) succeeded at the cancel-handling layer (CancelIgnored=True/PastCutover correctly set, PodRefSwapped=True written) but the migration ended Failed/Timeout because the SwiftGuest's GuestRunning condition stayed at False/VmStopped post-cutover.

## Walkthrough excerpt — W22 discovery

\`\`\`
dst pod swiftletd logs:
  21:43:30  migration_role role=receiver
  21:43:30  migration_receiver_mode
  21:43:30  action_loop_started
  21:43:30  action_accept namespace=migration kind=MigrationReceive id=s8-mig:recv:1
  21:44:09.805  dispatch_migration_receive_complete state=Running elapsed_ms=39739
  21:44:09.843  w16_guest_running_reported guest=mig-wt/faas-s8

SwiftGuest.status.conditions[GuestRunning] at the time of failure:
  status=False reason=VmStopped lastTransitionTime=2026-05-03T21:44:09Z
\`\`\`

The W16 \`w16_guest_running_reported\` log at **21:44:09.843** confirms the dst-side GuestRunning=True patch was issued. But the SwiftGuest's GuestRunning condition is **False** with the same-second lastTransitionTime — meaning the **src-side VmStopped write landed AFTER W16's True write**. Both writes are merge-patches on the same condition; last-write-wins.

In S1 happy path, dst's write tended to land last (lucky timing → GuestRunning=True). In S8 cancel-during-Resuming, the cancel-induced apiserver activity reordered things — src's VmStopped landed last. Race outcome is non-deterministic.

## Root cause

[\`rust/swiftletd/src/main.rs\`](https://github.com/projectbeskar/kubeswift/blob/main/rust/swiftletd/src/main.rs) writes \`GuestRunning=False/VmStopped\` whenever its CH exits cleanly:

\`\`\`rust
if exit_status.success() {
    log::info!(\"vm_stopped_gracefully\");
    report_running(false, Some(\"VmStopped\"));  // <-- always, regardless of cause
}
\`\`\`

But on the source side of a successful live migration, CH's clean exit is a **migration handoff**, NOT a guest shutdown. The guest is alive on the destination. Writing GuestRunning=False at this moment races the dst-side W16 GuestRunning=True write.

## Fix

Per operator direction: **track in-flight migration state locally in swiftletd-on-src** rather than coordinating with the controller. Matches D1's local-state-tracking pattern (D1 uses runtime_dir/ch.pid for the cancel handler) and preserves F2.4 (no controller→swiftletd command channel).

\`\`\`rust
// action.rs
pub static MIGRATION_SEND_COMPLETED: AtomicBool = AtomicBool::new(false);

pub fn migration_send_completed_clean() -> bool {
    MIGRATION_SEND_COMPLETED.load(Ordering::SeqCst)
}

// dispatch_migration_send success branch
MIGRATION_SEND_COMPLETED.store(true, Ordering::SeqCst);

// main.rs success-exit branch
if action::migration_send_completed_clean() {
    log::info!(\"vm_exited_post_send_migration; skipping VmStopped report (W22)\");
} else {
    log::info!(\"vm_stopped_gracefully\");
    report_running(false, Some(\"VmStopped\"));
}
\`\`\`

Process-lifetime flag: once a swiftletd has done a successful send, its CH is irrevocably retired (no clear-on-error path needed). Set inside the W1-gate-passing branch of \`dispatch_migration_send\`. main.rs reads via the public helper.

## Tests

- \`migration_send_completed_clean_default_false\`: flag default + helper read
- \`migration_send_completed_clean_after_set_true\`: helper reflects set state
- The kube-write race itself is validated by the cluster re-walkthrough (next session); unit tests cover the flag's atomic-read contract

\`cargo test -p swiftletd\` reports 83 passed (2 new for W22). Go test suite unchanged.

## Pattern: fifth finding-behind-a-finding

| Iter | Image | Finding | Layer |
|---|---|---|---|
| 1 | sha-4cde589 | W13 BLOCKING + W14 HIGH | controller (Go) |
| 2 | sha-ce68fa9 | W15 BLOCKING | controller (Go) |
| 3 | sha-4236252 | W16 BLOCKING | swiftletd (Rust) |
| 4 (clean) | sha-5c794ff | W17/W18/W19/W21 (non-blocking) | controller (Go) |
| 5 (re-walkthrough) | sha-e1847ae | **W22 RACE** | swiftletd (Rust) |

Each clean baseline exposed the next race/lifecycle issue at the src↔dst swiftletd boundary. The cluster-walkthrough discipline continues to pay for itself; unit tests with fake clients can't observe the race because they don't fire two writes from two different processes within milliseconds.

## Test plan

- [x] \`cargo test -p swiftletd\` passes (83 tests; 2 new for W22)
- [x] \`cargo build --release -p swiftletd\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`go test ./...\` clean (no Go-side regression — controller code unchanged)
- [ ] **Post-merge cluster re-walkthrough requires multiple consecutive S1 runs** to verify the race is genuinely fixed, not just shifted to a different timing window. S1 should pass deterministically with GuestRunning=True observed in every run. Suggested 3–5 consecutive runs.
- [ ] **Post-merge S8 re-run** to verify migration completes (not Failed/Timeout) with both CancelIgnored=True/PastCutover (W21) and GuestRunning=True (W22).
- [ ] If a sixth finding-behind-a-finding (W23) surfaces, stop and discuss disposition (per operator's guardrail: \"five iterations is already a lot; six would warrant scope discussion about whether Phase 3a's swiftletd↔controller boundary needs broader review\").

## Walkthrough log disposition

W22 will be appended to \`docs/migration/phase-3a-cluster-validation.md\` as the fifth iteration's finding. The pattern observation will be updated to note the cluster-walkthrough discipline surfaces issues at the src↔dst swiftletd boundary specifically — three of the five findings (W16, W22, plus W13's ack annotation gap) live at that boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)