### PR TITLE
ci(release-dev): fix chart version leading-zero rejection by Helm

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -27,7 +27,15 @@ jobs:
         id: version
         run: |
           SHORT=$(echo ${{ github.sha }} | cut -c1-7)
-          echo "version=0.0.0-dev.${SHORT}" >> $GITHUB_OUTPUT
+          # SemVer 2.0.0 §9 forbids leading zeroes in numeric pre-release
+          # identifiers, and Helm enforces this strictly. A 7-char short
+          # hash that happens to be all digits (e.g., "0781498" — the
+          # merge SHA of PR #49) is treated as numeric and rejected with
+          # "Version segment starts with 0". Prepend "g" (git describe
+          # convention) to make the segment alphanumeric, which bypasses
+          # the leading-zero rule. Docker image tag is unaffected
+          # because Docker tags don't use SemVer validation.
+          echo "version=0.0.0-dev.g${SHORT}" >> $GITHUB_OUTPUT
           echo "image_tag=sha-${SHORT}" >> $GITHUB_OUTPUT
           echo "git_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Fix release-dev chart-version leading-zero rejection

PR #49's release-dev workflow failed at the helm chart push step:

\`\`\`
Run CHART_VERSION=\"0.0.0-dev.0781498\"
helm package charts/kubeswift --version \"\$CHART_VERSION\" --app-version \"\$CHART_VERSION\"
Error: Version segment starts with 0
Error: Process completed with exit code 1.
\`\`\`

The chart-version fix from PR #49's discussion landed on that branch as commit \`de42302\` but **the PR was already merged before that commit landed**, so the fix did NOT make it to main. To make matters worse, the merge SHA of PR #49 itself is \`0781498\` — the same all-digits-leading-zero pattern that triggered the original failure — so subsequent release-dev runs on main will fail identically until this fix lands.

## Root cause

[SemVer 2.0.0 §9](https://semver.org/#spec-item-9): \"Numeric identifiers MUST NOT include leading zeroes.\" A pre-release identifier consisting entirely of digits is classified as numeric. Helm enforces this strictly via its semver dependency.

The workflow generates:
\`\`\`bash
SHORT=$(echo ${{ github.sha }} | cut -c1-7)
echo \"version=0.0.0-dev.${SHORT}\" >> $GITHUB_OUTPUT
\`\`\`

When SHORT happens to be all digits with a leading zero (probabilistically ~1 in ~16 commits, since hex hash chars are 0-9 a-f), the segment fails validation.

## Fix

Prepend \`g\` (git describe convention — the same prefix \`git describe\` uses for commit hashes: \`v1.2.3-5-gabc1234\`):

\`\`\`bash
echo \"version=0.0.0-dev.g${SHORT}\" >> $GITHUB_OUTPUT
\`\`\`

The segment becomes alphanumeric, bypassing the leading-zero rule. Result: \`0.0.0-dev.g0781498\` is a valid SemVer pre-release.

## Unaffected

Docker image tag generation (\`image_tag=sha-${SHORT}\`) is unchanged — Docker tags don't go through SemVer validation, so \`sha-0781498\` was always accepted and continues to work. Image tags throughout the workflow (controller-manager, gpu-discovery, swiftletd) all use \`image_tag\`, not \`version\`.

## Test plan

- [x] YAML syntax verified (no structural change to the workflow)
- [ ] Post-merge: release-dev workflow runs on the merge commit and the helm chart push step succeeds. Chart will publish as \`kubeswift-0.0.0-dev.g<short>\`.
- [ ] If subsequent runs hit further chart-version issues (extremely unlikely after this fix — \"g\" prefix is the canonical fix), open a follow-up. The fix is conservative and well-precedented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)