### PR TITLE
fix(swiftmigration): W27 — downtime metrics correctness (observedDowntime + observedPauseWindow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to KubeSwift are documented here.
 
 ## [Unreleased] - 2026-04-05
 
+### Fixed (Phase 3a downtime metrics — W27 follow-up)
+- W27a: `status.observedDowntime` previously measured two adjacent `metav1.Now()` calls in the same reconcile invocation, producing sub-millisecond nonsense (34-114µs across all 17 PR #46 + E12 walkthrough runs). Now anchored on new `status.cutoverStep2DispatchedAt` (stamped by `cutoverStep2` on Delete dispatch); reflects the operator-visible cutover-to-resume window. Defensive nil-check leaves the field unset rather than reporting a wrong value if the timestamp is missing.
+- W27b: `status.observedPauseWindow` plumbing was half-implemented — swiftletd-on-src wrote the `kubeswift.io/migration-pause-window-ms` annotation correctly but the controller had zero readers, leaving the field permanently nil. Now stamped at `substateSrcCompleted` (W1 gate observation), mirroring the snapshot controller's parallel pattern. Defensive parse-failure handling.
+- New status field `cutoverStep2DispatchedAt *metav1.Time` on SwiftMigration: operator-visible audit data (`kubectl get smig -o wide`) and authoritative anchor for `observedDowntime`. Phase 1 offline mode does not populate this field.
+- Closes Tracked Follow-up #7 in kubeswift_context.md.
+
 ### Added
 - Comprehensive networking operations guide for physical networks, VLANs, bonds, and isolated networks
 - VMware ESXi and Proxmox VE concept mapping for platform migration

--- a/api/migration/v1alpha1/swiftmigration_types.go
+++ b/api/migration/v1alpha1/swiftmigration_types.go
@@ -287,6 +287,27 @@ type SwiftMigrationStatus struct {
 	// Phase 1 offline mode does not populate this field.
 	// +optional
 	CutoverStep1At *metav1.Time `json:"cutoverStep1At,omitempty"`
+	// CutoverStep2DispatchedAt is when cutover step 2 (src pod Delete
+	// dispatch) was issued by the controller. This is the cutover
+	// commit point on the source side — vCPU pause begins inside CH
+	// at this moment, propagating to the dst migration receiver.
+	//
+	// W27a (PR #54 follow-up, Tracked Follow-up #7): this is the
+	// authoritative anchor for observedDowntime. The prior anchor
+	// (status.ResumingStartedAt) was stamped one apiserver round-trip
+	// later AND consumed in the same reconcile invocation, producing
+	// sub-millisecond observedDowntime values across all 17 PR #46 +
+	// E12 walkthrough runs. Anchoring on CutoverStep2DispatchedAt
+	// instead measures the actual operator-visible cutover-to-resume
+	// window: cutover-step-2-dispatch → GuestRunning=True observation.
+	//
+	// Stamped idempotently by cutoverStep2: only set if currently nil,
+	// preserving the original timestamp across leader-handover and
+	// cutover-mid-flight reconcile-recovery (§2.4) reentry.
+	//
+	// Phase 1 offline mode does not populate this field.
+	// +optional
+	CutoverStep2DispatchedAt *metav1.Time `json:"cutoverStep2DispatchedAt,omitempty"`
 	// ResumingStartedAt is when the SwiftMigration first transitioned
 	// to the Resuming phase (cutover step 3 — the controller's
 	// observable boundary between StopAndCopy completion and Resuming

--- a/api/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/api/migration/v1alpha1/zz_generated.deepcopy.go
@@ -157,6 +157,10 @@ func (in *SwiftMigrationStatus) DeepCopyInto(out *SwiftMigrationStatus) {
 		in, out := &in.CutoverStep1At, &out.CutoverStep1At
 		*out = (*in).DeepCopy()
 	}
+	if in.CutoverStep2DispatchedAt != nil {
+		in, out := &in.CutoverStep2DispatchedAt, &out.CutoverStep2DispatchedAt
+		*out = (*in).DeepCopy()
+	}
 	if in.ResumingStartedAt != nil {
 		in, out := &in.ResumingStartedAt, &out.ResumingStartedAt
 		*out = (*in).DeepCopy()

--- a/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
+++ b/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
@@ -269,6 +269,29 @@ spec:
                   Phase 1 offline mode does not populate this field.
                 format: date-time
                 type: string
+              cutoverStep2DispatchedAt:
+                description: |-
+                  CutoverStep2DispatchedAt is when cutover step 2 (src pod Delete
+                  dispatch) was issued by the controller. This is the cutover
+                  commit point on the source side — vCPU pause begins inside CH
+                  at this moment, propagating to the dst migration receiver.
+
+                  W27a (PR #54 follow-up, Tracked Follow-up #7): this is the
+                  authoritative anchor for observedDowntime. The prior anchor
+                  (status.ResumingStartedAt) was stamped one apiserver round-trip
+                  later AND consumed in the same reconcile invocation, producing
+                  sub-millisecond observedDowntime values across all 17 PR #46 +
+                  E12 walkthrough runs. Anchoring on CutoverStep2DispatchedAt
+                  instead measures the actual operator-visible cutover-to-resume
+                  window: cutover-step-2-dispatch → GuestRunning=True observation.
+
+                  Stamped idempotently by cutoverStep2: only set if currently nil,
+                  preserving the original timestamp across leader-handover and
+                  cutover-mid-flight reconcile-recovery (§2.4) reentry.
+
+                  Phase 1 offline mode does not populate this field.
+                format: date-time
+                type: string
               destinationNode:
                 description: DestinationNode is the resolved target node (after webhook
                   validation).

--- a/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
+++ b/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
@@ -269,6 +269,29 @@ spec:
                   Phase 1 offline mode does not populate this field.
                 format: date-time
                 type: string
+              cutoverStep2DispatchedAt:
+                description: |-
+                  CutoverStep2DispatchedAt is when cutover step 2 (src pod Delete
+                  dispatch) was issued by the controller. This is the cutover
+                  commit point on the source side — vCPU pause begins inside CH
+                  at this moment, propagating to the dst migration receiver.
+
+                  W27a (PR #54 follow-up, Tracked Follow-up #7): this is the
+                  authoritative anchor for observedDowntime. The prior anchor
+                  (status.ResumingStartedAt) was stamped one apiserver round-trip
+                  later AND consumed in the same reconcile invocation, producing
+                  sub-millisecond observedDowntime values across all 17 PR #46 +
+                  E12 walkthrough runs. Anchoring on CutoverStep2DispatchedAt
+                  instead measures the actual operator-visible cutover-to-resume
+                  window: cutover-step-2-dispatch → GuestRunning=True observation.
+
+                  Stamped idempotently by cutoverStep2: only set if currently nil,
+                  preserving the original timestamp across leader-handover and
+                  cutover-mid-flight reconcile-recovery (§2.4) reentry.
+
+                  Phase 1 offline mode does not populate this field.
+                format: date-time
+                type: string
               destinationNode:
                 description: DestinationNode is the resolved target node (after webhook
                   validation).

--- a/internal/controller/swiftmigration/cancel_live.go
+++ b/internal/controller/swiftmigration/cancel_live.go
@@ -21,14 +21,21 @@ import (
 // (rust/swiftletd/src/action.rs::MIGRATION_*_KEY). These are the
 // controller's side of the Phase 2 annotation surface.
 const (
-	AnnotationMigrationAction     = "kubeswift.io/migration-action"
-	AnnotationMigrationActionID   = "kubeswift.io/migration-action-id"
-	AnnotationMigrationStatus     = "kubeswift.io/migration-status"
-	AnnotationMigrationStatusID   = "kubeswift.io/migration-status-id"
-	AnnotationMigrationStatusDtl  = "kubeswift.io/migration-status-detail"
-	MigrationActionCancel         = "cancel"
-	MigrationStatusFailed         = "failed"
-	MigrationStatusFailedCancelDt = "cancelled" // expected substring in status-detail
+	AnnotationMigrationAction    = "kubeswift.io/migration-action"
+	AnnotationMigrationActionID  = "kubeswift.io/migration-action-id"
+	AnnotationMigrationStatus    = "kubeswift.io/migration-status"
+	AnnotationMigrationStatusID  = "kubeswift.io/migration-status-id"
+	AnnotationMigrationStatusDtl = "kubeswift.io/migration-status-detail"
+	// AnnotationMigrationPauseWindowMs is the swiftletd-on-src-reported
+	// vCPU-paused window (CH's actual pause-and-send measurement),
+	// written alongside `migration-status=complete` at send-complete
+	// (rust/swiftletd/src/action.rs::write_migration_status). Read by
+	// stopandcopy_live's substateSendComplete handler and stamped into
+	// status.ObservedPauseWindow per W27b.
+	AnnotationMigrationPauseWindowMs = "kubeswift.io/migration-pause-window-ms"
+	MigrationActionCancel            = "cancel"
+	MigrationStatusFailed            = "failed"
+	MigrationStatusFailedCancelDt    = "cancelled" // expected substring in status-detail
 
 	// MigrationStatusRejected is swiftletd's status for an action it
 	// refused to execute (Phase 2 PR-B's decide() rejection path —

--- a/internal/controller/swiftmigration/cutover.go
+++ b/internal/controller/swiftmigration/cutover.go
@@ -323,6 +323,7 @@ func (r *SwiftMigrationReconciler) cutoverStep2(
 	if srcPod == nil {
 		// deriveCutoverStep wouldn't return cutoverStep2Pending if
 		// srcPod is nil, but defensive: treat as already-done.
+		stampCutoverStep2DispatchedAt(status)
 		setPhaseDetail(status, migrationv1alpha1.PhaseDetailLiveCutoverCompleting)
 		return phaseRequeue(stopAndCopyLivePollInterval)
 	}
@@ -332,14 +333,35 @@ func (r *SwiftMigrationReconciler) cutoverStep2(
 			// Already gone — previous reconcile's Delete succeeded
 			// but controller crashed before observing. Treat as
 			// success.
+			stampCutoverStep2DispatchedAt(status)
 			setPhaseDetail(status, migrationv1alpha1.PhaseDetailLiveCutoverCompleting)
 			return phaseRequeue(stopAndCopyLivePollInterval)
 		}
 		return phaseTransient(fmt.Errorf("cutover step 2 (Delete src pod): %w", err))
 	}
 
+	stampCutoverStep2DispatchedAt(status)
 	setPhaseDetail(status, migrationv1alpha1.PhaseDetailLiveCutoverCompleting)
 	return phaseRequeue(stopAndCopyLivePollInterval)
+}
+
+// stampCutoverStep2DispatchedAt records the moment the controller
+// dispatched the src pod Delete (i.e., cutover step 2). This is the
+// authoritative anchor for status.ObservedDowntime per W27a (Tracked
+// Follow-up #7): cutover commit point on the source side, where vCPU
+// pause begins inside CH.
+//
+// Idempotent: only sets the timestamp if currently nil. Preserves the
+// original timestamp across leader-handover and cutover-mid-flight
+// reconcile-recovery (§2.4) reentry — re-dispatching Delete on an
+// already-deleted (NotFound) src pod must NOT shift the anchor; the
+// vCPU pause began at the original dispatch, not at the recovery
+// reentry.
+func stampCutoverStep2DispatchedAt(status *migrationv1alpha1.SwiftMigrationStatus) {
+	if status.CutoverStep2DispatchedAt == nil {
+		now := metav1.Now()
+		status.CutoverStep2DispatchedAt = &now
+	}
 }
 
 // cutoverStep3 transitions the SwiftMigration phase from StopAndCopy

--- a/internal/controller/swiftmigration/cutover_test.go
+++ b/internal/controller/swiftmigration/cutover_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -302,6 +303,51 @@ func TestCutover_Step2RetryInPlace_DeleteFails(t *testing.T) {
 	// Verify src pod gone.
 	if err := c.Get(context.Background(), client.ObjectKey{Name: src.Name, Namespace: "default"}, &pod); !apierrors.IsNotFound(err) {
 		t.Errorf("src pod should be deleted; got err=%v", err)
+	}
+}
+
+// W27a: cutoverStep2 stamps status.CutoverStep2DispatchedAt on
+// successful Delete dispatch. The timestamp anchors observedDowntime
+// computation in resuming_live; without it, observedDowntime stays
+// nil at Completed (defensive nil-check). Test covers both the
+// happy-path Delete and the NotFound-recovery path; both must stamp.
+func TestCutover_Step2_StampsCutoverStep2DispatchedAt_W27a(t *testing.T) {
+	mig, guest, src, dst := cutoverFixture(t)
+	guest.Status.PodRef = &corev1.ObjectReference{Name: "guest-mig-abcdef", Namespace: "default"}
+	now := metav1.Now()
+	mig.Status.CutoverStep1At = &now
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.Err != nil || res.FailureMsg != "" {
+		t.Fatalf("reconcile failed: err=%v msg=%q", res.Err, res.FailureMsg)
+	}
+	if status.CutoverStep2DispatchedAt == nil {
+		t.Fatalf("CutoverStep2DispatchedAt not stamped after successful Delete")
+	}
+}
+
+// W27a idempotency: repeated cutoverStep2 invocations (leader handover,
+// reconcile-recovery on NotFound retry) must NOT shift the timestamp;
+// the original dispatch is the cutover commit point.
+func TestCutover_Step2_StampIdempotent_PreservesOriginal_W27a(t *testing.T) {
+	mig, guest, src, dst := cutoverFixture(t)
+	guest.Status.PodRef = &corev1.ObjectReference{Name: "guest-mig-abcdef", Namespace: "default"}
+	now := metav1.Now()
+	mig.Status.CutoverStep1At = &now
+	originalStamp := metav1.NewTime(time.Now().Add(-90 * time.Second))
+	mig.Status.CutoverStep2DispatchedAt = &originalStamp
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+
+	status := mig.Status.DeepCopy()
+	_ = r.handleStopAndCopyLive(context.Background(), mig, status)
+	if status.CutoverStep2DispatchedAt == nil {
+		t.Fatalf("CutoverStep2DispatchedAt was cleared")
+	}
+	if !status.CutoverStep2DispatchedAt.Time.Equal(originalStamp.Time) {
+		t.Errorf("CutoverStep2DispatchedAt shifted from original stamp: original=%v now=%v",
+			originalStamp.Time, status.CutoverStep2DispatchedAt.Time)
 	}
 }
 

--- a/internal/controller/swiftmigration/resuming_live.go
+++ b/internal/controller/swiftmigration/resuming_live.go
@@ -9,6 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
@@ -183,24 +184,35 @@ func (r *SwiftMigrationReconciler) handleResumingLive(
 		status.TargetIP = ip
 	}
 
-	// Compute ObservedDowntime: now - ResumingStartedAt. The §6 doc
-	// definition uses cutover step 2 as the anchor; ResumingStartedAt
-	// stamps at cutover step 3 entry, which is one apiserver round-
-	// trip after step 2. The difference is sub-second and the
-	// ResumingStartedAt anchor is what we can reliably observe from
-	// B2.3's vantage point. B3 may refine to a step-2 anchor if it
-	// stamps a separate timestamp; until then this is the best
-	// approximation.
+	// W27a fix (PR #54 follow-up, Tracked Follow-up #7):
+	// observedDowntime is the wall-clock window between cutover step 2
+	// dispatch (src pod Delete; vCPU pause begins inside CH on src)
+	// and dst guest reaching GuestRunning=True (vCPU pause ends on
+	// dst). The prior implementation anchored on
+	// status.ResumingStartedAt — stamped one apiserver round-trip
+	// after step 2 AND consumed in the same reconcile invocation,
+	// producing sub-millisecond observedDowntime values across all 17
+	// PR #46 + E12 walkthrough runs. CutoverStep2DispatchedAt is the
+	// correct anchor.
+	//
+	// Defensive nil-check: CutoverStep2DispatchedAt is stamped by
+	// cutoverStep2 unconditionally (even on NotFound recovery), so
+	// reaching Resuming with it nil indicates a state-machine
+	// invariant violation. Log + leave ObservedDowntime nil so
+	// operators see a missing field, never a wrong one.
 	now := metav1.Now()
-	if status.ResumingStartedAt != nil {
-		downtime := metav1.Duration{Duration: now.Sub(status.ResumingStartedAt.Time)}
+	if status.CutoverStep2DispatchedAt != nil {
+		downtime := metav1.Duration{Duration: now.Sub(status.CutoverStep2DispatchedAt.Time)}
 		status.ObservedDowntime = &downtime
+	} else {
+		log.FromContext(ctx).Info(
+			"observedDowntime not computed: status.CutoverStep2DispatchedAt is nil at Resuming completion (state-machine invariant violation; W27a)",
+			"migration", mig.Name)
 	}
-	// status.ObservedPauseWindow is populated by B3 from src pod's
-	// migration-status-detail annotation during StopAndCopy. B2.3
-	// leaves it as-is — preserves whatever B3 wrote, leaves nil if
-	// B3 hasn't run yet (forward-compat hedge per the prompt's rule
-	// 5).
+	// status.ObservedPauseWindow is stamped by stopandcopy_live's
+	// substateSendComplete handler (W27b fix) reading the src pod's
+	// kubeswift.io/migration-pause-window-ms annotation. B2.3 leaves
+	// it as-is — preserves whatever StopAndCopy wrote.
 
 	status.CompletedAt = &now
 	setPhase(status, migrationv1alpha1.SwiftMigrationPhaseCompleted)

--- a/internal/controller/swiftmigration/resuming_live_test.go
+++ b/internal/controller/swiftmigration/resuming_live_test.go
@@ -67,6 +67,11 @@ func TestResumingLive_HappyPath_AdvancesToCompleted(t *testing.T) {
 	dst.Annotations = map[string]string{AnnotationGuestIP: "10.0.0.42"}
 	resumingStartedAt := metav1.NewTime(time.Now().Add(-2 * time.Second))
 	mig.Status.ResumingStartedAt = &resumingStartedAt
+	// W27a: ObservedDowntime now anchors on CutoverStep2DispatchedAt
+	// (stamped by cutoverStep2). Stamp slightly before
+	// ResumingStartedAt to mirror the production ordering.
+	cutoverStep2At := metav1.NewTime(time.Now().Add(-3 * time.Second))
+	mig.Status.CutoverStep2DispatchedAt = &cutoverStep2At
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -360,5 +365,75 @@ func TestResumingLive_PreservesObservedPauseWindow(t *testing.T) {
 	}
 	if status.ObservedPauseWindow == nil || status.ObservedPauseWindow.Duration != preset.Duration {
 		t.Errorf("ObservedPauseWindow modified; want %v, got %+v", preset, status.ObservedPauseWindow)
+	}
+}
+
+// W27a integration: observedDowntime is computed against
+// CutoverStep2DispatchedAt, NOT ResumingStartedAt. This test simulates
+// the production reality where step 2 dispatched ~45s ago and the dst
+// is now reaching GuestRunning=True. Pre-W27a the value was a
+// sub-millisecond nonsense reading from two adjacent metav1.Now()
+// calls in the same reconcile.
+func TestResumingLive_ObservedDowntime_AnchoredOnCutoverStep2_W27a(t *testing.T) {
+	scheme := testScheme(t)
+	mig, guest, dst := resumingLiveFixture(t)
+	setGuestRunningTrue(guest)
+	dst.Annotations = map[string]string{AnnotationGuestIP: "10.0.0.42"}
+	// Production timing: step 2 dispatched ~45s ago.
+	cutoverStep2At := metav1.NewTime(time.Now().Add(-45 * time.Second))
+	mig.Status.CutoverStep2DispatchedAt = &cutoverStep2At
+	// Resuming was entered shortly after step 2.
+	resumingStartedAt := metav1.NewTime(time.Now().Add(-44 * time.Second))
+	mig.Status.ResumingStartedAt = &resumingStartedAt
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest, dst).
+		WithStatusSubresource(mig).
+		Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	status := mig.Status.DeepCopy()
+	if res := r.handleResumingLive(context.Background(), mig, status); !res.Advanced {
+		t.Fatalf("expected Advanced; got %+v", res)
+	}
+	if status.ObservedDowntime == nil {
+		t.Fatalf("ObservedDowntime not computed")
+	}
+	// Must reflect ~45s; allow generous tolerance for test wall-clock
+	// drift. Pre-W27a value was ~50µs.
+	got := status.ObservedDowntime.Duration
+	if got < 40*time.Second || got > 50*time.Second {
+		t.Errorf("ObservedDowntime should reflect ~45s cutover-to-resume window; got %v", got)
+	}
+}
+
+// W27a defensive: missing CutoverStep2DispatchedAt (state-machine
+// invariant violation) leaves ObservedDowntime nil rather than
+// reporting a wrong value. Operators see a missing field, never the
+// pre-W27a sub-millisecond nonsense.
+func TestResumingLive_ObservedDowntime_NilCutoverStamp_LeavesFieldNil_W27a(t *testing.T) {
+	scheme := testScheme(t)
+	mig, guest, dst := resumingLiveFixture(t)
+	setGuestRunningTrue(guest)
+	dst.Annotations = map[string]string{AnnotationGuestIP: "10.0.0.42"}
+	resumingStartedAt := metav1.NewTime(time.Now().Add(-2 * time.Second))
+	mig.Status.ResumingStartedAt = &resumingStartedAt
+	// CutoverStep2DispatchedAt deliberately nil.
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest, dst).
+		WithStatusSubresource(mig).
+		Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	status := mig.Status.DeepCopy()
+	if res := r.handleResumingLive(context.Background(), mig, status); !res.Advanced {
+		t.Fatalf("expected Advanced; got %+v", res)
+	}
+	if status.ObservedDowntime != nil {
+		t.Errorf("ObservedDowntime should be nil when CutoverStep2DispatchedAt is missing; got %v",
+			status.ObservedDowntime)
 	}
 }

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
@@ -380,6 +382,15 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 		// src=complete implies dst CH is in Running state with the
 		// migrated guest.
 		//
+		// W27b: read swiftletd-reported pause window from launcher pod
+		// annotation. swiftletd-on-src writes
+		// kubeswift.io/migration-pause-window-ms alongside
+		// migration-status=complete (rust/swiftletd/src/action.rs::
+		// write_migration_status). Mirrors the snapshot pattern at
+		// internal/controller/swiftsnapshot/local.go:249-251. Idempotent
+		// (same observed value on every reconcile until cutover advances).
+		stampObservedPauseWindow(ctx, mig, status, srcArg)
+		//
 		// **B3.2 CUTOVER**: dispatch to the 3-step cutover sequence
 		// per §2.3 + §3.5 cutover ordering invariant. Each reconcile
 		// in the cutover handler executes ONLY the pending step;
@@ -483,6 +494,53 @@ func (r *SwiftMigrationReconciler) writeMigrationAction(
 // arguments (listen_url + guest_ip for receive; target_url for send).
 // Mirrors rust/swiftletd/src/action.rs::MIGRATION_ACTION_ARGS_KEY.
 const AnnotationMigrationActionArgs = "kubeswift.io/migration-action-args"
+
+// stampObservedPauseWindow reads the swiftletd-on-src reported vCPU
+// pause window from the src pod's
+// kubeswift.io/migration-pause-window-ms annotation and stamps it
+// into status.ObservedPauseWindow. swiftletd writes the annotation
+// alongside migration-status=complete via write_migration_status
+// (rust/swiftletd/src/action.rs:1383-1407). The value reflects the
+// CH-internal pause-and-send window, NOT the controller-orchestration
+// downtime (that's status.ObservedDowntime, anchored on
+// CutoverStep2DispatchedAt per W27a).
+//
+// Idempotent: every reconcile in substateSrcCompleted re-reads and
+// re-stamps the same value until cutover advances state. Mirrors the
+// snapshot controller's pattern at
+// internal/controller/swiftsnapshot/local.go:249-251.
+//
+// Defensive parse failure handling: malformed annotation (manual
+// operator tampering, apiserver quirk, swiftletd version skew without
+// the field) is logged and ObservedPauseWindow stays at its prior
+// value (typically nil). Operators see a missing field, not a wrong
+// one. W27b acceptance criterion.
+func stampObservedPauseWindow(
+	ctx context.Context,
+	mig *migrationv1alpha1.SwiftMigration,
+	status *migrationv1alpha1.SwiftMigrationStatus,
+	srcPod *corev1.Pod,
+) {
+	if srcPod == nil {
+		return
+	}
+	v := srcPod.Annotations[AnnotationMigrationPauseWindowMs]
+	if v == "" {
+		return
+	}
+	ms, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || ms < 0 {
+		log.FromContext(ctx).Info(
+			"observedPauseWindow not stamped: src pod annotation unparseable (W27b defensive)",
+			"migration", mig.Name,
+			"annotation", AnnotationMigrationPauseWindowMs,
+			"value", v,
+			"parseError", err)
+		return
+	}
+	pause := metav1.Duration{Duration: time.Duration(ms) * time.Millisecond}
+	status.ObservedPauseWindow = &pause
+}
 
 // normalizeStatusDetail returns a single-line, length-bounded variant
 // of the swiftletd-written status-detail annotation for inclusion in

--- a/internal/controller/swiftmigration/stopandcopy_live_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_live_test.go
@@ -790,6 +790,58 @@ func TestStopAndCopyLive_LeaderHandoverMidRecvIssued_ReentrantNoDuplicateWrite(t
 	}
 }
 
+// W27b: stampObservedPauseWindow reads the swiftletd-on-src reported
+// pause window from the src pod's
+// kubeswift.io/migration-pause-window-ms annotation and stamps it
+// into status.ObservedPauseWindow. Verifies the happy-path read.
+func TestStampObservedPauseWindow_HappyPath_W27b(t *testing.T) {
+	mig := &migrationv1alpha1.SwiftMigration{}
+	status := &migrationv1alpha1.SwiftMigrationStatus{}
+	src := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{AnnotationMigrationPauseWindowMs: "312"},
+		},
+	}
+	stampObservedPauseWindow(context.Background(), mig, status, src)
+	if status.ObservedPauseWindow == nil {
+		t.Fatalf("ObservedPauseWindow not stamped")
+	}
+	if got := status.ObservedPauseWindow.Duration; got != 312*time.Millisecond {
+		t.Errorf("ObservedPauseWindow: want 312ms, got %v", got)
+	}
+}
+
+// W27b defensive: malformed annotation leaves ObservedPauseWindow nil
+// (operators see a missing field, never a wrong one). Same posture as
+// W27a's defensive nil-check on missing CutoverStep2DispatchedAt.
+func TestStampObservedPauseWindow_ParseFailure_LeavesFieldNil_W27b(t *testing.T) {
+	mig := &migrationv1alpha1.SwiftMigration{}
+	status := &migrationv1alpha1.SwiftMigrationStatus{}
+	src := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{AnnotationMigrationPauseWindowMs: "garbage"},
+		},
+	}
+	stampObservedPauseWindow(context.Background(), mig, status, src)
+	if status.ObservedPauseWindow != nil {
+		t.Errorf("ObservedPauseWindow should be nil on parse failure; got %v",
+			status.ObservedPauseWindow)
+	}
+}
+
+// W27b: missing annotation (older swiftletd version, unexpected pod
+// state) is silent — no log spam, field stays nil.
+func TestStampObservedPauseWindow_MissingAnnotation_LeavesFieldNil_W27b(t *testing.T) {
+	mig := &migrationv1alpha1.SwiftMigration{}
+	status := &migrationv1alpha1.SwiftMigrationStatus{}
+	src := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: nil}}
+	stampObservedPauseWindow(context.Background(), mig, status, src)
+	if status.ObservedPauseWindow != nil {
+		t.Errorf("ObservedPauseWindow should be nil when annotation absent; got %v",
+			status.ObservedPauseWindow)
+	}
+}
+
 // key extracts the namespacedKey for a fixture pod (mirrors what
 // existing tests use ad-hoc; small local helper for readability).
 func key(p *corev1.Pod) namespacedKey {

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -580,7 +580,18 @@ This is not a PR #32 regression. Same shape as Phase 1 → Phase 2 → PR
 (spike scenarios under-constrain the design) restated yet again — this
 time at the API/runtime boundary.
 
-### 7. Phase 3a downtime-metrics observability broken / not wired (W27 — surfaced by E12 disk-boot validation 2026-05-04)
+### 7. Phase 3a downtime-metrics observability — SHIPPED via W27 follow-up PR
+
+**Status: SHIPPED.** W27a + W27b both fixed in a single follow-up PR.
+`status.observedDowntime` now anchors on a new
+`status.cutoverStep2DispatchedAt` timestamp (stamped at src pod
+Delete dispatch); `status.observedPauseWindow` is read from the
+swiftletd-written `kubeswift.io/migration-pause-window-ms` annotation
+at `substateSrcCompleted`. Both fields carry their documented
+semantics. Cluster validation pending after merge + redeploy.
+
+Original W27 audit notes preserved below for context (the diagnosis
+that drove the fix).
 
 E12 cluster validation surfaced **two metrics-observability bugs** in
 Phase 3a's `status.observedDowntime` and `status.observedPauseWindow`
@@ -1129,6 +1140,7 @@ in test infrastructure).
 | 62 | rbac (controller-manager ClusterRole) | StorageClass `list,watch` verbs missing — controller-runtime's cached client opens an informer on every GETable resource; PR #32's `checkStorageReady`'s `r.Get` on StorageClass triggered "Failed to watch" loop, starving SwiftGuest reconcile queue. Fake-client unit tests passed (no informer). Same shape as W7 (rolebindings). (W8 in PR #32 walkthrough.) | PR #32 |
 | 63 | rootdisk Copy Job + launcher pod builder + clone-grow-init + restore-receive launcher + RuntimeIntent producer + rust opacity contract | Block volumeMode runtime path: Copy Job branches to `volumeDevices` + `qemu-img convert + sgdisk -e` (no cp, no resize) for Block destinations; launcher pod uses VolumeDevices at `/dev/kubeswift-root`; clone-grow-init runs sgdisk -e against device path on Block (skips qemu-img resize as no-op); RuntimeIntent.RootDisk.Path resolves to device path for Block guests; rust crates verified suffix-free via Q2 grep audit. End-to-end cluster validation: RWX+Block guest boots, growpart succeeds, df reports ~37G of 40G, PVC persistence across pod recreate verified. Two findings (W10 noisy boot WARN non-blocking; W11=W9.x cloneStrategy=snapshot+Block fails at CSI provisioning, deferred). | PR #35 |
 | 64 | swiftmigration controller (validating_live + stopandcopy_live + cutover + preparing_live) | Phase 3a back-to-back live migrations false-fired SourcePodReplaced (and carried a latent guest-destruction vector at cutoverStep2). Three live-mode src-pod lookup sites derived src pod from cluster state; both literal-guest.Name (W15 fix) and canonicalPodName broke for chain migrations. Fix: stamp status.SourcePodRef.Name at Validating-live (mirrors existing SourcePodUID lock-in); use srcPodLookupName helper at all sites. Race-immune AND chain-safe. Workload-class-independent — same code runs for kernel-boot and disk-boot. (W26 in E12 disk-boot validation 2026-05-04.) | PR #53 |
+| 65 | swiftmigration controller (resuming_live + cutover + stopandcopy_live) | Phase 3a downtime metrics broken/half-wired. (W27a) status.observedDowntime measured two adjacent metav1.Now() calls in the same reconcile invocation, producing 34-114µs across all 17 walkthrough runs vs a real cutover window of ~38-48s. Fix: new status.cutoverStep2DispatchedAt timestamp stamped at cutoverStep2 Delete dispatch; observedDowntime computed against it at Resuming completion. (W27b) status.observedPauseWindow plumbing half-implemented — swiftletd wrote kubeswift.io/migration-pause-window-ms annotation correctly but controller had zero readers. Fix: stampObservedPauseWindow helper reads annotation at substateSrcCompleted (W1 gate observation), mirrors snapshot controller's pattern. Both fields now carry their documented semantics. Defensive nil/parse handling on both. (W27 follow-up to E12 walkthrough.) | (this PR) |
 
 ---
 


### PR DESCRIPTION
## Summary

Fix two broken downtime-metric surfaces in Phase 3a's SwiftMigration controller, both surfaced during E12 disk-boot validation and tracked as **Tracked Follow-up #7** in `kubeswift_context.md`. Closes that follow-up.

## Three commits

1. **fix(swiftmigration): W27a — anchor observedDowntime to cutover step 2 dispatch**
   New `status.cutoverStep2DispatchedAt` field; cutoverStep2 stamps it idempotently; resuming_live computes `observedDowntime = now - cutoverStep2DispatchedAt` instead of the prior sub-millisecond nonsense. CRD regenerated; chart YAML updated.

2. **fix(swiftmigration): W27b — read swiftletd pause-window annotation into status**
   New `AnnotationMigrationPauseWindowMs` constant + `stampObservedPauseWindow` helper, wired into `substateSrcCompleted`. Mirrors the snapshot controller's pattern at `swiftsnapshot/local.go:249-251`.

3. **docs: W27 follow-up landed; downtime metrics now meaningful**
   CHANGELOG entry; Tracked Follow-up #7 marked SHIPPED; bug-fixed table row 65.

## Background

`status.observedDowntime` measured 34–114µs across all 17 PR #46 + E12 walkthrough runs against a real cutover window of ~38–48s. Cause at [`resuming_live.go:130-198`](https://github.com/projectbeskar/kubeswift/blob/main/internal/controller/swiftmigration/resuming_live.go#L130-L198): two adjacent `metav1.Now()` calls in the same reconcile invocation. The existing comment at lines 186-193 admitted the field measured the wrong window ("B3 may refine to a step-2 anchor if it stamps a separate timestamp; until then this is the best approximation"). The deferral was never tracked until W27 audit.

`status.observedPauseWindow` was permanently nil because the swiftletd-written `kubeswift.io/migration-pause-window-ms` annotation had zero controller-side readers. Plumbing was half-implemented: rust side complete (computes + writes), Go side absent.

Both fields now carry their documented semantics. Defensive handling preserves the operator-visible-missing-field-not-wrong-field invariant from W27 audit.

## Tests

7 new unit tests:

- `TestCutover_Step2_StampsCutoverStep2DispatchedAt_W27a` — timestamp stamped on Delete dispatch
- `TestCutover_Step2_StampIdempotent_PreservesOriginal_W27a` — leader-handover and NotFound retry preserve original stamp
- `TestResumingLive_ObservedDowntime_AnchoredOnCutoverStep2_W27a` — ~45s simulated cutover window measured correctly
- `TestResumingLive_ObservedDowntime_NilCutoverStamp_LeavesFieldNil_W27a` — defensive nil-check
- `TestStampObservedPauseWindow_HappyPath_W27b` — 312ms annotation → 312ms in status
- `TestStampObservedPauseWindow_ParseFailure_LeavesFieldNil_W27b` — malformed annotation leaves field nil
- `TestStampObservedPauseWindow_MissingAnnotation_LeavesFieldNil_W27b` — missing annotation silent

Existing `TestResumingLive_HappyPath_AdvancesToCompleted` updated to set `CutoverStep2DispatchedAt` in fixture (mirrors the new production ordering). All other tests unchanged.

`go test ./...` green.

## Operator-visible surfaces affected

| Surface | Before W27 | After W27 |
|---|---|---|
| `kubectl describe smig` Downtime line | sub-millisecond microsecond value (gibberish) | wall-clock cutover-to-resume window (low seconds for default node-local networking) |
| `status.observedPauseWindow` | always nil | swiftletd-reported CH vCPU pause window (CH targets ~300ms) |
| `status.cutoverStep2DispatchedAt` (new) | n/a | timestamp of src pod Delete dispatch (audit data) |

## Phase 1 offline migration: unaffected

These fields are live-mode-specific. Phase 1 offline mode does not populate any of them.

## Test plan

- [x] `go test ./...` green (3 commits' tests + existing)
- [x] `make generate` clean (no uncommitted CRD changes)
- [ ] Cluster validation (separate operator session post-merge):
  - Kernel-boot S1: capture `observedDowntime`, `observedPauseWindow`, ping-loss-from-sibling-pod-on-frida × 50ms
  - Disk-boot S1: same three measurements
  - Append "W27 validation" subsection to `docs/migration/phase-3a-cluster-validation.md`
- [ ] Phase 3a metrics empirical baseline established for the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)