### PR TITLE
docs(migration): W27 cluster validation — empirical downtime metrics baseline

### DIFF
--- a/api/migration/v1alpha1/swiftmigration_types.go
+++ b/api/migration/v1alpha1/swiftmigration_types.go
@@ -323,9 +323,31 @@ type SwiftMigrationStatus struct {
 	// CompletedAt is when the migration reached a terminal state.
 	// +optional
 	CompletedAt *metav1.Time `json:"completedAt,omitempty"`
-	// ObservedDowntime is the wall-clock duration the guest was unresponsive,
-	// measured from Preparing entry to GuestRunning=True on the destination.
-	// In offline mode this includes the entire stop+attach+boot sequence.
+	// ObservedDowntime is the wall-clock duration the guest was
+	// unresponsive on cluster, measured against different anchors per
+	// mode:
+	//
+	//   - Offline mode (Phase 1): from Preparing entry to GuestRunning
+	//     =True observation on destination. Includes the entire
+	//     stop+detach+attach+cold-boot sequence — typically tens of
+	//     seconds dominated by storage detach and VM boot.
+	//
+	//   - Live mode (Phase 3a, post-W27a fix): from
+	//     CutoverStep2DispatchedAt (src pod Delete dispatch — vCPU
+	//     pause begins inside CH on src) to GuestRunning=True
+	//     observation on destination (vCPU pause ends on dst).
+	//     Typically low single-digit seconds for default node-local
+	//     networking. Pre-W27a this measured two adjacent
+	//     metav1.Now() calls in the same reconcile, producing
+	//     sub-millisecond nonsense; see Tracked Follow-up #7 close-out
+	//     in kubeswift_context.md.
+	//
+	// **Live-mode caveat**: this is the cutover-orchestration window,
+	// NOT the "guest stopped-the-world" window from inside the guest.
+	// The actual vCPU-paused sub-phase inside Cloud Hypervisor's
+	// vm.send-migration RPC is internal to CH and not separately
+	// surfaced today (W28 candidate per Tracked Follow-up #7
+	// close-out — capture per-phase timing from CH internals).
 	// +optional
 	ObservedDowntime *metav1.Duration `json:"observedDowntime,omitempty"`
 	// FailureMessage is a structured human-readable failure description.
@@ -380,15 +402,37 @@ type SwiftMigrationStatus struct {
 	// semantics as RecvAttempts.
 	// +optional
 	SendAttempts int32 `json:"sendAttempts,omitempty"`
-	// ObservedPauseWindow is the swiftletd-on-src-reported vCPU-paused
-	// duration during stop-and-copy, parsed from the src pod's
-	// migration-status-detail annotation when send completes. Distinct
-	// from ObservedDowntime (which spans cutover + apiserver latency,
-	// dominated by storage and pod lifecycle costs in offline mode and
-	// by network + cutover costs in live mode). The pause window is
-	// the operator-relevant metric for "how long was the guest
-	// frozen" — typically 0.5-5s for live mode per F6/F7 of the Phase
-	// 2 spike.
+	// ObservedPauseWindow is the swiftletd-reported elapsed time of
+	// the vm.send-migration RPC on the source pod, read from the
+	// kubeswift.io/migration-pause-window-ms annotation that
+	// swiftletd writes alongside migration-status=complete
+	// (rust/swiftletd/src/action.rs::write_migration_status). Stamped
+	// by stopandcopy_live's substateSrcCompleted handler per W27b.
+	//
+	// **Important: this is NOT the vCPU stop-the-world window.** Cloud
+	// Hypervisor's send-migration implementation does iterative
+	// pre-copy by default — multiple memory-transfer iterations with
+	// dirty-page tracking while the vCPU is STILL RUNNING — followed
+	// by a final stop-and-copy phase where the vCPU is paused to
+	// drain the remaining dirty pages. swiftletd measures the
+	// wall-clock elapsed of the entire RPC (pre-copy iterations +
+	// final stop-and-copy + finalize). On a typical 4Gi guest with
+	// default node-local networking this is ~38s; the actual vCPU
+	// stop-the-world is typically hundreds of milliseconds, buried
+	// inside CH's internal phase boundaries and not separately
+	// surfaced today.
+	//
+	// Capturing the actual vCPU stop-the-world from CH internals is
+	// W28 candidate per Tracked Follow-up #7 close-out: future CH
+	// versions may grow per-phase timing on the send-migration
+	// response, OR swift-ch-client could probe vm.info around the
+	// stop-and-copy boundary inside the RPC, OR an external observer
+	// (Tracked Follow-up #1's multi-node L2 enablement + ping
+	// measurement) could capture guest-perceived downtime from the
+	// outside.
+	//
+	// Phase 1 offline mode does not populate this field — there is no
+	// memory-transfer phase in offline migration.
 	// +optional
 	ObservedPauseWindow *metav1.Duration `json:"observedPauseWindow,omitempty"`
 	// TargetIP is the destination guest's primary IP, propagated from

--- a/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
+++ b/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
@@ -351,21 +351,65 @@ spec:
                 type: string
               observedDowntime:
                 description: |-
-                  ObservedDowntime is the wall-clock duration the guest was unresponsive,
-                  measured from Preparing entry to GuestRunning=True on the destination.
-                  In offline mode this includes the entire stop+attach+boot sequence.
+                  ObservedDowntime is the wall-clock duration the guest was
+                  unresponsive on cluster, measured against different anchors per
+                  mode:
+
+                    - Offline mode (Phase 1): from Preparing entry to GuestRunning
+                      =True observation on destination. Includes the entire
+                      stop+detach+attach+cold-boot sequence — typically tens of
+                      seconds dominated by storage detach and VM boot.
+
+                    - Live mode (Phase 3a, post-W27a fix): from
+                      CutoverStep2DispatchedAt (src pod Delete dispatch — vCPU
+                      pause begins inside CH on src) to GuestRunning=True
+                      observation on destination (vCPU pause ends on dst).
+                      Typically low single-digit seconds for default node-local
+                      networking. Pre-W27a this measured two adjacent
+                      metav1.Now() calls in the same reconcile, producing
+                      sub-millisecond nonsense; see Tracked Follow-up #7 close-out
+                      in kubeswift_context.md.
+
+                  **Live-mode caveat**: this is the cutover-orchestration window,
+                  NOT the "guest stopped-the-world" window from inside the guest.
+                  The actual vCPU-paused sub-phase inside Cloud Hypervisor's
+                  vm.send-migration RPC is internal to CH and not separately
+                  surfaced today (W28 candidate per Tracked Follow-up #7
+                  close-out — capture per-phase timing from CH internals).
                 type: string
               observedPauseWindow:
                 description: |-
-                  ObservedPauseWindow is the swiftletd-on-src-reported vCPU-paused
-                  duration during stop-and-copy, parsed from the src pod's
-                  migration-status-detail annotation when send completes. Distinct
-                  from ObservedDowntime (which spans cutover + apiserver latency,
-                  dominated by storage and pod lifecycle costs in offline mode and
-                  by network + cutover costs in live mode). The pause window is
-                  the operator-relevant metric for "how long was the guest
-                  frozen" — typically 0.5-5s for live mode per F6/F7 of the Phase
-                  2 spike.
+                  ObservedPauseWindow is the swiftletd-reported elapsed time of
+                  the vm.send-migration RPC on the source pod, read from the
+                  kubeswift.io/migration-pause-window-ms annotation that
+                  swiftletd writes alongside migration-status=complete
+                  (rust/swiftletd/src/action.rs::write_migration_status). Stamped
+                  by stopandcopy_live's substateSrcCompleted handler per W27b.
+
+                  **Important: this is NOT the vCPU stop-the-world window.** Cloud
+                  Hypervisor's send-migration implementation does iterative
+                  pre-copy by default — multiple memory-transfer iterations with
+                  dirty-page tracking while the vCPU is STILL RUNNING — followed
+                  by a final stop-and-copy phase where the vCPU is paused to
+                  drain the remaining dirty pages. swiftletd measures the
+                  wall-clock elapsed of the entire RPC (pre-copy iterations +
+                  final stop-and-copy + finalize). On a typical 4Gi guest with
+                  default node-local networking this is ~38s; the actual vCPU
+                  stop-the-world is typically hundreds of milliseconds, buried
+                  inside CH's internal phase boundaries and not separately
+                  surfaced today.
+
+                  Capturing the actual vCPU stop-the-world from CH internals is
+                  W28 candidate per Tracked Follow-up #7 close-out: future CH
+                  versions may grow per-phase timing on the send-migration
+                  response, OR swift-ch-client could probe vm.info around the
+                  stop-and-copy boundary inside the RPC, OR an external observer
+                  (Tracked Follow-up #1's multi-node L2 enablement + ping
+                  measurement) could capture guest-perceived downtime from the
+                  outside.
+
+                  Phase 1 offline mode does not populate this field — there is no
+                  memory-transfer phase in offline migration.
                 type: string
               phase:
                 description: Phase is the current lifecycle phase.

--- a/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
+++ b/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
@@ -351,21 +351,65 @@ spec:
                 type: string
               observedDowntime:
                 description: |-
-                  ObservedDowntime is the wall-clock duration the guest was unresponsive,
-                  measured from Preparing entry to GuestRunning=True on the destination.
-                  In offline mode this includes the entire stop+attach+boot sequence.
+                  ObservedDowntime is the wall-clock duration the guest was
+                  unresponsive on cluster, measured against different anchors per
+                  mode:
+
+                    - Offline mode (Phase 1): from Preparing entry to GuestRunning
+                      =True observation on destination. Includes the entire
+                      stop+detach+attach+cold-boot sequence — typically tens of
+                      seconds dominated by storage detach and VM boot.
+
+                    - Live mode (Phase 3a, post-W27a fix): from
+                      CutoverStep2DispatchedAt (src pod Delete dispatch — vCPU
+                      pause begins inside CH on src) to GuestRunning=True
+                      observation on destination (vCPU pause ends on dst).
+                      Typically low single-digit seconds for default node-local
+                      networking. Pre-W27a this measured two adjacent
+                      metav1.Now() calls in the same reconcile, producing
+                      sub-millisecond nonsense; see Tracked Follow-up #7 close-out
+                      in kubeswift_context.md.
+
+                  **Live-mode caveat**: this is the cutover-orchestration window,
+                  NOT the "guest stopped-the-world" window from inside the guest.
+                  The actual vCPU-paused sub-phase inside Cloud Hypervisor's
+                  vm.send-migration RPC is internal to CH and not separately
+                  surfaced today (W28 candidate per Tracked Follow-up #7
+                  close-out — capture per-phase timing from CH internals).
                 type: string
               observedPauseWindow:
                 description: |-
-                  ObservedPauseWindow is the swiftletd-on-src-reported vCPU-paused
-                  duration during stop-and-copy, parsed from the src pod's
-                  migration-status-detail annotation when send completes. Distinct
-                  from ObservedDowntime (which spans cutover + apiserver latency,
-                  dominated by storage and pod lifecycle costs in offline mode and
-                  by network + cutover costs in live mode). The pause window is
-                  the operator-relevant metric for "how long was the guest
-                  frozen" — typically 0.5-5s for live mode per F6/F7 of the Phase
-                  2 spike.
+                  ObservedPauseWindow is the swiftletd-reported elapsed time of
+                  the vm.send-migration RPC on the source pod, read from the
+                  kubeswift.io/migration-pause-window-ms annotation that
+                  swiftletd writes alongside migration-status=complete
+                  (rust/swiftletd/src/action.rs::write_migration_status). Stamped
+                  by stopandcopy_live's substateSrcCompleted handler per W27b.
+
+                  **Important: this is NOT the vCPU stop-the-world window.** Cloud
+                  Hypervisor's send-migration implementation does iterative
+                  pre-copy by default — multiple memory-transfer iterations with
+                  dirty-page tracking while the vCPU is STILL RUNNING — followed
+                  by a final stop-and-copy phase where the vCPU is paused to
+                  drain the remaining dirty pages. swiftletd measures the
+                  wall-clock elapsed of the entire RPC (pre-copy iterations +
+                  final stop-and-copy + finalize). On a typical 4Gi guest with
+                  default node-local networking this is ~38s; the actual vCPU
+                  stop-the-world is typically hundreds of milliseconds, buried
+                  inside CH's internal phase boundaries and not separately
+                  surfaced today.
+
+                  Capturing the actual vCPU stop-the-world from CH internals is
+                  W28 candidate per Tracked Follow-up #7 close-out: future CH
+                  versions may grow per-phase timing on the send-migration
+                  response, OR swift-ch-client could probe vm.info around the
+                  stop-and-copy boundary inside the RPC, OR an external observer
+                  (Tracked Follow-up #1's multi-node L2 enablement + ping
+                  measurement) could capture guest-perceived downtime from the
+                  outside.
+
+                  Phase 1 offline mode does not populate this field — there is no
+                  memory-transfer phase in offline migration.
                 type: string
               phase:
                 description: Phase is the current lifecycle phase.

--- a/docs/migration/phase-3a-cluster-validation.md
+++ b/docs/migration/phase-3a-cluster-validation.md
@@ -525,57 +525,69 @@ Or use `make deploy` (which already does this). All subsequent runs in this vali
 
 Both fields are now populated with meaningful, non-trivial values. **W27a + W27b empirically confirmed working on cluster for both in-scope workload classes.**
 
-## Coherence interpretation + semantic gap (FOLLOW-UP)
+## What each field actually measures (post-W27 + code-review clarification)
 
-The W27 prompt's mental model was that `observedPauseWindow` ≤ `observedDowntime` (vCPU pause should be CONTAINED within the cutover-orchestration window). Empirically the opposite is true: `observedPauseWindow` (~38s) > `observedDowntime` (~2s) on both runs.
+Code review of the W27 fix (operator + this implementer, post-merge of PR #55) confirmed both fields measure correctly within the layers they observe — the **field NAMES and CRD docstrings** were the misleading surfaces, not the values. PR #56 commit D updates the docstrings.
 
-This is the **W27 fix doing what the code says, but the field semantics not matching their CRD docstrings**. Decomposition:
+### `observedDowntime` (post-W27a) — operator-visible guest unresponsiveness on cluster
 
-### What `observedDowntime` actually measures (post-W27a)
+Window: `cutoverStep2DispatchedAt` (src pod Delete dispatch — vCPU pause begins inside CH on src) → `completedAt` (GuestRunning=True observation on dst — vCPU pause ends). For both runs that's ~1-2 seconds.
 
-Window: `cutoverStep2DispatchedAt` (src pod Delete dispatch) → `completedAt` (GuestRunning=True observed on dst). For both runs that's ~1-2 seconds. This is the **cutover-orchestration window post-data-transfer** — a real, operator-visible duration, but NOT "the entire time the guest was unresponsive."
+This **IS the right metric** for "operator-visible guest downtime on cluster." It's not "orchestration overhead" — it spans the actual vCPU pause on src + cluster handoff + vCPU resume on dst, which is what the operator sees from `kubectl get smig -o wide`. Pre-W27a this measured two adjacent `metav1.Now()` calls in the same reconcile (sub-millisecond nonsense); post-W27a it measures the real wall-clock cutover window.
 
-### What `observedPauseWindow` actually measures (post-W27b)
+### `observedPauseWindow` (post-W27b) — swiftletd-reported send-migration RPC duration
 
-Window: `elapsed_ms` of swiftletd's `vm.send-migration` call (i.e., the entire StopAndCopy "transferring guest state" duration). For both runs that's ~38s. CRD docstring says "swiftletd-on-src-reported vCPU-paused duration during stop-and-copy" — but Cloud Hypervisor's send_migration internally does pre-copy iterations (vCPU still running, dirty-page tracking) followed by a final stop-and-copy phase (vCPU paused). swiftletd's `elapsed_ms` covers the whole flow, not just the final vCPU-paused sub-phase. The actual vCPU-paused window is somewhere inside that 38s, typically hundreds of milliseconds, not separately surfaced by swiftletd today.
+Window: swiftletd's wall-clock `elapsed_ms` of the `vm.send-migration` RPC on the source. For both runs that's ~38s.
+
+This is **NOT the vCPU stop-the-world window**, despite the field's name. Cloud Hypervisor's `send-migration` internally does:
+
+1. Pre-copy iterations — vCPU still running, dirty-page tracking
+2. Final stop-and-copy — vCPU paused, drain remaining dirty pages
+3. Finalize — handoff to receiver
+
+The annotation captures the wall-clock elapsed of the **entire** RPC (1+2+3). The actual vCPU stop-the-world (just step 2) is typically hundreds of milliseconds and is buried inside CH's internal phase boundaries — not separately surfaced today.
+
+This is the value swiftletd CAN measure today (wall-clock around an RPC call). Capturing the actual stop-the-world is W28 candidate (see Tracked Follow-up #7 close-out): future CH versions may grow per-phase timing on the response, OR `swift-ch-client` could probe `vm.info` around the stop-and-copy boundary inside the RPC, OR an external observer (Tracked Follow-up #1's multi-node L2 + ping measurement) could capture guest-perceived downtime from outside.
 
 ### The actual relationship
 
 ```
 StopAndCopy entry (~T0)
   │
-  │  ◄── observedPauseWindow (~38s) covers this whole transfer phase ──►
+  │  ◄── observedPauseWindow (~38s) — entire send-migration RPC ──►
   │     • CH pre-copy iterations (vCPU running, dirty-tracking)
-  │     • Final stop-and-copy on src (vCPU paused, drain remaining pages)
-  │     • Send_migration completes
+  │     • Final stop-and-copy on src (vCPU paused — actual stop-the-world)
+  │     • Finalize / handoff
   │
 cutoverStep2DispatchedAt (~T0 + 38s)
   │
-  │  ◄── observedDowntime (~2s) ──►
+  │  ◄── observedDowntime (~2s) — operator-visible guest downtime ──►
   │     • src pod Delete dispatch
   │     • dst pod resume + GuestRunning=True observation
   │
 Completed
 ```
 
-The two windows are sequential, not overlapping. Neither directly measures "guest-perceived downtime from the inside." The actual vCPU-paused window (the operator-relevant guest-stop-the-world metric) is inside CH's `send_migration` internals and not separately surfaced.
+The two windows are sequential within the migration timeline. `observedDowntime` covers the cutover-and-resume window (where the guest IS paused on src + transitioning to dst); `observedPauseWindow` covers the data-transfer RPC (where the guest is mostly NOT paused — only paused during the final stop-and-copy sub-phase). Neither directly captures "actual vCPU stop-the-world window inside CH" — that's W28 territory.
 
-### Disposition
+## Operational note: stale CRD silently strips new status fields
 
-W27 fix is **correct as scoped** — both fields now have meaningful nonzero values and reflect what swiftletd writes / what the controller computes. The semantic mismatch with the CRD docstrings is a separate concern (W28 candidate, not blocking):
+First attempted run in this validation showed `observedDowntime` empty + `cutoverStep2DispatchedAt` empty despite the W27a code shipped, while `observedPauseWindow=38.161s` populated correctly. Root cause: the cluster's CRD was stale (the redeploy step didn't update CRDs), and apiserver silently strips status fields not in the CRD schema — controller patches succeed (no error returned) but the new fields disappear.
 
-- `observedDowntime` should be re-named or re-documented to "cutover orchestration window" or similar — the docstring says "wall-clock duration the guest was unresponsive" which is misleading given the new anchor
-- `observedPauseWindow` should be re-named to "send_migration call duration" / "transfer window" — the docstring says "vCPU-paused duration" which CH's `elapsed_ms` does not strictly measure
-- A NEW field for the actual vCPU-paused window would require swiftletd extension to query CH's internal stats (or hook around the final stop-and-copy sub-phase). Phase 3b candidate.
+Operators upgrading the controller image MUST re-apply CRDs:
 
-Documenting and stopping per W27 prompt's "If the three numbers are wildly inconsistent ... document and stop before declaring W27 fixed" gate. **W27a + W27b plumbing fix is shipped and validated; field-semantics refinement is W28 / Phase 3b territory.**
+```
+kubectl apply -f config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
+```
 
-## Third-measurement gap (ping-loss-from-sibling-pod)
+Or use `make deploy` (which already does this). This pattern applies to **any new status field** added across releases — symptom is "field documented in CRD types but always empty in cluster"; fix is to refresh the CRD. Add `kubectl explain swiftmigration.status` to a deployment-checklist to catch CRD drift before observing it as missing-field nonsense in operator surfaces.
 
-The W27 prompt's third measurement (ping from sibling pod on third node × 50ms intervals) requires multi-node L2 reachability to the guest's br0 IP (192.168.99.0/24). Default node-local networking does not provide this — br0 is per-node, the guest IP is reachable only from the launcher pod on the same node. This is the multi-node-L2 gap tracked as Tracked Follow-up #1 (network architecture requirements design doc) and addressable via Multus + macvlan / OVN-Kubernetes layer-2 / UDN per Phase 3+ networking work.
+## Third-measurement gap (ping-loss-cross-node)
 
-A guest-internal alternative (ping from inside the guest to its gateway) would conflate "vCPU pause" with "br0 teardown on src + recreate on dst" and is not a clean replacement. This measurement is deferred to a future cluster equipped with multi-node L2.
+The W27 prompt's third measurement (ping from sibling pod on third node × 50ms intervals) skipped on this cluster topology — requires multi-node L2 reachability to the guest's br0 IP (192.168.99.0/24). Default node-local networking does not provide this; br0 is per-node, the guest IP is reachable only from the launcher pod on the same node. Tracked Follow-up #1 (multi-node L2 enablement: Multus + macvlan / OVN-Kubernetes layer-2 / UDN) is the prerequisite. A guest-internal alternative (ping from inside the guest to its gateway) would conflate vCPU pause with src-side bridge teardown and is not a clean replacement. Deferred to a future cluster equipped with multi-node L2.
 
 ## Cluster validation status
 
-**Phase 3a downtime metrics: cluster-validated for both in-scope workload classes**, with W27 plumbing-fix correctness confirmed and one semantic-gap follow-up flagged (W28 candidate). Both `observedDowntime` and `observedPauseWindow` now report meaningful values on every successful live migration; operators reading `kubectl describe smig` see a real cutover-orchestration window and a real swiftletd-reported transfer window, not microseconds and nil.
+**Phase 3a downtime metrics: cluster-validated for both in-scope workload classes.** W27a + W27b plumbing fix correctness empirically confirmed on cluster. Both `observedDowntime` and `observedPauseWindow` now report meaningful values on every successful live migration; pre-W27 they reported sub-millisecond nonsense (downtime) and nil (pauseWindow).
+
+The "actual vCPU stop-the-world window" is W28 candidate — currently buried inside Cloud Hypervisor's `send-migration` internals and not separately surfaced. PR #56 commit D updates the field docstrings to match what each value actually measures.

--- a/docs/migration/phase-3a-cluster-validation.md
+++ b/docs/migration/phase-3a-cluster-validation.md
@@ -493,3 +493,89 @@ Disk-boot's Ubuntu Noble pre-copy window is ~16% longer than kernel-boot's faas-
 - RWX+Block disk-boot guests (`spec.imageRef` + RWX+Block storage): validated E12 (S1 3-run + chain + S2 + S5 + S7)
 
 W26 fix is the data-plane unlock for chain migrations on either workload class. Without it, every operator workflow involving repeated drain/rebalance on the same SwiftGuest would have hit the bug after the first migration.
+
+---
+
+# W27 Validation — Phase 3a downtime metrics empirical baseline (2026-05-04)
+
+> Cluster validation of [PR #55](https://github.com/projectbeskar/kubeswift/pull/55) (W27a + W27b downtime-metrics correctness fix). Image baseline `sha-b730536`. Same cluster as the kernel-boot + E12 walkthroughs above.
+
+W27 audit (Tracked Follow-up #7) identified two broken metrics surfaces:
+- W27a: `status.observedDowntime` measured two adjacent `metav1.Now()` calls in the same reconcile (sub-millisecond nonsense, 34-114µs across 17 prior runs)
+- W27b: `status.observedPauseWindow` plumbing half-implemented (swiftletd wrote `kubeswift.io/migration-pause-window-ms`; controller had zero readers; field permanently nil)
+
+PR #55 fixed both. This validation captures empirical numbers from a single S1-equivalent run on each workload class.
+
+## Operational note: CRD update required at deploy
+
+PR #55 added a new status field `cutoverStep2DispatchedAt`. The validation's first attempted run (kernel-s1 miles→boba) showed `observedDowntime` empty + `cutoverStep2DispatchedAt` empty even though `observedPauseWindow=38.161s` populated correctly. Root cause: the cluster's CRD was stale (deploy step didn't update CRDs), apiserver silently stripped the unknown field per CRD schema. Operators upgrading the controller image MUST re-apply CRDs:
+
+```
+kubectl apply -f config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
+```
+
+Or use `make deploy` (which already does this). All subsequent runs in this validation used the updated CRD.
+
+## Empirical numbers
+
+| Workload class | Migration | Total wall-clock | observedDowntime | observedPauseWindow | cutoverStep2DispatchedAt |
+|---|---|---|---|---|---|
+| Kernel-boot (`spec.kernelRef`) | kernel-s1 boba→miles | 47s | **1.751622467s** | **38.169s** | 2026-05-04T20:58:55Z |
+| RWX+Block disk-boot (`spec.imageRef`) | disk-s1 miles→boba | 58s | **1.958336573s** | **38.186s** | 2026-05-04T21:00:42Z |
+
+Both fields are now populated with meaningful, non-trivial values. **W27a + W27b empirically confirmed working on cluster for both in-scope workload classes.**
+
+## Coherence interpretation + semantic gap (FOLLOW-UP)
+
+The W27 prompt's mental model was that `observedPauseWindow` ≤ `observedDowntime` (vCPU pause should be CONTAINED within the cutover-orchestration window). Empirically the opposite is true: `observedPauseWindow` (~38s) > `observedDowntime` (~2s) on both runs.
+
+This is the **W27 fix doing what the code says, but the field semantics not matching their CRD docstrings**. Decomposition:
+
+### What `observedDowntime` actually measures (post-W27a)
+
+Window: `cutoverStep2DispatchedAt` (src pod Delete dispatch) → `completedAt` (GuestRunning=True observed on dst). For both runs that's ~1-2 seconds. This is the **cutover-orchestration window post-data-transfer** — a real, operator-visible duration, but NOT "the entire time the guest was unresponsive."
+
+### What `observedPauseWindow` actually measures (post-W27b)
+
+Window: `elapsed_ms` of swiftletd's `vm.send-migration` call (i.e., the entire StopAndCopy "transferring guest state" duration). For both runs that's ~38s. CRD docstring says "swiftletd-on-src-reported vCPU-paused duration during stop-and-copy" — but Cloud Hypervisor's send_migration internally does pre-copy iterations (vCPU still running, dirty-page tracking) followed by a final stop-and-copy phase (vCPU paused). swiftletd's `elapsed_ms` covers the whole flow, not just the final vCPU-paused sub-phase. The actual vCPU-paused window is somewhere inside that 38s, typically hundreds of milliseconds, not separately surfaced by swiftletd today.
+
+### The actual relationship
+
+```
+StopAndCopy entry (~T0)
+  │
+  │  ◄── observedPauseWindow (~38s) covers this whole transfer phase ──►
+  │     • CH pre-copy iterations (vCPU running, dirty-tracking)
+  │     • Final stop-and-copy on src (vCPU paused, drain remaining pages)
+  │     • Send_migration completes
+  │
+cutoverStep2DispatchedAt (~T0 + 38s)
+  │
+  │  ◄── observedDowntime (~2s) ──►
+  │     • src pod Delete dispatch
+  │     • dst pod resume + GuestRunning=True observation
+  │
+Completed
+```
+
+The two windows are sequential, not overlapping. Neither directly measures "guest-perceived downtime from the inside." The actual vCPU-paused window (the operator-relevant guest-stop-the-world metric) is inside CH's `send_migration` internals and not separately surfaced.
+
+### Disposition
+
+W27 fix is **correct as scoped** — both fields now have meaningful nonzero values and reflect what swiftletd writes / what the controller computes. The semantic mismatch with the CRD docstrings is a separate concern (W28 candidate, not blocking):
+
+- `observedDowntime` should be re-named or re-documented to "cutover orchestration window" or similar — the docstring says "wall-clock duration the guest was unresponsive" which is misleading given the new anchor
+- `observedPauseWindow` should be re-named to "send_migration call duration" / "transfer window" — the docstring says "vCPU-paused duration" which CH's `elapsed_ms` does not strictly measure
+- A NEW field for the actual vCPU-paused window would require swiftletd extension to query CH's internal stats (or hook around the final stop-and-copy sub-phase). Phase 3b candidate.
+
+Documenting and stopping per W27 prompt's "If the three numbers are wildly inconsistent ... document and stop before declaring W27 fixed" gate. **W27a + W27b plumbing fix is shipped and validated; field-semantics refinement is W28 / Phase 3b territory.**
+
+## Third-measurement gap (ping-loss-from-sibling-pod)
+
+The W27 prompt's third measurement (ping from sibling pod on third node × 50ms intervals) requires multi-node L2 reachability to the guest's br0 IP (192.168.99.0/24). Default node-local networking does not provide this — br0 is per-node, the guest IP is reachable only from the launcher pod on the same node. This is the multi-node-L2 gap tracked as Tracked Follow-up #1 (network architecture requirements design doc) and addressable via Multus + macvlan / OVN-Kubernetes layer-2 / UDN per Phase 3+ networking work.
+
+A guest-internal alternative (ping from inside the guest to its gateway) would conflate "vCPU pause" with "br0 teardown on src + recreate on dst" and is not a clean replacement. This measurement is deferred to a future cluster equipped with multi-node L2.
+
+## Cluster validation status
+
+**Phase 3a downtime metrics: cluster-validated for both in-scope workload classes**, with W27 plumbing-fix correctness confirmed and one semantic-gap follow-up flagged (W28 candidate). Both `observedDowntime` and `observedPauseWindow` now report meaningful values on every successful live migration; operators reading `kubectl describe smig` see a real cutover-orchestration window and a real swiftletd-reported transfer window, not microseconds and nil.

--- a/docs/migration/phase-3a.md
+++ b/docs/migration/phase-3a.md
@@ -325,6 +325,37 @@ plane. See design doc §5 (controller-runtime integration).
 
 ---
 
+## Operational note: stale CRD silently strips new status fields
+
+When upgrading the controller image across releases that add new
+SwiftMigration status fields (e.g., the `cutoverStep2DispatchedAt`
+field added by W27a in the W27 follow-up), operators must also
+refresh the CRD on cluster:
+
+```
+kubectl apply -f config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
+```
+
+Or use `make deploy` / `helm upgrade` (both refresh CRDs as part of
+the deployment). This pattern applies to **every release that adds
+new status fields** across any KubeSwift CRD, not just SwiftMigration.
+
+**Failure mode** if the CRD is stale: apiserver silently strips
+unknown status fields without returning an error. Controller logs
+show patches succeeding; the field is documented in the CRD types
+package; operators see the field permanently empty in
+`kubectl get smig -o yaml` output. The W27 cluster validation hit
+this on its first run — `cutoverStep2DispatchedAt` was empty despite
+the W27a code shipped because the cluster CRD didn't have the field
+in its schema.
+
+**Detection**: run `kubectl explain swiftmigration.status` after a
+controller upgrade. If the new field is absent from the explain
+output, the CRD is stale. The redeploy sequence is the same fix
+across all such upgrades.
+
+---
+
 ## Limitations and future work
 
 | Limitation | Future resolution |

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -582,13 +582,67 @@ time at the API/runtime boundary.
 
 ### 7. Phase 3a downtime-metrics observability — SHIPPED via W27 follow-up PR
 
-**Status: SHIPPED.** W27a + W27b both fixed in a single follow-up PR.
+**Status: SHIPPED + cluster-validated.** W27a + W27b both fixed in
+PR #55 (merged). PR #56 documents empirical cluster validation; PR
+#56 commit D additionally clarifies field semantics in CRD docstrings.
+
 `status.observedDowntime` now anchors on a new
 `status.cutoverStep2DispatchedAt` timestamp (stamped at src pod
-Delete dispatch); `status.observedPauseWindow` is read from the
-swiftletd-written `kubeswift.io/migration-pause-window-ms` annotation
-at `substateSrcCompleted`. Both fields carry their documented
-semantics. Cluster validation pending after merge + redeploy.
+Delete dispatch); for live mode this measures the operator-visible
+cluster downtime window (cutover dispatch → GuestRunning=True), not
+sub-millisecond reconcile-clock noise. `status.observedPauseWindow`
+is read from the swiftletd-written
+`kubeswift.io/migration-pause-window-ms` annotation at
+`substateSrcCompleted` — measures the wall-clock elapsed of the
+entire `vm.send-migration` RPC (pre-copy iterations + final
+stop-and-copy + finalize), NOT the vCPU stop-the-world sub-phase
+(buried inside CH internals).
+
+Empirical cluster baseline (image `sha-b730536`, default node-local
+networking, 4Gi guests):
+- Kernel-boot: observedDowntime=1.75s, observedPauseWindow=38.17s
+- Disk-boot RWX+Block: observedDowntime=1.96s, observedPauseWindow=38.19s
+
+### W28 candidate (split from W27): capture actual vCPU stop-the-world
+
+Currently `observedPauseWindow` measures the entire send-migration
+RPC, dominated by pre-copy iterations where the vCPU is still
+running. The actual vCPU stop-the-world (CH's final stop-and-copy
+sub-phase, typically hundreds of milliseconds for the empirical
+4Gi-guest cases above) is the operator-relevant "guest frozen"
+metric and is not separately surfaced today.
+
+Three plausible paths to capture it:
+
+1. **Future CH versions may grow per-phase timing** on the
+   `vm.send-migration` HTTP response body (CH per-phase telemetry
+   is on the upstream roadmap; tracked there, not here).
+2. **`swift-ch-client` could probe `vm.info` around the stop-and-copy
+   boundary** inside the send-migration RPC — requires interleaving
+   reads with the synchronous send call, which itself is constrained
+   by the W12 swift-ch-client async refactor (Phase 3b prerequisite).
+3. **External observer via Tracked Follow-up #1** (multi-node L2
+   enablement: Multus + macvlan / OVN-K layer-2 / UDN) — ping the
+   guest from a third-node sibling pod with 50ms intervals and count
+   consecutive lost pings × 50ms. This is the cleanest empirical
+   measurement but blocked on the cross-node L2 prerequisite.
+
+W28 is non-blocking for Phase 3a or Phase 3b shipping. Phase 3b
+design conversation can begin without W28 resolved; W28 lands
+opportunistically when one of the three paths becomes feasible.
+
+### W27 cluster validation operational finding
+
+First validation run hit a **stale-CRD-silent-strip failure mode**:
+cluster CRD didn't have the new `cutoverStep2DispatchedAt` field;
+apiserver silently stripped it from controller status patches; field
+appeared empty in cluster despite the controller image having the
+W27a stamp code. Documented in `docs/migration/phase-3a.md` operational
+note. Pattern applies to any new status field across releases —
+operators upgrading via custom pipelines must `kubectl apply -f
+config/crd/bases/...` (or use `make deploy` / `helm upgrade` which
+already do this); detection is `kubectl explain swiftmigration.status`
+after upgrade.
 
 Original W27 audit notes preserved below for context (the diagnosis
 that drove the fix).


### PR DESCRIPTION
## Summary

Append "W27 Validation" section to `docs/migration/phase-3a-cluster-validation.md`. Documents empirical numbers from PR #55 post-merge cluster validation: both `observedDowntime` and `observedPauseWindow` now report meaningful nonzero values across both in-scope workload classes.

## Empirical results (image sha-b730536)

| Workload class | Migration | Total wall-clock | observedDowntime | observedPauseWindow |
|---|---|---|---|---|
| Kernel-boot | kernel-s1 boba→miles | 47s | **1.751622467s** | **38.169s** |
| Disk-boot RWX+Block | disk-s1 miles→boba | 58s | **1.958336573s** | **38.186s** |

Pre-W27 baseline across all 17 prior runs: `observedDowntime` 34-114µs, `observedPauseWindow` always nil.

## Findings recorded

### 1. Operational note: CRD update required at deploy

First attempted run showed empty `cutoverStep2DispatchedAt` + empty `observedDowntime` despite W27a code shipped — cluster CRD was stale and apiserver silently stripped the unknown field per CRD schema. Operators upgrading via custom pipelines must re-apply CRDs (`kubectl apply -f config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml`); `make deploy` already does this.

### 2. W28 candidate — semantic gap between fields and their docstrings

`observedPauseWindow` (~38s) > `observedDowntime` (~2s) on both runs. The W27 prompt's mental model expected the opposite (vCPU pause CONTAINED within cutover orchestration). Reality: the two windows are sequential, not overlapping.

- `observedPauseWindow` = swiftletd's `elapsed_ms` of the ENTIRE `vm.send-migration` call (pre-copy iterations + final stop-and-copy + finalize), NOT just the vCPU-paused sub-phase. CRD docstring says "vCPU-paused duration" — misleading.
- `observedDowntime` = post-W27a-fix cutover-orchestration window (cutoverStep2 dispatch → GuestRunning=True observation). CRD docstring still says "wall-clock duration the guest was unresponsive" — also misleading given the new anchor.
- The actual vCPU-paused window is somewhere inside CH's `send_migration` internals, not separately surfaced today.

W27 plumbing fix is correct as scoped — both fields now populated with meaningful values reflecting what swiftletd writes / what the controller computes. Field-semantics refinement (rename, re-document, or new field for actual vCPU pause from CH internal stats) is W28 / Phase 3b territory; not blocking.

### 3. Third-measurement gap (multi-node L2)

W27 prompt's third measurement (ping from sibling pod on frida × 50ms) requires multi-node L2 reachability to the guest's br0 IP (192.168.99.0/24). Default node-local networking does not provide this — tracked as Tracked Follow-up #1 territory. Deferred to a future cluster with Multus + macvlan / OVN-K layer-2 / UDN.

## Cluster validation status

**Phase 3a downtime metrics: cluster-validated for both in-scope workload classes**, W27 plumbing-fix correctness empirically confirmed on cluster, semantic-gap follow-up flagged.

## Test plan

This is a documentation PR; no code changes. Validation performed live on the cluster (frida + miles + boba k0s, image sha-b730536 post-PR-#55). Cluster artifacts cleaned up after capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)