### PR TITLE
docs: PR 2 close-out — known-issues docs + tracked follow-ups

### DIFF
--- a/docs/design/known-issues-offline-after-live-pod-name-trap.md
+++ b/docs/design/known-issues-offline-after-live-pod-name-trap.md
@@ -1,0 +1,167 @@
+# Tracked Follow-Up: Offline Migration Hangs for a Previously Live-Migrated Guest (Canonical Pod-Name Mismatch)
+
+**Status**: OPEN — discovered during Phase 3b PR 2 walkthrough T8
+(2026-05-28). Not yet fixed. Captured for future work as a SEPARATE
+fix-forward (NOT bundled with PR 2 close-out).
+
+**Severity**: HIGH. Offline migration of any guest whose canonical
+launcher pod was renamed by a prior live migration hangs indefinitely
+in the Preparing phase. Not a data-loss bug — the source VM keeps
+running and the guest recovers cleanly when the SwiftMigration is
+deleted — but the migration never completes and the guest is left in
+an inconsistent state (`spec.runPolicy=Stopped` while the launcher pod
+is still Running).
+
+**NOT a Phase 3b PR 2 regression.** The offline Preparing code
+(`internal/controller/swiftmigration/preparing.go`) is Phase 1 code,
+untouched by PR 2. The bug only manifests when a Phase 3a *live*
+migration has previously renamed the guest's canonical pod. PR 2's
+walkthrough T8 surfaced it because T8 reused a guest that T7 had just
+live-migrated.
+
+**Severity rationale**: offline is a primary, supported migration mode
+(the only mode for VFIO/SR-IOV workloads, and the safe choice for
+maintenance). "Live-migrate for load-balancing, then later
+offline-migrate the same guest for maintenance" is a realistic
+operator sequence. Hitting it leaves the migration wedged forever
+(no `spec.timeout` default on the offline path observed here) and the
+guest with a Stopped runPolicy but a running pod — confusing to
+diagnose. Manual recovery is clean (delete the SwiftMigration), but an
+operator has to know to do that.
+
+## The bug
+
+The offline Preparing phase resolves the source launcher pod by
+`guest.Name`:
+
+```go
+// internal/controller/swiftmigration/preparing.go:133
+getErr := r.Get(ctx, client.ObjectKey{Name: guest.Name, Namespace: guest.Namespace}, &pod)
+```
+
+After a *live* migration, the guest's canonical pod is renamed to the
+`<guest>-mig-<short-uid>` form (the dst pod from the live cutover
+becomes the guest's running pod; `status.podRef.name` is updated to
+that name). On a subsequent *offline* migration:
+
+Failure chain:
+1. Guest was live-migrated earlier; its canonical pod is now e.g.
+   `t78-guest-mig-511016`, and `status.podRef.name` reflects that.
+2. Operator triggers an offline migration of the same guest.
+3. Offline Preparing patches `spec.runPolicy=Stopped` (this succeeds)
+   and then tries to delete the source pod via
+   `r.Get(Name: guest.Name)` → looks up `t78-guest` → **NotFound**
+   (the real pod is `t78-guest-mig-511016`).
+4. The NotFound branch is taken; the controller concludes the pod is
+   already gone and advances to the volume-detach wait.
+5. The real pod `t78-guest-mig-511016` is never stopped, keeps the
+   RWX+Block PVC attached, so `isPVCStillAttached` stays true forever.
+6. Preparing parks at `waiting for volume detach (PVC
+   "swiftguest-root-<guest>")` indefinitely. Guest left with
+   `runPolicy=Stopped` but pod Running.
+
+Note: the PVC name resolution at preparing.go:161
+(`RootDiskCloneName(guest.Name)` → `swiftguest-root-<guest>`) is
+*correct* — the PVC name is stable across migrations. The bug is
+solely the pod lookup at line 133.
+
+## Root cause — W26 canonical-pod-name lesson never applied to the offline path
+
+This is the **W26 lesson (LBA-2 / `srcPodLookupName` invariant)
+recurring in a code path that predates it.** Phase 3a's W26 fix
+(PR #53) established that, after a migration cutover,
+`status.podRef.name` points at the renamed pod, so src-pod resolution
+must use the canonical/locked-in name — NOT literal `guest.Name`. That
+fix was applied to the three *live*-mode src-pod lookup sites
+(`stopandcopy_live.go`, `cutover.go`, `preparing_live.go`) via
+`srcPodLookupName(mig, guest)` / `canonicalPodNameForGuest(guest)`.
+
+The *offline* Preparing path (`preparing.go`) is Phase 1 code and was
+never revisited — it still uses literal `guest.Name`. For a guest that
+has only ever been offline-migrated this is correct (offline reuses
+`guest.Name` as the recreated pod name — kubeswift_context "Approach A"
+note). It breaks only after a live migration introduces the
+`-mig-<uid>` canonical name.
+
+The pattern, restated: **a load-bearing invariant (canonical pod-name
+resolution) fixed in one code path but not its sibling. The two paths
+share the same underlying assumption; fixing one and not the other
+leaves a latent trap.** Same shape as the LBA-1/LBA-2/W26 family.
+
+## Fix shape (NOT yet implemented)
+
+Offline Preparing should resolve the source pod the same way the live
+path does — via the canonical name, not `guest.Name`:
+
+```go
+// preparing.go:133, replace:
+//   r.Get(ctx, client.ObjectKey{Name: guest.Name, ...}, &pod)
+// with:
+   r.Get(ctx, client.ObjectKey{Name: canonicalPodNameForGuest(&guest), ...}, &pod)
+```
+
+`canonicalPodNameForGuest(guest)` (in validating_live.go) returns
+`guest.Status.PodRef.Name` when set, falling back to `guest.Name` — so
+it is correct for both the fresh-guest offline case (returns
+`guest.Name`) and the post-live-migration case (returns the
+`-mig-<uid>` name). Likely small and localized (one call site; the PVC
+name resolution at line 161 is already correct and needs no change).
+
+**Audit the offline path for other `guest.Name`-based pod lookups**
+while fixing this — any other site in `preparing.go` /
+`stopandcopy.go` / `resuming.go` (offline) that resolves a pod by
+`guest.Name` has the same latent trap.
+
+**Consider an offline `spec.timeout` floor** as defense-in-depth: the
+hang was indefinite because no timeout bounded the volume-detach wait.
+Even with the pod-name fix, a backstop timeout would convert a future
+"waiting for detach" stall into a clean Failed rather than an
+indefinite hang.
+
+## Test that must accompany the fix
+
+Per the contract-level test discipline (TFU-2): a test exercising
+offline migration of a guest whose canonical pod was renamed by a
+prior live migration — i.e., a guest fixture with
+`status.podRef.name = "<guest>-mig-<uid>"` (≠ `guest.Name`) and a
+matching launcher pod, then assert offline Preparing finds and stops
+that pod (not a NotFound on `guest.Name`). The existing offline
+Preparing tests presumably use fresh guests whose pod name equals
+`guest.Name` — that's the gap that let this ship.
+
+## Reproduction (observed 2026-05-28, image sha-ed55768)
+
+1. Create a fresh guest `t78-guest` on miles (pod name `t78-guest`).
+2. Live-migrate it miles→boba (T7). Canonical pod becomes
+   `t78-guest-mig-511016`; `status.podRef.name` updated.
+3. Offline-migrate it boba→miles (T8, `mode=offline`).
+4. Observe: hangs at `phaseDetail=waiting for volume detach (PVC
+   "swiftguest-root-t78-guest")` for 240s+; `kubectl get pod t78-guest`
+   → NotFound; `t78-guest-mig-511016` still Running; guest
+   `runPolicy=Stopped` but pod up.
+5. Control: a fresh guest `t8b-guest` (pod name `t8b-guest`, never
+   live-migrated) offline-migrates cleanly — `Completed`,
+   `observedDowntime=40.77s` — confirming the bug is specific to the
+   post-live-migration canonical-pod-name mismatch, and that offline
+   itself is not regressed.
+
+## Manual recovery (for operators hitting this before the fix)
+
+Delete the hung SwiftMigration:
+`kubectl delete swiftmigration <name> -n <ns>`. The pre-cutover
+cleanup path restores `spec.runPolicy=Running` (verified: recovered in
+~3s, guest back to Running, unharmed). The guest stays on its current
+node (the offline migration never moved it).
+
+## Connection to tracked work
+
+- **W26 / PR #53 / LBA-2 (`srcPodLookupName`)** — this is the same
+  canonical-pod-name invariant; the fix should cite W26 and reuse
+  `canonicalPodNameForGuest`.
+- **TFU-2 (contract-level test discipline)** — the missing
+  offline-after-live test is another instance of the
+  isolated-tests-pass / cross-path-contract-drifts pattern.
+- **Phase 1 offline migration (Approach A)** — the `guest.Name`
+  assumption originates here; it was correct in a world with no live
+  migration (no pod renaming) and became a latent trap once Phase 3a
+  introduced canonical pod renaming.

--- a/docs/design/known-issues-vswiftimage-finalizer-trap.md
+++ b/docs/design/known-issues-vswiftimage-finalizer-trap.md
@@ -1,0 +1,139 @@
+# Tracked Follow-Up: vswiftimage Webhook Traps SwiftImage Deletion (Finalizer Removal Blocked)
+
+**Status**: OPEN — discovered during PR 2 walkthrough namespace cleanup
+(2026-05-28). Not yet fixed. Captured for future work.
+
+**Severity**: MEDIUM-HIGH. Not a data-loss bug, but it permanently
+traps namespace deletion and generates a continuous controller
+reconcile-error storm. Any SwiftImage that reaches
+`status.phase=Ready`, acquires a finalizer, and is then deleted will
+trap its namespace in Terminating forever until manually unstuck.
+
+**Severity rationale**: it does not corrupt or lose live data, but it
+is operationally severe — a stuck-terminating namespace blocks
+namespace reuse, the error storm pollutes controller logs (masking
+real errors), and the manual recovery requires temporarily removing a
+webhook from the cluster (a privileged, scary operation for an
+operator to perform under pressure). Left unfixed, every snapshot/pool
+walkthrough that creates a clone-seed-protected SwiftImage and tears
+down its namespace will hit this.
+
+## The bug
+
+The `vswiftimage` validating webhook enforces a spec-immutability rule
+("SwiftImage spec is immutable") when `status.phase=Ready`. It fires
+this rule on **all** UPDATE operations — including finalizer removal
+on an object that already has `metadata.deletionTimestamp` set.
+
+Failure chain:
+1. A SwiftImage reaches `status.phase=Ready` and carries the
+   `kubeswift.io/clone-seed-protected` finalizer (added for clone-seed
+   protection in snapshot Phase 1 cloneStrategy work).
+2. The SwiftImage is deleted (`deletionTimestamp` set), e.g. by
+   namespace deletion.
+3. The controller attempts to remove the finalizer — a metadata-only
+   UPDATE — so GC can proceed.
+4. The `vswiftimage` webhook rejects the UPDATE because
+   `status.phase=Ready` and it treats ANY update as a spec-mutation
+   attempt. The finalizer-removal patch is denied.
+5. Finalizer never clears → object never GC's → namespace stuck
+   Terminating forever → continuous reconcile-error storm in
+   controller logs.
+
+## Root cause — same family as PR #26
+
+This is the **PR #26 per-operation-discipline lesson recurring in a
+webhook that predates that discipline.** Design Principle #10 ("treat
+terminal states as terminal; validation logic must enumerate which
+operations it fires on; default-to-everything is the bug pattern") was
+written for exactly this. The SwiftMigration webhook was refactored to
+per-operation discipline (ValidateCreate full / ValidateUpdate
+shape-only / ValidateDelete pass-through) in PR #26. The `vswiftimage`
+webhook never got the same treatment — its spec-immutability rule
+fires on every UPDATE regardless of whether the update is a legitimate
+spec mutation or a being-deleted object shedding finalizers.
+
+The pattern, restated: **validation that fires on every operation
+needs to consider whether each operation is one where validation adds
+value vs. blocks legitimate work.** Finalizer removal on a
+being-deleted object is never a spec mutation; blocking it adds no
+protection and traps deletion.
+
+## Fix shape (NOT yet implemented)
+
+Two acceptable approaches:
+
+1. **Skip validation when being deleted** (simplest):
+   In the `vswiftimage` ValidateUpdate handler, return early (allow)
+   when `newObj.metadata.deletionTimestamp != nil`. A being-deleted
+   object's spec changes are moot, and finalizer removal must be
+   permitted for GC.
+
+2. **Compare only spec fields, allow metadata/finalizer changes**:
+   The immutability rule should compare `old.Spec` vs `new.Spec` and
+   reject only genuine spec mutations, allowing metadata-only changes
+   (finalizers, labels, annotations) through regardless of phase.
+
+Approach 1 is the minimal fix and directly mirrors the PR #26
+ValidateDelete pass-through intent. Approach 2 is more thorough (also
+allows label/annotation edits on a Ready image, which may or may not
+be desirable). Recommend Approach 1 unless there's a reason to allow
+metadata edits on Ready images generally.
+
+**Audit the OTHER webhooks for the same bug class while fixing this.**
+Any validating webhook with a phase-gated immutability rule that fires
+on UPDATE is a candidate. Known per-operation-disciplined: swiftmigration
+(PR #26). Suspect (predates discipline): vswiftimage (this bug), and
+potentially others — swiftsnapshot, swiftrestore, swiftguest,
+swiftguestpool webhooks should each be checked for "fires on all
+UPDATE including finalizer removal on being-deleted objects."
+
+## Test that must accompany the fix
+
+Per the contract-level test discipline (TFU-2): a test that creates a
+Ready SwiftImage with a finalizer, sets deletionTimestamp, attempts
+finalizer removal, and asserts the webhook ALLOWS it. The existing
+webhook tests presumably assert spec-immutability holds on Ready
+images (the rule that's correct); they're missing the "but finalizer
+removal on a being-deleted Ready image is allowed" case — the gap that
+let this ship.
+
+## Manual recovery procedure (for operators hitting this before the fix)
+
+This was performed 2026-05-28 to clear snapshots-wt-s2 and
+snapshots-wt-s3. All steps reversible, all verified:
+
+1. Back up the validating webhook config:
+   `kubectl get validatingwebhookconfiguration kubeswift-validating-webhook -o yaml > /tmp/vwc-backup.yaml`
+2. Temporarily remove ONLY the `vswiftimage` webhook entry from the
+   ValidatingWebhookConfiguration (it was index 1; verify before
+   editing).
+3. Strip the stuck finalizer from the trapped SwiftImage(s):
+   `kubectl patch swiftimage <name> -n <ns> --type=json -p '[{"op":"remove","path":"/metadata/finalizers/0"}]'`
+   (verify the finalizer index; clone-seed-protected was the one)
+4. Objects GC; namespaces complete deletion.
+5. Restore the `vswiftimage` webhook from backup (re-add the entry in
+   original order with original kubeswift-webhook-service config).
+   Verify serving (denial count returns, error storm stops).
+
+**Risk during recovery**: the webhook-down window allows spec
+mutations on Ready SwiftImages cluster-wide. Keep the window short.
+Note: during the 2026-05-28 recovery, two OTHER SwiftImages already
+stuck deletion-pending on the identical bug (default/ubuntu-noble-pool,
+default/ubuntu-noble-snap, plus orphaned ubuntu-noble-pool-clone-seed
+VolumeSnapshot) also cleared — benign, they were already
+deletion-marked and trapped by the same issue.
+
+## Connection to tracked work
+
+- **PR #26 per-operation-discipline** — this is the same lesson; the
+  fix should explicitly cite Design Principle #10.
+- **TFU-2 (contract-level test discipline)** — the missing
+  finalizer-removal-on-Ready test is another instance of the
+  isolated-tests-pass-contract-drifts pattern. Sixth data point if
+  counted alongside snapshot Tier A, W27 metrics, Finding 1, Finding 2,
+  fail:224.
+- **Snapshot Phase 1 cloneStrategy** — the clone-seed-protected
+  finalizer comes from this work; the webhook interaction was never
+  exercised in the snapshot walkthrough because no clone-seed-protected
+  image was deleted during it.

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -603,6 +603,8 @@ networking, 4Gi guests):
 - Kernel-boot: observedDowntime=1.75s, observedPauseWindow=38.17s
 - Disk-boot RWX+Block: observedDowntime=1.96s, observedPauseWindow=38.19s
 
+### 8. docs/design/known-issues-vswiftimage-finalizer-trap.md
+
 ### W28 candidate (split from W27): capture actual vCPU stop-the-world
 
 Currently `observedPauseWindow` measures the entire send-migration

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -603,8 +603,6 @@ networking, 4Gi guests):
 - Kernel-boot: observedDowntime=1.75s, observedPauseWindow=38.17s
 - Disk-boot RWX+Block: observedDowntime=1.96s, observedPauseWindow=38.19s
 
-### 8. docs/design/known-issues-vswiftimage-finalizer-trap.md
-
 ### W28 candidate (split from W27): capture actual vCPU stop-the-world
 
 Currently `observedPauseWindow` measures the entire send-migration
@@ -928,6 +926,38 @@ approach unblocks source-side cancel responsiveness.
 **Disposition:** documentation in PR 2; architectural fix deferred
 to Phase 3c+ when a worker-thread refactor on src is in scope.
 
+**Empirical duration measured (Phase 3b PR 2 walkthrough T3a + T6,
+2026-05-28, image sha-ed55768):** when the dst pod *disappears*
+mid-send (force-deleted or CH killed), the src `vm.send-migration`
+RPC stays blocked for the full `timeout_seconds` budget before
+returning. Measured directly from src swiftletd logs:
+`t3-killdst:send:1` dispatched 16:21:55, `w23_terminal_write_signal`
+fired 16:31:58 — **~10 minutes** (the default `timeout_seconds=600`).
+During the entire window the src action loop AND the CH HTTP API are
+blocked (a `vm.info` curl against the src CH API socket hung) — it is
+not just the one RPC that's wedged but the whole single-threaded
+surface. The controller correctly drives the migration to its
+terminal state (Failed/Cancelled) via its own informer-based
+observation, independent of the wedged src, and the **source VM keeps
+running** (live-migration pre-copy does not pause the source), so
+there is no data loss — but the src pod's `migration-status`
+annotation stays stale at `sending` and the guest cannot accept a new
+migration action for up to 10 minutes. T6 reproduced the same wedge
+via cancel-mid-send (cancel is a no-op on src until the RPC times
+out; the controller force-deletes the dst as the fallback per the
+30s dst-ack budget, marks the migration Cancelled, but the src RPC
+remains blocked until its own 600s timeout).
+
+This bounds the cost of the wedge for whoever works TFU-14: the
+fix should either (a) shorten the dst-disappearance detection →
+shorter effective timeout, (b) interrupt the in-flight
+`send_migration` on observed dst-pod-disappearance, or (c) the
+worker-thread refactor above (so the action loop can tick and
+process cancel / report failed without waiting for the RPC). Option
+(b) directly addresses the 10-minute wedge; the worker-thread
+refactor (c) addresses cancel responsiveness but the RPC itself
+would still block its own thread until timeout.
+
 ### 15. Destination cancel-post-receive-complete race (Phase 3b PR 1 walkthrough LOW-3 / T5 finding)
 
 Phase 3b PR 1 walkthrough's T5 surfaced that the destination swiftletd
@@ -1044,6 +1074,106 @@ visible to operators who run `make help`. Future config splits
 (e.g., GPU node opt-in, multi-NIC opt-in) should expose Make
 targets analogously rather than relying on operators to know
 which overlay path to invoke.
+
+### 17. vswiftimage webhook traps SwiftImage deletion (finalizer removal blocked)
+
+The vswiftimage validating webhook's spec-immutability rule fires
+on ALL UPDATE operations including finalizer removal on
+being-deleted objects (deletionTimestamp != nil). Traps namespace
+deletion indefinitely; generates continuous controller
+reconcile-error storm. Same PR #26 lesson (per-operation
+validation discipline) recurring in a webhook predating that
+discipline. Cite Design Principle #10.
+
+Severity: MEDIUM-HIGH. Not data-loss, but operationally severe
+(stuck-terminating namespaces, log pollution, manual recovery
+requires temporarily removing webhook from cluster).
+
+Fix shape known: skip validation when newObj.metadata.deletionTimestamp
+!= nil, OR compare only spec fields. Audit obligation: check
+sibling webhooks (swiftsnapshot, swiftrestore, swiftguest,
+swiftguestpool) for same pattern.
+
+See [`docs/design/known-issues-vswiftimage-finalizer-trap.md`](docs/design/known-issues-vswiftimage-finalizer-trap.md)
+for full diagnosis, manual recovery procedure (performed 2026-05-28),
+and test obligation per Tracked Follow-up #2.
+
+### 18. Offline migration hangs for previously-live-migrated guest (canonical pod name trap)
+
+preparing.go:133 (offline path) resolves source pod by guest.Name
+not canonical status.podRef.name. After a prior live migration
+renamed the pod to <guest>-mig-<uid>, the Get returns NotFound;
+controller assumes pod is gone; waits indefinitely for a volume
+detach that never happens because the real (renamed) pod still
+holds the PVC. Guest left inconsistent (runPolicy=Stopped, pod
+still Running).
+
+Root cause: W26 canonical-pod-name lesson (the srcPodLookupName /
+LBA-2 invariant) applied to the live path but never to the Phase 1
+offline path. Offline preparing.go predates W26.
+
+Severity: HIGH (indefinite hang, inconsistent state) but clean
+manual recovery (delete the SwiftMigration). NOT a PR 2 regression
+— offline preparing.go is Phase 1 code, untouched by PR 2.
+
+Trigger sequence (realistic): live-migrate for load-balancing,
+later offline-migrate same guest for maintenance.
+
+Fix shape: offline Preparing uses canonicalPodNameForGuest(&guest)
+instead of literal guest.Name. One call site; PVC name at :161
+already correct. Audit other offline guest.Name pod lookups.
+
+See [`docs/design/known-issues-offline-after-live-pod-name-trap.md`](docs/design/known-issues-offline-after-live-pod-name-trap.md)
+for full diagnosis, 2026-05-28 reproduction (PR 2 T8 walkthrough),
+and test obligation per Tracked Follow-up #2.
+
+### 19. FailureReasonDstScheduleFailed enum constant unused
+
+FailureReasonDstScheduleFailed enum constant ships in PR 2 (PR #64)
+but is not wired to any detection site. The condition it describes
+("dst pod could not be placed onto target node, scheduler rejected")
+currently collapses into preparing_live.go:206-208's 60s budget
+timeout, which since PR 2 stamps FailureReasonDstNeverReady.
+
+Wiring requires distinguishing pod.Status.Conditions[PodScheduled].
+Status == False from "scheduled but never Ready" — a detection-logic
+change of ~10-15 LOC plus a test. Out of scope for PR 2 (one-line
+stamping wirings only); future PR that refines preparing_live's
+failure taxonomy.
+
+Severity: LOW. Until wired, scheduling failures report as
+DstNeverReady — mildly imprecise but better than the pre-PR-2
+PodTerminated catch-all.
+
+### 20. canonicalPodNameForGuest stale import-cycle comment
+
+A comment in validating_live.go (around lines 181-185, near the
+canonicalPodNameForGuest call site) claims a swiftmigration →
+swiftguest import cycle exists. No such cycle exists; preparing.go,
+validating.go, and validating_live.go all import swiftguest without
+issue. The comment is stale and corrosive — future contributors
+reading it may believe the constraint exists and either work
+around it or replicate it.
+
+Fix: remove the comment. Cosmetic; future-contributor-confusion
+risk only.
+
+Severity: LOW.
+
+### 21. FailureReason constants are untyped strings (typed-enum hygiene candidate)
+
+Phase 3a established FailureReason* as untyped string constants
+(matched by PR 2 in Commit A for consistency rather than mixing
+patterns). A typed FailureReasonCode enum would be cleaner:
+typos compile-fail rather than reach the cluster; invalid values
+are caught at compile time.
+
+Refactor requires migrating all Phase 3a + PR 2 references
+across the swiftmigration package with careful cluster-state
+migration consideration. Out of scope for any specific feature
+PR; future standalone hygiene PR.
+
+Severity: LOW (cosmetic + minor type safety; no functional impact).
 
 ---
 


### PR DESCRIPTION
## Summary

PR 2 close-out documentation. Two known-issues docs (vswiftimage webhook
finalizer-trap, offline-after-live pod-name-trap) plus targeted
`kubeswift_context.md` additions.

Pure docs PR — **no code changes**. Closes the documentation surface for
#64 (PR 2) and #65 (fix-forward).

## Contents

- **`docs/design/known-issues-vswiftimage-finalizer-trap.md`** — webhook
  spec-immutability rule fires on finalizer-removal UPDATEs, trapping
  namespace deletion. (Doc landed in the folded-in commit 703e5a5.)
- **`docs/design/known-issues-offline-after-live-pod-name-trap.md`** —
  offline migration of a previously-live-migrated guest hangs because
  `preparing.go:133` resolves the source pod by `guest.Name` instead of
  the canonical `status.podRef.name`. **HIGH severity, NOT a PR 2
  regression** (offline `preparing.go` is Phase 1 code).
- **`kubeswift_context.md`**:
  - TFU-14 empirical-duration append (~10min `vm.send-migration` wedge
    when dst disappears mid-send; PR 2 T6 walkthrough, 2026-05-28).
  - TFU #17 → vswiftimage finalizer-trap pointer.
  - TFU #18 → offline-after-live pod-name-trap pointer.
  - TFU #19/#20/#21 → three LOW close-out hygiene items
    (`FailureReasonDstScheduleFailed` unused; stale import-cycle comment;
    untyped `FailureReason` string constants).
  - Removed a redundant, misnumbered `### 8` vswiftimage stub heading.

Both new findings were discovered during the PR 2 walkthrough but scoped
as separate fix-forwards (orthogonal to PR 2's scope). Each writeup
includes severity, root cause, fix shape, trigger sequence, test
obligation (TFU-2), and manual recovery procedure.

## Test plan

- [ ] Visual review of the two new markdown docs
- [ ] Verify `kubeswift_context.md` TFU numbering is contiguous 1–21 (no
      duplicate `### 8`)
- [ ] Confirm no code/build/test changes (docs-only diff)

Related: #64, #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)