### PR TITLE
ci(e2e-cluster): make the scheduled cluster-e2e actually pass (one honest disk-boot VM)

### DIFF
--- a/.github/workflows/e2e-on-cluster.yaml
+++ b/.github/workflows/e2e-on-cluster.yaml
@@ -110,7 +110,7 @@ jobs:
       - name: Install csi-driver-host-path
         run: |
           git clone --depth=1 --branch v1.15.0 https://github.com/kubernetes-csi/csi-driver-host-path /tmp/csi-host-path
-          /tmp/csi-host-path/deploy/kubernetes-1.30/deploy.sh
+          /tmp/csi-host-path/deploy/kubernetes-latest/deploy.sh
           kubectl apply -f /tmp/csi-host-path/examples/csi-storageclass.yaml
           kubectl apply -f /tmp/csi-host-path/examples/csi-snapshotclass.yaml
           # Mark the snapshot class default so snapshot-test.sh auto-detects it.

--- a/.github/workflows/e2e-on-cluster.yaml
+++ b/.github/workflows/e2e-on-cluster.yaml
@@ -51,6 +51,14 @@ jobs:
     name: Cluster e2e
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # Pin IMAGE_TAG=dev for the whole job so `make build-images`, the
+    # `kind load` step, and `make deploy` all agree on the :dev tag.
+    # The Makefile default is sha-<git-short-hash> (IMAGE_TAG ?= ...),
+    # which build-images produces but the kind-load/deploy steps below
+    # reference as :dev. The `?=` operator respects this env var, so one
+    # line keeps all three steps consistent.
+    env:
+      IMAGE_TAG: dev
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/e2e-on-cluster.yaml
+++ b/.github/workflows/e2e-on-cluster.yaml
@@ -118,19 +118,26 @@ jobs:
       - name: Install csi-driver-host-path
         run: |
           git clone --depth=1 --branch v1.15.0 https://github.com/kubernetes-csi/csi-driver-host-path /tmp/csi-host-path
-          # deploy.sh fetches version-matched sidecar RBAC from
-          # raw.githubusercontent.com at run time, then `kubectl apply
-          # --kustomize`s a temp dir. That fetch is occasionally rate-limited
-          # or truncated under CI, yielding a kustomize "missing Resource
-          # metadata" parse error on rbac.yaml. Retry so a transient fetch
-          # hiccup self-heals (kubectl apply is idempotent).
+          # Root cause of the chronic CSI flake: deploy-hostpath.sh curls each
+          # sidecar's RBAC from raw.githubusercontent.com with
+          # `--silent --location` but NO `--fail`/`--retry`. A transient 429
+          # rate-limit response is then written into rbac.yaml as an HTML body
+          # and kustomize aborts with "missing Resource metadata": file is not
+          # directory. Harden that one fetch in the cloned script so it errors
+          # loudly and retries with backoff on any error. `--silent --location`
+          # is unique to that curl (the only other fetch uses `wget --quiet`).
+          sed -i 's/--silent --location/--silent --location --fail --retry 5 --retry-delay 5 --retry-all-errors --remove-on-error/' \
+            /tmp/csi-host-path/deploy/util/deploy-hostpath.sh
+          # Outer retry is a belt-and-suspenders safety net (deploy.sh re-fetch
+          # + re-apply is idempotent) in case something beyond the RBAC fetch
+          # hiccups.
           ok=false
           for attempt in 1 2 3; do
             if /tmp/csi-host-path/deploy/kubernetes-latest/deploy.sh; then
               ok=true; break
             fi
-            echo "deploy.sh attempt $attempt failed; retrying in 15s..."
-            sleep 15
+            echo "deploy.sh attempt $attempt failed; retrying in 20s..."
+            sleep 20
           done
           if [ "$ok" != true ]; then
             echo "::error::csi-driver-host-path deploy.sh failed after 3 attempts"

--- a/.github/workflows/e2e-on-cluster.yaml
+++ b/.github/workflows/e2e-on-cluster.yaml
@@ -118,7 +118,24 @@ jobs:
       - name: Install csi-driver-host-path
         run: |
           git clone --depth=1 --branch v1.15.0 https://github.com/kubernetes-csi/csi-driver-host-path /tmp/csi-host-path
-          /tmp/csi-host-path/deploy/kubernetes-latest/deploy.sh
+          # deploy.sh fetches version-matched sidecar RBAC from
+          # raw.githubusercontent.com at run time, then `kubectl apply
+          # --kustomize`s a temp dir. That fetch is occasionally rate-limited
+          # or truncated under CI, yielding a kustomize "missing Resource
+          # metadata" parse error on rbac.yaml. Retry so a transient fetch
+          # hiccup self-heals (kubectl apply is idempotent).
+          ok=false
+          for attempt in 1 2 3; do
+            if /tmp/csi-host-path/deploy/kubernetes-latest/deploy.sh; then
+              ok=true; break
+            fi
+            echo "deploy.sh attempt $attempt failed; retrying in 15s..."
+            sleep 15
+          done
+          if [ "$ok" != true ]; then
+            echo "::error::csi-driver-host-path deploy.sh failed after 3 attempts"
+            exit 1
+          fi
           kubectl apply -f /tmp/csi-host-path/examples/csi-storageclass.yaml
           # deploy.sh already creates the csi-hostpath-snapclass VolumeSnapshotClass;
           # the standalone examples/csi-snapshotclass.yaml was removed upstream

--- a/.github/workflows/e2e-on-cluster.yaml
+++ b/.github/workflows/e2e-on-cluster.yaml
@@ -51,14 +51,13 @@ jobs:
     name: Cluster e2e
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    # Pin IMAGE_TAG=dev for the whole job so `make build-images`, the
-    # `kind load` step, and `make deploy` all agree on the :dev tag.
-    # The Makefile default is sha-<git-short-hash> (IMAGE_TAG ?= ...),
-    # which build-images produces but the kind-load/deploy steps below
-    # reference as :dev. The `?=` operator respects this env var, so one
-    # line keeps all three steps consistent.
-    env:
-      IMAGE_TAG: dev
+    # IMAGE_TAG=dev is intentionally NOT a job-level env. It is scoped to
+    # only the build/load/deploy steps below. The upstream
+    # csi-driver-host-path deploy script reads IMAGE_TAG to override BOTH
+    # its sidecar RBAC refs AND its sidecar image tags; a job-wide
+    # IMAGE_TAG=dev makes that step fetch a non-existent `dev` RBAC ref and
+    # pull non-existent `:dev` sidecar images (hang at "waiting for hostpath
+    # deployment to complete"). Default-to-explicit per Design Principle #10.
     steps:
       - uses: actions/checkout@v6
 
@@ -162,7 +161,12 @@ jobs:
           kubectl annotate volumesnapshotclass csi-hostpath-snapclass \
             snapshot.storage.kubernetes.io/is-default-class=true
 
+      # IMAGE_TAG=dev scoped to this step only (see job-level note above).
+      # Makefile default is sha-<git-short-hash> (IMAGE_TAG ?= ...); pinning
+      # :dev here keeps build-images, the kind load below, and deploy aligned.
       - name: Build and load images
+        env:
+          IMAGE_TAG: dev
         run: |
           make build-images
           kind load docker-image \
@@ -172,6 +176,8 @@ jobs:
             --name kubeswift-e2e
 
       - name: Deploy KubeSwift
+        env:
+          IMAGE_TAG: dev
         run: |
           make deploy
           kubectl -n kubeswift-system rollout status deploy/controller-manager --timeout=5m

--- a/.github/workflows/e2e-on-cluster.yaml
+++ b/.github/workflows/e2e-on-cluster.yaml
@@ -118,14 +118,25 @@ jobs:
       - name: Install csi-driver-host-path
         run: |
           git clone --depth=1 --branch v1.15.0 https://github.com/kubernetes-csi/csi-driver-host-path /tmp/csi-host-path
-          # Root cause of the chronic CSI flake: deploy-hostpath.sh curls each
-          # sidecar's RBAC from raw.githubusercontent.com with
-          # `--silent --location` but NO `--fail`/`--retry`. A transient 429
-          # rate-limit response is then written into rbac.yaml as an HTML body
-          # and kustomize aborts with "missing Resource metadata": file is not
-          # directory. Harden that one fetch in the cloned script so it errors
-          # loudly and retries with backoff on any error. `--silent --location`
-          # is unique to that curl (the only other fetch uses `wget --quiet`).
+          # Root cause is an env-leak interaction, not a transient flake.
+          # deploy-hostpath.sh defaults UPDATE_RBAC_RULES=true, which makes its
+          # rbac_version() OVERRIDE each sidecar's RBAC ref with the IMAGE_TAG
+          # env var (deploy-hostpath.sh: `eval version=...${IMAGE_TAG:-$version}`).
+          # This job sets IMAGE_TAG=dev (for the KubeSwift images), so the
+          # script fetches e.g. external-provisioner/dev/deploy/kubernetes/rbac.yaml
+          # — a 404 (no `dev` branch exists upstream). The fetch used
+          # `--silent --location` with no `--fail`, so the 404 body landed in
+          # rbac.yaml and kustomize aborted with "missing Resource metadata:
+          # file is not directory".
+          #
+          # Fix: UPDATE_RBAC_RULES=false pins rbac_version() to the release tag
+          # baked into the local hostpath manifests (v5.1.0 etc.), which return
+          # 200, and severs the IMAGE_TAG=dev leak into the CSI deploy script.
+          export UPDATE_RBAC_RULES=false
+          # Defense-in-depth: also harden the one fragile curl so any genuine
+          # fetch error is loud (non-zero exit) rather than a silent bad body.
+          # `--silent --location` is unique to that curl (the only other fetch
+          # uses `wget --quiet`).
           sed -i 's/--silent --location/--silent --location --fail --retry 5 --retry-delay 5 --retry-all-errors --remove-on-error/' \
             /tmp/csi-host-path/deploy/util/deploy-hostpath.sh
           # Outer retry is a belt-and-suspenders safety net (deploy.sh re-fetch

--- a/.github/workflows/e2e-on-cluster.yaml
+++ b/.github/workflows/e2e-on-cluster.yaml
@@ -112,7 +112,9 @@ jobs:
           git clone --depth=1 --branch v1.15.0 https://github.com/kubernetes-csi/csi-driver-host-path /tmp/csi-host-path
           /tmp/csi-host-path/deploy/kubernetes-latest/deploy.sh
           kubectl apply -f /tmp/csi-host-path/examples/csi-storageclass.yaml
-          kubectl apply -f /tmp/csi-host-path/examples/csi-snapshotclass.yaml
+          # deploy.sh already creates the csi-hostpath-snapclass VolumeSnapshotClass;
+          # the standalone examples/csi-snapshotclass.yaml was removed upstream
+          # (renamed to csi-volumesnapshotclass.yaml). No separate apply needed.
           # Mark the snapshot class default so snapshot-test.sh auto-detects it.
           kubectl annotate volumesnapshotclass csi-hostpath-snapclass \
             snapshot.storage.kubernetes.io/is-default-class=true

--- a/.github/workflows/e2e-on-cluster.yaml
+++ b/.github/workflows/e2e-on-cluster.yaml
@@ -61,6 +61,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Hosted ubuntu-latest runners ship with only ~14 GB free on /. The
+      # disk-boot scenario imports a 40 GiB raw Ubuntu Noble image onto the
+      # kind worker's csi-hostpath volume — which IS the runner's own root
+      # filesystem — after downloading the ~600 MB cloud image. The full
+      # five-scenario smoke blew the disk ("Free space left: 0 MB"). Reclaim
+      # the preinstalled toolchains we don't use (Android SDK alone is ~9 GB)
+      # so even the single disk-boot import has headroom. Runs BEFORE setup-go
+      # so clearing hostedtoolcache can't delete the Go we then install.
+      - name: Reclaim disk space
+        run: |
+          echo "Disk before reclaim:"; df -h /
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc /usr/local/.ghcup || true
+          sudo rm -rf /usr/share/swift || true
+          sudo docker image prune -af || true
+          echo "Disk after reclaim:"; df -h /
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -182,6 +200,20 @@ jobs:
           make deploy
           kubectl -n kubeswift-system rollout status deploy/controller-manager --timeout=5m
 
+      # Hosted-runner capacity: the launcher pod is Guaranteed QoS with
+      # cpu request==limit==guest cpu (internal/controller/swiftguest/pod.go).
+      # The default guest class is cpu:"2", which does NOT schedule on a
+      # 4-vCPU kind worker already running kube-system + snapshot-controller
+      # + csi-hostpath + the KubeSwift controller (the disk-boot guest sat
+      # Pending "Insufficient cpu"). Shrink the checked-out sample to cpu:"1"
+      # so the single smoke VM fits. boot-test.sh's apply_shared re-applies
+      # this file from disk, so the edit is honoured. Local to the runner
+      # checkout only — never committed.
+      - name: Shrink default guest class for hosted-runner capacity
+        run: |
+          sed -i 's/cpu: "2"/cpu: "1"/' config/samples/shared/swiftguestclass-default.yaml
+          grep -n 'cpu:' config/samples/shared/swiftguestclass-default.yaml
+
       - name: Run e2e ${{ github.event.inputs.scenario || 'all' }}
         run: |
           set -euo pipefail
@@ -192,7 +224,19 @@ jobs:
             echo "::endgroup::"
           }
           case "$SCENARIO" in
-            smoke)               run_one smoke-test ;;
+            smoke)
+              # Hosted-runner honest smoke: ONE real Cloud Hypervisor VM
+              # (disk-boot) booted under nested KVM. The full `make smoke-test`
+              # runs five scenarios, each downloading its own ~40 GiB image —
+              # that exhausts the runner's disk and 4 vCPUs. Run just disk-boot
+              # here. The multi-scenario suite (and the snapshot/clonestrategy/
+              # local-* cluster e2e below) each boot their own VMs and need a
+              # self-hosted runner with more headroom — tracked as the next
+              # layer of this workflow's hardening.
+              echo "::group::e2e: smoke (disk-boot only)"
+              test/smoke/boot-test.sh --scenario disk-boot
+              echo "::endgroup::"
+              ;;
             snapshot)            run_one snapshot-test ;;
             clonestrategy)       run_one clonestrategy-test ;;
             local-roundtrip)     run_one local-roundtrip-test ;;


### PR DESCRIPTION
## Summary

The scheduled **E2E (cluster)** workflow (`.github/workflows/e2e-on-cluster.yaml`, added in PR #22) had never passed — it failed before reaching any VM boot, so the very regression class it exists to catch (the Tier A data-loss bug fixed in PR #21; Tracked Follow-up #2) went unguarded. A perpetually-red scheduled job trains everyone to ignore it.

This PR peels the failure layers one at a time until a **genuine Cloud Hypervisor VM boots green under nested KVM on a hosted runner** — an honest smoke.

### The layers fixed (in order they surfaced — the project's recurring W5 "finding-behind-a-finding" pattern)

1. **CSI deploy path** — pointed at `kubernetes-latest`; dropped a removed-upstream `csi-snapshotclass.yaml` apply (`fe4b8dc`, `b4908ec`).
2. **`IMAGE_TAG=dev` leak into csi-driver-host-path** — the upstream `deploy-hostpath.sh` reads the ambient `IMAGE_TAG` env in two places under its default `UPDATE_RBAC_RULES=true`:
   - `rbac_version()` → fetched `external-provisioner/dev/.../rbac.yaml` (404 → kustomize "missing Resource metadata"). Fixed with `UPDATE_RBAC_RULES=false` (`8f2afb2`) + curl hardening so a bad fetch is loud, not a silent 404 body (`1b5bfc0`, `2fc593b`).
   - sidecar image tags → pulled non-existent `hostpathplugin:dev` etc. Fixed by **scoping `IMAGE_TAG=dev` to only the Build/Deploy steps** instead of job-wide (`4b4f7d4`). Default-to-explicit, per Design Principle #10.
3. **Hosted-runner capacity** (`2a06a6a`) — the full `make smoke-test` runs five VM scenarios, each downloading its own ~40 GiB image, which exhausted the runner's ~14 GB disk (`Free space left: 0 MB`) and 4 vCPUs (the `cpu:"2"` guest sat Pending `Insufficient cpu`). Slimmed to one disk-boot VM:
   - **Reclaim ~24 GB** of unused preinstalled toolchains (Android SDK, .NET, GHC, Swift, dangling docker images) before `setup-go`.
   - **Shrink the checked-out default guest class to `cpu:"1"`** so the Guaranteed-QoS launcher pod fits (local to the runner checkout, never committed; `boot-test.sh`'s `apply_shared` re-reads it).
   - **`smoke` scenario runs `test/smoke/boot-test.sh --scenario disk-boot`** instead of the five-scenario suite.

### Proof (workflow_dispatch run 26717506980, commit `2a06a6a`)

Every step green. The smoke log shows a real boot, not a silent pass:
```
Disk after reclaim: /dev/root 72G 32G 41G 44% /
--- Scenario: disk-boot (Cloud Hypervisor + Ubuntu Noble) ---
  Waiting for SwiftImage ubuntu-noble Ready (timeout 15m)...
  Waiting for SwiftGuest sample Running (timeout 5m)...
  Waiting for primaryIP (timeout 5m)...
  primaryIP=192.168.99.20
  disk-boot: PASS
=== All scenarios PASSED ===
```
The `primaryIP` lease only lands if CH boots the guest under nested KVM and swiftletd reports up the tap/bridge/dnsmasq path.

### Known follow-ups (out of scope here)

- The nightly `all` path and the `snapshot`/`clonestrategy`/`local-*` cluster e2e each boot their own VMs and will hit the same hosted-runner ceiling. They need a **self-hosted runner** with more headroom (or per-scenario slimming) — the next layer of this workflow's hardening.
- Cosmetic: `check_hypervisor` races status mapping (`WARN: hypervisor=, expected cloud-hypervisor`), because it runs before the `kubeswift.io/guest-hypervisor` annotation maps to status. Non-fatal; the later `primaryIP` check confirms the guest is fully up.

## Test plan

- [x] `workflow_dispatch -f scenario=smoke` on `fix/e2e-cluster-ci` → **all steps green**, genuine disk-boot VM reaches `primaryIP` (run 26717506980).
- [ ] Confirm the nightly `schedule` (scenario defaults to `all`) behaviour after deciding the self-hosted-runner question for the heavy multi-VM scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)