### PR TITLE
fix(tfu-17): vswiftimage allows finalizer removal on being-deleted images

### DIFF
--- a/docs/design/known-issues-vswiftimage-finalizer-trap.md
+++ b/docs/design/known-issues-vswiftimage-finalizer-trap.md
@@ -1,7 +1,47 @@
 # Tracked Follow-Up: vswiftimage Webhook Traps SwiftImage Deletion (Finalizer Removal Blocked)
 
-**Status**: OPEN — discovered during PR 2 walkthrough namespace cleanup
-(2026-05-28). Not yet fixed. Captured for future work.
+**Status**: RESOLVED 2026-05-29 via branch `fix/tfu-17-vswiftimage-finalizer-trap`
+(Approach 1; see Resolution below). Discovered during PR 2 walkthrough
+namespace cleanup (2026-05-28).
+
+## Resolution (2026-05-29)
+
+Fixed via **Approach 1**: `vswiftimage` `ValidateUpdate` now returns
+early (allow) when `newObj.GetDeletionTimestamp() != nil`. A being-
+deleted object shedding finalizers is never performing a spec mutation,
+so the immutability rule must not gate it. Mirrors PR #26's
+`ValidateDelete` pass-through intent (Design Principle #10). Regression
+tests added (contract test + over-allow guard) — see "Test that must
+accompany the fix" below, now satisfied.
+
+**Mechanism correction:** the diagnosis below ("it treats ANY update as
+a spec-mutation attempt") describes the *symptom*, not the mechanism.
+The rule *does* compare old vs. new spec fields — but
+`oldImg.Spec.Source != img.Spec.Source` is a **pointer-identity**
+comparison over `ImageSource`'s pointer fields (`HTTP`/`Upload`/
+`PVCClone`). The old (etcd) and new (admission request) objects are
+independent decodes, so their Source pointers always differ and the
+rule fires unconditionally on every Ready-image update. The `Format`
+half (a string) compares by content and is correct. This matters for
+the fix: Approach 1 carves out being-deleted objects regardless of the
+comparison; a literal reading of Approach 2 ("compare only spec fields")
+is *already* what the buggy code does — a correct Approach 2 needs
+**content/deep equality**, not just field comparison.
+
+**Sibling-webhook audit (obligation discharged):** of the six validating
+webhooks (swiftguest, swiftimage, swiftseedprofile, swiftsnapshot,
+swiftrestore, swiftmigration), **only vswiftimage was vulnerable**. The
+others are immune because their immutability checks use content/deep
+comparison (`specsEqual` / `identityEqual` / value-struct `!=`) or have
+no immutability rule at all — *not* because they check `deletionTimestamp`
+(none do). Cross-referenced with finalizer-adding sites: vulnerable
+webhook ∩ finalizer-bearing resource = SwiftImage only. (swiftguestpool
+has no webhook.)
+
+**Residual deferred:** Approach 1 does not fix the pointer-comparison
+defect for *non-deletion* metadata edits (e.g. relabeling a Ready image
+still trips the false rejection). Filed as Tracked Follow-up #23 in
+`kubeswift_context.md` (LOW severity).
 
 **Severity**: MEDIUM-HIGH. Not a data-loss bug, but it permanently
 traps namespace deletion and generates a continuous controller
@@ -59,9 +99,9 @@ value vs. blocks legitimate work.** Finalizer removal on a
 being-deleted object is never a spec mutation; blocking it adds no
 protection and traps deletion.
 
-## Fix shape (NOT yet implemented)
+## Fix shape (Approach 1 IMPLEMENTED 2026-05-29)
 
-Two acceptable approaches:
+Two acceptable approaches were available; Approach 1 shipped:
 
 1. **Skip validation when being deleted** (simplest):
    In the `vswiftimage` ValidateUpdate handler, return early (allow)
@@ -88,15 +128,26 @@ potentially others — swiftsnapshot, swiftrestore, swiftguest,
 swiftguestpool webhooks should each be checked for "fires on all
 UPDATE including finalizer removal on being-deleted objects."
 
-## Test that must accompany the fix
+## Test that must accompany the fix (DONE 2026-05-29)
 
 Per the contract-level test discipline (TFU-2): a test that creates a
 Ready SwiftImage with a finalizer, sets deletionTimestamp, attempts
 finalizer removal, and asserts the webhook ALLOWS it. The existing
-webhook tests presumably assert spec-immutability holds on Ready
-images (the rule that's correct); they're missing the "but finalizer
-removal on a being-deleted Ready image is allowed" case — the gap that
-let this ship.
+webhook tests asserted spec-immutability for the *cloneStrategy* rule
+but never set `phase=Ready` on an update — so the Source-immutability
+path (the buggy one) was entirely uncovered. That gap let this ship.
+
+Shipped in `validator_test.go`:
+
+- `TestValidateUpdate_FinalizerRemovalOnDeletingReadyImage_Allowed` —
+  the contract test. Verified load-bearing: it fails against
+  guard-stripped code with the exact "spec is immutable" rejection and
+  passes with the guard. `old`/`new` are built via separate `makeImage`
+  calls so their `Spec.Source` pointers differ as in real admission.
+- `TestValidateUpdate_SpecMutationOnReadyImage_StillRejected` —
+  over-allow guard: a genuine spec change on a Ready image that is NOT
+  being deleted is still rejected (passes with or without the carve-out,
+  confirming it exercises the immutability rule itself, not the guard).
 
 ## Manual recovery procedure (for operators hitting this before the fix)
 

--- a/internal/webhook/swiftimage/validator.go
+++ b/internal/webhook/swiftimage/validator.go
@@ -30,6 +30,24 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	if !ok {
 		return nil, fmt.Errorf("expected SwiftImage, got %T", oldObj)
 	}
+	// Per-operation discipline (Design Principle #10; same lesson as PR #26).
+	// A being-deleted object is shedding finalizers so GC can proceed;
+	// finalizer removal is a metadata-only UPDATE that is never a spec
+	// mutation. The spec-immutability rule must not block it, or the
+	// CloneSeedFinalizer can never be removed and the namespace stays
+	// Terminating forever (TFU-17).
+	//
+	// Note on why the rule fired here at all: validateSwiftImageUpdate
+	// compares Spec.Source with `!=`, which is a pointer-identity
+	// comparison over ImageSource's pointer fields (HTTP/Upload/PVCClone).
+	// The old (etcd) and new (admission request) objects are independent
+	// decodes, so their Source pointers always differ — the immutability
+	// rule fires on EVERY update of a Ready image, including finalizer
+	// removal. This guard is the carve-out; it does not depend on the
+	// comparison being fixed.
+	if img.GetDeletionTimestamp() != nil {
+		return nil, nil
+	}
 	return nil, validateSwiftImageUpdate(oldImg, img)
 }
 

--- a/internal/webhook/swiftimage/validator_test.go
+++ b/internal/webhook/swiftimage/validator_test.go
@@ -92,3 +92,53 @@ func TestValidateUpdate_CloneStrategyMutableInPending(t *testing.T) {
 		t.Errorf("changing strategy in Pending should be allowed: %v", err)
 	}
 }
+
+// TestValidateUpdate_FinalizerRemovalOnDeletingReadyImage_Allowed is the
+// TFU-17 contract test. A Ready, snapshot-strategy SwiftImage that carries
+// CloneSeedFinalizer and is being deleted (deletionTimestamp set) must be
+// allowed to shed its finalizer via UPDATE — otherwise GC can never reap it
+// and the namespace stays Terminating forever.
+//
+// old and new are built via separate makeImage calls, so their Spec.Source
+// pointers differ exactly as in a real admission request (etcd decode vs.
+// request decode). Before the deletionTimestamp carve-out this UPDATE was
+// rejected by the spec-immutability rule's pointer-identity comparison.
+func TestValidateUpdate_FinalizerRemovalOnDeletingReadyImage_Allowed(t *testing.T) {
+	now := metav1.Now()
+
+	old := makeImage("img", imagev1alpha1.CloneStrategySnapshot, "csi-class")
+	old.Status.Phase = imagev1alpha1.SwiftImagePhaseReady
+	old.DeletionTimestamp = &now
+	old.Finalizers = []string{"kubeswift.io/clone-seed-protected"}
+
+	// new is the post-removal object: same Ready spec, still being deleted,
+	// finalizer dropped.
+	new := makeImage("img", imagev1alpha1.CloneStrategySnapshot, "csi-class")
+	new.Status.Phase = imagev1alpha1.SwiftImagePhaseReady
+	new.DeletionTimestamp = &now
+	new.Finalizers = nil
+
+	v := &Validator{}
+	if _, err := v.ValidateUpdate(context.Background(), old, new); err != nil {
+		t.Errorf("finalizer removal on a being-deleted Ready image must be allowed: %v", err)
+	}
+}
+
+// TestValidateUpdate_SpecMutationOnReadyImage_StillRejected guards against
+// over-allowing: the deletionTimestamp carve-out must NOT weaken the
+// immutability rule for objects that are NOT being deleted. A genuine spec
+// change on a Ready image (not being deleted) must still be rejected.
+func TestValidateUpdate_SpecMutationOnReadyImage_StillRejected(t *testing.T) {
+	old := makeImage("img", imagev1alpha1.CloneStrategyCopy, "")
+	old.Status.Phase = imagev1alpha1.SwiftImagePhaseReady
+
+	new := makeImage("img", imagev1alpha1.CloneStrategyCopy, "")
+	new.Status.Phase = imagev1alpha1.SwiftImagePhaseReady
+	new.Spec.Source.HTTP.URL = "https://example.com/different.qcow2"
+
+	v := &Validator{}
+	_, err := v.ValidateUpdate(context.Background(), old, new)
+	if err == nil || !strings.Contains(err.Error(), "immutable") {
+		t.Errorf("spec mutation on a Ready image (not being deleted) must still be rejected, got: %v", err)
+	}
+}

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -1075,28 +1075,46 @@ visible to operators who run `make help`. Future config splits
 targets analogously rather than relying on operators to know
 which overlay path to invoke.
 
-### 17. vswiftimage webhook traps SwiftImage deletion (finalizer removal blocked)
+### 17. vswiftimage webhook traps SwiftImage deletion (finalizer removal blocked) — RESOLVED via branch fix/tfu-17
 
-The vswiftimage validating webhook's spec-immutability rule fires
-on ALL UPDATE operations including finalizer removal on
-being-deleted objects (deletionTimestamp != nil). Traps namespace
-deletion indefinitely; generates continuous controller
-reconcile-error storm. Same PR #26 lesson (per-operation
-validation discipline) recurring in a webhook predating that
-discipline. Cite Design Principle #10.
+**RESOLVED 2026-05-29** (branch `fix/tfu-17-vswiftimage-finalizer-trap`;
+Bug #67). The vswiftimage validating webhook's spec-immutability rule
+fired on every UPDATE of a Ready SwiftImage — including the controller's
+finalizer-removal patch during deletion. With CloneSeedFinalizer present
+(cloneStrategy=snapshot), the finalizer never cleared and the namespace
+stayed Terminating forever with a continuous reconcile-error storm. Same
+PR #26 lesson (per-operation validation discipline) recurring in a
+webhook predating it; Design Principle #10.
 
-Severity: MEDIUM-HIGH. Not data-loss, but operationally severe
-(stuck-terminating namespaces, log pollution, manual recovery
-requires temporarily removing webhook from cluster).
+**Mechanism correction (recon finding):** the rule did NOT "treat any
+update as a mutation." It compared `oldImg.Spec.Source != img.Spec.Source`,
+a POINTER-identity comparison over ImageSource's pointer fields
+(HTTP/Upload/PVCClone). Old (etcd) and new (admission request) objects
+are independent decodes, so their Source pointers always differ → the
+rule fired unconditionally on every Ready-image update. The `Format`
+half (a string) compared correctly; only the Source pointer comparison
+was the trap.
 
-Fix shape known: skip validation when newObj.metadata.deletionTimestamp
-!= nil, OR compare only spec fields. Audit obligation: check
-sibling webhooks (swiftsnapshot, swiftrestore, swiftguest,
-swiftguestpool) for same pattern.
+**Fix (Approach 1):** ValidateUpdate returns early (allow) when
+`newObj.GetDeletionTimestamp() != nil`. Minimal; mirrors PR #26's
+ValidateDelete pass-through intent; does not depend on the comparison
+being fixed. Regression tests added (contract test verified load-bearing
+against guard-stripped code + over-allow guard), satisfying the TFU-2
+test obligation.
+
+**Sibling-webhook audit (obligation discharged):** of the six validating
+webhooks (swiftguest, swiftimage, swiftseedprofile, swiftsnapshot,
+swiftrestore, swiftmigration), ONLY vswiftimage was vulnerable. The
+others are immune because their immutability checks use content/deep
+comparison (specsEqual / identityEqual / value-struct !=) or have no
+immutability rule at all — NOT because they check deletionTimestamp
+(none do). Cross-referenced with finalizer-adding sites: vulnerable
+webhook ∩ finalizer-bearing resource = SwiftImage only. (swiftguestpool
+has no webhook.) Residual lower-severity defect filed as TFU #23.
 
 See [`docs/design/known-issues-vswiftimage-finalizer-trap.md`](docs/design/known-issues-vswiftimage-finalizer-trap.md)
-for full diagnosis, manual recovery procedure (performed 2026-05-28),
-and test obligation per Tracked Follow-up #2.
+(now marked RESOLVED) for full diagnosis, the manual recovery procedure
+(performed 2026-05-28), and the discharged audit + test obligations.
 
 ### 18. Offline migration hangs for previously-live-migrated guest (canonical pod name trap)
 
@@ -1200,6 +1218,31 @@ doc; [`docs/design/live-migration-phase-3b.md`](docs/design/live-migration-phase
 §2.2 now describes the no-default reality.
 
 Surfaced 2026-05-28 by PR B Gate A1 verification.
+
+### 23. vswiftimage pointer-comparison falsely rejects non-deletion metadata edits on Ready images
+
+TFU #17's Approach 1 fix (deletionTimestamp carve-out) resolves the
+namespace-deletion trap but does NOT fix the underlying
+pointer-comparison defect at
+[`internal/webhook/swiftimage/validator.go:103`](internal/webhook/swiftimage/validator.go)
+(`oldImg.Spec.Source != img.Spec.Source`, a pointer-identity comparison
+over ImageSource's pointer fields HTTP/Upload/PVCClone). For a Ready
+SwiftImage that is NOT being deleted, any metadata-only UPDATE
+(adding/changing a label or annotation) still trips the "spec is
+immutable" rejection even though the spec content is unchanged — because
+the old (etcd) and new (request) Source pointers differ.
+
+Severity: LOW. Confusing edit failure, not a trap (operators rarely
+relabel Ready images; the carve-out handles the operationally severe
+deletion path). No data-loss or availability impact.
+
+Fix shape: switch the immutability comparison to content/deep equality —
+`apiequality.Semantic.DeepEqual(oldImg.Spec, img.Spec)` (or compare the
+Source sub-pointers by dereferenced content, mirroring swiftsnapshot's
+and swiftmigration's `specsEqual`). ~3 LOC + a test asserting a label
+edit on a Ready image is allowed while a genuine spec change is still
+rejected. Deferred from branch fix/tfu-17 to keep that change scoped to
+the HIGH-severity trap (TFU #17). Surfaced 2026-05-29 by the PR C recon.
 
 ---
 
@@ -1747,6 +1790,7 @@ in test infrastructure).
 | 64 | swiftmigration controller (validating_live + stopandcopy_live + cutover + preparing_live) | Phase 3a back-to-back live migrations false-fired SourcePodReplaced (and carried a latent guest-destruction vector at cutoverStep2). Three live-mode src-pod lookup sites derived src pod from cluster state; both literal-guest.Name (W15 fix) and canonicalPodName broke for chain migrations. Fix: stamp status.SourcePodRef.Name at Validating-live (mirrors existing SourcePodUID lock-in); use srcPodLookupName helper at all sites. Race-immune AND chain-safe. Workload-class-independent — same code runs for kernel-boot and disk-boot. (W26 in E12 disk-boot validation 2026-05-04.) | PR #53 |
 | 65 | swiftmigration controller (resuming_live + cutover + stopandcopy_live) | Phase 3a downtime metrics broken/half-wired. (W27a) status.observedDowntime measured two adjacent metav1.Now() calls in the same reconcile invocation, producing 34-114µs across all 17 walkthrough runs vs a real cutover window of ~38-48s. Fix: new status.cutoverStep2DispatchedAt timestamp stamped at cutoverStep2 Delete dispatch; observedDowntime computed against it at Resuming completion. (W27b) status.observedPauseWindow plumbing half-implemented — swiftletd wrote kubeswift.io/migration-pause-window-ms annotation correctly but controller had zero readers. Fix: stampObservedPauseWindow helper reads annotation at substateSrcCompleted (W1 gate observation), mirrors snapshot controller's pattern. Both fields now carry their documented semantics. Defensive nil/parse handling on both. (W27 follow-up to E12 walkthrough.) | PR #55 |
 | 66 | swiftctl (internal/cli/guest.go GuestResolver.ResolvePod) | swiftctl pod resolution had two foot-guns surfacing during Phase 3a live migration cutover and chain migration. **Foot-gun 1**: when status.podRef was set but the named pod returned NotFound (cutover transient: podRef just patched to dst-suffix but dst pod not yet created, OR src deleted before podRef patched), ResolvePod errored out instead of falling through to the label-selector path. **Foot-gun 2**: when the label selector returned multiple labeled pods (chain-migration transient: M1 src still Terminating + M2 dst Running, both labeled `swift.kubeswift.io/guest=<name>`), `list.Items[0]` was non-deterministic — apiserver might return Terminating-first. Fix: NotFound on PodRef.Get falls through to the label-selector path; multi-pod selector results stable-sorted by (non-Terminating > Running > newest CreationTimestamp); all-Terminating fallback returns newest with stderr warning. Function signatures unchanged. Cluster-validated: chain-migration dual-labeled-Running state captured at t+16s of M2; race probe ~290 calls during M3 hit zero "not found" errors; W2 walkthrough recorded clean state. (W2 walkthrough findings W2-1 + W2-2 are non-PR-2 issues filed as Tracked Follow-ups #8 + #9.) | PR #57 |
+| 67 | internal/webhook/swiftimage/validator.go | vswiftimage ValidateUpdate spec-immutability rule fired on every UPDATE of a Ready SwiftImage including the controller's finalizer-removal patch during deletion; with CloneSeedFinalizer present (cloneStrategy=snapshot) the finalizer never cleared and the namespace stayed Terminating forever with a reconcile-error storm. Root cause: PR #26 per-operation-validation lesson recurring in a webhook predating it (Design Principle #10); the immutability check compared Spec.Source with `!=`, a pointer-identity comparison over ImageSource's pointer fields (HTTP/Upload/PVCClone), so it fired unconditionally on Ready-image updates. Fix (Approach 1): ValidateUpdate returns early when newObj.GetDeletionTimestamp() != nil. Sibling-webhook audit discharged — of six validating webhooks only vswiftimage was vulnerable (others use content/deep comparison; none check deletionTimestamp); vulnerable-webhook ∩ finalizer-bearing = SwiftImage only. Regression tests added (contract test verified load-bearing + over-allow guard), satisfying TFU-2. Residual non-deletion metadata-edit false-rejection (pointer comparison) deferred to TFU #23. (TFU #17.) | branch fix/tfu-17 |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes TFU #17 — the `vswiftimage` validating webhook trapped SwiftImage deletion. Its spec-immutability rule fired on **every** UPDATE of a Ready SwiftImage, including the controller's finalizer-removal patch during deletion. With `CloneSeedFinalizer` present (`cloneStrategy: snapshot`), the finalizer never cleared → namespace stuck `Terminating` forever + continuous reconcile-error storm.

Same PR #26 lesson (per-operation validation discipline) recurring in a webhook that predates it — **Design Principle #10**.

**Mechanism (recon correction):** the rule did *not* "treat any update as a mutation." It compared `oldImg.Spec.Source != img.Spec.Source`, a **pointer-identity** comparison over `ImageSource`'s pointer fields (`HTTP`/`Upload`/`PVCClone`). Old (etcd) and new (admission request) objects are independent decodes → their Source pointers always differ → the rule fired unconditionally on Ready-image updates. The `Format` half (a string) compared correctly.

**Fix (Approach 1):** `ValidateUpdate` returns early (allow) when `newObj.GetDeletionTimestamp() != nil`. Minimal; mirrors PR #26's `ValidateDelete` pass-through intent; independent of the comparison defect.

**Sibling-webhook audit (obligation discharged):** of the six validating webhooks (swiftguest, swiftimage, swiftseedprofile, swiftsnapshot, swiftrestore, swiftmigration), **only vswiftimage was vulnerable**. The others are immune because their immutability checks use content/deep comparison (`specsEqual` / `identityEqual` / value-struct `!=`) or have no immutability rule — *not* because they check `deletionTimestamp` (none do). Cross-referenced with finalizer-adding sites: vulnerable webhook ∩ finalizer-bearing resource = SwiftImage only. (swiftguestpool has no webhook.)

**Deferred residual → TFU #23 (LOW):** Approach 1 does not fix the pointer-comparison defect for *non-deletion* metadata edits (relabeling a Ready image still trips the false rejection). Kept out of scope to keep this PR tight on the HIGH-severity trap.

No CRD/API changes (`make generate` / `verify-crd-sync` are no-ops).

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt` clean
- [x] `go test ./internal/webhook/swiftimage/...` green (8 tests)
- [x] New `TestValidateUpdate_FinalizerRemovalOnDeletingReadyImage_Allowed` verified **load-bearing** — fails against guard-stripped code with the exact "spec is immutable" rejection, passes with the guard
- [x] New `TestValidateUpdate_SpecMutationOnReadyImage_StillRejected` over-allow guard — genuine spec change on a non-deleting Ready image still rejected
- [ ] **Post-merge cluster confirmation (optional):** deploy via `make deploy-with-webhook`, create a `cloneStrategy: snapshot` SwiftImage → Ready + `CloneSeedFinalizer`, delete its namespace, confirm clean GC (old webhook would trap it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)