### PR TITLE
fix(swiftmigration): W26 — lock src pod name at Validating for chain-safe live migration

### DIFF
--- a/internal/controller/swiftmigration/cutover.go
+++ b/internal/controller/swiftmigration/cutover.go
@@ -155,16 +155,24 @@ func (r *SwiftMigrationReconciler) executeCutover(
 	srcPod *corev1.Pod, // nil if NotFound
 	dstName string,
 ) *phaseResult {
-	// Cutover step 2 looks up src pod BY guest.Name (the original
-	// pre-cutover pod name), NOT via canonicalPodName — which post-
-	// step-1 resolves to dst pod name and would mis-detect "src
-	// exists." Re-fetch src pod by guest.Name here; ignore the
-	// caller's srcPod argument (which may be the dst pod due to
-	// canonicalPodName's post-step-1 indirection).
+	// Cutover step 2 looks up src pod by status.SourcePodRef.Name
+	// (locked in at Validating-live, W26 fix). Pre-W26 this used
+	// literal guest.Name which was correct ONLY for first-migrations
+	// (where guest.Name = src pod name) and broke chain migrations
+	// (where the original src pod is the prior migration's dst-suffix
+	// pod, not guest.Name) — chain step 2 would silently skip src pod
+	// deletion (NotFound) leaking the prior dst pod on the source
+	// node. The locked-in name is also race-immune to the
+	// cutoverStep1 informer-fires-before-persist window, which is
+	// why stopandcopy_live's UID-check site uses the same helper.
+	// Caller's srcPod argument is preserved for API symmetry but
+	// ignored (may be the wrong pod under canonicalPodName-style
+	// resolution at the call site).
 	var srcByName corev1.Pod
 	_ = srcPod // suppress unused-param hint; caller passes for API symmetry
 	srcExistsByName := true
-	if err := r.Get(ctx, client.ObjectKey{Name: guest.Name, Namespace: guest.Namespace}, &srcByName); err != nil {
+	srcName := srcPodLookupName(mig, guest)
+	if err := r.Get(ctx, client.ObjectKey{Name: srcName, Namespace: guest.Namespace}, &srcByName); err != nil {
 		if apierrors.IsNotFound(err) {
 			srcExistsByName = false
 		} else {

--- a/internal/controller/swiftmigration/cutover_test.go
+++ b/internal/controller/swiftmigration/cutover_test.go
@@ -305,6 +305,60 @@ func TestCutover_Step2RetryInPlace_DeleteFails(t *testing.T) {
 	}
 }
 
+// W26 chain regression: post-step1, executeCutover must delete the
+// PRIOR migration's dst pod (= THIS migration's src), NOT THIS
+// migration's dst pod. Pre-W26 this site used literal guest.Name,
+// which silently skipped src deletion (Get NotFound) and leaked the
+// prior dst pod on the source node. canonicalPodName-style resolution
+// at the same site would have been worse: it would resolve to THIS
+// migration's dst pod (just patched into status.PodRef) and delete
+// the migrated guest. The W26 fix locks the src pod name at
+// Validating-live (status.SourcePodRef.Name) so step 2 always finds
+// the actual pre-cutover src pod, regardless of how many prior
+// migrations the guest has been through.
+func TestCutover_Step2_ChainMigration_DeletesPriorSrcPodNotDstPod_W26(t *testing.T) {
+	mig, guest, _, _ := cutoverFixture(t)
+	priorDstName := "guest-mig-firstrun" // THIS migration's src
+	thisDstName := "guest-mig-abcdef"    // matches dstPodName(mig, "guest") for the fixture
+	mig.Status.SourcePodRef = &migrationv1alpha1.SwiftMigrationPodRef{Name: priorDstName}
+	guest.Status.PodRef = &corev1.ObjectReference{Name: thisDstName, Namespace: "default"}
+	now := metav1.Now()
+	mig.Status.CutoverStep1At = &now
+
+	chainSrc := templateSrcPod(priorDstName, "default")
+	chainSrc.UID = "uid-PRIOR-DST"
+	stamp(chainSrc, migrationActionVerbSend, sendActionID(mig),
+		migrationStatusComplete, sendActionID(mig), "ok")
+	thisDst := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: thisDstName, Namespace: "default", UID: "uid-THIS-DST"},
+		Spec:       corev1.PodSpec{NodeName: "miles"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.244.1.43"},
+	}
+
+	r := newStopAndCopyReconciler(t, mig, guest, chainSrc, thisDst)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.Err != nil || res.FailureMsg != "" {
+		t.Fatalf("reconcile failed: err=%v msg=%q", res.Err, res.FailureMsg)
+	}
+
+	// Prior src pod (named priorDstName) must be deleted (or have a
+	// pending DeletionTimestamp).
+	var srcAfter corev1.Pod
+	srcErr := r.Get(context.Background(), client.ObjectKey{Name: priorDstName, Namespace: "default"}, &srcAfter)
+	if srcErr == nil && srcAfter.DeletionTimestamp == nil {
+		t.Errorf("prior src pod %q should be deleted by cutoverStep2; still exists with no DeletionTimestamp", priorDstName)
+	}
+
+	// THIS migration's dst pod must NOT be deleted.
+	var dstAfter corev1.Pod
+	if err := r.Get(context.Background(), client.ObjectKey{Name: thisDstName, Namespace: "default"}, &dstAfter); err != nil {
+		t.Errorf("dst pod %q must NOT be deleted by cutoverStep2 (would destroy migrated guest): err=%v", thisDstName, err)
+	} else if dstAfter.DeletionTimestamp != nil {
+		t.Errorf("dst pod %q must NOT be marked for deletion (would destroy migrated guest)", thisDstName)
+	}
+}
+
 // TestCutover_Step2NotFoundTreatedAsSuccess: src pod was deleted by a
 // previous reconcile but the controller crashed before observing.
 // Next reconcile observes step 1 done + src NotFound → step 3 derived,

--- a/internal/controller/swiftmigration/preparing_live.go
+++ b/internal/controller/swiftmigration/preparing_live.go
@@ -95,7 +95,7 @@ func (r *SwiftMigrationReconciler) handlePreparingLive(
 	// eviction, etc), which fails the migration.
 	if shouldCheckSourcePodUID(mig) && status.SourcePodUID != "" {
 		var srcPod corev1.Pod
-		err := r.Get(ctx, client.ObjectKey{Name: canonicalPodNameForGuest(&guest), Namespace: guest.Namespace}, &srcPod)
+		err := r.Get(ctx, client.ObjectKey{Name: srcPodLookupName(mig, &guest), Namespace: guest.Namespace}, &srcPod)
 		if apierrors.IsNotFound(err) {
 			return phaseFailure(
 				fmt.Sprintf("source pod for SwiftGuest %q no longer exists during Preparing", guest.Name),
@@ -121,7 +121,7 @@ func (r *SwiftMigrationReconciler) handlePreparingLive(
 	// fetched it for the UID check, but re-fetching is cheaper than
 	// threading it through; this code path runs once per reconcile.)
 	var srcPod corev1.Pod
-	if err := r.Get(ctx, client.ObjectKey{Name: canonicalPodNameForGuest(&guest), Namespace: guest.Namespace}, &srcPod); err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Name: srcPodLookupName(mig, &guest), Namespace: guest.Namespace}, &srcPod); err != nil {
 		if apierrors.IsNotFound(err) {
 			return phaseFailure(
 				fmt.Sprintf("source pod for SwiftGuest %q no longer exists; cannot template dst pod", guest.Name),

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -150,38 +150,35 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 		return phaseTransient(fmt.Errorf("get source guest: %w", err))
 	}
 
-	// Resolve src pod by guest.Name — NOT via canonicalPodName.
+	// Resolve src pod by status.SourcePodRef.Name (locked in at
+	// Validating-live).
 	//
-	// W15 (cluster walkthrough finding): canonicalPodNameForGuest
-	// resolves to the dst pod name post-cutoverStep1 (which patches
-	// SwiftGuest.status.podRef.name = dst). cutoverStep1 issues two
-	// separate apiserver writes (SwiftGuest podRef + SwiftMigration
-	// status); the SwiftGuest patch fires the SwiftGuest informer
-	// watch and triggers a SwiftMigration reconcile. If that race-
-	// reconcile lands before the SwiftMigration status patch persists
-	// (or before the controller's persist completes from the original
-	// cutover-step-1 reconcile), the new reconcile reads:
-	//   - mig.Status.PhaseDetail = LiveSrcCompleted (stale; pre-cutover)
-	//   - guest.Status.PodRef.Name = dst (already swapped)
-	// shouldCheckSourcePodUID returns true (LiveSrcCompleted is in the
-	// pre-cutover vocabulary), and canonicalPodName resolves to dst.
-	// The Get fetches the dst pod, whose UID never matches
-	// status.SourcePodUID, so the UID check fires SourcePodReplaced on
-	// a perfectly healthy migration.
+	// W15 + W26 background. Two prior single-mode fixes were tried and
+	// both broke the other case:
 	//
-	// The src pod is ALWAYS named guest.Name throughout its lifetime.
-	// Using guest.Name directly here makes the UID check race-free.
-	// canonicalPodName is the right abstraction for "the active
-	// canonical launcher pod" but wrong for "the original src pod
-	// whose UID we recorded at Validating".
+	//   - W15 fix (literal guest.Name): closes the cutoverStep1 race
+	//     window where canonicalPodName resolves to dst-name before
+	//     the SwiftMigration status persists. But fails on chain
+	//     migrations: after a prior migration's cutover, the original
+	//     src pod is named with the prior migration's dst-suffix, NOT
+	//     guest.Name; literal guest.Name lookup hits NotFound and
+	//     false-fires SourcePodReplaced.
+	//   - canonicalPodName: works for chains (resolves to the prior
+	//     dst-suffix = current src). But re-opens the W15 race AND
+	//     in cutover.go::executeCutover post-step1 would resolve to
+	//     THIS migration's dst pod and cutoverStep2 would delete the
+	//     migrated guest.
 	//
-	// Same shape as the B3.2 fix in cutover.go::executeCutover, which
-	// also explicitly fetches src by guest.Name to bypass the same
-	// canonicalPodName-post-step-1 ambiguity. The fix didn't propagate
-	// to this outer site until W15 surfaced on cluster.
+	// W26 fix: lock in the src pod name at Validating time
+	// (status.SourcePodRef.Name), use it consistently here and in
+	// cutover.go::executeCutover. Race-immune (locked at validation,
+	// not derived from cluster state) AND chain-safe (the recorded
+	// name is the actual src pod, regardless of how many prior
+	// migrations the guest has been through).
 	var srcPod corev1.Pod
 	srcPodPresent := true
-	if err := r.Get(ctx, client.ObjectKey{Name: guest.Name, Namespace: guest.Namespace}, &srcPod); err != nil {
+	srcName := srcPodLookupName(mig, &guest)
+	if err := r.Get(ctx, client.ObjectKey{Name: srcName, Namespace: guest.Namespace}, &srcPod); err != nil {
 		if apierrors.IsNotFound(err) {
 			srcPodPresent = false
 		} else {

--- a/internal/controller/swiftmigration/stopandcopy_live_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_live_test.go
@@ -30,6 +30,10 @@ func stopAndCopyFixture(t *testing.T, srcUID types.UID) (*migrationv1alpha1.Swif
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseStopAndCopy
 	mig.Status.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	mig.Status.SourcePodUID = srcUID
+	// W26: src pod name locked at Validating; mirror that in the
+	// fixture so srcPodLookupName resolves to the original src pod
+	// regardless of guest.Status.PodRef drift across cutover/race.
+	mig.Status.SourcePodRef = &migrationv1alpha1.SwiftMigrationPodRef{Name: "guest"}
 	startedAt := metav1.NewTime(time.Now().Add(-30 * time.Second))
 	mig.Status.StartedAt = &startedAt
 
@@ -695,6 +699,60 @@ func TestStopAndCopyLive_PostCutoverStep1_RaceReconcile_DoesNotFalseFireUIDCheck
 	// + cutoverStep1At unset means cutoverStep1Timestamp recovery path,
 	// or step 2 if CutoverStep1At was set via fixture. Either way,
 	// no SourcePodReplaced.
+}
+
+// W26 regression: chain migration. After a prior migration's cutover,
+// SwiftGuest.status.podRef.Name points at the prior dst pod (= the new
+// migration's src). Pre-W26 the StopAndCopy UID-check resolved src by
+// literal guest.Name → NotFound → false-fired SourcePodReplaced on a
+// perfectly healthy chain migration. The W26 fix locks the src pod
+// name at Validating-live (status.SourcePodRef.Name) so resolution is
+// chain-safe.
+//
+// Discovered on cluster during Phase 3a PR 1 disk-boot E12 validation
+// (S1 run 2, miles→boba→miles). Same code path runs for kernel-boot
+// and disk-boot — workload-class-independent bug; disk-boot validation
+// happened to exercise back-to-back migrations and surface it.
+func TestStopAndCopyLive_ChainMigration_SrcResolvesToPriorDstPod_NoFalseFire_W26(t *testing.T) {
+	mig, guest, _, dst := stopAndCopyFixture(t, "uid-PRIOR-DST")
+	// Chain state: SwiftGuest's canonical pod is now the prior
+	// migration's dst-suffix pod. status.SourcePodRef.Name was locked
+	// in at Validating-live to that same name (the "src" for THIS
+	// migration).
+	priorDstPodName := "guest-mig-firstrun"
+	mig.Status.SourcePodRef = &migrationv1alpha1.SwiftMigrationPodRef{Name: priorDstPodName}
+	guest.Status.PodRef = &corev1.ObjectReference{Name: priorDstPodName, Namespace: guest.Namespace}
+	// The actual src pod for THIS migration has the prior-dst-suffix
+	// name. Literal guest.Name lookup ("guest") would NotFound; fix
+	// resolves via locked-in name.
+	chainSrc := templateSrcPod(priorDstPodName, "default")
+	chainSrc.UID = "uid-PRIOR-DST"
+	chainSrc.Annotations = map[string]string{AnnotationGuestIP: "10.0.0.5"}
+	r := newStopAndCopyReconciler(t, mig, guest, chainSrc, dst)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason == migrationv1alpha1.FailureReasonSourcePodReplaced {
+		t.Errorf("UID check false-fired SourcePodReplaced; W26 chain regression. msg=%q",
+			res.FailureMsg)
+	}
+}
+
+// W26 first-migration smoke: nothing fancy here, but the W26 fix
+// hinges on srcPodLookupName falling back to canonicalPodNameForGuest
+// when status.SourcePodRef is unset. Regress against accidental
+// removal of the fallback.
+func TestStopAndCopyLive_FirstMigration_SrcResolvesToGuestName_W26Fallback(t *testing.T) {
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
+	// Simulate a Validating-live that didn't run yet (e.g., recovery
+	// reconcile or test scenario): SourcePodRef unset. Fallback should
+	// land on canonicalPodNameForGuest = guest.Name (no prior podRef).
+	mig.Status.SourcePodRef = nil
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason == migrationv1alpha1.FailureReasonSourcePodReplaced {
+		t.Errorf("fallback path false-fired SourcePodReplaced; msg=%q", res.FailureMsg)
+	}
 }
 
 func TestStopAndCopyLive_DefensiveGuard_NotLiveMode(t *testing.T) {

--- a/internal/controller/swiftmigration/validating_live.go
+++ b/internal/controller/swiftmigration/validating_live.go
@@ -99,6 +99,18 @@ func (r *SwiftMigrationReconciler) handleValidatingLive(
 		return phaseTransient(fmt.Errorf("get source pod: %w", err))
 	}
 	status.SourcePodUID = srcPod.UID
+	// W26: lock in the src pod NAME at Validating time, mirroring the
+	// existing SourcePodUID lock-in. Pre-W26, downstream sites resolved
+	// the src pod by either guest.Name (W15 fix in cutover.go +
+	// stopandcopy_live.go) or canonicalPodName (preparing_live.go). Both
+	// derive from current cluster state and are wrong for back-to-back
+	// migrations: after a prior migration's cutover, guest.Status.PodRef
+	// .Name points at the prior dst pod (= this migration's src), which
+	// is NOT guest.Name. Locking the name in here makes src-pod
+	// resolution race-immune AND chain-safe; downstream sites use
+	// status.SourcePodRef.Name consistently regardless of cluster state
+	// drift mid-migration.
+	status.SourcePodRef = &migrationv1alpha1.SwiftMigrationPodRef{Name: srcPod.Name}
 
 	// IPWillChange surfacing (same logic as offline path; live mode
 	// on default networking still loses the IP because Cloud Hypervisor
@@ -176,4 +188,37 @@ func canonicalPodNameForGuest(guest *swiftv1alpha1.SwiftGuest) string {
 		return guest.Status.PodRef.Name
 	}
 	return guest.Name
+}
+
+// srcPodLookupName returns the launcher pod name to use for src pod
+// lookups in live-mode Preparing / StopAndCopy / cutover phases. Uses
+// the SwiftMigration's status.SourcePodRef.Name when set (locked in at
+// Validating-live), falling back to canonicalPodNameForGuest for
+// pre-Validating reconciles or recovery cases where the field is
+// somehow unset.
+//
+// Why locked-in beats current-cluster-state derivation: between the
+// time Validating captures the src pod identity and the time cutover
+// patches guest.Status.PodRef.Name to the dst pod, the cluster-state
+// derivation diverges from the original src pod. Two separate
+// failure modes both blocked by locking in:
+//
+//   - W15 race: cutoverStep1 patches SwiftGuest podRef before the
+//     SwiftMigration status persists; informer-driven race-reconcile
+//     reads (phaseDetail=LiveSrcCompleted, podRef=dstName,
+//     PodRefSwapped=False). Without locking, canonicalPodName resolves
+//     to dst pod and false-fires the F4.2 UID check.
+//   - W26 chain: after a prior migration's cutover, status.PodRef.Name
+//     points at the prior dst pod (= this migration's src). Without
+//     locking, literal guest.Name lookup misses (NotFound) and
+//     false-fires SourcePodReplaced; canonicalPodName resolves to the
+//     prior dst pod which IS the src for this migration but in
+//     cutover.go's executeCutover would post-step1 resolve to THIS
+//     migration's dst pod and cutoverStep2 would delete the migrated
+//     guest. Locking eliminates both modes uniformly.
+func srcPodLookupName(mig *migrationv1alpha1.SwiftMigration, guest *swiftv1alpha1.SwiftGuest) string {
+	if mig.Status.SourcePodRef != nil && mig.Status.SourcePodRef.Name != "" {
+		return mig.Status.SourcePodRef.Name
+	}
+	return canonicalPodNameForGuest(guest)
 }


### PR DESCRIPTION
## Summary

Phase 3a back-to-back live migrations on the same SwiftGuest fail
with false-positive `SourcePodReplaced` (and a latent
guest-destruction bug at cutover step 2). Workload-class-independent
bug in the SwiftMigration controller — same code runs for kernel-boot
and disk-boot. PR #46's kernel-boot determinism gate didn't surface
it (different validation question: timing-race elimination per W22
lesson, not chain correctness). Phase 3a PR 1 disk-boot E12
validation surfaced it via the documented "or sequential migrations
on miles→boba→miles→boba" S1 path.

## Root cause

Three live-mode sites resolved src pod via current cluster state:

- [`stopandcopy_live.go:184`](https://github.com/projectbeskar/kubeswift/blob/main/internal/controller/swiftmigration/stopandcopy_live.go#L184) — literal `guest.Name` (W15 fix)
- [`cutover.go:167`](https://github.com/projectbeskar/kubeswift/blob/main/internal/controller/swiftmigration/cutover.go#L167) — literal `guest.Name` (W15 fix)
- [`preparing_live.go:98,124`](https://github.com/projectbeskar/kubeswift/blob/main/internal/controller/swiftmigration/preparing_live.go) — `canonicalPodNameForGuest`

After a prior migration's cutover, `SwiftGuest.status.podRef.Name`
points at the prior dst pod (= the new migration's src), which is
NOT `guest.Name`. The W15 fix's docstring assumed "src pod is named
guest.Name throughout its lifetime" — true for first migrations only.

| Approach | First migration | Chain migration N+1 |
|---|---|---|
| Literal `guest.Name` | ✓ | ✗ false `SourcePodReplaced` (stopandcopy); silent leak (cutoverStep2) |
| `canonicalPodName` | ✓ pre-step1; W15 race window post-step1 | ✓ pre-step1; **destroys migrated guest** post-step1 in cutoverStep2 |
| **Locked at Validating** | ✓ | ✓ |

## Fix

Stamp `status.SourcePodRef.Name = srcPod.Name` at Validating-live,
mirroring the existing `SourcePodUID` lock-in. Three downstream sites
use a `srcPodLookupName` helper that returns `SourcePodRef.Name` when
set, else falls back to `canonicalPodNameForGuest` for defense.
Race-immune (locked at validation, not derived from cluster state)
AND chain-safe.

Phase 1 offline mode is unaffected — Approach A reuses `guest.Name`
as the post-migration pod name, so literal-`guest.Name` lookups
remain correct there. Fix is live-mode-only.

## Cluster repro

Phase 3a PR 1 disk-boot E12 validation, S1 run 2 miles→boba→miles,
2026-05-04, against image `sha-8c86ffa`:

- Run 1 miles→boba: PASS at t+59s, sentinel md5 preserved
  (`115d66eb9b976fce183413f2cf4c8e4c`)
- Run 2 boba→miles: **FAILED** at t+21s with
  `failureReason=SourcePodReplaced`,
  `failureMessage="source pod for SwiftGuest \"disk-s1\" no longer exists during StopAndCopy"`
- Verification: src pod `disk-s1-mig-4a3376` (UID `0b596b96`) STILL
  Running on boba post-failure — false-positive

## Tests

- `TestStopAndCopyLive_ChainMigration_SrcResolvesToPriorDstPod_NoFalseFire_W26`
  reproduces the cluster failure mode at unit-test scope
- `TestStopAndCopyLive_FirstMigration_SrcResolvesToGuestName_W26Fallback`
  guards the `SourcePodRef`-unset fallback path
- `TestCutover_Step2_ChainMigration_DeletesPriorSrcPodNotDstPod_W26`
  locks in chain-safe step 2 (delete prior src, NOT this migration's
  dst — would have been a silent guest-destruction bug under the
  rejected canonicalPodName-everywhere alternative)
- Existing W15 race-regression test continues to pass (fixture
  updated to set `SourcePodRef.Name = "guest"`)
- All 91 swiftmigration tests pass; full `go test ./...` green

## Validation methodology note

PR #46's three-run kernel-boot determinism gate validated
**timing-race elimination** (W22 lesson). It did not validate
**chain-migration correctness** — different question. Disk-boot E12
validation surfaced the gap because back-to-back migrations on a
single SwiftGuest naturally landed in chain territory. Future Phase
3a/3b validation should include explicit chain-migration scenarios
alongside three-run determinism.

## Test plan

- [x] Unit: 3 new W26 tests + W15 regression + full suite green
- [ ] Cluster: kernel-boot chain (miles→boba→miles on a kernel-boot
      guest, run 2 must succeed) — validates fix on the workload
      class that was paper-shipped without chain coverage
- [ ] Cluster: disk-boot chain (resume disk-s1 runs 2/3 from the
      walkthrough) — chain-migration determinism on disk-boot
- [ ] Cluster: disk-boot S2/S5/S7 as originally planned

🤖 Generated with [Claude Code](https://claude.com/claude-code)