### PR TITLE
fix(swiftletd): PR 1 hotfix #5 — W23 (graceful shutdown signaling)

### DIFF
--- a/rust/swiftletd/src/action.rs
+++ b/rust/swiftletd/src/action.rs
@@ -68,7 +68,10 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
+use tokio::sync::Notify;
 
 /// W22 (PR #46 follow-up cluster re-walkthrough): tracks whether a
 /// migration-send has completed cleanly. Set inside
@@ -96,6 +99,52 @@ pub static MIGRATION_SEND_COMPLETED: AtomicBool = AtomicBool::new(false);
 /// suppress the post-launch VmStopped report (W22).
 pub fn migration_send_completed_clean() -> bool {
     MIGRATION_SEND_COMPLETED.load(Ordering::SeqCst)
+}
+
+/// W23 (PR #46 follow-up cluster re-walkthrough, post-W22): graceful-
+/// shutdown signal between the action loop and main.rs on the
+/// migration-send terminal write.
+///
+/// **Distinct from W22 — do not conflate.** W22's
+/// MIGRATION_SEND_COMPLETED flag prevents `main.rs` from writing
+/// GuestRunning=False/VmStopped after a successful migration-send
+/// (avoiding the race against dst-side W16 GuestRunning=True). W23
+/// addresses a different race that the W22 fix INTRODUCED:
+///
+///   - Pre-W22: main's post-launch path called report_running(false,
+///     VmStopped), whose apiserver Patch round-trip incidentally
+///     gave the action loop ~tens of ms to finish writing the
+///     terminal `migration-status: complete` annotation.
+///   - Post-W22: main's W22-flag-set branch skips the patch and
+///     returns immediately, killing the action loop thread before
+///     its terminal-status write call lands. The src pod retains
+///     `migration-status: running` forever; the controller never
+///     observes the W1 gate and stalls until spec.timeout.
+///
+/// Fix: action loop fires `notify_one()` on this Notify AFTER the
+/// terminal write for a MigrationSend action returns (success or
+/// failure). main.rs's W22 success branch awaits `.notified()` with
+/// a 10s bounded timeout before exiting. On timeout, log warn and
+/// exit anyway — controller's spec.timeout is the ultimate floor.
+///
+/// Notify semantics: notify_one before notified wakes the next
+/// notified call; notify_one is idempotent (at most one stored
+/// permit). Matches the "fire once at terminal-write completion,
+/// wait once in main" contract.
+///
+/// F2.4 preserved: no controller→swiftletd channel; this is purely
+/// swiftletd-internal main↔action-loop coordination via standard
+/// Rust primitives.
+static MIGRATION_SEND_TERMINAL_WRITTEN: OnceLock<Arc<Notify>> = OnceLock::new();
+
+/// Returns the singleton Notify used by the action loop to signal
+/// "terminal-status write for MigrationSend has completed". main.rs
+/// awaits `.notified()` on this with a bounded timeout. Initialised
+/// lazily on first call.
+pub fn migration_send_terminal_signal() -> Arc<Notify> {
+    MIGRATION_SEND_TERMINAL_WRITTEN
+        .get_or_init(|| Arc::new(Notify::new()))
+        .clone()
 }
 
 use kube::api::{Api, Patch, PatchParams};
@@ -1838,6 +1887,30 @@ async fn handle_namespace(
             {
                 log::error!("action_status_write_failed: {}", e);
             }
+            // W23: signal main.rs that the terminal write for a
+            // MigrationSend action has completed (success or failure).
+            // main.rs's W22 success branch awaits this before exiting,
+            // ensuring the apiserver actually received the
+            // `migration-status: complete` annotation patch before the
+            // process exits and kills this thread mid-flight.
+            //
+            // Fired AFTER the write call returns — the whole point is
+            // ensuring the write lands. Send-failure on the channel is
+            // benign (notify_one stores at most one permit; idempotent
+            // if no awaiter is parked yet).
+            //
+            // Scoped to MigrationSend only because that's the action
+            // whose completion triggers main's exit. Other actions
+            // (snapshot, restore, MigrationReceive, MigrationCancel)
+            // don't have main.rs exiting on their completion so they
+            // don't need the signal. Defensive completeness: fire on
+            // both success ("complete") and failure paths since a
+            // future code change might add an exit-on-send-failure
+            // path; cheap to fire either way.
+            if pending.kind == ActionKind::MigrationSend {
+                migration_send_terminal_signal().notify_one();
+                log::info!("w23_terminal_write_signal_fired id={}", pending.id);
+            }
             state.in_flight = None;
             state.last_completed_id = Some(pending.id);
         }
@@ -2984,6 +3057,67 @@ mod tests {
         assert!(migration_send_completed_clean());
         // Reset so other tests see the default.
         MIGRATION_SEND_COMPLETED.store(false, Ordering::SeqCst);
+    }
+
+    // ─── W23 (PR #46 follow-up cluster re-walkthrough, post-W22) ────
+    //
+    // Cluster re-walkthrough Scenarios 1+8 against the W22 image
+    // (sha-8dd1a51) showed src pod's migration-status stuck at
+    // "running" because main exited before the action loop's
+    // terminal-status write landed. W23 adds graceful shutdown
+    // signaling: action loop fires Notify after the terminal
+    // write returns; main awaits with 10s bounded timeout before
+    // exiting on the W22 success path.
+    //
+    // Unit-testable surface: the Notify primitive's signal-receive
+    // and timeout-expiry contracts. The full kube-write-then-signal
+    // shutdown flow is exercised by the cluster re-walkthrough.
+
+    #[tokio::test]
+    async fn w23_signal_received_within_timeout() {
+        // Two threads (or in this case, two tokio tasks) sharing the
+        // singleton Notify: one fires notify_one shortly; the other
+        // awaits .notified() with a 10s bound. The await must
+        // complete via signal, NOT timeout.
+        let signal = migration_send_terminal_signal();
+        let firer_signal = signal.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            firer_signal.notify_one();
+        });
+        let result = tokio::time::timeout(Duration::from_secs(10), signal.notified()).await;
+        assert!(result.is_ok(), "signal must be received within 10s timeout");
+    }
+
+    #[tokio::test]
+    async fn w23_signal_timeout_path_returns_err() {
+        // No firer; ensure timeout fires after a short bound.
+        // Use a *fresh* Notify (not the singleton) since the
+        // singleton may have a stored permit from prior tests.
+        let fresh = Arc::new(Notify::new());
+        let result = tokio::time::timeout(Duration::from_millis(100), fresh.notified()).await;
+        assert!(
+            result.is_err(),
+            "timeout-expiry path must return Err (Elapsed)"
+        );
+    }
+
+    #[tokio::test]
+    async fn w23_signal_idempotent_notify_one_before_notified() {
+        // Notify semantics: notify_one before notified stores at
+        // most one permit; the next notified() wakes immediately.
+        // This is the load-bearing property for the W23 contract:
+        // if the action loop fires before main awaits, main still
+        // wakes promptly.
+        let fresh = Arc::new(Notify::new());
+        fresh.notify_one();
+        // Second notify_one is benign (still at most one permit).
+        fresh.notify_one();
+        let result = tokio::time::timeout(Duration::from_millis(100), fresh.notified()).await;
+        assert!(
+            result.is_ok(),
+            "notify_one before notified must wake the next notified() call"
+        );
     }
 
     #[test]

--- a/rust/swiftletd/src/main.rs
+++ b/rust/swiftletd/src/main.rs
@@ -338,6 +338,42 @@ fn main() {
                             log::info!(
                                 "vm_exited_post_send_migration; skipping VmStopped report (W22)"
                             );
+                            // W23 (PR #46 follow-up cluster re-walkthrough,
+                            // post-W22): wait for the action loop's terminal
+                            // `migration-status: complete` write to land
+                            // before exiting. W22's flag-set-and-skip path
+                            // removed the implicit ~tens-of-ms apiserver
+                            // round-trip from the previous report_running
+                            // call, exposing a race where main exited
+                            // before the action loop's separate-thread
+                            // tokio runtime could complete its kube
+                            // client patch — leaving src pod's
+                            // migration-status at "running" forever and
+                            // stalling the controller until spec.timeout.
+                            //
+                            // 10s bounded timeout — typical apiserver
+                            // Patch is sub-100ms p50, sub-1s p99; 10s
+                            // gives 100x headroom over normal latency.
+                            // Timeout-expiry path logs warn and exits
+                            // anyway — controller's spec.timeout (5min
+                            // default) is the ultimate floor for stuck-
+                            // migration detection.
+                            let signal = action::migration_send_terminal_signal();
+                            let waited = rt.block_on(async {
+                                tokio::time::timeout(
+                                    std::time::Duration::from_secs(10),
+                                    signal.notified(),
+                                )
+                                .await
+                                .is_ok()
+                            });
+                            if waited {
+                                log::info!("w23_terminal_write_signal_received; safe to exit");
+                            } else {
+                                log::warn!(
+                                    "w23_terminal_write_signal_timeout after 10s; exiting anyway (controller spec.timeout will detect any stuck migration)"
+                                );
+                            }
                         } else {
                             log::info!("vm_stopped_gracefully");
                             report_running(false, Some("VmStopped"));


### PR DESCRIPTION
# PR 1 hotfix #5: W23 — graceful shutdown signaling for migration-send terminal write

PR #46 follow-up cluster re-walkthrough surfaced this **sixth finding-behind-a-finding** while validating W22's GuestRunning-race fix. Three consecutive S1 runs against the W22 image (\`sha-8dd1a51\`) all stuck in StopAndCopy at T+180s+ with src pod's \`migration-status\` annotation at \"running\" instead of \"complete\". W22 was working correctly (GuestRunning=True/VmRunning observed) but a different race emerged.

## Walkthrough excerpt — W23 discovery

\`\`\`
S1 RUN 1: T+181s phase=StopAndCopy GuestRunning=True/VmRunning podRef=faas-s1
S1 RUN 2: T+182s phase=StopAndCopy GuestRunning=True/VmRunning podRef=faas-s1
S1 RUN 3: T+182s phase=StopAndCopy GuestRunning=True/VmRunning podRef=faas-s1
\`\`\`

(\`podRef=faas-s1\` = src pod name; cutover step 1 never ran. Controller never observed src=complete.)

src pod state at terminal: \`Completed 0/1\` (launcher exited).
src pod \`migration-status\` annotation: **\`running\`** (not \`complete\`).

swiftletd logs:

\`\`\`
09:58:34.035  dispatch_migration_send_complete id=s1-mig:send:1
              elapsed_ms=38163 w22_send_completed_flag=set
09:58:34.036  vm_exited_post_send_migration; skipping VmStopped report (W22)
              <-- process exits 1ms after action loop sets the flag
\`\`\`

The action loop's \`write_migration_status(\"complete\")\` call never appears in logs because main.rs returned and the process exited before it could fire.

## Root cause (per operator's diagnosis)

Pre-W22: main's else branch (no flag) called \`report_running(false, VmStopped)\`, whose **apiserver Patch round-trip (~tens of ms) was incidentally a timing pad** that let the action loop complete its own terminal write_migration_status call before main returned.

Post-W22: main's if branch (flag set) skips the patch and returns immediately. The action loop's separate-thread tokio runtime is killed mid-flight before its kube client patch lands. The race was always present; W22 just removed the implicit pad that masked it.

This is **a process-shutdown sequencing bug, not a write-coordination bug**. Single-thread (one writer, no contention); the issue is main exits without waiting for the action loop's pending work. No analogous bug elsewhere — dst's CH stays alive; main doesn't exit on receive completion; controller is event-driven.

## Fix

Tokio \`Notify\` primitive in action.rs as a singleton via \`OnceLock<Arc<Notify>>\`:

\`\`\`rust
static MIGRATION_SEND_TERMINAL_WRITTEN: OnceLock<Arc<Notify>> = OnceLock::new();

pub fn migration_send_terminal_signal() -> Arc<Notify> {
    MIGRATION_SEND_TERMINAL_WRITTEN
        .get_or_init(|| Arc::new(Notify::new()))
        .clone()
}
\`\`\`

**Action loop**: in \`handle_namespace\`'s Accept branch, after the terminal write_migration_status returns (success or failure), fire \`notify_one()\` if \`pending.kind == ActionKind::MigrationSend\`.

**main.rs**: in the W22 success branch, await \`.notified()\` with 10s bounded timeout before exiting:

\`\`\`rust
if action::migration_send_completed_clean() {
    log::info!(\"vm_exited_post_send_migration; skipping VmStopped report (W22)\");
    let signal = action::migration_send_terminal_signal();
    let waited = rt.block_on(async {
        tokio::time::timeout(
            std::time::Duration::from_secs(10),
            signal.notified(),
        ).await.is_ok()
    });
    if waited {
        log::info!(\"w23_terminal_write_signal_received; safe to exit\");
    } else {
        log::warn!(
            \"w23_terminal_write_signal_timeout after 10s; exiting anyway\"
        );
    }
}
\`\`\`

10s timeout chosen for 100x headroom over typical apiserver Patch latency (sub-100ms p50, sub-1s p99). On timeout, exit anyway — controller's \`spec.timeout\` (5min default) is the ultimate floor.

### Why Notify over oneshot

Notify's level-triggered semantics (notify_one before notified stores at most one permit; next \`notified()\` wakes immediately) handle the typical case where the action loop fires BEFORE main reaches the await without needing Sender-ownership ceremony. Singleton via OnceLock avoids plumbing through \`spawn_action_loop\`'s signature.

### Scoped to MigrationSend only

Other actions (snapshot, restore, MigrationReceive, MigrationCancel) don't have main exiting on their completion. Defensive completeness: fires on both success (\"complete\") and failure paths since a future code change might add an exit-on-send-failure path.

## Preserved guarantees

| Property | Status |
|---|---|
| W22's MIGRATION_SEND_COMPLETED flag | Unchanged. W23 layered on top |
| migration_send_completed_clean() helper | Unchanged |
| F2.4 (no controller→swiftletd channel) | Preserved — purely swiftletd-internal main↔action-loop coordination |
| Phase 1 offline migration | Unchanged — new signal path inert for offline |

Code comments at both W22 (flag) and W23 (Notify) cross-reference each other to prevent future contributor conflation.

## Tests

- \`w23_signal_received_within_timeout\`: cross-task fire+await; signal arrives via notify, not timeout
- \`w23_signal_timeout_path_returns_err\`: no firer; tokio::time::timeout returns Err (Elapsed)
- \`w23_signal_idempotent_notify_one_before_notified\`: notify_one before .notified() must wake the next notified() — load-bearing for the typical W23 case

\`cargo test -p swiftletd\` reports **86 passed** (3 new for W23). \`cargo build --release\` clean. Go test suite unchanged.

## Pattern: sixth finding-behind-a-finding

| Iter | Image | Finding | Layer | Bug shape |
|---|---|---|---|---|
| 1 | sha-4cde589 | W13/W14 | controller | missing annotation + missing terminal recognition |
| 2 | sha-ce68fa9 | W15 | controller | race-window between two-step status patches |
| 3 | sha-4236252 | W16 | swiftletd | lifecycle gap in receiver-mode post-receive |
| 4 (clean) | sha-5c794ff | W17/W18/W19/W21 | controller | non-blocking |
| 5 (re-walkthrough) | sha-e1847ae | W22 RACE | swiftletd | dual-writer race on SwiftGuest condition |
| **6** | **sha-8dd1a51** | **W23 SHUTDOWN** | **swiftletd** | **process-exit sequencing race** |

W23 differs from the prior chain in that it's NOT a write-coordination bug. The architectural diagnosis predicts **W24 should not appear** in re-walkthrough — if it does, the prediction is wrong and broader architectural review is warranted per the operator's W22-prompt guardrail.

## Test plan (post-merge cluster re-walkthrough)

Operator-driven, separate session:

- [ ] **S1 sanity 3-5 consecutive runs** — all reach phase=Completed AND src pod ends with \`migration-status: complete\` AND SwiftGuest GuestRunning=True/VmRunning. Pre-W23 this stuck in StopAndCopy 100% of the time; post-W23 should pass deterministically.
- [ ] **S8 cancel-during-Resuming** — reaches Completed with CancelIgnored=True/PastCutover (W21) AND GuestRunning=True (W22) AND migration-status=complete on src (W23).
- [ ] If any S1 run completes with \`migration-status: running\` instead of \`complete\`, the timeout fired before action loop's write landed — investigate, do NOT silently increase timeout.
- [ ] If a 7th finding-behind-a-finding (W24) surfaces, STOP and discuss disposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)