### PR TITLE
feat(phase-3b): PR 3 — swiftctl --preferred-mode, describe progress/transfer, printer column, runbook

### DIFF
--- a/api/migration/v1alpha1/swiftmigration_types.go
+++ b/api/migration/v1alpha1/swiftmigration_types.go
@@ -575,6 +575,7 @@ type SwiftMigrationStatus struct {
 // +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.status.mode`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Downtime",type=string,JSONPath=`.status.observedDowntime`
+// +kubebuilder:printcolumn:name="Transfer",type=string,JSONPath=`.status.observedTransferDuration`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type SwiftMigration struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
+++ b/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
@@ -35,6 +35,9 @@ spec:
     - jsonPath: .status.observedDowntime
       name: Downtime
       type: string
+    - jsonPath: .status.observedTransferDuration
+      name: Transfer
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/cmd/swiftctl/migration.go
+++ b/cmd/swiftctl/migration.go
@@ -18,6 +18,7 @@ var (
 	migrateTargetNode    string
 	migrateAllowIPChange bool
 	migrateName          string
+	migratePreferredMode string
 	migrationListAllNS   bool
 )
 
@@ -29,22 +30,33 @@ var migrateCmd = &cobra.Command{
 	Short: "Move a SwiftGuest to another node by creating a SwiftMigration",
 	Long: `Create a SwiftMigration that moves a SwiftGuest to a target node.
 
-Phase 1 ships offline migration: the source guest is fully stopped,
-its root-disk PVC is detached on the source node, and the guest is
-recreated on the target node with the same disk content. Downtime
-is bounded by storage detach + VM boot — ~70s on Longhorn full-copy,
-~25s on true CoW drivers (Rook Ceph RBD, EBS).
+--preferred-mode selects the strategy:
 
-VFIO/SR-IOV guests cannot cross-node-migrate in Phase 1 (no release-
-and-reallocate primitive yet — Phase 4+ work). The webhook rejects
-those at submission time with a clear error.
+  auto    (default) live-migrate when the guest is eligible
+          (ReadWriteMany+Block storage or kernel-boot, and no VFIO/
+          SR-IOV), otherwise fall back to offline. Read status.mode
+          to see which the controller picked.
+  live    live migration: memory + device state stream to the target
+          while the guest keeps running; sub-3s operator-visible
+          downtime. Rejected if the guest is ineligible.
+  offline the source guest is fully stopped, its root-disk PVC is
+          detached on the source node, and the guest is recreated on
+          the target with the same disk content. Downtime ~70s on
+          Longhorn full-copy, ~25s on true CoW drivers. The only mode
+          for VFIO/SR-IOV guests.
+
+VFIO/SR-IOV guests cannot live-migrate (no release-and-reallocate
+primitive yet — Phase 4+ work); use offline. The webhook rejects an
+explicit --preferred-mode live for an ineligible guest with a clear
+error.
 
 Default node-local-bridge networking does not preserve guest IPs
 across nodes. Pass --allow-ip-change to acknowledge and proceed,
 or attach the guest to a multi-node network (Multus + macvlan or
 OVN-K layer-2) for IP preservation.`,
 	Example: `  swiftctl migrate db --to worker-3
-  swiftctl migrate web --to worker-3 --allow-ip-change
+  swiftctl migrate web --to worker-3 --preferred-mode live --allow-ip-change
+  swiftctl migrate db --to worker-3 --preferred-mode offline
   swiftctl migrate db --to worker-3 --name db-rebalance-2026-04-28`,
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
@@ -91,6 +103,8 @@ func init() {
 		"Acknowledge that the guest IP will change cross-node on default node-local networking")
 	migrateCmd.Flags().StringVar(&migrateName, "name", "",
 		"Optional SwiftMigration resource name (default: <guest>-migrate-<rand>)")
+	migrateCmd.Flags().StringVar(&migratePreferredMode, "preferred-mode", "auto",
+		"Migration mode: auto (live when eligible, else offline), live, or offline")
 	_ = migrateCmd.MarkFlagRequired("to")
 
 	migrationListCmd.Flags().BoolVarP(&migrationListAllNS, "all-namespaces", "A", false, "List across all namespaces")
@@ -108,9 +122,28 @@ func newMigrationClient() (client.Client, error) {
 	return client.New(cfg, client.Options{Scheme: scheme.Scheme})
 }
 
+// parsePreferredMode validates the --preferred-mode flag and maps it to
+// the SwiftMigration spec.mode value. The flag is named --preferred-mode
+// (design doc Section 6.1) but the CRD field is spec.mode; this is the
+// translation point. Empty is treated as auto.
+func parsePreferredMode(s string) (migrationv1alpha1.SwiftMigrationMode, error) {
+	switch m := migrationv1alpha1.SwiftMigrationMode(s); m {
+	case "", migrationv1alpha1.SwiftMigrationModeAuto:
+		return migrationv1alpha1.SwiftMigrationModeAuto, nil
+	case migrationv1alpha1.SwiftMigrationModeLive, migrationv1alpha1.SwiftMigrationModeOffline:
+		return m, nil
+	default:
+		return "", fmt.Errorf("invalid --preferred-mode %q (must be auto, live, or offline)", s)
+	}
+}
+
 func runMigrate(cmd *cobra.Command, args []string) error {
 	guestName := args[0]
 	ns := getNamespace()
+	mode, err := parsePreferredMode(migratePreferredMode)
+	if err != nil {
+		return err
+	}
 	c, err := newMigrationClient()
 	if err != nil {
 		return err
@@ -129,7 +162,7 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 		Spec: migrationv1alpha1.SwiftMigrationSpec{
 			GuestRef:      migrationv1alpha1.SwiftMigrationGuestRef{Name: guestName},
 			Target:        migrationv1alpha1.SwiftMigrationTarget{NodeName: migrateTargetNode},
-			Mode:          migrationv1alpha1.SwiftMigrationModeAuto,
+			Mode:          mode,
 			AllowIPChange: migrateAllowIPChange,
 		},
 	}

--- a/cmd/swiftctl/migration.go
+++ b/cmd/swiftctl/migration.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,6 +15,14 @@ import (
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	"github.com/projectbeskar/kubeswift/internal/scheme"
 )
+
+// migrationProgressEstimateAnnotation mirrors the key swiftletd-source
+// writes during the live send RPC (rust/swiftletd/src/action.rs
+// MIGRATION_PROGRESS_ESTIMATE_KEY). Per Phase 3b design doc §5.4 the
+// estimate is annotation-only (not mirrored to a CRD status field), so
+// swiftctl reads it directly off the source pod when describing an
+// in-flight live migration.
+const migrationProgressEstimateAnnotation = "kubeswift.io/migration-progress-estimate"
 
 var (
 	migrateTargetNode    string
@@ -222,7 +232,36 @@ func runMigrationDescribe(cmd *cobra.Command, args []string) error {
 		}
 		return err
 	}
-	out := cmd.OutOrStdout()
+	// Best-effort: the live-transfer progress estimate lives only on the
+	// source pod's annotation (design §5.4, not mirrored to status). Fetch
+	// it while a live transfer is in flight so the renderer can surface
+	// it. Ignore errors — progress is informational, never load-bearing.
+	var srcPod *corev1.Pod
+	if isLiveTransferInFlight(&m) {
+		var pod corev1.Pod
+		if getErr := c.Get(context.Background(), client.ObjectKey{Name: m.Status.SourcePodRef.Name, Namespace: ns}, &pod); getErr == nil {
+			srcPod = &pod
+		}
+	}
+	renderMigrationDescribe(cmd.OutOrStdout(), &m, srcPod)
+	return nil
+}
+
+// isLiveTransferInFlight reports whether a live migration is in its
+// memory-transfer phase, where the source pod carries the progress
+// estimate. Live mode reuses the StopAndCopy phase constant
+// (distinguished by status.mode), so there is no StopAndCopyLive phase
+// to match on — gate on phase==StopAndCopy AND mode==live.
+func isLiveTransferInFlight(m *migrationv1alpha1.SwiftMigration) bool {
+	return m.Status.Phase == migrationv1alpha1.SwiftMigrationPhaseStopAndCopy &&
+		m.Status.Mode == migrationv1alpha1.SwiftMigrationModeLive &&
+		m.Status.SourcePodRef != nil && m.Status.SourcePodRef.Name != ""
+}
+
+// renderMigrationDescribe writes the human-readable describe output.
+// Pure (no cluster access) so it is unit-testable: srcPod is the already-
+// fetched source pod (nil unless a live transfer is in flight).
+func renderMigrationDescribe(out io.Writer, m *migrationv1alpha1.SwiftMigration, srcPod *corev1.Pod) {
 	fmt.Fprintf(out, "Name:           %s\n", m.Name)
 	fmt.Fprintf(out, "Namespace:      %s\n", m.Namespace)
 	fmt.Fprintf(out, "Guest:          %s\n", m.Spec.GuestRef.Name)
@@ -253,6 +292,11 @@ func runMigrationDescribe(cmd *cobra.Command, args []string) error {
 	if m.Status.ObservedDowntime != nil {
 		fmt.Fprintf(out, "Downtime:       %s\n", m.Status.ObservedDowntime.Duration.Truncate(1e9))
 	}
+	// Transfer duration (live mode only — offline leaves it nil). Renamed
+	// from the deprecated observedPauseWindow; see CRD docstring.
+	if m.Status.ObservedTransferDuration != nil {
+		fmt.Fprintf(out, "Transfer:       %s\n", m.Status.ObservedTransferDuration.Duration.Truncate(1e9))
+	}
 	if m.Status.FailureMessage != "" {
 		fmt.Fprintf(out, "Failure:        %s\n", m.Status.FailureMessage)
 	}
@@ -263,6 +307,26 @@ func runMigrationDescribe(cmd *cobra.Command, args []string) error {
 				c.Type, c.Status, c.Reason, c.Message)
 		}
 	}
+	// Live-transfer progress estimate (best-effort, heuristic).
+	if srcPod != nil {
+		if pct := srcPod.Annotations[migrationProgressEstimateAnnotation]; pct != "" {
+			fmt.Fprintf(out, "Progress (estimate): %s%%\n", pct)
+			fmt.Fprintln(out, "")
+			fmt.Fprintln(out, "  Note: Progress is a heuristic based on ~108 MB/s baseline pod-network")
+			fmt.Fprintln(out, "  bandwidth (spike Q4); actual rate depends on the workload's memory")
+			fmt.Fprintln(out, "  dirty rate. The guest stays responsive throughout the transfer.")
+		}
+	}
+	// Completed live migration: gloss the two metrics, which mean
+	// different things. Offline leaves ObservedTransferDuration nil, so
+	// this only fires for live (offline downtime is self-explanatory).
+	if m.Status.Phase == migrationv1alpha1.SwiftMigrationPhaseCompleted && m.Status.ObservedTransferDuration != nil {
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "Downtime is the operator-visible cluster downtime window (cutover")
+		fmt.Fprintln(out, "dispatch -> guest healthy on destination). Transfer is the full")
+		fmt.Fprintln(out, "vm.send-migration RPC (pre-copy + stop-and-copy + finalize); the")
+		fmt.Fprintln(out, "guest stays responsive throughout most of that window.")
+	}
 	// UX hint: Resuming is boot-bound, not stuck. Operators reading
 	// this output during the boot window should see the explanation
 	// inline rather than reach for kubectl describe.
@@ -271,7 +335,6 @@ func runMigrationDescribe(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(out, "Note: Resuming waits for the guest VM to boot on the destination")
 		fmt.Fprintln(out, "node (~17s on a warm cache). The controller is not stuck.")
 	}
-	return nil
 }
 
 func runMigrationCancel(cmd *cobra.Command, args []string) error {

--- a/cmd/swiftctl/migration.go
+++ b/cmd/swiftctl/migration.go
@@ -203,16 +203,20 @@ func runMigrationList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAMESPACE\tNAME\tGUEST\tFROM\tTO\tMODE\tPHASE\tDOWNTIME\tAGE")
+	fmt.Fprintln(w, "NAMESPACE\tNAME\tGUEST\tFROM\tTO\tMODE\tPHASE\tDOWNTIME\tTRANSFER\tAGE")
 	for _, m := range list.Items {
 		downtime := "-"
 		if m.Status.ObservedDowntime != nil {
 			downtime = m.Status.ObservedDowntime.Duration.Truncate(1e9).String()
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		transfer := "-"
+		if m.Status.ObservedTransferDuration != nil {
+			transfer = m.Status.ObservedTransferDuration.Duration.Truncate(1e9).String()
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			m.Namespace, m.Name, m.Spec.GuestRef.Name,
 			emptyDash(m.Status.SourceNode), emptyDash(m.Status.DestinationNode),
-			emptyDash(string(m.Status.Mode)), m.Status.Phase, downtime,
+			emptyDash(string(m.Status.Mode)), m.Status.Phase, downtime, transfer,
 			cliAge(m.CreationTimestamp.Time))
 	}
 	return w.Flush()

--- a/cmd/swiftctl/migration_test.go
+++ b/cmd/swiftctl/migration_test.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 )
@@ -36,5 +42,92 @@ func TestParsePreferredMode(t *testing.T) {
 				t.Errorf("parsePreferredMode(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+func dur(s string) *metav1.Duration {
+	d, _ := time.ParseDuration(s)
+	return &metav1.Duration{Duration: d}
+}
+
+// TestRenderMigrationDescribe_CompletedLive: a completed live migration
+// shows both Downtime and Transfer, plus the semantic gloss distinguishing
+// them.
+func TestRenderMigrationDescribe_CompletedLive(t *testing.T) {
+	m := &migrationv1alpha1.SwiftMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+		Spec: migrationv1alpha1.SwiftMigrationSpec{
+			GuestRef: migrationv1alpha1.SwiftMigrationGuestRef{Name: "g"},
+			Target:   migrationv1alpha1.SwiftMigrationTarget{NodeName: "boba"},
+			Mode:     migrationv1alpha1.SwiftMigrationModeLive,
+		},
+		Status: migrationv1alpha1.SwiftMigrationStatus{
+			Phase:                    migrationv1alpha1.SwiftMigrationPhaseCompleted,
+			Mode:                     migrationv1alpha1.SwiftMigrationModeLive,
+			ObservedDowntime:         dur("2.8s"),
+			ObservedTransferDuration: dur("38.2s"),
+		},
+	}
+	var buf bytes.Buffer
+	renderMigrationDescribe(&buf, m, nil)
+	out := buf.String()
+	for _, want := range []string{"Downtime:", "Transfer:", "Downtime is the operator-visible", "vm.send-migration RPC"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+// TestRenderMigrationDescribe_CompletedOffline: offline leaves
+// ObservedTransferDuration nil, so neither the Transfer line nor the
+// live-only gloss appear (would confuse operators — offline has no send RPC).
+func TestRenderMigrationDescribe_CompletedOffline(t *testing.T) {
+	m := &migrationv1alpha1.SwiftMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+		Spec:       migrationv1alpha1.SwiftMigrationSpec{GuestRef: migrationv1alpha1.SwiftMigrationGuestRef{Name: "g"}},
+		Status: migrationv1alpha1.SwiftMigrationStatus{
+			Phase:            migrationv1alpha1.SwiftMigrationPhaseCompleted,
+			Mode:             migrationv1alpha1.SwiftMigrationModeOffline,
+			ObservedDowntime: dur("40s"),
+		},
+	}
+	var buf bytes.Buffer
+	renderMigrationDescribe(&buf, m, nil)
+	out := buf.String()
+	if !strings.Contains(out, "Downtime:") {
+		t.Errorf("offline output should show Downtime\n---\n%s", out)
+	}
+	if strings.Contains(out, "Transfer:") || strings.Contains(out, "vm.send-migration RPC") {
+		t.Errorf("offline output must not show Transfer line or live gloss\n---\n%s", out)
+	}
+}
+
+// TestRenderMigrationDescribe_LiveProgress: an in-flight live transfer
+// surfaces the source pod's progress-estimate annotation with the
+// heuristic note.
+func TestRenderMigrationDescribe_LiveProgress(t *testing.T) {
+	m := &migrationv1alpha1.SwiftMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+		Spec:       migrationv1alpha1.SwiftMigrationSpec{GuestRef: migrationv1alpha1.SwiftMigrationGuestRef{Name: "g"}},
+		Status: migrationv1alpha1.SwiftMigrationStatus{
+			Phase: migrationv1alpha1.SwiftMigrationPhaseStopAndCopy,
+			Mode:  migrationv1alpha1.SwiftMigrationModeLive,
+		},
+	}
+	srcPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "g-mig-abc123",
+			Namespace:   "default",
+			Annotations: map[string]string{migrationProgressEstimateAnnotation: "47"},
+		},
+	}
+	var buf bytes.Buffer
+	renderMigrationDescribe(&buf, m, srcPod)
+	out := buf.String()
+	if !strings.Contains(out, "Progress (estimate): 47%") {
+		t.Errorf("output missing progress estimate\n---\n%s", out)
+	}
+	if !strings.Contains(out, "heuristic") {
+		t.Errorf("output missing heuristic note\n---\n%s", out)
 	}
 }

--- a/cmd/swiftctl/migration_test.go
+++ b/cmd/swiftctl/migration_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+)
+
+func TestParsePreferredMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    migrationv1alpha1.SwiftMigrationMode
+		wantErr bool
+	}{
+		{"empty defaults to auto", "", migrationv1alpha1.SwiftMigrationModeAuto, false},
+		{"auto", "auto", migrationv1alpha1.SwiftMigrationModeAuto, false},
+		{"live", "live", migrationv1alpha1.SwiftMigrationModeLive, false},
+		{"offline", "offline", migrationv1alpha1.SwiftMigrationModeOffline, false},
+		{"invalid value", "fast", "", true},
+		{"case-sensitive: Live is invalid", "Live", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parsePreferredMode(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parsePreferredMode(%q) = %q, nil; want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePreferredMode(%q) unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("parsePreferredMode(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
+++ b/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
@@ -35,6 +35,9 @@ spec:
     - jsonPath: .status.observedDowntime
       name: Downtime
       type: string
+    - jsonPath: .status.observedTransferDuration
+      name: Transfer
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/docs/design/live-migration-phase-3b.md
+++ b/docs/design/live-migration-phase-3b.md
@@ -234,6 +234,13 @@ listed below.
 
 ### 3.1 `spec.preferredMode`
 
+> **Shipped-code correction (PR 3):** the CRD field is **`spec.mode`**
+> (`SwiftMigrationMode`), not `spec.preferredMode` — that name only ever
+> existed in this design doc's prose; the Phase 3a Go types declared
+> `Mode`. The resolved value is `status.mode`. The swiftctl flag is named
+> `--preferred-mode` (Section 6.1) and maps to `spec.mode`. Read every
+> `spec.preferredMode` below as `spec.mode`.
+
 Existing field (`migration.kubeswift.io/v1alpha1.SwiftMigrationSpec`).
 Phase 3a shipped with three values; Phase 3b lights up `live`:
 
@@ -1045,27 +1052,25 @@ guest stays responsive throughout most of this window.
 
 ### 6.3 `kubectl describe smig` (controller-rendered)
 
-`kubectl describe` reads CRD printer columns + status fields.
-Phase 3b PR 3 updates the SwiftMigration CRD printer columns
-to surface the new field names:
+`kubectl get smig -o wide` reads CRD printer columns.
+
+> **Shipped-code correction (PR 3):** there was **no `PauseWindow`
+> column to remove** — the shipped Phase 3a columns are
+> Guest/From/To/Mode/Phase/Downtime/Age (the deprecated
+> `observedPauseWindow` was never surfaced as a column). PR 3 simply
+> **adds** a `Transfer` column reading `status.observedTransferDuration`,
+> after `Downtime`:
 
 ```diff
-- additionalPrinterColumns:
--   - name: Phase
--   - name: Mode
--   - name: Downtime
--   - name: PauseWindow
-+ additionalPrinterColumns:
-+   - name: Phase
-+   - name: Mode
-+   - name: Downtime
+  additionalPrinterColumns:
+    - name: Downtime
+      jsonPath: .status.observedDowntime
 +   - name: Transfer
++     jsonPath: .status.observedTransferDuration
+    - name: Age
 ```
 
-`PauseWindow` column → `Transfer` column reading from
-`observedTransferDuration`. The deprecated alias
-`observedPauseWindow` is still populated but not surfaced in
-the wide-output columns.
+`swiftctl migration list` gains a matching `TRANSFER` column for parity.
 
 ### 6.4 Operator runbook (`docs/migration/phase-3b.md`)
 

--- a/docs/migration/phase-3b.md
+++ b/docs/migration/phase-3b.md
@@ -1,0 +1,186 @@
+# Live Migration (Phase 3b) — Operator Runbook
+
+> Phase 3b lights up `mode: live` for SwiftMigration: guest memory and
+> device state stream to the target node while the VM keeps running, with
+> sub-3s operator-visible downtime. This runbook is the operator-facing
+> companion to the design doc
+> [`docs/design/live-migration-phase-3b.md`](../design/live-migration-phase-3b.md).
+>
+> Phase 3a (offline mode) runbook: [`phase-3a.md`](phase-3a.md).
+
+---
+
+## 1. Quick start
+
+```bash
+swiftctl migrate <guest> --to <node>
+```
+
+With no `--preferred-mode` flag the mode defaults to `auto`: the
+controller live-migrates when the guest is eligible (Section 2) and falls
+back to offline otherwise. Read the resolved mode back from the
+SwiftMigration:
+
+```bash
+kubectl get smig -o wide        # MODE column = status.mode (resolved)
+swiftctl migration describe <name>
+```
+
+To force a mode:
+
+```bash
+swiftctl migrate <guest> --to <node> --preferred-mode live
+swiftctl migrate <guest> --to <node> --preferred-mode offline
+```
+
+`--preferred-mode` maps to the CRD field `spec.mode`; the controller
+writes the resolved mode to `status.mode`.
+
+On KubeSwift's default node-local-bridge networking a cross-node
+migration changes the guest IP — add `--allow-ip-change` to acknowledge
+(see Section 5).
+
+---
+
+## 2. Is my guest live-eligible?
+
+A guest is eligible for live migration when **all** hold:
+
+- **Storage is live-migratable**: either a kernel-boot guest
+  (`spec.kernelRef`, no root-disk PVC), or a disk-boot guest on
+  **ReadWriteMany + Block** storage backed by a Longhorn StorageClass
+  with `parameters.migratable: "true"`.
+- **No VFIO/SR-IOV devices**: no `spec.gpuProfileRef` and no
+  `type: sriov` interface. These cannot live-migrate (upstream Cloud
+  Hypervisor constraint #2251) — use offline.
+
+Check the resolved storage on the guest:
+
+```bash
+kubectl get sg <guest> -o jsonpath='{.status.storage}{"\n"}'
+# live-eligible disk-boot example:
+# {"accessMode":"ReadWriteMany","volumeMode":"Block","storageClassName":"longhorn-migratable"}
+```
+
+Eligibility is computed from the resolved spec at admission/validation
+time (not read from status), so it is correct even immediately after a
+cluster restore.
+
+**Explicit `--preferred-mode live` for an ineligible guest is rejected**
+at admission with a structured error telling you which condition failed.
+`--preferred-mode auto` silently resolves such a guest to offline
+instead.
+
+---
+
+## 3. Reading migration metrics
+
+Two distinct timings are reported; they mean different things.
+
+| Field (`status.`) | `kubectl get smig` column | Meaning |
+|---|---|---|
+| `observedDowntime` | `Downtime` | Operator-visible cluster downtime: cutover dispatch → guest healthy on the destination. **This is the SLO-relevant number.** |
+| `observedTransferDuration` | `Transfer` | Full `vm.send-migration` RPC: pre-copy iterations + final stop-and-copy + finalize. The guest stays **responsive** through almost all of this; it is a capacity-planning input, not downtime. (Offline migrations leave this empty.) |
+
+`swiftctl migration describe <name>` prints both, with an inline gloss,
+and — during an in-flight live transfer — a best-effort
+`Progress (estimate): N%`.
+
+Empirical baselines (4 GiB guest, default Calico pod network,
+`cloud-hypervisor v51.1`):
+
+| Workload | `Transfer` | `Downtime` |
+|---|---|---|
+| No stress (cluster-validated, disk-boot RWX+Block) | ~38s | ~2.9s |
+| stress-ng MED (2×256M dirtying) | ~68s | ~2.6s |
+| stress-ng HIGH (50% of RAM dirtied) | ~87s | ~2.6s |
+
+`Downtime` stays bounded ~2–3s across the whole workload range;
+`Transfer` scales with the memory dirty rate. Sizing rule of thumb:
+
+```
+expected Transfer ≈ (guest_RAM × 1.05) / pod_network_bandwidth
+```
+
+For offline migrations, `Downtime` is the whole window (~36–70s on
+Longhorn full-copy, ~25s on true CoW drivers) and `Transfer` is empty.
+
+---
+
+## 4. The progress estimate is a heuristic
+
+`describe` surfaces `kubeswift.io/migration-progress-estimate` (emitted
+by swiftletd-source every ~5s during the send RPC). It is computed from a
+fixed ~108 MB/s Calico-VXLAN bandwidth baseline (spike Q4) and the guest
+RAM size — **not** from Cloud Hypervisor's actual per-iteration progress
+(CH v51.1 does not expose that). It is capped at 95% and can over- or
+under-predict on hostile memory-dirtying workloads or on non-Calico CNIs.
+Treat it as a "something is happening" signal, not a precise ETA. It is
+annotation-only and not persisted to status.
+
+---
+
+## 5. Caveats
+
+- **IP change cross-node.** Default node-local-bridge networking does not
+  preserve guest IPs across nodes; live and offline cross-node both
+  require `--allow-ip-change`. For IP preservation, attach the guest to a
+  multi-node network (Multus + macvlan, or OVN-Kubernetes layer-2). See
+  Tracked Follow-up #1 in `kubeswift_context.md`.
+- **VFIO/SR-IOV is offline-only**, permanently (until upstream CH #2251).
+  GPU and SR-IOV-NIC guests are rejected for live and must use offline.
+- **CPU-feature mismatch is NOT detected.** The validation pipeline does
+  not compare source/destination CPU flags. On heterogeneous-microarch
+  clusters a live migration can succeed at transfer time and then fault
+  in the guest when it loads an unavailable feature. **Operator
+  discipline:** verify `lscpu` flag uniformity across nodes that
+  participate in live migration. A `swiftctl migrate --check` pre-flight
+  is tracked (Follow-up #10).
+- **Complete swiftletd rollouts before live-migrating.** A live migration
+  reuses the source pod's launcher image for the destination pod
+  (clone-src pod builder); mid-rollout image skew can stall the
+  destination image pull.
+- **No default `spec.timeout`.** An unset timeout means no runaway gate;
+  set `--timeout` (live mode enforces a 60s floor) on workloads where a
+  stuck migration must auto-fail. Cancel anytime with
+  `swiftctl migration cancel <name>`.
+
+---
+
+## 6. Troubleshooting
+
+- **Stuck in `PreparingLive` / "waiting for destination pod ready":**
+  check the destination pod's image-pull status, the migration TCP
+  listener bind, and the `kubeswift.io/migration-phase2-unsafe-plaintext: ack`
+  annotation. The destination-listener timeout (~60s) drives a
+  `DstNeverReady` failure if the source never connects.
+- **`Failed`, `failureReason=EligibilityMismatch`:** the guest's storage
+  changed to non-live-eligible between submission and reconcile (e.g. the
+  PVC rebound to a non-migratable StorageClass). Reconfirm eligibility
+  (Section 2) and resubmit, or use `--preferred-mode offline`.
+- **`Failed`, `failureReason=RpcError`:** a Cloud Hypervisor error during
+  transfer. Tail the source pod's logs for the un-sanitized message:
+  `kubectl logs <guest-or-mig-pod> -n <ns>`.
+- **`Failed`, `failureReason=DstScheduleFailed` / `DstNeverReady`:** the
+  destination pod could not schedule or never reached receive-ready;
+  check target-node capacity and the boot-type node label
+  (`kubeswift.io/kernel-node=true` for kernel-boot guests).
+- **`describe` shows `Resuming` for a while:** expected — Resuming waits
+  for the guest to report healthy on the destination (~17s warm cache).
+  The controller is not stuck.
+- **Resume after offline migration of a previously live-migrated guest:**
+  fixed in TFU #18 — offline now resolves the live-renamed pod correctly.
+  If you see an offline migration stuck at "waiting for volume detach"
+  on an older build, that is the pre-fix symptom.
+
+---
+
+## 7. Validation history
+
+- PR 1 (#61) — swiftletd send/receive + progress emitter + CRD rename;
+  manual-demo walkthrough
+  [`phase-3b-pr1-walkthrough.md`](phase-3b-pr1-walkthrough.md).
+- PR 2 (#64/#65) — controller live-mode integration; walkthrough
+  [`phase-3b-pr2-walkthrough.md`](phase-3b-pr2-walkthrough.md).
+- PR 3 — this UX surface (`--preferred-mode`, `describe` Transfer +
+  progress, `Transfer` printer column, this runbook).


### PR DESCRIPTION
## Summary

Phase 3b PR 3 — the operator UX surface for live migration. Builds on PR 1 (#61, swiftletd + CRD field) and PR 2 (#64/#65, controller integration). No new runtime behavior; this exposes what already ships.

- **`swiftctl migrate --preferred-mode {auto,live,offline}`** (default `auto`, preserving current behavior) → maps to `spec.mode`. Validation extracted to a unit-tested `parsePreferredMode`.
- **`swiftctl migration describe`**: adds `Transfer` (`observedTransferDuration`, live-only), `Progress (estimate): N%` during an in-flight live transfer (best-effort read of the source pod's `migration-progress-estimate` annotation — annotation-only per design §5.4) with a heuristic Note, and a downtime-vs-transfer semantic gloss on completed live migrations. Refactored into a pure `renderMigrationDescribe` + fetch wrapper so the output contract is unit-testable.
- **CRD `Transfer` printer column** (`kubectl get smig -o wide`) + matching `TRANSFER` column in `swiftctl migration list`.
- **Operator runbook** `docs/migration/phase-3b.md`.

## Shipped-code corrections (design doc vs. reality)

Three divergences from `live-migration-phase-3b.md`, corrected in this PR:
1. CRD field is **`spec.mode`**, not `spec.preferredMode` (the latter never shipped; the `--preferred-mode` flag maps to `spec.mode`). §3.1 annotated.
2. No **`StopAndCopyLive`** phase constant — live reuses `StopAndCopy` distinguished by `status.mode`; progress gates on `phase==StopAndCopy && mode==live`.
3. No **`PauseWindow`** printer column to remove (§6.3 assumed one); PR 3 just adds `Transfer`. §6.3 corrected.

## Test plan

- [x] `go build ./...` clean · `gofmt` clean
- [x] `go test ./cmd/swiftctl/... ./internal/controller/swiftmigration/...` green (parsePreferredMode + 3 describe-renderer tests + regression)
- [x] `make generate` + `verify-crd-sync` OK; CRD regenerated with controller-gen **v0.20.1** (repo baseline) so the diff is scoped to the new column (no version-marker churn)
- [ ] **Optional post-merge cluster check:** `swiftctl migrate <g> --to <n> --preferred-mode live`, confirm `describe` shows Transfer + Progress and `kubectl get smig -o wide` shows the Transfer column on a real live migration.

## Follow-up noted (not in this PR)

controller-gen version drift: the Makefile uses unpinned `GOPATH/bin/controller-gen`; a newer local version (v0.21.0) churns all 11 CRD version markers on `make generate`. Worth pinning in the Makefile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)