### PR TITLE
cleanup(TFU-16): add make deploy-with-webhook target + correct context-doc framing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
 
 .PHONY: build build-go build-rust build-images build-controller-image build-swiftletd-image \
-	build-gpu-discovery-image generate deploy undeploy load-images smoke-test smoke-test-cleanup \
+	build-gpu-discovery-image generate deploy deploy-with-webhook undeploy load-images smoke-test smoke-test-cleanup \
 	clonestrategy-test snapshot-test local-roundtrip-test local-clone-identity-test \
 	b0-cross-node-tcp-test e2e-tests \
 	verify-e2e-scripts \
@@ -41,7 +41,8 @@ help:
 	@echo "  print-version         Print version info from hack/version.sh"
 	@echo "  generate              Generate CRDs and deepcopy (also syncs charts/ + runs verify-crd-sync)"
 	@echo "  verify-crd-sync       Fail if config/crd/kustomization.yaml drifts from config/crd/bases/"
-	@echo "  deploy                Apply CRDs and KubeSwift to cluster"
+	@echo "  deploy                Deploy controller-manager (minimal install, no webhooks). Use deploy-with-webhook for webhook-enabled deploys (requires cert-manager)."
+	@echo "  deploy-with-webhook   Deploy controller-manager with admission webhooks enabled (requires cert-manager cluster-side; applies config/overlays/webhook on top of the minimal install)"
 	@echo "  undeploy              Remove KubeSwift from cluster, then CRDs"
 	@echo "  load-images           Load built images into kind/minikube (local clusters)"
 	@echo "  smoke-test            Run boot smoke test (requires KubeSwift cluster)"
@@ -156,6 +157,34 @@ deploy: generate verify-crd-sync
 	@# GPU discovery: set image tag and deploy RBAC + DaemonSet.
 	kubectl apply -f config/rbac/gpu-discovery-rbac.yaml
 	sed 's|gpu-discovery:latest|gpu-discovery:$(IMAGE_TAG)|' config/daemonset/gpu-discovery.yaml | kubectl apply -f -
+
+# deploy-with-webhook layers config/overlays/webhook on top of the minimal
+# install. The overlay composes config/default + config/webhook and patches
+# the controller-manager Deployment to --webhook-enabled=true with the
+# cert-manager TLS Secret volumeMount. Requires cert-manager installed
+# cluster-side (the overlay's Certificate + Issuer reference cert-manager
+# CRDs).
+#
+# Operators reaching for an apply path that doesn't strand the cluster's
+# ValidatingWebhookConfiguration / MutatingWebhookConfiguration resources
+# pointing at a webhook-disabled controller (TFU-16 walkthrough finding):
+# use this target instead of `make deploy` when the cluster has the
+# webhook resources installed.
+deploy-with-webhook: deploy
+	@echo "Layering webhook overlay (patches deployment to --webhook-enabled=true + cert volume; applies config/webhook resources)"
+	@# Same IMAGE_TAG sed-patch trick as `deploy` — the overlay composes
+	@# config/manager, so kustomize re-renders manager with the patch on top.
+	cd config/manager && sed -i 's/newTag: .*/newTag: $(IMAGE_TAG)/' kustomization.yaml
+	kubectl apply -k config/overlays/webhook
+	cd config/manager && sed -i 's/newTag: .*/newTag: latest/' kustomization.yaml
+	@# Re-set the launcher image env var — the overlay's deployment patch
+	@# replaces the spec.template.spec.containers[].args list, which
+	@# triggers a rollout. The env var set by `deploy` survives across
+	@# kustomize-apply because env is not declared in deployment.yaml,
+	@# but re-set defensively to handle the case where it was cleared.
+	kubectl set env deployment/controller-manager -n kubeswift-system \
+		KUBESWIFT_LAUNCHER_IMAGE=$(IMAGE_REGISTRY)/swiftletd:$(IMAGE_TAG)
+	kubectl -n kubeswift-system rollout status deploy/controller-manager --timeout=120s
 
 undeploy:
 	kubectl delete -k config/default --ignore-not-found --timeout=60s

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -962,51 +962,86 @@ naming it explicitly is the bug pattern.
 W21 gate; cross-reference from PR 2's controller cancel handler to
 this follow-up. No swiftletd-side change required.
 
-### 16. `make deploy` vs Helm chart webhook-enabled default mismatch (Phase 3b PR 1 walkthrough deploy-time observation)
+### 16. `make deploy` cluster-state-drift with persistent VWC/MWC resources (Phase 3b PR 1 walkthrough deploy-time observation; resolved via `make deploy-with-webhook` target)
 
-Phase 3b PR 1 walkthrough's deploy step exposed a pre-existing
-tension between two deployment paths:
+**Original framing was wrong; corrected here.** The PR 1 walkthrough
+finding described this as a "chronic mismatch between `make deploy`
+and Helm chart webhook-enabled defaults." TFU-16's Phase 0
+reconnaissance (before the cleanup PR) confirmed both defaults
+agree (webhook-disabled):
 
-- [`config/manager/deployment.yaml:27`](config/manager/deployment.yaml#L27)
-  sets `--webhook-enabled=false` (used by `make deploy` via
-  `config/default`).
-- [`charts/kubeswift/templates/controller-manager/deployment.yaml:35`](charts/kubeswift/templates/controller-manager/deployment.yaml#L35)
-  sets `--webhook-enabled=true` (Helm chart default).
+- [`config/manager/deployment.yaml:27`](config/manager/deployment.yaml#L27):
+  `--webhook-enabled=false`.
+- [`charts/kubeswift/values.yaml`](charts/kubeswift/values.yaml):
+  `webhook.enabled: false` (chart template branches on this).
 
-The cluster's `ValidatingWebhookConfiguration` resources persist
-across redeploys. When `make deploy` overwrites the deployment with
-webhook-disabled, the webhook service endpoint exists but its pod
-serves nothing — every CRD create attempt fails with
+Both deployment paths default to webhook-disabled deliberately —
+the comment at the top of
+[`config/default/kustomization.yaml`](config/default/kustomization.yaml)
+explicitly states "minimal: no webhook" for clusters without
+cert-manager. The webhook-enabled path is opt-in via
+[`config/overlays/webhook/`](config/overlays/webhook/) (kustomize) or
+`--set webhook.enabled=true` (Helm).
+
+**The actual problem is cluster-state drift, not a defaults
+mismatch.** `ValidatingWebhookConfiguration` and
+`MutatingWebhookConfiguration` are cluster-scoped resources owned
+by neither `config/default` nor `config/manager` alone. Once an
+operator opts in once (via the webhook overlay or Helm value),
+these resources persist across redeploys. A subsequent `make
+deploy` blindly applies `config/default`, reverting the
+controller-manager Deployment to webhook-disabled mode — but
+leaving the VWC/MWC resources pointing at the now-non-serving
+webhook endpoint. Every CRD create attempt then fails
 `connection refused` on port 9443.
 
-**Walkthrough workaround:** patched the deployment args live to
-`--webhook-enabled=true` and triggered a re-rollout.
+**Resolved in PR #63** (cleanup branch
+`cleanup/tfu-16-deploy-with-webhook` off main): added a
+`make deploy-with-webhook` target that wraps
+`kubectl apply -k config/overlays/webhook` (composes
+`config/default` + `config/webhook` + the deployment-patch flipping
+args to `--webhook-enabled=true` + cert volumeMount). Updated
+`make deploy` help text to make its minimal-install nature
+explicit. No code changes; no config changes.
 
-**Phase 3b PR 1 not affected** — PR 1 doesn't add new webhook
-admission rules; existing Phase 3a validating webhooks (image,
-guest, migration) and the offline-mode webhook are what stalled.
+**Operational guidance for operators going forward:**
 
-**Operationally relevant for PR 2:** PR 2 adds the SwiftMigration
-webhook eligibility check (live-mode-when-ineligible rejection
-per design doc §3.3). If `make deploy` continues to default to
-webhook-disabled, operators running PR 2 against the dev cluster
-will see explicit-live SwiftMigrations admit when they should
-reject (because the webhook is dead), and the controller's
-defense-in-depth Validating-phase eligibility check catches it —
-but the failure surface is more confusing (dst pod creation
-attempt + fail + cleanup vs admission rejection).
+- Cluster without webhook resources installed: `make deploy`
+  (minimal, no cert-manager dependency).
+- Cluster with webhook resources installed OR cluster where you
+  want webhook admission to fire: `make deploy-with-webhook`
+  (requires cert-manager installed cluster-side; the overlay's
+  Certificate + Issuer resources need the cert-manager CRDs).
+- Switching between the two: applying the opposite target
+  doesn't auto-clean the VWC/MWC resources from the prior
+  install. To switch from webhook-enabled back to minimal,
+  manually `kubectl delete -k config/webhook` first.
 
-**Disposition:** worth a small cleanup PR before PR 2 lands. Two
-options:
-1. Update `config/default` to include the webhook overlay by
-   default (matches Helm chart behavior).
-2. Update `make deploy` to either run the webhook overlay
-   explicitly OR document that operators must `make
-   deploy-with-webhooks` (separate target) for full functionality.
+**Operationally relevant for Phase 3b PR 2:** PR 2 adds the
+SwiftMigration webhook eligibility check (live-mode-when-
+ineligible rejection per design doc §3.3). Operators running PR 2
+against the dev cluster should use `make deploy-with-webhook` to
+get accurate admission-time rejection. The controller's
+defense-in-depth Validating-phase eligibility check still catches
+the case via a `Failed` transition, but admission-time rejection
+gives operators a clearer failure surface (single error message
+at SwiftMigration creation rather than dst pod creation attempt +
+fail + cleanup).
 
-Recommend option 1 — eliminate the surprise without adding a
-second target operators must remember. Filed for cleanup before
-PR 2's webhook eligibility check lands.
+**Cross-reference for PR 3 operator runbook work** (`docs/migration/phase-3b.md`):
+include a "Deploying KubeSwift" subsection that distinguishes
+the two targets and the cert-manager prerequisite for
+deploy-with-webhook.
+
+**Pattern note** (similar to LBA-1 / W26): "default to minimal,
+opt-in for the heavier surface" works when the opt-in target is
+discoverable. The TFU-16 walkthrough finding shows that opt-in
+discoverability via README/comment alone isn't enough — an
+explicit `make deploy-with-webhook` target makes the choice
+visible to operators who run `make help`. Future config splits
+(e.g., GPU node opt-in, multi-NIC opt-in) should expose Make
+targets analogously rather than relying on operators to know
+which overlay path to invoke.
 
 ---
 


### PR DESCRIPTION
## Summary

Cleanup of TFU-16 (Phase 3b PR 1 walkthrough deploy-time observation) before Phase 3b PR 2 begins. Two changes in one commit:

1. **`make deploy-with-webhook` target** added — layers `config/overlays/webhook` on top of `make deploy`'s minimal install. The overlay composes `config/default` + `config/webhook` and patches the controller-manager Deployment to `--webhook-enabled=true` with the cert-manager TLS Secret volumeMount.

2. **TFU-16 entry in `kubeswift_context.md` corrected** — the original walkthrough framing as a "chronic mismatch between `make deploy` and Helm chart webhook-enabled defaults" was wrong; both defaults agree (webhook-disabled). The actual problem is cluster-state drift between persistent VWC/MWC resources and the deployment overlay used at redeploy time. Entry rewritten to reflect the accurate diagnosis with operational guidance and a pattern note for future config splits.

## Recon

Full Phase 0 reconnaissance findings led to Shape B (Makefile fix, preserve config/default's deliberate "minimal: no webhook" semantics):

- `config/manager/deployment.yaml`: `--webhook-enabled=false`, **and no cert volumeMount** — the deployment as-is can't serve webhooks even with the flag flipped.
- `config/overlays/webhook/`: complete opt-in overlay that patches args + adds cert volumeMount. The composition is intentional design, not legacy drift.
- `charts/kubeswift/values.yaml`: `webhook.enabled: false` (chart template branches). **Helm default agrees with config/default** — disproved the original walkthrough framing.
- `cmd/controller-manager/main.go:55,106,192`: `--webhook-enabled` flag is load-bearing (gates webhook server creation AND all six webhook registrations). Not vestigial.
- Cluster-side `kubeswift-validating-webhook` / `kubeswift-mutating-webhook` are 20 days old — installed once via the overlay path or Helm override; they persist across redeploys, stranding when `make deploy` reverts the controller to webhook-disabled mode.

## Shape

**Shape B (chosen)**: Makefile-level cleanup. New `deploy-with-webhook` target invokes `kubectl apply -k config/overlays/webhook` after `make deploy`'s minimal install (depends on `deploy`, then layers the webhook patch + applies `config/webhook` resources).

Why not Shape A (flip defaults): would force cert-manager dependency on all operators; contradicts the deliberate "minimal: no webhook" framing of `config/default`. Per operator confirmation declined.

Why not Shape C (remove flag): flag is load-bearing in the controller binary; not viable.

## Operational guidance

- **Cluster without webhook resources installed:** `make deploy` (minimal, no cert-manager dependency).
- **Cluster with webhook resources installed OR cluster where you want webhook admission to fire:** `make deploy-with-webhook` (requires cert-manager).
- **Switching back to minimal:** apply the opposite target doesn't auto-clean VWC/MWC; manually `kubectl delete -k config/webhook` first.

Phase 3b PR 2 deployments should use `make deploy-with-webhook` so the new SwiftMigration eligibility check fires at admission time.

## Gates

- ✅ `make -n deploy-with-webhook` dry-run: clean (renders deploy + new overlay-apply commands)
- ✅ `kubectl kustomize config/overlays/webhook | grep webhook-enabled`: emits `--webhook-enabled=true`
- ✅ `make help`: both targets listed with clear distinction
- ✅ `go test ./...` unaffected (no code touched)
- ✅ `make build` unaffected (no code touched)

## Test plan

- [ ] Apply on dev cluster: `make deploy-with-webhook`
- [ ] Verify deployment args: `kubectl -n kubeswift-system get deploy controller-manager -o jsonpath='{.spec.template.spec.containers[0].args}'`
- [ ] Verify webhook serving: `kubectl -n kubeswift-system logs deploy/controller-manager | grep -i "Serving webhook"`
- [ ] Verify CRD admission (e.g., create a SwiftMigration): should be rejected/accepted by the actual webhook (not connection-refused)

After verification, merge. Phase 3b PR 2 reconnaissance begins next session on a clean foundation.

🤖 Generated with Claude Code