### PR TITLE
fix(swiftctl): harden ResolvePod against migration-cutover races

### DIFF
--- a/internal/cli/guest.go
+++ b/internal/cli/guest.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -50,7 +52,41 @@ func (r *GuestResolver) ResolveGuest(ctx context.Context, namespace, name string
 }
 
 // ResolvePod fetches the pod for the given SwiftGuest.
-// Uses status.podRef if set; otherwise finds by label swift.kubeswift.io/guest=<name>.
+//
+// Resolution order:
+//  1. status.podRef (authoritative when present and reachable). The
+//     SwiftGuest controller patches this at cutover step 1 of a live
+//     migration, so post-migration it points at the destination pod
+//     name (typically <guest>-mig-<uid>). Pre-migration it equals
+//     <guest>.
+//  2. Label selector swift.kubeswift.io/guest=<guest.Name> as a
+//     fallback. Triggered when (a) podRef is nil (pre-controller-
+//     stamp transient, e.g., very early after SwiftGuest create), or
+//     (b) podRef is set but the named pod returns NotFound (cutover
+//     race — podRef has been patched to dst but dst pod is not yet
+//     created, OR src pod was already deleted but this controller's
+//     status patch is still in flight).
+//
+// When the label selector returns multiple pods (chain-migration
+// transient: M1 src still Terminating while M2 dst is Running, both
+// labeled with the same guest name), pods are stable-sorted with the
+// best match first by:
+//
+//  1. Non-Terminating before Terminating (DeletionTimestamp == nil wins)
+//  2. Running before non-Running (Status.Phase == Running wins)
+//  3. Newest CreationTimestamp first (latest wins on tie)
+//
+// The first item after the sort is returned. If every candidate is
+// Terminating, the newest one is returned with a stderr warning so
+// the operator at least gets something to inspect; this matches the
+// "best-effort" posture of swiftctl during transient cluster states.
+//
+// Other Get errors (timeout, auth, conflict) propagate immediately.
+// Only NotFound triggers the label-selector fallback.
+//
+// TODO: route the all-Terminating warning through structured logging
+// when internal/cli grows a logger; today it prints to stderr to
+// avoid scope creep.
 func (r *GuestResolver) ResolvePod(ctx context.Context, guest *swiftv1alpha1.SwiftGuest) (*corev1.Pod, error) {
 	namespace := guest.Namespace
 	name := guest.Name
@@ -61,26 +97,61 @@ func (r *GuestResolver) ResolvePod(ctx context.Context, guest *swiftv1alpha1.Swi
 			Namespace: guest.Status.PodRef.Namespace,
 			Name:      guest.Status.PodRef.Name,
 		}, &pod)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return nil, fmt.Errorf("pod for guest %q not found", name)
-			}
+		if err == nil {
+			return &pod, nil
+		}
+		if !errors.IsNotFound(err) {
 			return nil, err
 		}
-		return &pod, nil
+		// NotFound: fall through to the label-selector path. The
+		// named pod is gone (cutover race) but a labeled candidate
+		// may still resolve.
 	}
 
-	// Fallback: list pods by label
 	sel := labels.SelectorFromSet(map[string]string{GuestLabelKey: name})
 	var list corev1.PodList
-	err := r.List(ctx, &list, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: sel})
-	if err != nil {
+	if err := r.List(ctx, &list, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: sel}); err != nil {
 		return nil, err
 	}
 	if len(list.Items) == 0 {
 		return nil, fmt.Errorf("pod for guest %q not found", name)
 	}
-	return &list.Items[0], nil
+
+	pods := list.Items
+	sort.SliceStable(pods, func(i, j int) bool {
+		ti := pods[i].DeletionTimestamp != nil
+		tj := pods[j].DeletionTimestamp != nil
+		if ti != tj {
+			// Non-Terminating wins.
+			return !ti
+		}
+		ri := pods[i].Status.Phase == corev1.PodRunning
+		rj := pods[j].Status.Phase == corev1.PodRunning
+		if ri != rj {
+			// Running wins.
+			return ri
+		}
+		// Tie-break by newest CreationTimestamp.
+		return pods[i].CreationTimestamp.After(pods[j].CreationTimestamp.Time)
+	})
+
+	// All-Terminating warn path: surface a hint that what we return
+	// is actively being deleted; operator may need to wait for the
+	// next reconcile or pick a different action.
+	allTerminating := true
+	for i := range pods {
+		if pods[i].DeletionTimestamp == nil {
+			allTerminating = false
+			break
+		}
+	}
+	if allTerminating {
+		fmt.Fprintf(os.Stderr,
+			"warning: all %d candidate pod(s) for guest %q are Terminating; returning newest (%q). The operation may fail; retry once the next launcher pod is Running.\n",
+			len(pods), name, pods[0].Name)
+	}
+
+	return &pods[0], nil
 }
 
 // Resolve fetches both guest and pod.

--- a/internal/cli/guest_test.go
+++ b/internal/cli/guest_test.go
@@ -1,0 +1,221 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	kubeswiftscheme "github.com/projectbeskar/kubeswift/internal/scheme"
+)
+
+// newTestResolver builds a GuestResolver backed by a controller-runtime
+// fake client populated with the given objects. Both core/v1 and the
+// swift API group are registered so SwiftGuests with PodRef can be
+// resolved alongside their pods.
+func newTestResolver(t *testing.T, objs ...client.Object) *GuestResolver {
+	t.Helper()
+	fc := fake.NewClientBuilder().
+		WithScheme(kubeswiftscheme.Scheme).
+		WithObjects(objs...).
+		Build()
+	return &GuestResolver{Client: fc}
+}
+
+// newGuest builds a SwiftGuest with optional status.podRef pointing at
+// the given pod name (empty podRefName leaves the field nil).
+func newGuest(name, namespace, podRefName string) *swiftv1alpha1.SwiftGuest {
+	g := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: "guest-uid"},
+	}
+	if podRefName != "" {
+		g.Status.PodRef = &corev1.ObjectReference{
+			Kind:      "Pod",
+			Namespace: namespace,
+			Name:      podRefName,
+		}
+	}
+	return g
+}
+
+// newLabeledPod builds a pod carrying the swift.kubeswift.io/guest=<guestName>
+// label, with the requested phase, optional DeletionTimestamp (Terminating),
+// and a creationTimestamp set to now-age (positive age yields older pods).
+func newLabeledPod(name, namespace, guestName string, phase corev1.PodPhase, terminating bool, age time.Duration) *corev1.Pod {
+	created := metav1.NewTime(time.Now().Add(-age))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			Labels:            map[string]string{GuestLabelKey: guestName},
+			CreationTimestamp: created,
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+	if terminating {
+		// Fake client tolerates a manually set DeletionTimestamp on
+		// pods registered via WithObjects, BUT only when at least one
+		// finalizer is present (otherwise the validating admission
+		// strips the timestamp). The finalizer never fires in tests
+		// because nothing reconciles it.
+		now := metav1.NewTime(time.Now())
+		pod.DeletionTimestamp = &now
+		pod.Finalizers = []string{"kubeswift.io/test-pin"}
+	}
+	return pod
+}
+
+// T1: PodRef set, pod exists -> returns named pod.
+func TestResolvePod_PodRefHit_ReturnsNamedPod(t *testing.T) {
+	guest := newGuest("g1", "ns", "g1")
+	pod := newLabeledPod("g1", "ns", "g1", corev1.PodRunning, false, 5*time.Minute)
+	r := newTestResolver(t, guest, pod)
+
+	got, err := r.ResolvePod(context.Background(), guest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "g1" {
+		t.Errorf("Name: want g1, got %q", got.Name)
+	}
+}
+
+// T2: PodRef set, pod NotFound, no labeled pods -> returns "not found".
+func TestResolvePod_PodRefNotFound_NoLabeledPods_ReturnsNotFound(t *testing.T) {
+	guest := newGuest("g1", "ns", "g1-mig-abcdef") // podRef points at gone dst
+	r := newTestResolver(t, guest)                 // no pods at all
+
+	_, err := r.ResolvePod(context.Background(), guest)
+	if err == nil {
+		t.Fatalf("want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error: want substring 'not found', got %q", err.Error())
+	}
+}
+
+// T3: PodRef set, pod NotFound, one labeled pod -> returns labeled pod.
+// Foot-gun 1 fix.
+func TestResolvePod_PodRefNotFound_OneLabeledPod_ReturnsLabeledPod(t *testing.T) {
+	guest := newGuest("g1", "ns", "g1-mig-abcdef") // podRef points at not-yet-created dst
+	pod := newLabeledPod("g1", "ns", "g1", corev1.PodRunning, false, 5*time.Minute)
+	r := newTestResolver(t, guest, pod)
+
+	got, err := r.ResolvePod(context.Background(), guest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "g1" {
+		t.Errorf("Name: want g1 (fallback labeled pod), got %q", got.Name)
+	}
+}
+
+// T4: PodRef nil, one labeled pod -> returns labeled pod.
+func TestResolvePod_PodRefNil_OneLabeledPod_ReturnsLabeledPod(t *testing.T) {
+	guest := newGuest("g1", "ns", "")
+	pod := newLabeledPod("g1", "ns", "g1", corev1.PodRunning, false, 5*time.Minute)
+	r := newTestResolver(t, guest, pod)
+
+	got, err := r.ResolvePod(context.Background(), guest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "g1" {
+		t.Errorf("Name: want g1, got %q", got.Name)
+	}
+}
+
+// T5: Two labeled pods (one Running, one Terminating) -> returns Running.
+// Foot-gun 2 primary case.
+func TestResolvePod_TwoLabeled_RunningVsTerminating_PrefersRunning(t *testing.T) {
+	guest := newGuest("g1", "ns", "")
+	terminating := newLabeledPod("g1", "ns", "g1", corev1.PodRunning, true, 10*time.Minute)
+	running := newLabeledPod("g1-mig-abcdef", "ns", "g1", corev1.PodRunning, false, 1*time.Minute)
+	r := newTestResolver(t, guest, terminating, running)
+
+	got, err := r.ResolvePod(context.Background(), guest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "g1-mig-abcdef" {
+		t.Errorf("Name: want g1-mig-abcdef (Running, non-Terminating), got %q", got.Name)
+	}
+}
+
+// T6: Two labeled pods both Running, different CreationTimestamp -> newest.
+// Foot-gun 2 tie-break.
+func TestResolvePod_TwoRunning_TieBreakByNewest(t *testing.T) {
+	guest := newGuest("g1", "ns", "")
+	older := newLabeledPod("g1", "ns", "g1", corev1.PodRunning, false, 10*time.Minute)
+	newer := newLabeledPod("g1-mig-abcdef", "ns", "g1", corev1.PodRunning, false, 1*time.Minute)
+	r := newTestResolver(t, guest, older, newer)
+
+	got, err := r.ResolvePod(context.Background(), guest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "g1-mig-abcdef" {
+		t.Errorf("Name: want g1-mig-abcdef (newest), got %q", got.Name)
+	}
+}
+
+// T7: Three labeled pods (Pending, Running, Terminating) -> returns Running.
+// Foot-gun 2 full ordering.
+func TestResolvePod_ThreeCandidates_PendingRunningTerminating_PrefersRunning(t *testing.T) {
+	guest := newGuest("g1", "ns", "")
+	pending := newLabeledPod("g1-mig-aaa", "ns", "g1", corev1.PodPending, false, 1*time.Minute)
+	running := newLabeledPod("g1-mig-bbb", "ns", "g1", corev1.PodRunning, false, 5*time.Minute)
+	terminating := newLabeledPod("g1", "ns", "g1", corev1.PodRunning, true, 30*time.Minute)
+	r := newTestResolver(t, guest, pending, running, terminating)
+
+	got, err := r.ResolvePod(context.Background(), guest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "g1-mig-bbb" {
+		t.Errorf("Name: want g1-mig-bbb (Running, non-Terminating), got %q", got.Name)
+	}
+}
+
+// T8: All pods Terminating -> returns newest, no error.
+// Foot-gun 2 all-terminating fallback.
+func TestResolvePod_AllTerminating_ReturnsNewestNoError(t *testing.T) {
+	guest := newGuest("g1", "ns", "")
+	older := newLabeledPod("g1", "ns", "g1", corev1.PodRunning, true, 10*time.Minute)
+	newer := newLabeledPod("g1-mig-abcdef", "ns", "g1", corev1.PodRunning, true, 1*time.Minute)
+	r := newTestResolver(t, guest, older, newer)
+
+	got, err := r.ResolvePod(context.Background(), guest)
+	if err != nil {
+		t.Fatalf("unexpected error (all-Terminating must not error): %v", err)
+	}
+	if got.Name != "g1-mig-abcdef" {
+		t.Errorf("Name: want g1-mig-abcdef (newest), got %q", got.Name)
+	}
+}
+
+// T9: PodRef set, pod exists; a stale labeled pod also exists with
+// matching guest label and different name. PodRef remains authoritative.
+func TestResolvePod_PodRefHit_IgnoresLabeledCandidate(t *testing.T) {
+	// PodRef points at the post-cutover dst pod. A stale src pod is
+	// still hanging around with the same guest label (e.g., kubelet
+	// has not finished termination). PodRef wins.
+	guest := newGuest("g1", "ns", "g1-mig-abcdef")
+	dst := newLabeledPod("g1-mig-abcdef", "ns", "g1", corev1.PodRunning, false, 1*time.Minute)
+	stale := newLabeledPod("g1", "ns", "g1", corev1.PodRunning, true, 10*time.Minute)
+	r := newTestResolver(t, guest, dst, stale)
+
+	got, err := r.ResolvePod(context.Background(), guest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "g1-mig-abcdef" {
+		t.Errorf("Name: want g1-mig-abcdef (PodRef authoritative), got %q", got.Name)
+	}
+}


### PR DESCRIPTION
## Summary

`GuestResolver.ResolvePod` ([internal/cli/guest.go](internal/cli/guest.go)) is the single shared entry point for `swiftctl console / ssh / logs / debug / restart / start / stop`. Two foot-guns surfaced during Phase 3a live migration cutover transients and chain migrations.

## Foot-gun 1: PodRef-NotFound has no fallback

When `guest.Status.PodRef` is set but the named pod returns NotFound, the prior implementation returned `pod for guest %q not found` without trying the label-selector path. This bites operators running `swiftctl console <guest>` during the cutover window where PodRef has been patched to dstName but the dst pod has not yet been created (or the src pod has been deleted but PodRef has not yet been patched — same shape, different direction).

**Fix**: when `PodRef.Get` returns NotFound, fall through to the label-selector path. Other Get errors (timeout, auth, conflict) propagate immediately as before — only NotFound triggers fallback.

## Foot-gun 2: label selector picks first match without disambiguating

The prior implementation returned `list.Items[0]`. During chain migration (M1 src still Terminating while M2 dst is Running, both carrying `swift.kubeswift.io/guest=<name>`), the selector picks whichever pod the API server lists first — non-deterministic, often the wrong one. The SwiftMigration controller solved the equivalent problem with `srcPodLookupName` locked at Validating time (W26); swiftctl has no such invariant available.

**Fix**: stable-sort the candidate list with the best match first by:

1. Non-Terminating before Terminating (`DeletionTimestamp == nil` wins)
2. Running before non-Running (`Status.Phase == PodRunning` wins)
3. Newest `CreationTimestamp` first (latest wins on tie)

Return `list.Items[0]` after the sort.

**All-Terminating fallback**: return newest with a stderr warning so the operator at least gets something to inspect; matches swiftctl's best-effort posture during transient cluster states. TODO comment notes structured logging is a future polish (internal/cli has no logger today).

## Tests (new file [internal/cli/guest_test.go](internal/cli/guest_test.go), 9 cases)

| # | Scenario | Expected |
|---|---|---|
| T1 | PodRef set, pod exists | Named pod (regression) |
| T2 | PodRef set, NotFound, no labeled pods | "not found" error |
| T3 | PodRef set, NotFound, one labeled pod | Labeled pod (foot-gun 1) |
| T4 | PodRef nil, one labeled pod | Labeled pod (regression) |
| T5 | Running + Terminating | Running (foot-gun 2 primary) |
| T6 | Two Running, different ages | Newest (foot-gun 2 tie-break) |
| T7 | Pending + Running + Terminating | Running (foot-gun 2 ordering) |
| T8 | All Terminating | Newest, no error (foot-gun 2 fallback) |
| T9 | PodRef hit + stale labeled candidate | PodRef pod (authoritative) |

All 9 PASS. Full `go test ./...` green.

## What's NOT changed

- Function signature of `ResolvePod`, `Resolve`, `GuestID`, `ResolveGuest`, `DeletePod`, `PatchRunPolicy`
- Any caller in [cmd/swiftctl/](cmd/swiftctl/)
- Any file outside [internal/cli/](internal/cli/)
- No new public API
- No new dependencies

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/cli/...` clean
- [x] `go test ./internal/cli/...` 9 cases green
- [x] `go test ./...` full suite green
- [ ] Cluster validation post-merge (operator session): exercise the fix via real cutover transient + chain migration + verify swiftctl console still works on happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)