### PR TITLE
ci(release-dev): conditional 'g'-prefix only for SemVer-rejected hashes

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -28,14 +28,23 @@ jobs:
         run: |
           SHORT=$(echo ${{ github.sha }} | cut -c1-7)
           # SemVer 2.0.0 §9 forbids leading zeroes in numeric pre-release
-          # identifiers, and Helm enforces this strictly. A 7-char short
-          # hash that happens to be all digits (e.g., "0781498" — the
-          # merge SHA of PR #49) is treated as numeric and rejected with
-          # "Version segment starts with 0". Prepend "g" (git describe
-          # convention) to make the segment alphanumeric, which bypasses
-          # the leading-zero rule. Docker image tag is unaffected
-          # because Docker tags don't use SemVer validation.
-          echo "version=0.0.0-dev.g${SHORT}" >> $GITHUB_OUTPUT
+          # identifiers; Helm enforces strictly. A 7-char hex hash is
+          # rejected ONLY when it is all-digits AND starts with 0 (e.g.,
+          # "0781498" — PR #49's merge SHA). Probability ~0.4% per
+          # commit. For the rejected case, prepend "g" (git describe
+          # convention) to make the segment alphanumeric. For all
+          # other ~99.6% of commits, preserve the documented format
+          # `0.0.0-dev.<shortsha>` so consumers (Makefile,
+          # hack/chart-version.sh, hack/version.sh, docs/deploy.md,
+          # docs/releases.md, docs/install/helm-oci.md, operator
+          # deploy scripts) continue to compute the right version
+          # without conditional logic of their own.
+          if [[ "$SHORT" =~ ^0[0-9]{6}$ ]]; then
+            CHART_VERSION="0.0.0-dev.g${SHORT}"
+          else
+            CHART_VERSION="0.0.0-dev.${SHORT}"
+          fi
+          echo "version=$CHART_VERSION" >> $GITHUB_OUTPUT
           echo "image_tag=sha-${SHORT}" >> $GITHUB_OUTPUT
           echo "git_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT

--- a/hack/chart-version.sh
+++ b/hack/chart-version.sh
@@ -10,7 +10,15 @@ TYPE="${1:-dev}"
 case "$TYPE" in
   dev)
     GIT_COMMIT_SHORT="${GIT_COMMIT_SHORT:-$(git rev-parse HEAD | cut -c1-7)}"
-    echo "0.0.0-dev.${GIT_COMMIT_SHORT}"
+    # SemVer §9 leading-zero guard: only ~0.4% of commits hit this
+    # (all-digit hash starting with 0). Mirror the same conditional
+    # the release-dev workflow applies; otherwise local computation
+    # would diverge from published chart versions.
+    if [[ "$GIT_COMMIT_SHORT" =~ ^0[0-9]{6}$ ]]; then
+      echo "0.0.0-dev.g${GIT_COMMIT_SHORT}"
+    else
+      echo "0.0.0-dev.${GIT_COMMIT_SHORT}"
+    fi
     ;;
   rc|stable)
     GIT_TAG="${GIT_TAG:-$(git describe --tags --exact-match 2>/dev/null)}"

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -25,7 +25,15 @@ if [[ -n "$GIT_TAG" ]]; then
   fi
 else
   # Dev (no tag): 0.0.0-dev.<shortsha>
-  VERSION="0.0.0-dev.${GIT_COMMIT_SHORT}"
+  # SemVer §9 leading-zero guard: only ~0.4% of commits hit this
+  # (all-digit hash starting with 0). Mirror the same conditional
+  # the release-dev workflow applies; otherwise local computation
+  # would diverge from published chart versions.
+  if [[ "$GIT_COMMIT_SHORT" =~ ^0[0-9]{6}$ ]]; then
+    VERSION="0.0.0-dev.g${GIT_COMMIT_SHORT}"
+  else
+    VERSION="0.0.0-dev.${GIT_COMMIT_SHORT}"
+  fi
   VERSION_TAG="v${VERSION}"
   IMAGE_TAG="sha-${GIT_COMMIT_SHORT}"
   CHART_VERSION="$VERSION"


### PR DESCRIPTION
# Conditional 'g'-prefix — preserve documented chart-version format

## Problem

[PR #50](https://github.com/projectbeskar/kubeswift/pull/50) fixed the SemVer leading-zero crash but did so by applying the \`g\` prefix **unconditionally** to every dev chart version. That broke the documented format \`0.0.0-dev.<shortsha>\` for the ~99.6% of commits that don't have leading-zero issues.

Operator hit this immediately:

\`\`\`
$ export SHORT_SHA=$(git rev-parse --short=7 HEAD)        # 845d4f8
$ export DEV_VERSION=0.0.0-dev.$SHORT_SHA                  # 0.0.0-dev.845d4f8
$ helm upgrade kubeswift oci://ghcr.io/projectbeskar/charts/kubeswift --version \"\$DEV_VERSION\" ...
Error: ghcr.io/projectbeskar/charts/kubeswift:0.0.0-dev.845d4f8: not found
\`\`\`

Published chart was \`0.0.0-dev.g845d4f8\` (with the unconditional \`g\`); operator's script computed without it.

Affected consumers of the documented format:

- \`Makefile\` (helm-publish-dev target)
- \`hack/chart-version.sh\` (local computation by Makefile et al.)
- \`hack/version.sh\` (canonical exported VERSION/CHART_VERSION)
- \`docs/deploy.md\`, \`docs/releases.md\`, \`docs/install/helm-oci.md\`, \`docs/operator/troubleshooting.md\`
- Operator deploy scripts that follow the documented pattern

## Fix

Apply the \`g\` prefix **conditionally**, only when the short hash is all-digits with a leading zero — the only case SemVer §9 rejects. All other commits keep the documented \`0.0.0-dev.<shortsha>\` format.

Mirrored conditional in three places that compute the version:

- \`.github/workflows/release-dev.yaml\` (publishes the chart)
- \`hack/chart-version.sh\` (local computation by Makefile et al.)
- \`hack/version.sh\` (canonical exported VERSION/CHART_VERSION)

## Smoke test

Local test of all four hash patterns:

| Hash | Output | Notes |
|---|---|---|
| \`845d4f8\` | \`0.0.0-dev.845d4f8\` | Current main; **matches operator's deploy script** |
| \`0781498\` | \`0.0.0-dev.g0781498\` | PR #49 case (all-digit + leading zero); g-prefix applied |
| \`1234567\` | \`0.0.0-dev.1234567\` | All-digit no-leading-zero; valid numeric SemVer |
| \`0abc123\` | \`0.0.0-dev.0abc123\` | Alphanumeric leading-0; valid (contains letter) |

## Probability

Conditional fires when SHORT matches \`^0[0-9]{6}$\` — all-digit hash with leading zero. Probability: \`(1/16) × (10/16)^6 ≈ 0.4%\` of commits. Negligible operator confusion vs. the alternative (always-g, which broke 99.6% of the documented path).

## Remaining edge case

In the rare leading-zero case, an operator's naive deploy script (\`DEV_VERSION=0.0.0-dev.\$SHORT_SHA\`) will still fail because the chart is published as \`0.0.0-dev.g<sha>\`. That's a 0.4% occurrence; documenting via Makefile / hack scripts is sufficient — operators running the canonical helpers (\`source hack/version.sh\` or \`./hack/chart-version.sh dev\`) get the right answer.

Docs are deliberately not updated. The documented format remains canonical; the conditional is a guard that activates rarely enough that introducing it into operator-facing docs would create more confusion than the rare failure case warrants. Contributors who need to understand the conditional find it commented in all three implementation files.

## Test plan

- [x] Local smoke test all four hash patterns (above)
- [ ] Post-merge: release-dev workflow runs on the merge commit; chart publishes as \`0.0.0-dev.<merge-sha-short>\` (without g, assuming merge SHA isn't all-digit-leading-zero)
- [ ] Operator's deploy script (\`DEV_VERSION=0.0.0-dev.\$SHORT_SHA\`) succeeds for the new chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)