### PR TITLE
Phase 3c PR 1: live-migration mTLS cert-provisioning foundation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
 
 .PHONY: build build-go build-rust build-images build-controller-image build-swiftletd-image \
-	build-gpu-discovery-image generate deploy deploy-with-webhook undeploy load-images smoke-test smoke-test-cleanup \
+	build-gpu-discovery-image generate deploy deploy-with-webhook deploy-with-mtls undeploy load-images smoke-test smoke-test-cleanup \
 	clonestrategy-test snapshot-test local-roundtrip-test local-clone-identity-test \
 	b0-cross-node-tcp-test e2e-tests \
 	verify-e2e-scripts \
@@ -53,6 +53,7 @@ help:
 	@echo "  verify-crd-sync       Fail if config/crd/kustomization.yaml drifts from config/crd/bases/"
 	@echo "  deploy                Deploy controller-manager (minimal install, no webhooks). Use deploy-with-webhook for webhook-enabled deploys (requires cert-manager)."
 	@echo "  deploy-with-webhook   Deploy controller-manager with admission webhooks enabled (requires cert-manager cluster-side; applies config/overlays/webhook on top of the minimal install)"
+	@echo "  deploy-with-mtls      Deploy controller-manager with live-migration mTLS cert provisioner enabled (Phase 3c; requires cert-manager cluster-side; applies config/overlays/migration-mtls on top of the minimal install)"
 	@echo "  undeploy              Remove KubeSwift from cluster, then CRDs"
 	@echo "  load-images           Load built images into kind/minikube (local clusters)"
 	@echo "  smoke-test            Run boot smoke test (requires KubeSwift cluster)"
@@ -192,6 +193,27 @@ deploy-with-webhook: deploy
 	@# triggers a rollout. The env var set by `deploy` survives across
 	@# kustomize-apply because env is not declared in deployment.yaml,
 	@# but re-set defensively to handle the case where it was cleared.
+	kubectl set env deployment/controller-manager -n kubeswift-system \
+		KUBESWIFT_LAUNCHER_IMAGE=$(IMAGE_REGISTRY)/swiftletd:$(IMAGE_TAG)
+	kubectl -n kubeswift-system rollout status deploy/controller-manager --timeout=120s
+
+# deploy-with-mtls layers config/overlays/migration-mtls on top of the
+# minimal install. The overlay composes config/default + the cert-manager
+# PKI chain (selfSigned Issuer -> CA Certificate -> CA Issuer) and patches
+# the controller-manager Deployment to --migration-mtls-enabled=true, which
+# registers the migrationcert reconciler (one per-node leaf Certificate,
+# SAN=nodeName). Requires cert-manager installed cluster-side (the overlay's
+# Issuer + Certificate reference cert-manager CRDs). Mirrors the Helm
+# migration.mtls.enabled gate. Phase 3c, Option B.
+deploy-with-mtls: deploy
+	@echo "Layering migration-mtls overlay (patches deployment to --migration-mtls-enabled=true; applies cert-manager PKI chain)"
+	@# Same IMAGE_TAG sed-patch trick as `deploy` — the overlay composes
+	@# config/manager, so kustomize re-renders manager with the patch on top.
+	cd config/manager && sed -i 's/newTag: .*/newTag: $(IMAGE_TAG)/' kustomization.yaml
+	kubectl apply -k config/overlays/migration-mtls
+	cd config/manager && sed -i 's/newTag: .*/newTag: latest/' kustomization.yaml
+	@# Re-set the launcher image env var defensively — the overlay's
+	@# deployment patch replaces the args list, which triggers a rollout.
 	kubectl set env deployment/controller-manager -n kubeswift-system \
 		KUBESWIFT_LAUNCHER_IMAGE=$(IMAGE_REGISTRY)/swiftletd:$(IMAGE_TAG)
 	kubectl -n kubeswift-system rollout status deploy/controller-manager --timeout=120s

--- a/charts/kubeswift/templates/controller-manager/deployment.yaml
+++ b/charts/kubeswift/templates/controller-manager/deployment.yaml
@@ -36,6 +36,9 @@ spec:
             {{- else }}
             - --webhook-enabled=false
             {{- end }}
+            {{- if .Values.migration.mtls.enabled }}
+            - --migration-mtls-enabled=true
+            {{- end }}
           ports:
             - containerPort: 9443
               name: webhook

--- a/charts/kubeswift/templates/controller-manager/rbac.yaml
+++ b/charts/kubeswift/templates/controller-manager/rbac.yaml
@@ -45,9 +45,14 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # secrets — get,list,watch for general reads; create,update added for
+  # the Phase 3c live-migration mTLS path (migration.mtls.enabled): the
+  # migrationcert controller copies a node's cert-manager-issued identity
+  # Secret into guest namespaces (distribution, not issuance). The verbs
+  # are harmless when mTLS is disabled (the reconciler is not registered).
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "create", "update"]
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch"]
@@ -135,6 +140,18 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["get", "list", "watch", "create"]
+  # cert-manager.io Certificates — the Phase 3c migrationcert controller
+  # (migration.mtls.enabled) creates one per-node leaf Certificate
+  # (SAN=nodeName, Option B) and deletes stale ones. list+watch are
+  # required by controller-runtime's cached client (same informer pattern
+  # as W7/W8 — without them the cache fails to sync). cert-manager must be
+  # installed when mTLS is enabled; when disabled the reconciler is not
+  # registered, so this grant is dormant. The CA Issuer + CA Certificate
+  # are Helm-managed (templates/migration/issuer.yaml), not controller-
+  # created, so no issuers/clusterissuers grant is needed here.
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["get", "list", "watch", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/kubeswift/templates/migration/issuer.yaml
+++ b/charts/kubeswift/templates/migration/issuer.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.migration.mtls.enabled }}
+# Live-migration mTLS PKI (Phase 3c, Option B: per-node identity + SAN pinning).
+#
+# Bootstrap chain, all in {{ .Values.namespace }}:
+#   1. a self-signed Issuer that mints the migration CA,
+#   2. the migration CA Certificate (isCA),
+#   3. a CA Issuer backed by that CA Secret.
+# The controller's migrationcert reconciler then issues one leaf Certificate
+# per worker node (SAN = nodeName) signed by the CA Issuer below. The stunnel
+# sidecar presents that leaf and pins the peer via verify=4 + checkHost.
+#
+# Namespaced Issuers (not ClusterIssuers) are deliberate: a ClusterIssuer
+# with ca.secretName reads the CA Secret from cert-manager's own namespace,
+# not this release's. Keeping the CA Secret and the per-node leaf
+# Certificates co-located in {{ .Values.namespace }} avoids that gotcha.
+#
+# Requires cert-manager installed cluster-side (same prerequisite as the
+# webhook serving cert). Gated entirely on migration.mtls.enabled — off by
+# default, so clusters without cert-manager are unaffected.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kubeswift-migration-selfsigned-issuer
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: migration-mtls
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kubeswift-migration-ca
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: migration-mtls
+spec:
+  isCA: true
+  commonName: kubeswift-migration-ca
+  secretName: kubeswift-migration-ca
+  duration: 87600h # 10 years (CA)
+  renewBefore: 720h # 30 days
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: kubeswift-migration-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kubeswift-migration-ca-issuer
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: migration-mtls
+spec:
+  ca:
+    secretName: kubeswift-migration-ca
+{{- end }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -58,3 +58,15 @@ gpuDiscovery:
 # Admission webhooks (optional). Requires cert-manager. When enabled, controller-manager runs with --webhook-enabled=true.
 webhook:
   enabled: false
+
+# Live migration settings.
+migration:
+  # mTLS transport for cross-node live migration (Phase 3c, Option B per-node
+  # identity). When enabled the chart provisions a per-namespace cert-manager
+  # PKI (selfSigned Issuer -> CA -> CA Issuer) in .Values.namespace and the
+  # controller-manager runs with --migration-mtls-enabled=true (issues one
+  # leaf Certificate per worker node). Requires cert-manager installed
+  # cluster-side. Off by default — default clusters incur no cert-manager
+  # dependency and no behavior change.
+  mtls:
+    enabled: false

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -20,6 +20,7 @@ import (
 	seedv1alpha1 "github.com/projectbeskar/kubeswift/api/seed/v1alpha1"
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/migrationcert"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftgpu"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftguestpool"
@@ -53,6 +54,7 @@ const (
 func main() {
 	showVersion := flag.Bool("version", false, "Print version and exit")
 	webhookEnabled := flag.Bool("webhook-enabled", false, "Enable admission webhooks (requires TLS certs)")
+	migrationMTLSEnabled := flag.Bool("migration-mtls-enabled", false, "Enable the live-migration mTLS cert provisioner (Phase 3c; requires cert-manager)")
 	leaderElect := flag.Bool("leader-elect", false, "Enable leader election for controller manager")
 	webhookPort := flag.Int("webhook-port", defaultWebhookPort, "Port for webhook server")
 	webhookHost := flag.String("webhook-host", defaultWebhookHost, "Host for webhook server")
@@ -187,6 +189,24 @@ func main() {
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftMigration controller")
 		os.Exit(1)
+	}
+
+	// Live-migration mTLS cert provisioner (Phase 3c, Option B per-node
+	// identity). Registered ONLY when --migration-mtls-enabled=true. The
+	// reconciler issues one cert-manager Certificate per worker node
+	// (SAN=nodeName) into the system namespace; it is dormant (not
+	// registered) by default so clusters without cert-manager are
+	// unaffected. SystemNamespace is the controller's own namespace
+	// (POD_NAMESPACE), where the Helm/overlay-managed CA Issuer lives.
+	if *migrationMTLSEnabled {
+		if err = (&migrationcert.MigrationCertReconciler{
+			Client:          mgr.GetClient(),
+			Scheme:          mgr.GetScheme(),
+			SystemNamespace: leaderElectionNS,
+		}).SetupWithManager(mgr); err != nil {
+			klog.ErrorS(err, "unable to create migrationcert controller")
+			os.Exit(1)
+		}
 	}
 
 	if *webhookEnabled {

--- a/config/manager/controller-manager-rbac.yaml
+++ b/config/manager/controller-manager-rbac.yaml
@@ -97,9 +97,14 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # secrets — get,list,watch for general reads; create,update added for
+  # the Phase 3c live-migration mTLS path (--migration-mtls-enabled): the
+  # migrationcert controller copies a node's cert-manager-issued identity
+  # Secret into guest namespaces (distribution, not issuance). The verbs
+  # are dormant when mTLS is disabled (the reconciler is not registered).
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "create", "update"]
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch"]
@@ -151,6 +156,18 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["get", "list", "watch", "create"]
+  # cert-manager.io Certificates — the Phase 3c migrationcert controller
+  # (--migration-mtls-enabled) creates one per-node leaf Certificate
+  # (SAN=nodeName, Option B) and deletes stale ones. list+watch are
+  # required by controller-runtime's cached client (same informer pattern
+  # as W7/W8 — without them the cache fails to sync). cert-manager must be
+  # installed when mTLS is enabled; when disabled the reconciler is not
+  # registered, so this grant is dormant. The CA Issuer + CA Certificate
+  # are Helm/overlay-managed (config/overlays/migration-mtls/issuer.yaml),
+  # not controller-created, so no issuers/clusterissuers grant is needed.
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["get", "list", "watch", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -25,6 +25,11 @@ spec:
           args:
             - --leader-elect
             - --webhook-enabled=false
+            # Live-migration mTLS (Phase 3c) is off in the minimal install.
+            # The config/overlays/migration-mtls overlay flips this to true
+            # and provisions the cert-manager PKI chain (mirrors the Helm
+            # migration.mtls.enabled gate). See `make deploy-with-mtls`.
+            - --migration-mtls-enabled=false
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/config/overlays/migration-mtls/deployment-patch.yaml
+++ b/config/overlays/migration-mtls/deployment-patch.yaml
@@ -1,0 +1,22 @@
+# Patch controller-manager Deployment for live-migration mTLS mode.
+# Flips --migration-mtls-enabled to true so the migrationcert reconciler
+# registers and issues one per-node leaf Certificate (SAN=nodeName).
+#
+# The args list is replaced wholesale by strategic-merge (it is a list of
+# scalars), so the full minimal arg set must be restated here. webhook
+# stays disabled — composing webhook + mTLS is done via the webhook
+# overlay separately; this overlay is the minimal-plus-mTLS install.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: kubeswift-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: controller-manager
+          args:
+            - --leader-elect
+            - --webhook-enabled=false
+            - --migration-mtls-enabled=true

--- a/config/overlays/migration-mtls/issuer.yaml
+++ b/config/overlays/migration-mtls/issuer.yaml
@@ -1,0 +1,62 @@
+# Live-migration mTLS PKI (Phase 3c, Option B: per-node identity + SAN pinning).
+#
+# Bootstrap chain, all in kubeswift-system:
+#   1. a self-signed Issuer that mints the migration CA,
+#   2. the migration CA Certificate (isCA),
+#   3. a CA Issuer backed by that CA Secret.
+# The controller's migrationcert reconciler then issues one leaf Certificate
+# per worker node (SAN = nodeName) signed by the CA Issuer below. The stunnel
+# sidecar (PR 2/3) presents that leaf and pins the peer via verify=4 + checkHost.
+#
+# Namespaced Issuers (not ClusterIssuers) are deliberate: a ClusterIssuer
+# with ca.secretName reads the CA Secret from cert-manager's own namespace,
+# not this release's. Keeping the CA Secret and the per-node leaf
+# Certificates co-located in kubeswift-system avoids that gotcha.
+#
+# Requires cert-manager installed cluster-side (same prerequisite as the
+# webhook serving cert). This is the kustomize mirror of the Helm chart's
+# templates/migration/issuer.yaml (gated on migration.mtls.enabled).
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kubeswift-migration-selfsigned-issuer
+  namespace: kubeswift-system
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: migration-mtls
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kubeswift-migration-ca
+  namespace: kubeswift-system
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: migration-mtls
+spec:
+  isCA: true
+  commonName: kubeswift-migration-ca
+  secretName: kubeswift-migration-ca
+  duration: 87600h # 10 years (CA)
+  renewBefore: 720h # 30 days
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: kubeswift-migration-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kubeswift-migration-ca-issuer
+  namespace: kubeswift-system
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: migration-mtls
+spec:
+  ca:
+    secretName: kubeswift-migration-ca

--- a/config/overlays/migration-mtls/kustomization.yaml
+++ b/config/overlays/migration-mtls/kustomization.yaml
@@ -1,0 +1,23 @@
+# Migration-mTLS overlay: enables the Phase 3c live-migration mTLS cert
+# provisioner (Option B per-node identity). Layers on top of the minimal
+# install (config/default) and adds the cert-manager PKI chain
+# (selfSigned Issuer -> CA Certificate -> CA Issuer) plus a patch that
+# flips the controller-manager to --migration-mtls-enabled=true.
+#
+# Requires cert-manager installed cluster-side (the issuer.yaml resources
+# reference cert-manager CRDs). Apply: kubectl apply -k config/overlays/migration-mtls
+# Minimal path (no mTLS): kubectl apply -k config/default
+#
+# Mirrors the Helm migration.mtls.enabled gate (charts/kubeswift) — the
+# Helm chart provisions the same three resources from
+# templates/migration/issuer.yaml.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../default
+  - issuer.yaml
+patches:
+  - path: deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: controller-manager

--- a/docs/design/live-migration-phase-3c.md
+++ b/docs/design/live-migration-phase-3c.md
@@ -462,19 +462,35 @@ guest running and recoverable. mTLS adds handshake-rejection as a new
 
 1. **§3 cert identity model** — **RESOLVED 2026-05-30: Option B**
    (per-node identity + SAN pinning).
-2. **§3.B per-node cert provisioning** — per-node cert-manager
-   `Certificate` + `nodeName`-keyed Secret selection (lean (a)) vs
-   cert-manager csi-driver ((b)). Settle at implementation; leaning (a).
-3. **Sidecar image** — pin a maintained stunnel image + digest, or build a
-   tiny first-party one (alpine + stunnel, ASCII-only entrypoint per the
-   container-script rule). Supply-chain review for the third-party option.
+2. **§3.B per-node cert provisioning** — **RESOLVED 2026-05-31: (a)**
+   per-node cert-manager `Certificate` + `nodeName`-keyed Secret
+   selection (not the csi-driver (b)). Implemented in PR 1
+   (`internal/controller/migrationcert`): a Node-watch reconciler issues
+   one long-lived `Certificate` per worker node, SAN=nodeName, on node
+   join — satisfying the §3.B(a) / §4.4 precondition that no cert-manager
+   call sits on any migration path (the leaf is already issued; the
+   migration path only consumes the Secret). cert-manager types are
+   handled as `unstructured.Unstructured` to avoid a go.mod dependency on
+   an optional, operator-installed operator.
+3. **Sidecar image** — **RESOLVED 2026-05-31: build a tiny first-party
+   image** (alpine + stunnel, ASCII-only entrypoint per the
+   container-script rule), avoiding third-party supply-chain review.
+   Built in PR 2.
 4. **Cert lifetime vs `spec.timeout`** — ensure cert validity ≫ the
    longest permitted migration; document the relationship.
 5. **Ack-gate retirement sequencing** (§6.2) — controller-stop vs
    swiftletd-require-removal ordering across a rolling upgrade.
-6. **Cluster-level enable** — is mTLS unconditional once shipped, or gated
-   by a Helm value during rollout? (Lean: unconditional on the secured
-   path; no per-SwiftMigration opt-out, since plaintext is being retired.)
+6. **Cluster-level enable** — **RESOLVED 2026-05-31: Helm-gated opt-in
+   during rollout.** mTLS is gated by `migration.mtls.enabled` (off by
+   default) while Phase 3c lands across PRs 1-5, so clusters without
+   cert-manager are unaffected and the rollout is incremental. This is the
+   rollout posture, NOT a per-SwiftMigration opt-out: plaintext retirement
+   on the secured path (the `migration-phase2-unsafe-plaintext: ack` gate
+   becoming a one-way switch) still lands in PR 4 as designed. PR 1 ships
+   the `migration.mtls.enabled` Helm gate, the static
+   `--migration-mtls-enabled` flag, and the `deploy-with-mtls` kustomize
+   overlay (TFU-16 pattern: opt-in surfaces get an explicit Make target +
+   overlay).
 
 ---
 

--- a/internal/controller/migrationcert/certificate.go
+++ b/internal/controller/migrationcert/certificate.go
@@ -1,0 +1,188 @@
+// Package migrationcert provisions the per-node TLS identities used by
+// the Phase 3c live-migration mTLS transport (stunnel sidecar).
+//
+// Design contract: docs/design/live-migration-phase-3c.md, Option B
+// (per-node identity + SAN pinning). Each worker node gets one
+// cert-manager Certificate whose SAN (and CN) is the node name; the
+// stunnel sidecar on a migration's source/destination pod presents
+// that cert and the peer pins it via `verify = 4` + `checkHost =
+// <peer-node-name>`. A bare `verify = 2` (verifyChain without subject
+// checks) is insufficient (W-3c-4) — the SAN pin is what proves "this
+// is the legitimate src/dst node for THIS migration", not merely "the
+// peer holds a CA-signed cert".
+//
+// This file owns the per-node Certificate lifecycle:
+//   - newNodeCertificate builds the cert-manager Certificate object,
+//   - ensureNodeCertificate creates it idempotently,
+//   - deleteNodeCertificate garbage-collects it when a node goes away
+//     or is (re)labeled control-plane.
+//
+// Per §3.B(a) the per-node Certificate is a long-lived precondition —
+// issued once when a worker joins, NOT minted mid-migration (§4.4: no
+// cert-manager call sits on any migration path). The migration data
+// path only ever consumes the already-issued Secret (copied into guest
+// namespaces by secret.go).
+//
+// cert-manager is a prerequisite when migration mTLS is enabled (same
+// dependency as the webhook serving cert). The reconciler that drives
+// these helpers is only constructed when --migration-mtls-enabled=true,
+// so clusters without cert-manager are unaffected by default.
+//
+// cert-manager types are addressed as unstructured.Unstructured rather
+// than importing the cert-manager Go module: it keeps cert-manager out
+// of go.mod (it is an optional, operator-installed dependency) and the
+// Certificate shape we emit is small and stable.
+package migrationcert
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	certManagerGroup      = "cert-manager.io"
+	certManagerVersion    = "v1"
+	certManagerAPIVersion = certManagerGroup + "/" + certManagerVersion
+	certificateKind       = "Certificate"
+
+	// MigrationCAIssuerName is the namespaced cert-manager Issuer (in the
+	// controller's system namespace) that signs per-node migration leaf
+	// certificates. The Helm chart's migration issuer template
+	// (charts/kubeswift/templates/migration/issuer.yaml) creates it as a
+	// CA Issuer backed by the kubeswift-migration-ca Secret. Exported so
+	// PR 3's sidecar-wiring code can reference the same name.
+	MigrationCAIssuerName = "kubeswift-migration-ca-issuer"
+
+	// migrationNodeLabel records which node a Certificate/Secret belongs
+	// to (used for filtering and human inspection).
+	migrationNodeLabel = "kubeswift.io/migration-node"
+
+	// certNamePrefix is prepended to the node name to form the per-node
+	// Certificate (and Secret) name.
+	certNamePrefix = "kubeswift-migration-node-"
+
+	// certDuration / certRenewBefore mirror the webhook serving-cert
+	// cadence (1y lifetime, renew ~15d early). cert-manager handles the
+	// rotation; secret.go re-copies the rotated material on the next
+	// migration that needs it.
+	certDuration    = "8760h"
+	certRenewBefore = "360h"
+)
+
+var certificateGVK = schema.GroupVersionKind{
+	Group:   certManagerGroup,
+	Version: certManagerVersion,
+	Kind:    certificateKind,
+}
+
+// MigrationNodeCertName returns the cert-manager Certificate name for a node.
+func MigrationNodeCertName(nodeName string) string { return certNamePrefix + nodeName }
+
+// MigrationNodeSecretName returns the name of the Secret holding a node's
+// migration identity (tls.crt / tls.key / ca.crt). It matches the
+// Certificate's secretName — cert-manager writes the issued keypair there.
+// PR 3 copies this Secret into guest namespaces (see secret.go).
+func MigrationNodeSecretName(nodeName string) string { return certNamePrefix + nodeName }
+
+// MigrationNodeCertSAN returns the SAN (and CN) stamped into a node's
+// migration certificate. Option B pins peer identity on this value via
+// stunnel `checkHost`; it is exactly the node name.
+func MigrationNodeCertSAN(nodeName string) string { return nodeName }
+
+// newCertShell returns an empty Certificate object with its GVK set, for
+// use as the receiver of a Get or the target of a Delete.
+func newCertShell() *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(certificateGVK)
+	return u
+}
+
+func nodeCertLabels(nodeName string) map[string]interface{} {
+	return map[string]interface{}{
+		"app.kubernetes.io/name":       "kubeswift",
+		"app.kubernetes.io/component":  "migration-mtls",
+		"app.kubernetes.io/managed-by": "kubeswift-controller-manager",
+		migrationNodeLabel:             nodeName,
+	}
+}
+
+// newNodeCertificate builds the cert-manager Certificate for a worker node.
+// SAN/CN = nodeName (the Option B identity); usages cover both server auth
+// (the node acts as the dst stunnel TLS server) and client auth (the node
+// acts as the src stunnel TLS client). Signed by the namespaced CA Issuer.
+func newNodeCertificate(systemNamespace, nodeName string) *unstructured.Unstructured {
+	san := MigrationNodeCertSAN(nodeName)
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": certManagerAPIVersion,
+			"kind":       certificateKind,
+			"metadata": map[string]interface{}{
+				"name":      MigrationNodeCertName(nodeName),
+				"namespace": systemNamespace,
+				"labels":    nodeCertLabels(nodeName),
+			},
+			"spec": map[string]interface{}{
+				"secretName":  MigrationNodeSecretName(nodeName),
+				"duration":    certDuration,
+				"renewBefore": certRenewBefore,
+				"commonName":  san,
+				"dnsNames":    []interface{}{san},
+				// Node is both the TLS client (src) and TLS server (dst)
+				// across different migrations, so it needs both usages.
+				"usages": []interface{}{"server auth", "client auth"},
+				"issuerRef": map[string]interface{}{
+					"name":  MigrationCAIssuerName,
+					"kind":  "Issuer",
+					"group": certManagerGroup,
+				},
+			},
+		},
+	}
+}
+
+// ensureNodeCertificate creates the per-node Certificate if absent.
+// Idempotent: returns nil when the Certificate already exists (fast-path
+// Get, plus an AlreadyExists tolerance for the create race). cert-manager
+// owns the Certificate's contents thereafter; this helper never mutates an
+// existing one.
+func ensureNodeCertificate(ctx context.Context, c client.Client, systemNamespace, nodeName string) error {
+	key := types.NamespacedName{Namespace: systemNamespace, Name: MigrationNodeCertName(nodeName)}
+
+	existing := newCertShell()
+	err := c.Get(ctx, key, existing)
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get migration certificate %s: %w", key, err)
+	}
+
+	cert := newNodeCertificate(systemNamespace, nodeName)
+	if err := c.Create(ctx, cert); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("create migration certificate %s: %w", key, err)
+	}
+	return nil
+}
+
+// deleteNodeCertificate removes the per-node Certificate. Tolerates
+// NotFound (already gone). Deleting the Certificate causes cert-manager to
+// remove the backing Secret in the system namespace; copied per-namespace
+// Secrets are independent and outlive this (PR 3 owns their lifecycle).
+func deleteNodeCertificate(ctx context.Context, c client.Client, systemNamespace, nodeName string) error {
+	cert := newCertShell()
+	cert.SetNamespace(systemNamespace)
+	cert.SetName(MigrationNodeCertName(nodeName))
+	if err := c.Delete(ctx, cert); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	return nil
+}

--- a/internal/controller/migrationcert/controller.go
+++ b/internal/controller/migrationcert/controller.go
@@ -1,0 +1,126 @@
+package migrationcert
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// Node role labels Kubernetes stamps on control-plane members. A node
+// carrying either is excluded from per-node migration certificates:
+// disk-boot guests (the live-migration-capable workload class) schedule
+// onto workers, and control-plane nodes do not run launcher pods.
+const (
+	controlPlaneRoleLabel = "node-role.kubernetes.io/control-plane"
+	masterRoleLabel       = "node-role.kubernetes.io/master"
+)
+
+// MigrationCertReconciler ensures one cert-manager Certificate per worker
+// node for the Phase 3c live-migration mTLS transport (Option B per-node
+// identity). It watches Nodes directly: a worker joining triggers
+// Certificate creation; a worker leaving (or being relabeled
+// control-plane) triggers cleanup.
+//
+// This reconciler is only constructed when --migration-mtls-enabled=true.
+// It requires cert-manager installed cluster-side. With the flag off it
+// is never registered, so default clusters incur no cert-manager
+// dependency and no behavior change.
+type MigrationCertReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	// SystemNamespace is where per-node Certificates (and their
+	// cert-manager-written Secrets) live — the controller's own
+	// namespace. Sourced from POD_NAMESPACE (same value as leader
+	// election). Per-node Certs live here, NOT in guest namespaces;
+	// secret.go distributes the issued Secret to guest namespaces at
+	// migration time.
+	SystemNamespace string
+}
+
+// Reconcile ensures the per-node Certificate matches the node's existence
+// and role.
+func (r *MigrationCertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	nodeName := req.Name
+
+	var node corev1.Node
+	if err := r.Get(ctx, req.NamespacedName, &node); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Node deleted: garbage-collect its per-node Certificate.
+			// The cert name derives from the node name, which survives
+			// in req even though the Node object is gone.
+			if derr := deleteNodeCertificate(ctx, r.Client, r.SystemNamespace, nodeName); derr != nil {
+				return ctrl.Result{}, derr
+			}
+			logger.Info("node deleted, removed migration certificate", "node", nodeName)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !isWorkerNode(&node) {
+		// Control-plane node: ensure no stale per-node cert lingers
+		// (e.g. a node that was a worker first and got relabeled).
+		if err := deleteNodeCertificate(ctx, r.Client, r.SystemNamespace, nodeName); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if err := ensureNodeCertificate(ctx, r.Client, r.SystemNamespace, nodeName); err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.V(1).Info("ensured migration certificate", "node", nodeName)
+	return ctrl.Result{}, nil
+}
+
+// isWorkerNode reports whether a node should hold a per-node migration
+// certificate. Any control-plane/master role label excludes it.
+func isWorkerNode(node *corev1.Node) bool {
+	labels := node.GetLabels()
+	if _, ok := labels[controlPlaneRoleLabel]; ok {
+		return false
+	}
+	if _, ok := labels[masterRoleLabel]; ok {
+		return false
+	}
+	return true
+}
+
+// workerNodePredicate keeps the reconciler off the node-heartbeat churn.
+// Create/Delete always enqueue (a node appearing or disappearing changes
+// the desired cert set). Update enqueues only when worker/control-plane
+// membership flips — the only Node mutation that changes desired state.
+func (r *MigrationCertReconciler) workerNodePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool { return true },
+		DeleteFunc: func(event.DeleteEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode, ok1 := e.ObjectOld.(*corev1.Node)
+			newNode, ok2 := e.ObjectNew.(*corev1.Node)
+			if !ok1 || !ok2 {
+				return false
+			}
+			return isWorkerNode(oldNode) != isWorkerNode(newNode)
+		},
+	}
+}
+
+// SetupWithManager registers the reconciler. The Node IS the reconcile
+// target (For), so no map function is needed — unlike SwiftKernel, which
+// watches Nodes only to re-enqueue SwiftKernel CRs.
+func (r *MigrationCertReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}, builder.WithPredicates(r.workerNodePredicate())).
+		Named("migrationcert").
+		Complete(r)
+}

--- a/internal/controller/migrationcert/controller_test.go
+++ b/internal/controller/migrationcert/controller_test.go
@@ -1,0 +1,250 @@
+package migrationcert
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+const testSystemNS = "kubeswift-system"
+
+// certScheme registers the cert-manager Certificate GVK as unstructured so
+// the fake client can track it. Mirrors how the cached client treats
+// cert-manager types in production (we never import the cert-manager Go
+// module — see certificate.go).
+func certScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("clientgoscheme: %v", err)
+	}
+	s.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: certManagerGroup, Version: certManagerVersion, Kind: certificateKind},
+		&unstructured.Unstructured{},
+	)
+	s.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: certManagerGroup, Version: certManagerVersion, Kind: certificateKind + "List"},
+		&unstructured.UnstructuredList{},
+	)
+	return s
+}
+
+func getCert(ctx context.Context, c client.Client, ns, name string) (*unstructured.Unstructured, error) {
+	u := newCertShell()
+	err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, u)
+	return u, err
+}
+
+func TestMigrationNodeNames(t *testing.T) {
+	if got := MigrationNodeCertName("miles"); got != "kubeswift-migration-node-miles" {
+		t.Errorf("MigrationNodeCertName = %q", got)
+	}
+	if got := MigrationNodeSecretName("miles"); got != "kubeswift-migration-node-miles" {
+		t.Errorf("MigrationNodeSecretName = %q", got)
+	}
+	// SAN/checkHost pin value MUST be exactly the node name (Option B).
+	if got := MigrationNodeCertSAN("miles"); got != "miles" {
+		t.Errorf("MigrationNodeCertSAN = %q, want node name verbatim", got)
+	}
+}
+
+// TestNewNodeCertificate_Fields pins the cert-manager Certificate shape:
+// SAN=nodeName (the Option B identity), both server+client usages (a node
+// is dst-server in one migration and src-client in another), and the CA
+// Issuer reference. A regression here silently breaks SAN pinning.
+func TestNewNodeCertificate_Fields(t *testing.T) {
+	u := newNodeCertificate(testSystemNS, "boba")
+
+	if u.GetNamespace() != testSystemNS {
+		t.Errorf("namespace = %q, want %q", u.GetNamespace(), testSystemNS)
+	}
+	if u.GetName() != "kubeswift-migration-node-boba" {
+		t.Errorf("name = %q", u.GetName())
+	}
+	if u.GetAPIVersion() != "cert-manager.io/v1" || u.GetKind() != "Certificate" {
+		t.Errorf("GVK = %s/%s", u.GetAPIVersion(), u.GetKind())
+	}
+
+	secretName, _, _ := unstructured.NestedString(u.Object, "spec", "secretName")
+	if secretName != "kubeswift-migration-node-boba" {
+		t.Errorf("spec.secretName = %q", secretName)
+	}
+	cn, _, _ := unstructured.NestedString(u.Object, "spec", "commonName")
+	if cn != "boba" {
+		t.Errorf("spec.commonName = %q, want boba", cn)
+	}
+	dnsNames, _, _ := unstructured.NestedStringSlice(u.Object, "spec", "dnsNames")
+	if len(dnsNames) != 1 || dnsNames[0] != "boba" {
+		t.Errorf("spec.dnsNames = %v, want [boba]", dnsNames)
+	}
+	usages, _, _ := unstructured.NestedStringSlice(u.Object, "spec", "usages")
+	if len(usages) != 2 || usages[0] != "server auth" || usages[1] != "client auth" {
+		t.Errorf("spec.usages = %v, want [server auth, client auth]", usages)
+	}
+	issuerName, _, _ := unstructured.NestedString(u.Object, "spec", "issuerRef", "name")
+	if issuerName != MigrationCAIssuerName {
+		t.Errorf("spec.issuerRef.name = %q, want %q", issuerName, MigrationCAIssuerName)
+	}
+	issuerKind, _, _ := unstructured.NestedString(u.Object, "spec", "issuerRef", "kind")
+	if issuerKind != "Issuer" {
+		t.Errorf("spec.issuerRef.kind = %q, want Issuer (namespaced, not ClusterIssuer)", issuerKind)
+	}
+}
+
+func TestIsWorkerNode(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{"plain worker", nil, true},
+		{"labeled worker", map[string]string{"kubeswift.io/some": "x"}, true},
+		{"control-plane", map[string]string{controlPlaneRoleLabel: ""}, false},
+		{"master", map[string]string{masterRoleLabel: ""}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n", Labels: tc.labels}}
+			if got := isWorkerNode(node); got != tc.want {
+				t.Errorf("isWorkerNode = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWorkerNodePredicate_Update pins that the predicate ignores
+// heartbeat/status churn but fires when worker<->control-plane membership
+// flips. Without the membership filter the reconciler would re-run on
+// every node status heartbeat.
+func TestWorkerNodePredicate_Update(t *testing.T) {
+	r := &MigrationCertReconciler{}
+	p := r.workerNodePredicate()
+
+	worker := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n"}}
+	workerHeartbeat := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n", ResourceVersion: "2"}}
+	cp := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n", Labels: map[string]string{controlPlaneRoleLabel: ""}}}
+
+	if p.Update(event.UpdateEvent{ObjectOld: worker, ObjectNew: workerHeartbeat}) {
+		t.Error("predicate fired on no-op heartbeat update")
+	}
+	if !p.Update(event.UpdateEvent{ObjectOld: worker, ObjectNew: cp}) {
+		t.Error("predicate did not fire on worker->control-plane relabel")
+	}
+	if !p.Update(event.UpdateEvent{ObjectOld: cp, ObjectNew: worker}) {
+		t.Error("predicate did not fire on control-plane->worker relabel")
+	}
+	if !p.Create(event.CreateEvent{Object: cp}) {
+		t.Error("Create predicate must always enqueue")
+	}
+	if !p.Delete(event.DeleteEvent{Object: worker}) {
+		t.Error("Delete predicate must always enqueue")
+	}
+}
+
+func TestEnsureNodeCertificate_CreatesWhenAbsent(t *testing.T) {
+	scheme := certScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ctx := context.Background()
+
+	if err := ensureNodeCertificate(ctx, c, testSystemNS, "miles"); err != nil {
+		t.Fatalf("ensureNodeCertificate: %v", err)
+	}
+	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-miles"); err != nil {
+		t.Fatalf("expected certificate to exist: %v", err)
+	}
+}
+
+func TestEnsureNodeCertificate_IdempotentWhenPresent(t *testing.T) {
+	scheme := certScheme(t)
+	pre := newNodeCertificate(testSystemNS, "miles")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pre).Build()
+	ctx := context.Background()
+
+	if err := ensureNodeCertificate(ctx, c, testSystemNS, "miles"); err != nil {
+		t.Fatalf("ensureNodeCertificate (idempotent): %v", err)
+	}
+	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-miles"); err != nil {
+		t.Fatalf("certificate should still exist: %v", err)
+	}
+}
+
+func TestDeleteNodeCertificate(t *testing.T) {
+	scheme := certScheme(t)
+	pre := newNodeCertificate(testSystemNS, "miles")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pre).Build()
+	ctx := context.Background()
+
+	if err := deleteNodeCertificate(ctx, c, testSystemNS, "miles"); err != nil {
+		t.Fatalf("deleteNodeCertificate: %v", err)
+	}
+	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-miles"); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected NotFound after delete, got %v", err)
+	}
+	// Idempotent: deleting again tolerates NotFound.
+	if err := deleteNodeCertificate(ctx, c, testSystemNS, "miles"); err != nil {
+		t.Fatalf("deleteNodeCertificate (NotFound) must be tolerated: %v", err)
+	}
+}
+
+func TestReconcile_WorkerNode_CreatesCert(t *testing.T) {
+	scheme := certScheme(t)
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+	r := &MigrationCertReconciler{Client: c, SystemNamespace: testSystemNS}
+	ctx := context.Background()
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "miles"}}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-miles"); err != nil {
+		t.Fatalf("worker node should get a certificate: %v", err)
+	}
+}
+
+func TestReconcile_ControlPlaneNode_DeletesStaleCert(t *testing.T) {
+	scheme := certScheme(t)
+	// A node that was a worker (has a cert) and is now control-plane.
+	staleCert := newNodeCertificate(testSystemNS, "frida")
+	cpNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "frida",
+		Labels: map[string]string{controlPlaneRoleLabel: ""},
+	}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cpNode, staleCert).Build()
+	r := &MigrationCertReconciler{Client: c, SystemNamespace: testSystemNS}
+	ctx := context.Background()
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "frida"}}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-frida"); !apierrors.IsNotFound(err) {
+		t.Fatalf("control-plane node's stale cert should be deleted, got %v", err)
+	}
+}
+
+func TestReconcile_NodeGone_DeletesCert(t *testing.T) {
+	scheme := certScheme(t)
+	// Node object absent; its cert lingers and must be GC'd.
+	orphanCert := newNodeCertificate(testSystemNS, "gone")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(orphanCert).Build()
+	r := &MigrationCertReconciler{Client: c, SystemNamespace: testSystemNS}
+	ctx := context.Background()
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "gone"}}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-gone"); !apierrors.IsNotFound(err) {
+		t.Fatalf("deleted node's cert should be GC'd, got %v", err)
+	}
+}

--- a/internal/controller/migrationcert/secret.go
+++ b/internal/controller/migrationcert/secret.go
@@ -1,0 +1,125 @@
+package migrationcert
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Standard kubernetes.io/tls Secret keys cert-manager writes, plus the CA
+// bundle. stunnel needs all three: tls.crt + tls.key to present the node's
+// identity, ca.crt to verify the peer's chain.
+const (
+	migrationSecretTLSCert = "tls.crt"
+	migrationSecretTLSKey  = "tls.key"
+	migrationSecretCACert  = "ca.crt"
+)
+
+// EnsureMigrationIdentitySecret distributes a node's already-issued
+// migration identity Secret into a guest namespace.
+//
+// This is DISTRIBUTION, not issuance: cert-manager mints the per-node
+// Certificate in the system namespace ahead of time (§3.B(a), a
+// precondition); the Secret it produces is copied verbatim here. No
+// cert-manager call sits on the migration path (§4.4) — the design
+// requires identities exist BEFORE a migration starts; this helper merely
+// places an existing one where the launcher pod can mount it.
+//
+// Same-namespace fast-path: when the guest runs in the system namespace,
+// cert-manager already wrote the Secret there — nothing to copy.
+//
+// Source-missing is a precondition failure, surfaced as an error. PR 3's
+// Validating-live phase calls this; a missing source Secret means the
+// node's Certificate has not been issued/ready yet, and the migration must
+// not proceed (it would fall back to an insecure or broken channel).
+//
+// The copied Secret carries NO ownerRef: like the swiftletd-reporter
+// RoleBinding it is shared across all guests/migrations in the namespace
+// and must outlive any single one. Create-if-absent, update-if-differs
+// keeps it current across cert-manager rotation.
+//
+// NOTE: wired by PR 3 (controller sidecar integration). PR 1 ships and
+// tests it but does not call it from any reconcile path.
+func EnsureMigrationIdentitySecret(ctx context.Context, c client.Client, systemNamespace, targetNamespace, nodeName string) error {
+	if targetNamespace == systemNamespace {
+		// cert-manager already wrote the Secret in this namespace.
+		return nil
+	}
+
+	secretName := MigrationNodeSecretName(nodeName)
+	srcKey := types.NamespacedName{Namespace: systemNamespace, Name: secretName}
+
+	var source corev1.Secret
+	if err := c.Get(ctx, srcKey, &source); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("migration identity secret %s not yet provisioned (cert-manager precondition not ready): %w", srcKey, err)
+		}
+		return fmt.Errorf("get source migration identity secret %s: %w", srcKey, err)
+	}
+
+	desiredData := map[string][]byte{}
+	for _, k := range []string{migrationSecretTLSCert, migrationSecretTLSKey, migrationSecretCACert} {
+		if v, ok := source.Data[k]; ok {
+			desiredData[k] = v
+		}
+	}
+
+	targetKey := types.NamespacedName{Namespace: targetNamespace, Name: secretName}
+	var existing corev1.Secret
+	err := c.Get(ctx, targetKey, &existing)
+	if err == nil {
+		if existing.Type == source.Type && secretDataEqual(existing.Data, desiredData) {
+			return nil
+		}
+		existing.Type = source.Type
+		existing.Data = desiredData
+		if uerr := c.Update(ctx, &existing); uerr != nil {
+			return fmt.Errorf("update copied migration identity secret %s: %w", targetKey, uerr)
+		}
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get target migration identity secret %s: %w", targetKey, err)
+	}
+
+	copySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: targetNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "kubeswift",
+				"app.kubernetes.io/component":  "migration-mtls",
+				"app.kubernetes.io/managed-by": "kubeswift-controller-manager",
+				migrationNodeLabel:             nodeName,
+			},
+		},
+		Type: source.Type,
+		Data: desiredData,
+	}
+	if cerr := c.Create(ctx, copySecret); cerr != nil {
+		if apierrors.IsAlreadyExists(cerr) {
+			return nil
+		}
+		return fmt.Errorf("create copied migration identity secret %s: %w", targetKey, cerr)
+	}
+	return nil
+}
+
+func secretDataEqual(a, b map[string][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok || !bytes.Equal(av, bv) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/migrationcert/secret_test.go
+++ b/internal/controller/migrationcert/secret_test.go
@@ -1,0 +1,153 @@
+package migrationcert
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func secretScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("clientgoscheme: %v", err)
+	}
+	return s
+}
+
+func sourceSecret(ns, nodeName string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: MigrationNodeSecretName(nodeName), Namespace: ns},
+		Type:       corev1.SecretTypeTLS,
+		Data:       data,
+	}
+}
+
+var tlsData = map[string][]byte{
+	migrationSecretTLSCert: []byte("CERT"),
+	migrationSecretTLSKey:  []byte("KEY"),
+	migrationSecretCACert:  []byte("CA"),
+}
+
+// TestEnsureMigrationIdentitySecret_SameNamespaceNoop pins the fast-path:
+// when the guest runs in the system namespace, cert-manager already wrote
+// the Secret — copying would be redundant (and would risk fighting
+// cert-manager's ownership).
+func TestEnsureMigrationIdentitySecret_SameNamespaceNoop(t *testing.T) {
+	scheme := secretScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ctx := context.Background()
+
+	// No source secret present; same-namespace must still be a no-op
+	// (it returns before any Get).
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, testSystemNS, "miles"); err != nil {
+		t.Fatalf("same-namespace must be a no-op, got: %v", err)
+	}
+}
+
+// TestEnsureMigrationIdentitySecret_SourceMissingErrors pins the
+// precondition contract: a missing source Secret (per-node Certificate not
+// issued/ready yet) is an error, NOT a silent skip. PR 3's Validating-live
+// phase relies on this to refuse a migration that would otherwise fall
+// back to a broken/insecure channel.
+func TestEnsureMigrationIdentitySecret_SourceMissingErrors(t *testing.T) {
+	scheme := secretScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ctx := context.Background()
+
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "miles"); err == nil {
+		t.Fatal("expected error when source secret missing (precondition not ready)")
+	}
+}
+
+func TestEnsureMigrationIdentitySecret_CopiesToTarget(t *testing.T) {
+	scheme := secretScheme(t)
+	src := sourceSecret(testSystemNS, "miles", tlsData)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(src).Build()
+	ctx := context.Background()
+
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "miles"); err != nil {
+		t.Fatalf("EnsureMigrationIdentitySecret: %v", err)
+	}
+
+	var copied corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "kubeswift-migration-node-miles"}, &copied); err != nil {
+		t.Fatalf("expected copied secret in team-a: %v", err)
+	}
+	if copied.Type != corev1.SecretTypeTLS {
+		t.Errorf("copied secret Type = %q, want kubernetes.io/tls", copied.Type)
+	}
+	for k, v := range tlsData {
+		if string(copied.Data[k]) != string(v) {
+			t.Errorf("copied data[%q] = %q, want %q", k, copied.Data[k], v)
+		}
+	}
+	// No ownerRef: the copy outlives any single guest/migration in the
+	// namespace (same invariant as the swiftletd-reporter RoleBinding).
+	if len(copied.OwnerReferences) != 0 {
+		t.Errorf("copied secret must carry no ownerRef, got %d", len(copied.OwnerReferences))
+	}
+	if copied.Labels["app.kubernetes.io/managed-by"] != "kubeswift-controller-manager" {
+		t.Errorf("copied secret missing managed-by label")
+	}
+}
+
+// TestEnsureMigrationIdentitySecret_UpdatesOnRotation pins that when
+// cert-manager rotates the source keypair, the next call refreshes the
+// copy rather than leaving a stale cert in the guest namespace.
+func TestEnsureMigrationIdentitySecret_UpdatesOnRotation(t *testing.T) {
+	scheme := secretScheme(t)
+	src := sourceSecret(testSystemNS, "miles", tlsData)
+	staleCopy := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "kubeswift-migration-node-miles", Namespace: "team-a"},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			migrationSecretTLSCert: []byte("OLD-CERT"),
+			migrationSecretTLSKey:  []byte("OLD-KEY"),
+			migrationSecretCACert:  []byte("CA"),
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(src, staleCopy).Build()
+	ctx := context.Background()
+
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "miles"); err != nil {
+		t.Fatalf("EnsureMigrationIdentitySecret (rotation): %v", err)
+	}
+
+	var refreshed corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "kubeswift-migration-node-miles"}, &refreshed); err != nil {
+		t.Fatalf("get refreshed: %v", err)
+	}
+	if string(refreshed.Data[migrationSecretTLSCert]) != "CERT" {
+		t.Errorf("rotation not propagated: tls.crt = %q, want CERT", refreshed.Data[migrationSecretTLSCert])
+	}
+}
+
+// TestEnsureMigrationIdentitySecret_IdempotentWhenCurrent pins that a
+// second call with matching data performs no update (no churn).
+func TestEnsureMigrationIdentitySecret_IdempotentWhenCurrent(t *testing.T) {
+	scheme := secretScheme(t)
+	src := sourceSecret(testSystemNS, "miles", tlsData)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(src).Build()
+	ctx := context.Background()
+
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "miles"); err != nil {
+		t.Fatalf("first copy: %v", err)
+	}
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "miles"); err != nil {
+		t.Fatalf("second copy (idempotent): %v", err)
+	}
+	var copied corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "kubeswift-migration-node-miles"}, &copied); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(copied.Data[migrationSecretTLSCert]) != "CERT" {
+		t.Errorf("data corrupted on idempotent call")
+	}
+}


### PR DESCRIPTION
## Summary

PR 1 of ~5 for Live Migration **Phase 3c** (mTLS migration transport). Phase 3a/3b ship the migration data channel as plaintext over the pod network, gated only by an operator-ack annotation; Phase 3c wraps it in a mutually-authenticated TLS tunnel via a `stunnel` sidecar — **no Cloud Hypervisor change, no swiftletd data-path change**. Design contract: [`docs/design/live-migration-phase-3c.md`](docs/design/live-migration-phase-3c.md), design-locked on **Option B** (per-node identity + SAN pinning, `verify=4` + `checkHost`).

This PR is the **cert-provisioning foundation**. It produces artifacts a later PR consumes and has **no behavior when `migration.mtls.enabled=false`** (the default both deploy paths render).

- **`migrationcert` controller** (`internal/controller/migrationcert`): a Node-watch reconciler that issues one cert-manager `Certificate` per worker node (SAN=nodeName) into the system namespace. cert-manager types are handled as `unstructured.Unstructured` to avoid a `go.mod` dependency on an optional, operator-installed operator. Per the W-3c-4 / §3.B(a) / §4.4 precondition, the per-node leaf is **long-lived** (issued on node join, not minted mid-migration), so no cert-manager call sits on any migration path.
- **Secret-distribution helper** (`secret.go`): copies a node's identity Secret into a guest namespace (distribution, not issuance; no ownerRef so the copy outlives any single guest). **Tested but unwired in PR 1** — consumed by PR 3.
- **`--migration-mtls-enabled` flag** gating reconciler registration; dormant (unregistered) by default.
- **Helm-gated cert-manager PKI chain** (selfSigned Issuer → CA Cert → CA Issuer) + matching `config/overlays/migration-mtls` kustomize mirror. Namespaced Issuers (not ClusterIssuers) keep the CA Secret co-located with the per-node leaves.
- **RBAC**: secrets `create,update` (for the PR 3 distribution path) and `cert-manager.io/certificates` `get,list,watch,create,delete`, in both the Helm chart and the `config/manager` kustomize mirror.
- **`deploy-with-mtls` Make target** + `values.yaml` gate (TFU-16 pattern: opt-in surfaces get an explicit target + overlay).
- **Doc**: `§10` open questions Q2/Q3/Q6 marked RESOLVED with the decisions this PR implements.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/controller/migrationcert/... ./cmd/controller-manager/...` clean
- [x] `gofmt -l` clean on touched files
- [x] `go test ./internal/controller/migrationcert/...` — 15 tests pass
- [x] `helm lint charts/kubeswift` — 0 failed
- [x] Helm default renders **no** mTLS resources / no flag
- [x] Helm `--set migration.mtls.enabled=true` renders the flag + 3-resource CA chain
- [x] `kubectl kustomize config/default` renders `--migration-mtls-enabled=false`
- [x] `kubectl kustomize config/overlays/migration-mtls` renders `=true` + CA chain
- [ ] No cluster validation in PR 1 — the controller is inert when disabled (default). First cluster-validated Phase 3c PR is PR 3 (sidecar inject + controller wiring + consuming the issued certs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)