### PR TITLE
feat(migration): Phase 3c PR 2 — stunnel mTLS sidecar image + ConfigMap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,3 +138,21 @@ jobs:
           file: ./images/swiftletd/Containerfile
           push: false
           load: true
+
+  migration-stunnel-image:
+    name: migration-stunnel image
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build migration-stunnel image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./images/migration-stunnel/Containerfile
+          push: false
+          load: true

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -104,6 +104,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push migration-stunnel
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./images/migration-stunnel/Containerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/migration-stunnel:${{ steps.version.outputs.image_tag }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            GIT_COMMIT=${{ steps.version.outputs.git_commit }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:

--- a/.github/workflows/release-rc.yaml
+++ b/.github/workflows/release-rc.yaml
@@ -87,6 +87,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push migration-stunnel
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./images/migration-stunnel/Containerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/migration-stunnel:${{ steps.version.outputs.tag }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            GIT_COMMIT=${{ steps.version.outputs.git_commit }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -93,6 +93,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push migration-stunnel
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./images/migration-stunnel/Containerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/migration-stunnel:${{ steps.version.outputs.tag }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            GIT_COMMIT=${{ steps.version.outputs.git_commit }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
@@ -163,6 +177,7 @@ jobs:
             - `ghcr.io/projectbeskar/kubeswift/controller-manager:${{ needs.build-and-push.outputs.tag }}`
             - `ghcr.io/projectbeskar/kubeswift/swiftletd:${{ needs.build-and-push.outputs.tag }}`
             - `ghcr.io/projectbeskar/kubeswift/gpu-discovery:${{ needs.build-and-push.outputs.tag }}`
+            - `ghcr.io/projectbeskar/kubeswift/migration-stunnel:${{ needs.build-and-push.outputs.tag }}`
 
             ## swiftctl
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ IMAGE_TAG ?= sha-$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown
 CONTROLLER_IMAGE ?= ghcr.io/projectbeskar/kubeswift/controller-manager:$(IMAGE_TAG)
 SWIFTLETD_IMAGE ?= ghcr.io/projectbeskar/kubeswift/swiftletd:$(IMAGE_TAG)
 GPU_DISCOVERY_IMAGE ?= ghcr.io/projectbeskar/kubeswift/gpu-discovery:$(IMAGE_TAG)
+MIGRATION_STUNNEL_IMAGE ?= ghcr.io/projectbeskar/kubeswift/migration-stunnel:$(IMAGE_TAG)
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/kubeswift
 # Push destination: parent OCI repo only (Helm appends chart name from Chart.yaml)
 CHART_OCI_PUSH ?= oci://ghcr.io/projectbeskar/charts
@@ -28,7 +29,7 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
 
 .PHONY: build build-go build-rust build-images build-controller-image build-swiftletd-image \
-	build-gpu-discovery-image generate deploy deploy-with-webhook deploy-with-mtls undeploy load-images smoke-test smoke-test-cleanup \
+	build-gpu-discovery-image build-migration-stunnel-image generate deploy deploy-with-webhook deploy-with-mtls undeploy load-images smoke-test smoke-test-cleanup \
 	clonestrategy-test snapshot-test local-roundtrip-test local-clone-identity-test \
 	b0-cross-node-tcp-test e2e-tests \
 	verify-e2e-scripts \
@@ -42,6 +43,7 @@ help:
 	@echo "  build-images          Build all container images (with version stamping)"
 	@echo "  build-controller-image  Build controller-manager image"
 	@echo "  build-swiftletd-image Build swiftletd image"
+	@echo "  build-migration-stunnel-image  Build live-migration mTLS stunnel sidecar image (Phase 3c)"
 	@echo "  push-images           Push images to registry (requires auth)"
 	@echo "  package-chart         Package Helm chart"
 	@echo "  push-chart            Push chart to OCI registry"
@@ -75,7 +77,7 @@ build-go:
 build-rust:
 	cd rust && KUBESWIFT_VERSION="$(VERSION)" KUBESWIFT_GIT_COMMIT="$(GIT_COMMIT)" KUBESWIFT_BUILD_DATE="$(BUILD_DATE)" cargo build
 
-build-images: build-controller-image build-swiftletd-image build-gpu-discovery-image
+build-images: build-controller-image build-swiftletd-image build-gpu-discovery-image build-migration-stunnel-image
 
 build-controller-image:
 	docker build -f images/controller-manager/Containerfile . -t $(CONTROLLER_IMAGE) \
@@ -89,10 +91,15 @@ build-gpu-discovery-image:
 	docker build -f images/gpu-discovery/Containerfile . -t $(GPU_DISCOVERY_IMAGE) \
 		--build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_DATE=$(BUILD_DATE)
 
+build-migration-stunnel-image:
+	docker build -f images/migration-stunnel/Containerfile . -t $(MIGRATION_STUNNEL_IMAGE) \
+		--build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT)
+
 push-images: build-images
 	docker push $(CONTROLLER_IMAGE)
 	docker push $(SWIFTLETD_IMAGE)
 	docker push $(GPU_DISCOVERY_IMAGE)
+	docker push $(MIGRATION_STUNNEL_IMAGE)
 
 package-chart:
 	@CHART_VER="$${CHART_VERSION:-$$(./hack/chart-version.sh dev 2>/dev/null || echo "0.0.0-dev.unknown")}"; \

--- a/charts/kubeswift/templates/migration/issuer.yaml
+++ b/charts/kubeswift/templates/migration/issuer.yaml
@@ -7,7 +7,9 @@
 #   3. a CA Issuer backed by that CA Secret.
 # The controller's migrationcert reconciler then issues one leaf Certificate
 # per worker node (SAN = nodeName) signed by the CA Issuer below. The stunnel
-# sidecar presents that leaf and pins the peer via verify=4 + checkHost.
+# sidecar presents that leaf and pins the peer via verifyChain + checkHost
+# (chains to this CA AND matches the expected peer-node SAN; not literal
+# verify=4, which would pin the exact leaf and break cert rotation).
 #
 # Namespaced Issuers (not ClusterIssuers) are deliberate: a ClusterIssuer
 # with ca.secretName reads the CA Secret from cert-manager's own namespace,

--- a/charts/kubeswift/templates/migration/stunnel-configmap.yaml
+++ b/charts/kubeswift/templates/migration/stunnel-configmap.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.migration.mtls.enabled }}
+# Live-migration mTLS stunnel sidecar configs (Phase 3c, Option B).
+#
+# ONE ConfigMap carrying BOTH the server and client stunnel configs. The
+# sidecar entrypoint self-selects by STUNNEL_ROLE and injects the peer IP /
+# peer SAN from env (__DST_POD_IP__ / __CHECK_HOST__ placeholders). W-3c-2:
+# role and peer are env-parameterized, never image-baked, so the controller
+# can DeepCopy the source pod's sidecar onto the destination and flip its role.
+#
+# Gated entirely on migration.mtls.enabled - off by default. The SwiftMigration
+# controller (PR 3) mounts this ConfigMap into each migration sidecar. The
+# kustomize mirror is config/overlays/migration-mtls/stunnel-configmap.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeswift-migration-stunnel
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: migration-mtls
+data:
+  # SERVER role (destination pod): terminates the cross-pod TLS connection and
+  # forwards plaintext to the co-located CH receiver on localhost.
+  server.conf: |
+    foreground = yes
+    syslog = no
+    debug = info
+    ; No pid file - runs in the container's non-root user, no daemonization.
+    pid =
+
+    [migration]
+    ; Cross-pod TLS: accept the source node's sidecar over the pod network.
+    accept = 0.0.0.0:6789
+    ; Forward decrypted bytes to the local CH receiver (vm.receive-migration,
+    ; listen_url=tcp:127.0.0.1:6790). Localhost-only; no plaintext leaves the pod.
+    connect = 127.0.0.1:6790
+    ; This sidecar's own per-node identity (migration Secret, SAN = nodeName).
+    cert = /etc/migration-tls/tls.crt
+    key = /etc/migration-tls/tls.key
+    ; The migration CA that signed every node's leaf.
+    CAfile = /etc/migration-tls/ca.crt
+    ; Require + chain-verify the peer's client cert AND pin it to the expected
+    ; source-node SAN. verifyChain proves "chains to the migration CA";
+    ; checkHost closes the W-3c-4 subject-check gap. NOT verify=4: that ignores
+    ; the CA chain and pins the exact leaf, breaking on cert-manager rotation.
+    verifyChain = yes
+    checkHost = __CHECK_HOST__
+  # CLIENT role (source pod): accepts the local CH sender's plaintext and
+  # tunnels it over TLS to the destination node's sidecar.
+  client.conf: |
+    foreground = yes
+    syslog = no
+    debug = info
+    pid =
+    client = yes
+
+    [migration]
+    ; Accept the local CH sender (vm.send-migration target_url=tcp:127.0.0.1:6790).
+    ; Localhost-only; no plaintext leaves the pod.
+    accept = 127.0.0.1:6790
+    ; Dial the destination node's sidecar over the pod network (TLS). The
+    ; controller substitutes __DST_POD_IP__ once the dst pod is scheduled.
+    connect = __DST_POD_IP__:6789
+    ; This sidecar's own per-node identity (migration Secret, SAN = nodeName).
+    cert = /etc/migration-tls/tls.crt
+    key = /etc/migration-tls/tls.key
+    ; The migration CA that signed every node's leaf.
+    CAfile = /etc/migration-tls/ca.crt
+    ; Chain-verify the destination sidecar's server cert AND pin it to the
+    ; expected destination-node SAN. See server.conf for why not verify=4.
+    verifyChain = yes
+    checkHost = __CHECK_HOST__
+{{- end }}

--- a/config/overlays/migration-mtls/issuer.yaml
+++ b/config/overlays/migration-mtls/issuer.yaml
@@ -6,7 +6,9 @@
 #   3. a CA Issuer backed by that CA Secret.
 # The controller's migrationcert reconciler then issues one leaf Certificate
 # per worker node (SAN = nodeName) signed by the CA Issuer below. The stunnel
-# sidecar (PR 2/3) presents that leaf and pins the peer via verify=4 + checkHost.
+# sidecar (PR 2/3) presents that leaf and pins the peer via verifyChain +
+# checkHost (chains to this CA AND matches the expected peer-node SAN; not
+# literal verify=4, which would pin the exact leaf and break cert rotation).
 #
 # Namespaced Issuers (not ClusterIssuers) are deliberate: a ClusterIssuer
 # with ca.secretName reads the CA Secret from cert-manager's own namespace,

--- a/config/overlays/migration-mtls/kustomization.yaml
+++ b/config/overlays/migration-mtls/kustomization.yaml
@@ -16,6 +16,7 @@ kind: Kustomization
 resources:
   - ../../default
   - issuer.yaml
+  - stunnel-configmap.yaml
 patches:
   - path: deployment-patch.yaml
     target:

--- a/config/overlays/migration-mtls/stunnel-configmap.yaml
+++ b/config/overlays/migration-mtls/stunnel-configmap.yaml
@@ -1,0 +1,71 @@
+# Live-migration mTLS stunnel sidecar configs (Phase 3c, Option B).
+#
+# Kustomize mirror of the Helm chart's templates/migration/stunnel-configmap.yaml
+# (gated there on migration.mtls.enabled). ONE ConfigMap carrying BOTH the
+# server and client stunnel configs; the sidecar entrypoint self-selects by
+# STUNNEL_ROLE and injects the peer IP / peer SAN from env (__DST_POD_IP__ /
+# __CHECK_HOST__ placeholders). W-3c-2: role and peer are env-parameterized,
+# never image-baked.
+#
+# The SwiftMigration controller (PR 3) mounts this ConfigMap into each
+# migration sidecar.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeswift-migration-stunnel
+  namespace: kubeswift-system
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: migration-mtls
+data:
+  # SERVER role (destination pod): terminates the cross-pod TLS connection and
+  # forwards plaintext to the co-located CH receiver on localhost.
+  server.conf: |
+    foreground = yes
+    syslog = no
+    debug = info
+    ; No pid file - runs in the container's non-root user, no daemonization.
+    pid =
+
+    [migration]
+    ; Cross-pod TLS: accept the source node's sidecar over the pod network.
+    accept = 0.0.0.0:6789
+    ; Forward decrypted bytes to the local CH receiver (vm.receive-migration,
+    ; listen_url=tcp:127.0.0.1:6790). Localhost-only; no plaintext leaves the pod.
+    connect = 127.0.0.1:6790
+    ; This sidecar's own per-node identity (migration Secret, SAN = nodeName).
+    cert = /etc/migration-tls/tls.crt
+    key = /etc/migration-tls/tls.key
+    ; The migration CA that signed every node's leaf.
+    CAfile = /etc/migration-tls/ca.crt
+    ; Require + chain-verify the peer's client cert AND pin it to the expected
+    ; source-node SAN. verifyChain proves "chains to the migration CA";
+    ; checkHost closes the W-3c-4 subject-check gap. NOT verify=4: that ignores
+    ; the CA chain and pins the exact leaf, breaking on cert-manager rotation.
+    verifyChain = yes
+    checkHost = __CHECK_HOST__
+  # CLIENT role (source pod): accepts the local CH sender's plaintext and
+  # tunnels it over TLS to the destination node's sidecar.
+  client.conf: |
+    foreground = yes
+    syslog = no
+    debug = info
+    pid =
+    client = yes
+
+    [migration]
+    ; Accept the local CH sender (vm.send-migration target_url=tcp:127.0.0.1:6790).
+    ; Localhost-only; no plaintext leaves the pod.
+    accept = 127.0.0.1:6790
+    ; Dial the destination node's sidecar over the pod network (TLS). The
+    ; controller substitutes __DST_POD_IP__ once the dst pod is scheduled.
+    connect = __DST_POD_IP__:6789
+    ; This sidecar's own per-node identity (migration Secret, SAN = nodeName).
+    cert = /etc/migration-tls/tls.crt
+    key = /etc/migration-tls/tls.key
+    ; The migration CA that signed every node's leaf.
+    CAfile = /etc/migration-tls/ca.crt
+    ; Chain-verify the destination sidecar's server cert AND pin it to the
+    ; expected destination-node SAN. See server.conf for why not verify=4.
+    verifyChain = yes
+    checkHost = __CHECK_HOST__

--- a/docs/design/live-migration-phase-3c.md
+++ b/docs/design/live-migration-phase-3c.md
@@ -175,9 +175,21 @@ prove "this peer is the legitimate src/dst for THIS migration." Under a
 shared leaf, any pod that can mount the migration Secret is accepted.
 
 **`verify = 2` alone is not shippable** — the chosen model adds subject/
-SAN pinning (`verify = 4` + `checkHost = <expected-peer-SAN>`). The axis
-the decision settled is **how strongly the cert identity binds to the
+SAN pinning (`verifyChain = yes` + `checkHost = <expected-peer-SAN>`). The
+axis the decision settled is **how strongly the cert identity binds to the
 migration, vs. how much provisioning machinery it costs.**
+
+> **Directive note (PR 2 correction):** earlier drafts wrote this as
+> `verify = 4`; that was imprecise shorthand for "chain-verify *and*
+> subject-pin." The implemented sidecar config (PR 2) uses
+> `verifyChain = yes` (numerically `verify = 2`) **plus** `checkHost`.
+> stunnel's literal `verify = 4` is the wrong primitive for Option B:
+> it ignores the CA chain and pins the *exact* leaf, which would require
+> each sidecar to mount its peer's exact cert and would break on
+> cert-manager rotation (the per-node certs renew via `renewBefore`).
+> `verifyChain` proves "chains to the migration CA"; `checkHost` closes
+> the W-3c-4 subject-check gap — together they authorize a *specific*
+> peer while staying rotation-safe.
 
 ### Option A — Shared long-lived leaf (what the spike used)
 
@@ -272,8 +284,9 @@ path. Option A remains an **explicit fallback** for clusters unwilling to
 provision per-node certs (shipping *only* with S1 + a tightly-scoped
 Secret); Option C is held for a future multi-tenancy phase.
 
-The choice sets, downstream: the `verify = 4` + `checkHost = <peer-node
-SAN>` config the controller stamps onto each sidecar (§4.2); **no** cert
+The choice sets, downstream: the `verifyChain = yes` + `checkHost =
+<peer-node SAN>` config the controller stamps onto each sidecar (§4.2;
+see the directive note above on why not literal `verify = 4`); **no** cert
 issuance in the state machine — the per-node cert is a precondition
 (§4.4); the cert-manager dependency stays at "already required" (§6.3);
 and the failure modes reduce to precondition + handshake + expiry (§7).
@@ -439,9 +452,12 @@ guest running and recoverable. mTLS adds handshake-rejection as a new
    patch during cutover would poison it to `lifecycle: stop`.
 5. **CH/swiftletd speak localhost plaintext only** (§5): the cross-pod hop
    is the sidecar's, exclusively. No TLS below the controller.
-6. **`verify = 4` + SAN pinning, never bare `verify = 2`** (W-3c-4): the
-   shippable config authorizes a *specific* peer, not merely a CA-signed
-   one.
+6. **`verifyChain = yes` + SAN pinning (`checkHost`), never bare
+   `verify = 2`** (W-3c-4): the shippable config authorizes a *specific*
+   peer, not merely a CA-signed one. (Earlier drafts said `verify = 4`;
+   see the §3 directive note — literal `verify = 4` pins the exact leaf
+   and breaks cert rotation, so the implementation uses
+   `verifyChain` + `checkHost`.)
 
 ---
 

--- a/images/migration-stunnel/Containerfile
+++ b/images/migration-stunnel/Containerfile
@@ -1,0 +1,35 @@
+# KubeSwift live-migration mTLS stunnel sidecar (Phase 3c).
+#
+# Minimal first-party image: alpine + stunnel + a role-selecting entrypoint.
+# It owns the cross-pod TLS hop so Cloud Hypervisor and swiftletd stay
+# plaintext-on-localhost and unaware of TLS (the spike's load-bearing
+# non-change). See docs/design/live-migration-phase-3c.md.
+#
+# The stunnel server/client configs are NOT baked into this image: they
+# arrive via a mounted ConfigMap (ONE ConfigMap, BOTH configs). The
+# entrypoint self-selects server-vs-client from STUNNEL_ROLE and injects the
+# peer IP / peer SAN from env (DST_POD_IP / CHECK_HOST). W-3c-2 load-bearing
+# property: role and peer are env-parameterized, never image-baked, so the
+# controller can DeepCopy the source pod's sidecar onto the destination and
+# flip its role rather than maintaining two images.
+FROM alpine:3.20
+
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.title="kubeswift-migration-stunnel"
+LABEL org.opencontainers.image.description="stunnel mTLS sidecar for KubeSwift live migration (Phase 3c)"
+
+RUN apk add --no-cache stunnel
+
+COPY images/migration-stunnel/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod 0755 /usr/local/bin/entrypoint.sh
+
+# Non-root. stunnel binds 0.0.0.0:6789 (server) or 127.0.0.1:6790 (client) -
+# both unprivileged ports - reads the per-node identity from a mounted Secret
+# at /etc/migration-tls/, and renders its active config + logs under /tmp.
+# No Linux capabilities required.
+USER 65534:65534
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/images/migration-stunnel/entrypoint.sh
+++ b/images/migration-stunnel/entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# KubeSwift live-migration mTLS stunnel sidecar entrypoint (Phase 3c).
+#
+# Selects the server-vs-client stunnel config by STUNNEL_ROLE and injects the
+# per-migration parameters (peer IP, peer SAN) from env. Role and peer are
+# env-parameterized, NEVER image-baked - W-3c-2 load-bearing property: the
+# controller DeepCopies the source pod's sidecar onto the destination and
+# flips STUNNEL_ROLE rather than maintaining two images.
+#
+# Env contract (stamped by the SwiftMigration controller in PR 3):
+#   STUNNEL_ROLE   server | client          (required)
+#   CHECK_HOST     expected peer node SAN    (required, both roles)
+#   DST_POD_IP     destination pod IP        (required, client role only)
+#
+# The mounted ConfigMap (STUNNEL_CONFIG_DIR) carries server.conf + client.conf
+# with __CHECK_HOST__ / __DST_POD_IP__ placeholders; this script renders the
+# active config into a writable runtime path and execs stunnel on it.
+#
+# Pure ASCII; explicit interpreter; POSIX sh (BusyBox-compatible).
+set -eu
+
+CONFIG_DIR="${STUNNEL_CONFIG_DIR:-/etc/stunnel-config}"
+RUNTIME_DIR="${STUNNEL_RUNTIME_DIR:-/tmp}"
+ROLE="${STUNNEL_ROLE:-}"
+
+case "${ROLE}" in
+  server)
+    SRC_CONF="${CONFIG_DIR}/server.conf"
+    ;;
+  client)
+    SRC_CONF="${CONFIG_DIR}/client.conf"
+    ;;
+  *)
+    echo "stunnel-sidecar: STUNNEL_ROLE must be 'server' or 'client' (got '${ROLE}')" >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -f "${SRC_CONF}" ]; then
+  echo "stunnel-sidecar: config not found: ${SRC_CONF} (is the ConfigMap mounted at ${CONFIG_DIR}?)" >&2
+  exit 1
+fi
+
+# CHECK_HOST (expected peer node SAN) is required for BOTH roles. It is the
+# subject-check that closes the W-3c-4 gap: verifyChain alone proves "chains
+# to the migration CA"; checkHost pins the peer to the specific node the
+# controller chose from the SwiftMigration CR. Fail fast if unset rather than
+# render a config that would accept any CA-signed peer.
+if [ -z "${CHECK_HOST:-}" ]; then
+  echo "stunnel-sidecar: CHECK_HOST (expected peer node SAN) is required" >&2
+  exit 1
+fi
+
+# DST_POD_IP is the TLS connect target; required only for the client (source)
+# sidecar. It is known only after the destination pod is scheduled, so the
+# controller stamps it during Preparing-live (W-3c-2 sequencing).
+if [ "${ROLE}" = "client" ] && [ -z "${DST_POD_IP:-}" ]; then
+  echo "stunnel-sidecar: DST_POD_IP is required for client role" >&2
+  exit 1
+fi
+
+ACTIVE_CONF="${RUNTIME_DIR}/stunnel.conf"
+# The mounted ConfigMap is read-only; render the substituted config into a
+# writable runtime path.
+cp "${SRC_CONF}" "${ACTIVE_CONF}"
+sed -i "s|__CHECK_HOST__|${CHECK_HOST}|g" "${ACTIVE_CONF}"
+if [ "${ROLE}" = "client" ]; then
+  sed -i "s|__DST_POD_IP__|${DST_POD_IP}|g" "${ACTIVE_CONF}"
+fi
+
+echo "stunnel-sidecar: starting role=${ROLE} peer-SAN=${CHECK_HOST}${DST_POD_IP:+ dst-ip=${DST_POD_IP}}" >&2
+exec stunnel "${ACTIVE_CONF}"


### PR DESCRIPTION
## Summary

PR 2 of ~5 for **Live Migration Phase 3c** (mTLS migration transport, design-locked on Option B: per-node identity + SAN pinning). Ships the first-party `stunnel` sidecar that owns the cross-pod TLS hop, so Cloud Hypervisor and swiftletd stay **plaintext-on-localhost and TLS-unaware** — the spike's load-bearing non-change.

**This PR is inert.** No controller wiring; the sidecar is never injected into any pod until PR 3. Nothing in the live-migration data path changes.

## What's in it

- **`images/migration-stunnel/`** — minimal `alpine:3.20` + `stunnel` image with an ASCII-only POSIX `sh` entrypoint. Runs as `USER 65534:65534`, no capabilities. The server/client configs are **not baked into the image**; the entrypoint self-selects role from `STUNNEL_ROLE` and injects peer IP / peer SAN from `DST_POD_IP` / `CHECK_HOST` at runtime. Role and peer are env-parameterized, never image-baked (**W-3c-2** load-bearing property — lets PR 3 DeepCopy the src sidecar onto the dst and flip its role).
- **ConfigMap** — ONE ConfigMap carrying BOTH `server.conf` and `client.conf`, shipped two ways:
  - Helm template `charts/kubeswift/templates/migration/stunnel-configmap.yaml`, gated on `migration.mtls.enabled` (off by default).
  - Kustomize mirror `config/overlays/migration-mtls/stunnel-configmap.yaml`.
  - Port plan: dst = TLS server (`accept 0.0.0.0:6789` → `connect 127.0.0.1:6790`); src = TLS client (`accept 127.0.0.1:6790` → `connect <dst-ip>:6789`). Plaintext leg is localhost-only.
- **Peer verification = `verifyChain = yes` + `checkHost`** (chains to the migration CA **AND** pins the expected peer-node SAN) — **not** literal `verify = 4`. stunnel's `verify = 4` ignores the CA chain and pins the exact leaf, which would require each sidecar to mount its peer's exact cert and would break cert-manager rotation of the per-node certs (PR 1 certs renew via `renewBefore`). `verifyChain` closes the W-3c-4 gap together with `checkHost`. Corrected the `verify = 4` shorthand in design doc §3/§8 and both `issuer.yaml` comments.
- **Build/release wiring** — `Makefile` build/push targets + help line; CI `migration-stunnel-image` build-validation job (push:false, load:true); `release-dev/rc/stable` build-and-push steps + the stable release-notes image list.

## Test plan

- [x] `sh -n images/migration-stunnel/entrypoint.sh` clean; pure ASCII; `#!/bin/sh` shebang.
- [x] `helm lint charts/kubeswift` — 0 failed.
- [x] `helm template` default renders **0** stunnel ConfigMaps; `--set migration.mtls.enabled=true` renders **1**.
- [x] `kubectl kustomize config/default` renders **0**; `config/overlays/migration-mtls` renders **1** and builds clean.
- [x] All four workflow YAMLs parse.
- [x] Rendered `server.conf` confirms the port plan, cert paths under `/etc/migration-tls/`, and `verifyChain = yes` + `checkHost`.
- [ ] CI build-validation job builds the image (validates the `apk add stunnel` + entrypoint COPY end-to-end).

## Not in this PR

- Controller wiring into `newDstPod` (server-role flip on dst, `DST_POD_IP`+`CHECK_HOST` onto src, `lifecycle: run` freeze, URL repoint to `127.0.0.1:6790`, `migrationListenPort` 6789/6790 split) — **PR 3**.
- S1 URLs-from-CR enforcement, ack-gate retirement, audit Events — PR 4.
- Cluster mini-walkthrough + `docs/migration/phase-3c.md` + THREAT-MODEL update — PR 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)