### PR TITLE
fix(swiftguest): tolerate AlreadyExists during stale-PodRef self-heal

### DIFF
--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -367,7 +367,15 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if staleMigrationPodRef(&guest) {
 			status.PodRef = nil
 		}
-		if err := r.Create(ctx, desiredPod); err != nil {
+		// Tolerate AlreadyExists. During the stale-PodRef self-heal above,
+		// the lookup name (canonicalPodName) and the create name
+		// (guest.Name) diverge, so a concurrent reconcile reading the
+		// pre-clear guest can race us to create the guest.Name pod. The
+		// pod existing is the desired outcome; the next reconcile (PodRef
+		// now cleared) resolves it via canonicalPodName and maps status.
+		// Without this, every offline-after-live migration logs a spurious
+		// ERROR-level "already exists" line even though it succeeds.
+		if err := r.Create(ctx, desiredPod); err != nil && !apierrors.IsAlreadyExists(err) {
 			return ctrl.Result{}, err
 		}
 		// Pod just created; set initial status (Pending/Scheduling)


### PR DESCRIPTION
## Summary

Follow-up to the TFU #18 Bug 2 fix (PR #69), addressing the LOW finding surfaced during PR #69 cluster validation.

The stale-PodRef self-heal clears `status.PodRef` on the create branch so `canonicalPodName` falls back to `guest.Name`. But during that window the **lookup name** (`canonicalPodName`, still the stale `<guest>-mig-<uid>`) and the **create name** (`guest.Name`) diverge, so a concurrent reconcile reading the pre-clear guest can race to create the `guest.Name` pod. One reconcile's `Create` then returns `AlreadyExists`.

The flow already converges (the next reconcile finds the pod via the cleared PodRef and maps status — the guest reaches Running, the migration completes), but it logged a spurious **ERROR-level** `pods "<guest>" already exists` line **once per offline-after-live migration** — misleading on a successful migration.

Fix: tolerate `AlreadyExists` on the launcher-pod create (`!apierrors.IsAlreadyExists(err)`). The pod existing is the desired outcome; this bounds the self-heal to a silent single retry.

## Cluster evidence (PR #69 validation, image sha-0dc892f)

Offline-after-live migration of `tfu18g` (boba→miles) reached `Completed`, guest Running on miles, `podRef` self-healed `tfu18g-mig-cf678f` → `tfu18g` — with **exactly one** `pods "tfu18g" already exists` error at the create-race instant (not a loop). This PR silences that transient.

## Test plan

- [x] `go build ./...` clean · `gofmt` clean
- [x] `go test ./internal/controller/swiftguest/... ./internal/controller/swiftmigration/...` green
- [ ] **No dedicated unit test** — the create branch is only reachable via the full SwiftGuest `Reconcile`, which has no fake-client harness in this package (same constraint noted in PR #69). Verified by cluster observation; next deploy confirms the `already exists` line is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)