### PR TITLE
docs(phase-3c): mTLS transport spike findings + prep

### DIFF
--- a/docs/design/live-migration-phase-3c-mtls-spike.md
+++ b/docs/design/live-migration-phase-3c-mtls-spike.md
@@ -1,0 +1,341 @@
+# Live Migration Phase 3c — mTLS Transport Spike (Findings)
+
+> **Status:** Complete. Ready for Phase 3c design alignment.
+> Last updated: 2026-05-30.
+> Spike branch `spike/phase-3c-mtls` is **NOT for merge** (spike contract);
+> only this findings doc lands on `main`.
+
+---
+
+## Goal
+
+Empirically validate that Cloud Hypervisor live migration runs unchanged
+over a mutually-authenticated TLS channel terminated by a sidecar (stunnel),
+**before** the Phase 3c design doc is written. Same discipline as prior
+spikes: findings either confirm assumptions or correct them BEFORE design
+begins.
+
+The architecture under test (from
+[`live-migration-phase-3c-spike-prep.md`](live-migration-phase-3c-spike-prep.md) §3):
+Cloud Hypervisor speaks **plaintext to localhost only**; an stunnel sidecar
+in the same pod netns owns the cross-pod TLS hop. No CH change, no swiftletd
+change — the migration channel is wrapped, not rewritten.
+
+```
+src pod (miles)                                  dst pod (boba)
+┌───────────────────────────┐                    ┌───────────────────────────┐
+│ swiftletd/CH               │                    │ swiftletd/CH (receiver)    │
+│  vm.send-migration         │                    │  vm.receive-migration      │
+│  target_url=               │                    │  listen_url=               │
+│   tcp:127.0.0.1:6790  ─────┼──┐              ┌───┼─► tcp:127.0.0.1:6790       │
+│                            │  │ plaintext    │   │       (localhost only)     │
+│ stunnel CLIENT             │  │ (localhost)  │   │ stunnel SERVER             │
+│  accept 127.0.0.1:6790 ◄───┼──┘              └───┼── connect 127.0.0.1:6790   │
+│  connect <dst-ip>:6789 ────┼───── mTLS ──────────┼─► accept 0.0.0.0:6789      │
+└───────────────────────────┘   (cross-pod)       └───────────────────────────┘
+```
+
+**Cluster:** 3-node k0s (frida cp; miles + boba workers), CH v51.1,
+`longhorn-migratable` RWX/Block storage, cert-manager. swiftletd image
+`sha-e1db826` (unmodified shipped image — the spike adds no Rust change).
+
+**Reproduction harness:** `tools/spike/phase-3c-mtls/` —
+`launch-mtls-pods.sh` (Fork-B hand-crafted src/dst pair) +
+`trigger-mtls-migration.sh` (annotation-driven migration) + `certs.yaml`
+(Layer A cert-manager hierarchy) + the two stunnel configs.
+
+---
+
+## Headline result
+
+**All four spike questions PASS.** CH live migration over mutual TLS is
+correct, has negligible performance cost, and the channel genuinely
+authenticates (both invalid clients rejected at the TLS handshake, zero
+bytes reaching CH). The Q4 wiring exercise surfaced three controller-
+integration findings and one trust-model gap (`verifyChain` without
+subject checks) that the Phase 3c design doc must resolve.
+
+| Q | Question | Result |
+|---|---|---|
+| Q1 | CH-through-tunnel correctness | **PASS** — sentinel md5 identical src→dst |
+| Q2 | Performance vs. plaintext baseline | **PASS** — 111.86 MB/s, ~1% delta (within noise) |
+| Q3 | Enforcement (negative test) | **PASS** — no-cert AND wrong-CA both rejected at handshake; 0 bytes to CH |
+| Q4 | Wiring sketch | **Done** — 3 controller-integration findings + identity-pinning gap |
+
+---
+
+## Q1 — CH-through-tunnel correctness: PASS
+
+A 4 GiB Ubuntu Noble guest (RWX/Block PVC) was cold-booted on the src pod,
+an **in-memory tmpfs sentinel** was written (so survival proves MEMORY
+transfer, not just the shared PVC), then migrated miles→boba entirely over
+the TLS tunnel with **localhost CH URLs** on both ends.
+
+- Pre-migration sentinel (src guest tmpfs): `MTLS-MEMPROOF-1780122581`,
+  md5 `e187f76732140367822efbd7ac675019`.
+- Post-migration sentinel (dst guest tmpfs): **md5 identical** —
+  `e187f76732140367822efbd7ac675019`.
+- src `migration-status = complete`; dst `migration-status = running`
+  (successful cutover; guest live on boba).
+- Guest IP `192.168.99.20` (br0 `192.168.99.0/24`, the B0 fix subnet).
+
+CH's `vm.send-migration` (`target_url=tcp:127.0.0.1:6790`) and
+`vm.receive-migration` (`listen_url=tcp:127.0.0.1:6790`) completed cleanly
+with stunnel forwarding in between. **CH required no awareness of the
+tunnel** — from its perspective it dialed/listened on localhost.
+
+---
+
+## Q2 — Performance: PASS (negligible overhead)
+
+| Metric | mTLS (this spike) | Plaintext baseline (Phase 3b Q2/Q4) |
+|---|---|---|
+| `vm.send-migration` RPC duration | 38675 ms | ~38.2 s |
+| Bytes across the cross-pod channel | 4326154986 (~4.03 GiB) | ~4.03 GiB |
+| Effective throughput | **111.86 MB/s** | ~107–113 MB/s |
+| observedDowntime class | ~2–3 s (cutover-bound) | ~2–3 s |
+
+Throughput computed from the dst stunnel SERVER close-stats —
+`4326154986 byte(s) sent to socket` (decrypted and forwarded to CH on
+`127.0.0.1:6790`) over the 38.675 s RPC = **111.86 MB/s**. That is within
+noise of the Phase 3b Q4 raw-TCP ceiling (112.75 MB/s) and the inferred CH
+data-path rate (107.2 MB/s).
+
+**Conclusion:** AES-NI ≫ gigabit, exactly as predicted. The TLS layer is
+not the bottleneck on this hardware; the pod-network bandwidth is. No
+dedicated migration network or hardware-crypto tuning is needed for Phase
+3c on commodity gigabit interconnects. Operator sizing formula from Phase
+3b (`pauseWindow ≈ guest_RAM × 1.05 / pod_network_bandwidth`) carries over
+unchanged.
+
+---
+
+## Q3 — Enforcement (negative test): PASS
+
+The transport must **authenticate**, not merely encrypt. stunnel `verify = 2`
+on both ends (require AND verify the peer cert chains to the shared CA).
+
+### Positive (both peers mutually verified)
+
+From the live stunnel logs of the successful migration:
+
+```
+# dst SERVER verifying the src's CLIENT cert:
+LOG5[0]: Service [migration] accepted connection from 10.244.125.169:54124
+LOG5[0]: Certificate accepted at depth=0: CN=kubeswift-migration
+LOG5[0]: Connection closed: 112 byte(s) sent to TLS, 4326154986 byte(s) sent to socket
+
+# src CLIENT verifying the dst's SERVER cert:
+LOG5[0]: s_connect: connected 10.244.213.54:6789
+LOG5[0]: Certificate accepted at depth=0: CN=kubeswift-migration
+```
+
+Both directions verified the peer → **mutual TLS**, not one-way server auth.
+
+### Negative Test A — client presents NO cert
+
+src stunnel client config stripped of `cert`/`key`. The dst SERVER log:
+
+```
+LOG5[1]: Service [migration] accepted connection from 10.244.125.169:39524
+... peer did not return a certificate ...
+LOG5[1]: Connection reset/closed: 0 byte(s) sent to TLS, 0 byte(s) sent to socket
+```
+
+### Negative Test B — client cert from a DIFFERENT CA
+
+A leaf (`CN=attacker`) issued by a second, unrelated self-signed CA. The
+dst SERVER log:
+
+```
+LOG5[2]: Service [migration] accepted connection from 10.244.125.169:33334
+LOG4[2]: Rejected by CERT at depth=0: CN=attacker
+LOG5[2]: SSL_accept: ssl/.../statem_srvr.c: error:0A000086: ... certificate verify failed
+LOG5[2]: Connection reset/closed: 0 byte(s) sent to TLS, 0 byte(s) sent to socket
+```
+
+**Both invalid clients are rejected at the TLS handshake; in both cases
+`0 byte(s) sent to socket` — CH on `127.0.0.1:6790` is NEVER reached.** The
+rejection is at the transport layer, not the CH layer. This is the bar the
+spike-prep §5 set for calling the transport secure, and it is met.
+
+---
+
+## Q4 — Wiring sketch + findings for the design doc
+
+The spike hand-crafted the pods (Fork B). Translating that into controller
+integration (`internal/controller/swiftmigration`) surfaced four findings.
+
+### Finding W-3c-1 — `lifecycle: stop` poisons the receiver pod
+
+**Symptom:** the first run, both launchers logged
+`lifecycle=stop, skipping launch` and neither booted/received.
+
+**Root cause:** the crafted pods mounted the controller-managed
+`<guest>-runtime-intent` ConfigMap. When the harness patches
+`runPolicy: Stopped` to release the controller pod, the SwiftGuest
+controller **rewrites that same ConfigMap to `lifecycle: stop`**.
+swiftletd's launch gate (`rust/swiftletd/src/main.rs:201`,
+`if intent.lifecycle == "stop" { skip launch }`) fires for **all** launch
+paths — **including `migration_receiver_mode`**. Receiver mode is selected
+by the env var `KUBESWIFT_MIGRATION_ROLE=receiver`, not by intent JSON, so
+it does not exempt the pod from the lifecycle gate.
+
+**Spike fix:** mint a frozen `lifecycle: run` intent ConfigMap and repoint
+the `runtime-intent` volume on both crafted pods to it (now baked into
+`launch-mtls-pods.sh`).
+
+**Design-doc consequence (load-bearing):** the controller-integrated **dst
+(receiver) pod must carry a `lifecycle: run` intent and the receiver role,
+and must never inherit a stopped lifecycle from the source guest's intent.**
+Since `newDstPod` DeepCopies the source pod (see W-3c-2), and the source
+guest may legitimately be `runPolicy: Stopped`-adjacent during cutover,
+the dst-pod construction path must explicitly set/freeze `lifecycle: run`
+in the dst's intent — not reuse a live, controller-mutable intent CM that
+could flip to `stop` mid-migration.
+
+### Finding W-3c-2 — `newDstPod` DeepCopy needs role-aware sidecar config
+
+The spike used a **single sidecar image** (`dweomer/stunnel:latest`) +
+**single ConfigMap** carrying both server and client configs; the sidecar
+entrypoint self-selects server-vs-client from `STUNNEL_ROLE` and injects
+the peer IP from `DST_POD_IP` (sed over `__DST_POD_IP__`).
+
+This maps directly onto Phase 3a's
+[`dst_pod.go::newDstPod`](../../internal/controller/swiftmigration/dst_pod.go),
+which constructs the dst by `srcPod.DeepCopy()`. The DeepCopy hands you the
+**source's CLIENT-role sidecar config**; the controller must then **flip it
+to SERVER on the dst** (and, symmetrically, the src sidecar must be a
+CLIENT pointed at the dst IP). Concretely the controller must, post-DeepCopy:
+
+- set `STUNNEL_ROLE=server` on the dst sidecar (the src is `client`);
+- set `DST_POD_IP` on the **src** sidecar to the dst pod IP — which is
+  only known **after** the dst pod is scheduled and gets an IP. This is a
+  **sequencing constraint**: dst pod created → dst IP observed → src
+  sidecar (re)configured with that IP. The spike resolved this by crafting
+  the dst first, reading its `podIP`, then crafting the src. The controller
+  state machine has the same ordering already (Preparing-live creates the
+  dst before StopAndCopy on the src), so the dst IP is available to stamp
+  onto the src — but the **src sidecar config must be parameterized by env,
+  mutated after DeepCopy, not baked into an image.** A future refactor that
+  bakes role/peer into the image would break the single-image model and
+  re-introduce a build-time coupling. (Same W26-class lesson: name the
+  load-bearing property so a "cleaner" refactor doesn't regress it.)
+
+### Finding W-3c-3 — `runPolicy: Stopped` is reactive-only (restated)
+
+The harness's first cut waited for the controller pod to disappear after
+`runPolicy: Stopped`; it never did. `runPolicy: Stopped` prevents the
+controller from **recreating** the pod but does **not delete** the running
+one (the Phase 1 stop-guard finding). The spike fix patches Stopped
+(no-recreate) then explicitly `kubectl delete pod --wait`. Not a Phase 3c
+design item per se, but it confirms — again — that any controller path that
+needs a launcher pod **gone** must delete it, never assume Stopped does.
+
+### Finding W-3c-4 (trust-model gap) — `verifyChain` without subject checks
+
+The src stunnel CLIENT logged, at startup:
+
+```
+LOG4[ui]: Service [migration] uses "verifyChain" without subject checks
+```
+
+stunnel `verify = 2` validates that the peer cert **chains to the CA** — it
+does **NOT** pin the peer's subject/CN/SAN. In this spike **both** pods
+present the **same** leaf (`CN=kubeswift-migration`, a single shared
+`migration-leaf` Secret), so any peer holding any CA-signed cert is
+accepted. That is exactly the spike-prep §5 "authenticate ≠ authorize"
+gap made concrete: mTLS here proves "this peer has a CA-signed cert"; it
+does **not** prove "this is the legitimate src/dst for THIS migration."
+
+This is the central question the Phase 3c **design doc** must answer (it is
+explicitly out of scope for the spike). Options, with the trade-off the
+spike clarifies:
+
+- **Shared long-lived leaf (what the spike used).** Zero issuance latency
+  in the cutover hot path; weakest authz (any CA-signed peer accepted).
+  Acceptable only if the CA is tightly scoped (e.g., per-cluster, only
+  swiftletd pods can mount it).
+- **Per-node / per-swiftletd identity** (SAN = node or ServiceAccount) +
+  stunnel `verify = 4` / `checkHost`. Pins peer to a known identity;
+  still not per-migration; no per-migration issuance latency.
+- **Per-migration identity** (SAN = migration UID), cert-manager
+  Certificate per migration. Strongest authz (binds the channel to THIS
+  migration); adds cert issuance to **every** migration's critical path
+  and a hard cert-manager dependency in cutover. The spike did not measure
+  issuance latency — design must, if this option is on the table.
+
+**Whatever the choice, `verify = 2` alone is insufficient for production:
+the design must add subject/SAN pinning** (`verify = 4` + `checkHost`, or
+per-peer cert constraints), or the channel authenticates "a swiftletd" but
+not "the right swiftletd."
+
+---
+
+## Trust-model carry-forwards (for the Phase 3c design doc)
+
+From spike-prep §5, now informed by what the spike observed:
+
+- **mTLS does NOT subsume S1 (URLs-from-CR).** mTLS closes "redirect to an
+  arbitrary attacker endpoint" (attacker has no CA-signed cert — proven by
+  Q3 Test B). It does **not** close "redirect to a different *valid*
+  migration pod" (which has a valid cert under a shared-leaf model — see
+  W-3c-4) nor "operator-writable annotation inputs." **Both** mTLS *and*
+  URLs-from-SwiftMigration-CR are required for defense-in-depth; neither
+  subsumes the other. The Phase 2 S1 work (read URLs from the CR, not pod
+  annotations) remains a Phase 3c must-have alongside this transport work.
+- **`migration-phase2-unsafe-plaintext: ack` becomes a one-way switch.**
+  Once mTLS ships, the design must either reject plaintext on the
+  controller side too, or delete the annotation key entirely
+  (THREAT-MODEL Phase 3 must-have). The spike still relied on the ack gate
+  (the shipped swiftletd image enforces it); Phase 3c retires it.
+- **`spec.allowVersionSkew` is OBSOLETE** — retired in the Phase 3b spike
+  (`newDstPod` clone-src structurally prevents skew). Do not carry it into
+  the Phase 3c API surface.
+- **Audit events** for migration phase transitions remain a THREAT-MODEL
+  Phase 3 must-have (not exercised by this spike).
+
+---
+
+## What the spike did NOT cover (explicitly design-doc territory)
+
+- Per-migration cert identity / authz (SAN binding the peer to THIS
+  migration) and the cert-issuance-latency measurement that choice needs.
+- Controller-integration wiring beyond the sketch in W-3c-1/2: Certificate
+  per pod vs. per-node, issuance timing, rotation, secret mount plumbing.
+- The S1 annotations→SwiftMigration-CR migration (separate composing
+  workstream).
+- RWO disk-boot live migration (orthogonal storage-architecture question;
+  this spike used RWX/Block like Phase 3a/3b).
+- tcpdump confirmation that the cross-pod path carries only TLS records —
+  inferred from the stunnel close-stats (`0 byte(s) sent to socket` on
+  rejects; encrypted bytes only on the accepted path) rather than a packet
+  capture. A packet capture is a cheap belt-and-suspenders add if the
+  design review wants it.
+
+---
+
+## Reproduction
+
+```bash
+export KUBECONFIG=.../kubeswift-cluster.yaml
+cd tools/spike/phase-3c-mtls
+
+# Layer A — cert hierarchy (idempotent)
+kubectl apply -f certs.yaml          # ns mtls-spike; migration-leaf Secret
+
+# Layer B — bring up the mTLS src/dst pair (folds in the choreography fix)
+./launch-mtls-pods.sh
+
+# write an in-memory sentinel into the src guest (serial console), then:
+export NS=mtls-spike SRC_POD=mtls-guest-mig-src DST_POD=mtls-guest-mig-dst
+./trigger-mtls-migration.sh
+
+# Layer C/D evidence
+kubectl -n mtls-spike logs mtls-guest-mig-dst -c stunnel   # SERVER: verify + bytes
+kubectl -n mtls-spike logs mtls-guest-mig-src -c stunnel   # CLIENT: verify + warning
+```
+
+The spike branch `spike/phase-3c-mtls` carries the harness, the certs, the
+stunnel configs, and the Layer A→D walkthrough. **It is not for merge** —
+only this findings doc lands on `main`.

--- a/docs/design/live-migration-phase-3c-spike-prep.md
+++ b/docs/design/live-migration-phase-3c-spike-prep.md
@@ -1,0 +1,259 @@
+# Live Migration Phase 3c — mTLS Transport Spike (Prep)
+
+> This is the **spike-prep** doc, not findings. It captures the framing,
+> candidate architecture, trust-model context, the spike questions, and
+> Layer A's done state so a fresh session can pick up Layer B without
+> re-deriving any of it.
+>
+> Spike branch: `spike/phase-3c-mtls` — **NOT for merge** (project spike
+> contract; findings doc lands separately).
+> Last updated: 2026-05-29.
+>
+> **Status (2026-05-30): the spike is COMPLETE.** All four questions in §4
+> were answered empirically (all PASS). See the findings in
+> [`live-migration-phase-3c-mtls-spike.md`](live-migration-phase-3c-mtls-spike.md).
+> The "to resume" / "Resume checklist" language below is the original
+> planning text, preserved as the spike's design-intent record; the
+> Layer B–D walkthrough and the reproduction harness live on the unmerged
+> `spike/phase-3c-mtls` branch.
+
+---
+
+## 1. Why this spike, and why first
+
+Phase 3a/3b shipped live migration over **plaintext TCP**. The source
+swiftletd calls Cloud Hypervisor's `vm.send-migration` with
+`destination_url=tcp:<dst-pod-ip>:6789`; the destination listens via
+`vm.receive-migration` on `tcp:0.0.0.0:6789`. Full guest memory crosses
+the pod network in cleartext, gated only by a controller-auto-set
+`kubeswift.io/migration-phase2-unsafe-plaintext: ack` annotation —
+operators get the plaintext path without a real per-migration ack.
+
+`docs/design/THREAT-MODEL.md` "Phase 3 must-have-before-production-
+traffic" lists this as non-negotiable for production: **mTLS on the
+migration channel** (sidecar with stunnel/socat **or** upstream CH
+support); plus the related S1 work (URLs from SwiftMigration CR, not
+operator-writable annotations) and audit events. (#4
+`spec.allowVersionSkew` is **obsolete** — retired in the Phase 3b spike
+because `newDstPod` clone-src structurally prevents skew.)
+
+Phase 3c kicked off with the decision to **spike the mTLS transport
+first** — validate the highest-risk unknown on the real cluster before
+authoring the design doc. The candidate approach is a TLS-tunneling
+sidecar (stunnel) per launcher pod, with **no Cloud Hypervisor
+changes**: CH keeps speaking plaintext TCP to localhost; the sidecar
+owns the cross-pod TLS.
+
+**Spike scope intentionally narrowed:** the *transport* mechanics +
+performance + enforcement. **The cert identity model** (per-migration
+cert with SAN=migration UID vs. a longer-lived per-node/swiftletd
+identity) is *the* key trust-model decision — but the spike validates
+the transport with a **simple shared cluster-CA + single leaf identity**
+to de-risk the mechanics; per-migration identity is then a design-doc
+decision informed by the spike's cert-lifecycle observations.
+
+---
+
+## 2. Recon facts (verified on `main`)
+
+| What | Where | Value |
+|---|---|---|
+| CH send body | `rust/swift-ch-client/src/methods.rs:164` | `{"destination_url":"tcp:<host>:<port>"}` — explicitly plaintext (line 128) |
+| CH receive body | `rust/swift-ch-client/src/methods.rs:219` | `{"receiver_url":"tcp:0.0.0.0:<port>"}` |
+| Migration port | `internal/controller/swiftmigration/stopandcopy_live.go:35` | `migrationListenPort = 6789` |
+| Controller wires | `stopandcopy_live.go:335,380` | `ListenURL=tcp:0.0.0.0:6789`, `TargetURL=tcp:<dst-ip>:6789` |
+| Dst pod build | `internal/controller/swiftmigration/dst_pod.go::newDstPod` | DeepCopies src pod spec → a sidecar added to launcher pod is **inherited by dst** |
+| Launcher pod shape | `internal/controller/swiftguest/pod.go:227,361` | Single launcher container + init-containers (network-init, clone-grow-init) → a sidecar = one appended container |
+| cert-manager | `kubectl get pods -n cert-manager` | Running with `certificates.cert-manager.io` etc. CRDs |
+| Manual-demo scaffolding | `test/migration/manual/{source,destination,run,verify}.sh`, `tools/manual-demo/phase-3b-pr1/{launch-pods,trigger-migration,cleanup}.sh`, `Makefile:215 migration-phase2-manual` | The lever for driving CH through localhost-redirected URLs without modifying the shipped controller/swiftletd |
+
+**The annotation/CR boundary the spike must be aware of:** swiftletd
+currently reads `target_url`/`listen_url`/`guest_ip` from the
+`migration-action-args` pod annotation (the three `SECURITY-S1` sites).
+Manual-demo path can set these annotations directly — that's how the
+spike will inject localhost URLs without touching swiftletd source.
+
+---
+
+## 3. Candidate architecture (under test)
+
+**stunnel sidecar per launcher pod, no CH change:**
+
+- **Destination pod:** stunnel runs as TLS **server** on `0.0.0.0:6789`,
+  required-and-verifies client cert against the CA, forwards decrypted
+  plaintext to `127.0.0.1:<local>` where CH's `vm.receive-migration`
+  listens. swiftletd points CH at `tcp:127.0.0.1:<local>` instead of
+  `0.0.0.0:6789`.
+- **Source pod:** stunnel runs as TLS **client** on `127.0.0.1:<local>`,
+  presenting a client cert. CH's `vm.send-migration` targets that local
+  port. stunnel TLS-dials `<dst-pod-ip>:6789`, verifies the server cert
+  against the CA, streams.
+- **Cert material:** the `migration-leaf` Secret (`mtls-spike`
+  namespace) mounted into both pods as `/etc/migration-tls/{tls.crt,
+  tls.key,ca.crt}`. `usages: [server auth, client auth]` so one
+  identity serves both ends (spike-only simplification).
+
+**Where the dst-pod-IP gets injected into the src sidecar config** is a
+real wiring question the spike should at least surface (env var written
+by an init container? `kubectl exec`-driven sed? for the spike, hand-
+configure the src stunnel with the known dst IP).
+
+---
+
+## 4. Spike questions
+
+1. **CH-through-tunnel correctness.** Does CH's `vm.send-migration`
+   (destination_url=localhost) and `vm.receive-migration`
+   (receiver_url=localhost) complete cleanly with stunnel forwarding
+   in between? Guest resumes intact (sentinel survives).
+2. **Performance.** Throughput / transfer duration / downtime vs. the
+   shipped plaintext baseline (~108 MB/s, ~38s transfer, ~2-3s downtime
+   for a 4 GiB guest). Expectation: AES-NI ≫ gigabit, so impact should
+   be minimal — but measure on real hardware.
+3. **Enforcement (negative test).** A client presenting no cert / a
+   cert from a different CA is **rejected** at TLS handshake. The
+   transport actually authenticates, not just encrypts.
+4. **Wiring sketch.** Where dst-pod-IP and cert material get injected
+   into the sidecar config — enough to inform the controller-integration
+   design.
+
+**Out of scope for this spike (design-doc territory):** per-migration
+cert identity / authz model (cert SAN binding the peer to *this*
+migration), the controller-integration wiring (Certificate per pod vs.
+per-node, issuance timing, rotation), audit events, the S1 annotations
+→ SwiftMigration CR migration.
+
+---
+
+## 5. Trust-model framing (for the design doc after the spike)
+
+The spike validates **transport** (mTLS authenticated channel). The
+deeper trust questions the design doc must answer, informed by what the
+spike observes:
+
+- **Identity model.** What does each side's cert *assert* — pod-name
+  SAN? ServiceAccount? SPIFFE? — and how does each side *authorize*
+  (not merely authenticate) the peer? mTLS only proves "this peer has
+  a CA-signed cert"; it does **not** prove "this is the legitimate src
+  for THIS migration." Binding to a specific migration needs either
+  per-migration cert identity (SAN = migration UID) OR a pre-shared
+  per-migration secret carried in-band.
+- **Trust anchor + cert lifecycle for dynamic pods.** cert-manager
+  Certificate→Secret→Volume, but the dst pod is created *per migration*
+  by the controller. Per-migration certs add issuance latency to every
+  migration (and a cert-manager dependency in the cutover hot path);
+  longer-lived per-node/per-swiftletd certs avoid latency but weaken
+  per-migration authz. The spike's cert-lifecycle observations should
+  inform this choice.
+- **Composition with S1 (URLs-from-CR).** mTLS **does** close
+  "redirect to an arbitrary attacker endpoint" (attacker has no
+  CA-signed cert). It does **not** close "redirect to a different
+  *valid* migration pod" (which has a valid cert) nor "operator-
+  writable inputs." So **both** mTLS *and* URLs-from-CR are needed for
+  defense-in-depth; design must do both, neither subsumes the other.
+- **What the spike must prove to call the transport secure (Q3
+  negative test):** peer with no cert *and* peer with wrong-CA cert
+  both rejected at handshake.
+
+---
+
+## 6. Layer A status (DONE)
+
+cert-manager resources at `tools/spike/phase-3c-mtls/certs.yaml`,
+applied to namespace `mtls-spike`. Hierarchy:
+
+- `Issuer/selfsigned` (bootstrap)
+- `Certificate/mtls-ca` (self-signed CA root, ECDSA P-256, isCA=true,
+  duration 1y) → `Secret/mtls-ca`
+- `Issuer/mtls-ca-issuer` (references CA secret)
+- `Certificate/migration-leaf` (commonName `kubeswift-migration`, dnsName
+  `kubeswift-migration`, ECDSA P-256, **usages: server auth + client
+  auth**, duration 1y) → `Secret/migration-leaf` carrying
+  `ca.crt`/`tls.crt`/`tls.key`
+
+Verified on cluster: both Certificates `Ready=True`; the
+`migration-leaf` Secret has all three keys. Either reuse the live
+state on resume, or `kubectl apply -f` the manifest fresh.
+
+---
+
+## 7. Layers B–D plan (to resume)
+
+### Layer B — stunnel mTLS transport + CH-through-tunnel (the crux)
+
+1. Read `test/migration/manual/{source,destination,run}.sh` and
+   `tools/manual-demo/phase-3b-pr1/launch-pods.sh` to understand
+   exactly how the manual-demo rig templates launcher pods + drives
+   the migration via `kubectl annotate`.
+2. Augment the launcher pod template with an **stunnel sidecar
+   container**:
+   - Image candidate: a maintained stunnel container (e.g., `dweomer/stunnel` or build a tiny one from `alpine` + `stunnel`).
+   - Mount `Secret/migration-leaf` at `/etc/migration-tls/`.
+   - Stunnel configs (server on dst, client on src) — choose a port
+     pair (e.g., CH listens on 127.0.0.1:6790, stunnel public on
+     :6789; CH dials 127.0.0.1:6790 on src, stunnel-client dials
+     `<dst-ip>:6789`).
+   - For the spike, hand-write the dst-IP into the src stunnel config
+     (controller-integration wiring is design-doc territory).
+3. Apply two augmented launcher pods (one on miles, one on boba) and
+   verify both sidecars are Ready + cert-mounted.
+4. Drive a manual live migration via annotations with **localhost**
+   URLs: `listen_url=tcp:127.0.0.1:6790` on dst,
+   `target_url=tcp:127.0.0.1:6790` on src.
+5. Assertions: migration succeeds, guest sentinel survives on dst, no
+   plaintext traffic on the cross-pod path (could verify with a quick
+   `tcpdump` capture showing only TLS handshake + encrypted records).
+
+### Layer C — performance
+
+Run baseline (current plaintext shipped path, kernel-boot 4 GiB
+guest): downtime, transfer duration, throughput. Then the augmented
+mTLS pods, same workload, same nodes. Compare. Expect minor delta;
+record numbers for the design doc.
+
+### Layer D — enforcement / negative test
+
+- Start the dst with the leaf cert + CA; try src connection with no
+  cert → reject at TLS handshake.
+- Issue a leaf cert from a *different* self-signed CA in another
+  namespace; src uses that; dst still using `mtls-spike` CA → reject.
+- Both must be rejected at TLS handshake, not at CH layer.
+
+### Findings doc (after Layer D)
+
+`docs/design/live-migration-phase-3c-mtls-spike.md` records the
+question-by-question answers, headline numbers, and the design-doc
+decisions the spike informs (per-migration vs. longer-lived identity,
+sidecar image choice, wiring sketch). Per the spike contract, the
+spike branch is **not merged**; only the findings doc lands on `main`.
+
+---
+
+## 8. Open follow-ups to flag in the findings doc
+
+These don't gate the spike but should be carried into the Phase 3c
+design:
+
+- **S1 annotations → SwiftMigration CR** (separate but composing
+  workstream; see §5).
+- **`migration-phase2-unsafe-plaintext: ack` gate** — once mTLS ships,
+  this gate becomes a one-way switch: plaintext rejected on the
+  controller side too, or the annotation key is deleted entirely (the
+  THREAT-MODEL Phase 3 must-have).
+- **Audit events** for migration phase transitions (THREAT-MODEL
+  Phase 3 must-have #3).
+- **`spec.allowVersionSkew` must-have is OBSOLETE** (retired in Phase
+  3b spike — `newDstPod` clone-src structurally prevents skew). Drop
+  it from the must-have list when the design doc is written.
+
+---
+
+## 9. Resume checklist for the next session
+
+1. `git checkout spike/phase-3c-mtls && git pull origin spike/phase-3c-mtls`.
+2. `KUBECONFIG=/home/wrkode/code/vmm-kubeswift/dev-tests/kubeswift/kubeswift-cluster.yaml kubectl get certificate -n mtls-spike` —
+   verify Layer A is still live; if not, `kubectl apply -f
+   tools/spike/phase-3c-mtls/certs.yaml`.
+3. Read this doc §3 and §7 — that's the architecture and the
+   step-by-step.
+4. Start Layer B step 1 (read the manual-demo scripts).


### PR DESCRIPTION
## Summary

Lands the **Phase 3c mTLS transport spike** findings on `main`. The spike
empirically validated that Cloud Hypervisor live migration runs unchanged
over a mutually-authenticated TLS channel terminated by an stunnel sidecar
(CH speaks plaintext to localhost only; the sidecar owns the cross-pod TLS
hop). **No CH change, no swiftletd change.**

Two docs land here; the spike branch (`spike/phase-3c-mtls`: harness,
certs, stunnel configs, Layer A–D walkthrough) stays **unmerged** per the
project spike contract. The spike-prep doc is brought alongside the
findings doc so their cross-link resolves on `main`.

## Results — all four spike questions PASS

Cluster: miles→boba, CH v51.1, unmodified swiftletd `sha-e1db826`, 4 GiB
RWX/Block Ubuntu Noble guest.

- **Q1 correctness** — in-memory tmpfs sentinel md5 **identical** src→dst
  (proves MEMORY transfer, not the shared PVC); dst resumes live.
- **Q2 performance** — 4.03 GiB across the tunnel in 38675 ms =
  **111.86 MB/s**, ~1% delta vs the plaintext baseline (AES-NI ≫ gigabit).
- **Q3 enforcement** — both peers mutually verified `CN=kubeswift-migration`;
  **no-cert AND wrong-CA clients rejected at the TLS handshake with 0 bytes
  reaching CH** on `127.0.0.1:6790`.
- **Q4 wiring** — controller-integration findings for the design doc:
  - `lifecycle:stop` poisons the receiver pod (dst intent must be frozen
    `lifecycle:run` + receiver role, never inherit a stopped lifecycle);
  - `newDstPod` DeepCopy hands you the src's *client* sidecar config — the
    controller must flip role→server on dst and stamp the dst-IP onto the
    src sidecar after the dst gets an IP (env-parameterized, not baked into
    the image);
  - `runPolicy:Stopped` is reactive-only (restated);
  - **trust-model gap**: stunnel `verify=2` is `verifyChain` *without*
    subject checks — design must add SAN/subject pinning; **mTLS does NOT
    subsume S1** (URLs-from-CR) — both are needed.

## Not in scope (design-doc territory)

Per-migration vs. per-node cert identity + issuance-latency measurement,
controller-integration wiring beyond the sketch, S1 annotations→CR
migration, RWO disk-boot live migration.

## Test plan

- [x] Q1–Q4 validated on cluster (evidence quoted inline from live stunnel
      logs + migration annotations).
- [x] Relative markdown links in both docs resolve on this branch.
- [ ] Docs-only change — no code, no CI build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)