### PR TITLE
feat(migration): Phase 3c PR 3 — destination-side mTLS controller wiring

### DIFF
--- a/api/migration/v1alpha1/swiftmigration_types.go
+++ b/api/migration/v1alpha1/swiftmigration_types.go
@@ -189,6 +189,16 @@ const (
 	// owner ref, etc.). Distinguishes a clean leader-handover idempotent
 	// re-entry from a name collision with foreign state.
 	FailureReasonDstPodConflict = "DstPodConflict"
+	// FailureReasonMigrationIdentityNotReady — set by the Validating-live
+	// precondition (Phase 3c, Option B) when live-migration mTLS is
+	// enabled but a participating node's per-node identity Secret is not
+	// yet provisioned in the system namespace (cert-manager precondition
+	// not ready). Per design §4.4 the per-node cert is a long-lived
+	// precondition, not a per-migration artifact — failing fast here keeps
+	// a missing/expired node identity from ever reaching the cutover
+	// window. Untyped string (TFU #21) for consistency with the rest of
+	// this enum.
+	FailureReasonMigrationIdentityNotReady = "MigrationIdentityNotReady"
 )
 
 // Phase 3a phaseDetail vocabulary additions (live mode only). These

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -186,6 +186,12 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("swiftmigration-controller"),
+		// Phase 3c (Option B): destination-side mTLS wiring is gated on
+		// the same --migration-mtls-enabled flag that registers the
+		// migrationcert provisioner below. SystemNamespace is where the
+		// per-node identity Secrets live (cert-manager writes them there).
+		MigrationMTLSEnabled: *migrationMTLSEnabled,
+		SystemNamespace:      leaderElectionNS,
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftMigration controller")
 		os.Exit(1)

--- a/internal/controller/migrationcert/certificate.go
+++ b/internal/controller/migrationcert/certificate.go
@@ -5,11 +5,14 @@
 // (per-node identity + SAN pinning). Each worker node gets one
 // cert-manager Certificate whose SAN (and CN) is the node name; the
 // stunnel sidecar on a migration's source/destination pod presents
-// that cert and the peer pins it via `verify = 4` + `checkHost =
-// <peer-node-name>`. A bare `verify = 2` (verifyChain without subject
+// that cert and the peer pins it via `verifyChain = yes` + `checkHost =
+// <peer-node-name>`. A bare `verifyChain` (verify=2 without subject
 // checks) is insufficient (W-3c-4) — the SAN pin is what proves "this
 // is the legitimate src/dst node for THIS migration", not merely "the
-// peer holds a CA-signed cert".
+// peer holds a CA-signed cert". (Not literal stunnel `verify = 4`,
+// which ignores the CA chain and pins the exact leaf, breaking
+// cert-manager rotation — see docs/design/live-migration-phase-3c.md
+// §3 directive note.)
 //
 // This file owns the per-node Certificate lifecycle:
 //   - newNodeCertificate builds the cert-manager Certificate object,

--- a/internal/controller/swiftmigration/controller.go
+++ b/internal/controller/swiftmigration/controller.go
@@ -81,6 +81,32 @@ type SwiftMigrationReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+
+	// MigrationMTLSEnabled mirrors the controller-manager's
+	// --migration-mtls-enabled flag (Phase 3c, Option B). When false
+	// (default) the live-migration data channel is plaintext exactly as
+	// in Phase 3a/3b — no sidecar, no precondition check, no URL repoint.
+	// When true the destination-side mTLS wiring fires: newDstPod injects
+	// the stunnel server sidecar, the dst CH listen_url is repointed to
+	// localhost (behind the sidecar), and Validating-live requires both
+	// node identity Secrets to be present.
+	//
+	// NOTE (Phase 3c PR 3 = destination side only): the SOURCE-side
+	// sidecar + target_url repoint land in PR 3b (downward-API + poll
+	// delivery of DST_POD_IP into the pre-existing, immutable launcher
+	// pod). Between PR 3 and PR 3b, enabling this flag yields a
+	// half-wired channel (dst expects TLS; src still sends plaintext) —
+	// acceptable because the flag is off by default and end-to-end mTLS
+	// is validated in PR 5.
+	MigrationMTLSEnabled bool
+
+	// SystemNamespace is the controller-manager's own namespace
+	// (POD_NAMESPACE / leader-election namespace), where the migration CA
+	// Issuer and the per-node identity Secrets live. Used by the
+	// Validating-live precondition to copy a node's identity Secret into
+	// the guest namespace (EnsureMigrationIdentitySecret). Only consulted
+	// when MigrationMTLSEnabled.
+	SystemNamespace string
 }
 
 // phaseResult is the return type of every per-phase handler. It

--- a/internal/controller/swiftmigration/dst_pod.go
+++ b/internal/controller/swiftmigration/dst_pod.go
@@ -139,16 +139,34 @@ func dstPodName(mig *migrationv1alpha1.SwiftMigration, guestName string) (string
 //   - scheme: needed by SetControllerReference to resolve the
 //     SwiftGuest's GVK for the ownerRef.
 //
+// dstSidecarConfig carries the Phase 3c (Option B) mTLS parameters
+// newDstPod needs to optionally inject the destination stunnel sidecar.
+// The zero value (mtlsEnabled=false) reproduces the pre-Phase-3c
+// destination pod byte-for-byte — the plaintext path is unchanged.
+//
+// srcNodeName: the SOURCE node. The dst sidecar pins its SAN via
+// CHECK_HOST so the TLS channel authorizes the specific source node for
+// THIS migration (W-3c-4), not merely any CA-signed peer.
+// dstNodeName: the DESTINATION node, whose per-node identity Secret the
+// dst sidecar mounts and presents.
+type dstSidecarConfig struct {
+	mtlsEnabled bool
+	srcNodeName string
+	dstNodeName string
+}
+
 // Returns an error if dstPodName() fails, if SetControllerReference
-// fails (scheme without SwiftGuest registered), or if the launcher
-// container can't be found (corrupt src pod). All errors are
-// programming-error class — callers should phaseFailure with
-// FailureReasonOther.
+// fails (scheme without SwiftGuest registered), if the launcher
+// container can't be found (corrupt src pod), or if mTLS is enabled but
+// the src/dst node names are empty (the SAN pin / identity Secret would
+// be unresolvable). All errors are programming-error class — callers
+// should phaseFailure with FailureReasonOther.
 func newDstPod(
 	mig *migrationv1alpha1.SwiftMigration,
 	guest *swiftv1alpha1.SwiftGuest,
 	srcPod *corev1.Pod,
 	scheme *runtime.Scheme,
+	sidecar dstSidecarConfig,
 ) (*corev1.Pod, error) {
 	name, err := dstPodName(mig, guest.Name)
 	if err != nil {
@@ -182,6 +200,29 @@ func newDstPod(
 	// Add KUBESWIFT_MIGRATION_ROLE=receiver to the launcher container.
 	if err := addReceiverEnvToLauncher(pod); err != nil {
 		return nil, err
+	}
+
+	// Phase 3c (Option B): inject the destination stunnel sidecar (TLS
+	// server). Gated on mtlsEnabled; the plaintext path skips this
+	// entirely. The dst CH receives on localhost behind this sidecar
+	// (listen_url repoint in stopandcopy_live), so swiftletd/CH stay
+	// TLS-unaware (design §5 opacity contract).
+	//
+	// W-3c-1 lifecycle:run freeze is intentionally NOT done here: the
+	// controller-driven live cutover Deletes the src pod and never
+	// patches runPolicy:Stopped (cutover.go), and the dst receiver reads
+	// its runtime intent once at boot during Preparing-live — before any
+	// cutover action — so the <guest>-runtime-intent CM cannot flip to
+	// lifecycle:stop while this pod depends on it. The freeze is
+	// defense-in-depth for a hypothetical future stop-during-migration
+	// path (e.g., Phase 4 drain integration); tracked as a follow-up.
+	if sidecar.mtlsEnabled {
+		if sidecar.srcNodeName == "" || sidecar.dstNodeName == "" {
+			return nil, fmt.Errorf(
+				"dst pod construction: mTLS enabled but node names unresolved (src=%q dst=%q); cannot pin SAN / mount identity Secret",
+				sidecar.srcNodeName, sidecar.dstNodeName)
+		}
+		injectDstStunnelSidecar(pod, sidecar.srcNodeName, sidecar.dstNodeName)
 	}
 
 	// Reset pod status (Create rejects non-empty status; defensive even

--- a/internal/controller/swiftmigration/dst_pod_test.go
+++ b/internal/controller/swiftmigration/dst_pod_test.go
@@ -113,7 +113,7 @@ func TestNewDstPod_SetsNameLabelsAnnotationsEnvNodeName(t *testing.T) {
 	}
 	src := templateSrcPod("guest", "default")
 
-	dst, err := newDstPod(mig, guest, src, scheme)
+	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{})
 	if err != nil {
 		t.Fatalf("newDstPod: %v", err)
 	}
@@ -190,6 +190,15 @@ func TestNewDstPod_SetsNameLabelsAnnotationsEnvNodeName(t *testing.T) {
 	if dst.Status.Phase != "" {
 		t.Errorf("status should be reset; got phase=%q", dst.Status.Phase)
 	}
+	// mTLS off (zero config): no stunnel sidecar, no extra volumes.
+	if len(dst.Spec.Containers) != 1 {
+		t.Errorf("mTLS-off dst pod must have exactly the launcher container; got %d containers", len(dst.Spec.Containers))
+	}
+	for _, c := range dst.Spec.Containers {
+		if c.Name == stunnelSidecarContainerName {
+			t.Errorf("mTLS-off dst pod must NOT carry the stunnel sidecar")
+		}
+	}
 }
 
 func TestNewDstPod_NoLauncherContainer_Errors(t *testing.T) {
@@ -202,8 +211,108 @@ func TestNewDstPod_NoLauncherContainer_Errors(t *testing.T) {
 	src := templateSrcPod("guest", "default")
 	src.Spec.Containers[0].Name = "not-launcher"
 
-	if _, err := newDstPod(mig, guest, src, scheme); err == nil {
+	if _, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}); err == nil {
 		t.Errorf("expected error when launcher container is missing")
+	}
+}
+
+// TestNewDstPod_MTLS_InjectsServerSidecar verifies the Phase 3c
+// destination-side wiring: with mTLS enabled, newDstPod appends the
+// stunnel server sidecar (role=server, peer-SAN pinned to the SOURCE
+// node) plus the config + identity-Secret volumes, and leaves the
+// launcher container untouched.
+func TestNewDstPod_MTLS_InjectsServerSidecar(t *testing.T) {
+	scheme := testScheme(t)
+	mig := newMigrationWithUID("mig-a", "default", "abcdef1234567890abcdef1234567890")
+	mig.Spec.Target.NodeName = "miles"
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
+	}
+	src := templateSrcPod("guest", "default")
+
+	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
+		mtlsEnabled: true,
+		srcNodeName: "boba",  // source node — dst pins this SAN
+		dstNodeName: "miles", // destination node — dst presents this identity
+	})
+	if err != nil {
+		t.Fatalf("newDstPod (mTLS): %v", err)
+	}
+
+	// Launcher container still present and is still the FIRST container
+	// (receiver-env lookup + launcherContainerImage rely on finding it by
+	// name, but its primacy keeps existing index-0 assumptions valid).
+	if dst.Spec.Containers[0].Name != LauncherContainerName {
+		t.Fatalf("launcher must remain the first container; got %q", dst.Spec.Containers[0].Name)
+	}
+
+	// Exactly one stunnel sidecar, role=server, CHECK_HOST=source node.
+	var sidecar *corev1.Container
+	for i := range dst.Spec.Containers {
+		if dst.Spec.Containers[i].Name == stunnelSidecarContainerName {
+			sidecar = &dst.Spec.Containers[i]
+			break
+		}
+	}
+	if sidecar == nil {
+		t.Fatalf("mTLS dst pod must carry the %q sidecar", stunnelSidecarContainerName)
+	}
+	env := map[string]string{}
+	for _, e := range sidecar.Env {
+		env[e.Name] = e.Value
+	}
+	if env[envStunnelRole] != stunnelRoleServer {
+		t.Errorf("sidecar role: want %q, got %q", stunnelRoleServer, env[envStunnelRole])
+	}
+	if env[envStunnelCheckHost] != "boba" {
+		t.Errorf("sidecar CHECK_HOST: want source node %q, got %q", "boba", env[envStunnelCheckHost])
+	}
+	if _, present := env[envStunnelDstPodIP]; present {
+		t.Errorf("server-role sidecar must NOT set DST_POD_IP (that is client-only, PR 3b)")
+	}
+
+	// Config + identity volumes present; identity Secret is the DST node's.
+	wantVols := map[string]bool{stunnelConfigVolumeName: false, stunnelCertVolumeName: false}
+	for _, v := range dst.Spec.Volumes {
+		if _, ok := wantVols[v.Name]; ok {
+			wantVols[v.Name] = true
+		}
+		if v.Name == stunnelCertVolumeName {
+			if v.Secret == nil || v.Secret.SecretName != "kubeswift-migration-node-miles" {
+				t.Errorf("identity volume must mount the DST node Secret kubeswift-migration-node-miles; got %+v", v.Secret)
+			}
+		}
+		if v.Name == stunnelConfigVolumeName {
+			if v.ConfigMap == nil || v.ConfigMap.Name != stunnelConfigMapName {
+				t.Errorf("config volume must mount %q; got %+v", stunnelConfigMapName, v.ConfigMap)
+			}
+		}
+	}
+	for name, found := range wantVols {
+		if !found {
+			t.Errorf("mTLS dst pod missing expected volume %q", name)
+		}
+	}
+}
+
+// TestNewDstPod_MTLS_EmptyNode_Errors verifies the guard: mTLS enabled
+// with an unresolved node name is a clean construction error rather than
+// a sidecar with an empty SAN pin / unresolvable identity Secret.
+func TestNewDstPod_MTLS_EmptyNode_Errors(t *testing.T) {
+	scheme := testScheme(t)
+	mig := newMigrationWithUID("m", "default", "abcdef1234567890abcdef1234567890")
+	mig.Spec.Target.NodeName = "miles"
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
+	}
+	src := templateSrcPod("guest", "default")
+
+	if _, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
+		mtlsEnabled: true,
+		srcNodeName: "", // unresolved
+		dstNodeName: "miles",
+	}); err == nil {
+		t.Errorf("expected error when mTLS enabled but source node name empty")
 	}
 }
 

--- a/internal/controller/swiftmigration/preparing_live.go
+++ b/internal/controller/swiftmigration/preparing_live.go
@@ -142,7 +142,20 @@ func (r *SwiftMigrationReconciler) handlePreparingLive(
 	switch {
 	case apierrors.IsNotFound(getErr):
 		// No dst pod yet — construct and Create.
-		dst, buildErr := newDstPod(mig, &guest, &srcPod, r.Scheme)
+		//
+		// Phase 3c: when mTLS is enabled, newDstPod injects the dst
+		// stunnel sidecar. srcNodeName is the node the source guest runs
+		// on right now (its identity is what the dst pins via CHECK_HOST);
+		// dstNodeName is the migration target (whose identity Secret the
+		// dst sidecar presents). Both are guaranteed non-empty here:
+		// Validating-live verified the guest is scheduled and the target
+		// node exists, and (when mTLS is on) distributed both identity
+		// Secrets into this namespace.
+		dst, buildErr := newDstPod(mig, &guest, &srcPod, r.Scheme, dstSidecarConfig{
+			mtlsEnabled: r.MigrationMTLSEnabled,
+			srcNodeName: guest.Status.NodeName,
+			dstNodeName: mig.Spec.Target.NodeName,
+		})
 		if buildErr != nil {
 			return phaseFailure(
 				fmt.Sprintf("construct dst pod: %v", buildErr),

--- a/internal/controller/swiftmigration/sidecar.go
+++ b/internal/controller/swiftmigration/sidecar.go
@@ -1,0 +1,170 @@
+package swiftmigration
+
+import (
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/projectbeskar/kubeswift/internal/controller/migrationcert"
+)
+
+// Phase 3c (Option B) live-migration mTLS stunnel sidecar wiring.
+//
+// The sidecar owns the cross-pod TLS hop so Cloud Hypervisor and
+// swiftletd stay plaintext-on-localhost and TLS-unaware (the spike's
+// load-bearing non-change — design §5). This file builds the
+// DESTINATION-side sidecar (TLS server) that newDstPod injects.
+//
+// PR 3 scope is destination-only. The SOURCE-side sidecar (TLS client)
+// is added to the pre-existing launcher pod at SwiftGuest-pod-creation
+// time in PR 3b, with DST_POD_IP / CHECK_HOST delivered via a
+// downward-API annotation volume + a polling entrypoint (the src pod is
+// immutable once running, so env injection at migration time is
+// impossible — design §4.2 corrected by the PR 3 walkthrough).
+//
+// Image and configs are NOT baked together: the image (alpine + stunnel
+// + entrypoint, images/migration-stunnel) carries only the binary and a
+// role-selecting entrypoint; the server.conf / client.conf arrive via
+// the kubeswift-migration-stunnel ConfigMap (charts + kustomize overlay,
+// PR 2). The entrypoint self-selects by STUNNEL_ROLE and pins the peer
+// via CHECK_HOST (verifyChain + checkHost — W-3c-4).
+const (
+	// MigrationStunnelImageEnv overrides the sidecar image. Mirrors
+	// swiftguest.LauncherImageEnv. The release pipeline sets this to the
+	// version-stamped tag; local dev and tests fall back to the default.
+	MigrationStunnelImageEnv = "KUBESWIFT_MIGRATION_STUNNEL_IMAGE"
+	// MigrationStunnelImageDefault is the default sidecar image.
+	MigrationStunnelImageDefault = "ghcr.io/projectbeskar/kubeswift/migration-stunnel:latest"
+
+	// stunnelSidecarContainerName is the dst pod's sidecar container.
+	// Distinct from LauncherContainerName so dstPodMatches and the
+	// launcher-container lookups (addReceiverEnvToLauncher,
+	// launcherContainerImage) never mistake it for the swiftletd
+	// container.
+	stunnelSidecarContainerName = "migration-stunnel"
+
+	// stunnelConfigMapName is the ConfigMap carrying server.conf +
+	// client.conf (PR 2: charts/kubeswift/templates/migration/
+	// stunnel-configmap.yaml + config/overlays/migration-mtls). Must
+	// exist in the guest namespace for the sidecar to start; the Helm
+	// chart/overlay provision it in .Values.namespace, and operators
+	// running migrations in other namespaces must replicate it (PR 5
+	// documents this — same shape as the migration identity Secret copy).
+	stunnelConfigMapName = "kubeswift-migration-stunnel"
+
+	// stunnelConfigDir is where the ConfigMap mounts (matches the PR 2
+	// entrypoint's STUNNEL_CONFIG_DIR default).
+	stunnelConfigDir = "/etc/stunnel-config"
+	// migrationTLSDir is where the per-node identity Secret mounts
+	// (matches the cert/key/CAfile paths baked into the PR 2 configs).
+	migrationTLSDir = "/etc/migration-tls"
+
+	// stunnelConfigVolumeName / stunnelCertVolumeName name the two
+	// sidecar volumes on the dst pod.
+	stunnelConfigVolumeName = "migration-stunnel-config"
+	stunnelCertVolumeName   = "migration-tls"
+
+	// Env keys the entrypoint reads (PR 2 entrypoint.sh contract).
+	envStunnelRole      = "STUNNEL_ROLE"
+	envStunnelConfigDir = "STUNNEL_CONFIG_DIR"
+	envStunnelCheckHost = "CHECK_HOST"
+	// envStunnelDstPodIP is the client-only connect target. Destination
+	// sidecars (server role) do not set it; PR 3b stamps it on the src
+	// sidecar via downward API.
+	envStunnelDstPodIP = "DST_POD_IP"
+
+	// stunnelRoleServer is the dst sidecar role (TLS server: accept
+	// 0.0.0.0:6789, forward to the local CH receiver on 127.0.0.1:6790).
+	stunnelRoleServer = "server"
+	// stunnelRoleClient is the src sidecar role (PR 3b).
+	stunnelRoleClient = "client"
+)
+
+// MigrationStunnelImage returns the stunnel sidecar image, from
+// KUBESWIFT_MIGRATION_STUNNEL_IMAGE env or MigrationStunnelImageDefault.
+func MigrationStunnelImage() string {
+	if img := os.Getenv(MigrationStunnelImageEnv); img != "" {
+		return img
+	}
+	return MigrationStunnelImageDefault
+}
+
+// dstStunnelSidecar builds the destination-side stunnel sidecar
+// container (TLS server). srcNodeSAN is the source node's SAN — the dst
+// pins it via CHECK_HOST so the channel authorizes the *specific*
+// source node for THIS migration, not merely any CA-signed peer
+// (W-3c-4). Role/peer are env-parameterized, never image-baked, so a
+// future refactor cannot collapse the two roles into separate images
+// without first seeing this constraint (W-3c-2 / W26 discipline).
+func dstStunnelSidecar(srcNodeSAN string) corev1.Container {
+	noEsc := false
+	nonRoot := true
+	return corev1.Container{
+		Name:            stunnelSidecarContainerName,
+		Image:           MigrationStunnelImage(),
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Env: []corev1.EnvVar{
+			{Name: envStunnelRole, Value: stunnelRoleServer},
+			{Name: envStunnelCheckHost, Value: srcNodeSAN},
+			{Name: envStunnelConfigDir, Value: stunnelConfigDir},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: stunnelConfigVolumeName, MountPath: stunnelConfigDir, ReadOnly: true},
+			{Name: stunnelCertVolumeName, MountPath: migrationTLSDir, ReadOnly: true},
+		},
+		// Minimal privilege: a TLS proxy needs no Linux capabilities.
+		// The image already runs as USER 65534; this makes the
+		// non-root + no-cap posture explicit so a node default-policy
+		// change can't silently grant more.
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: &noEsc,
+			RunAsNonRoot:             &nonRoot,
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		},
+	}
+}
+
+// dstStunnelVolumes returns the two pod volumes the dst sidecar mounts:
+// the shared stunnel-config ConfigMap and this node's per-node identity
+// Secret (dstSecretName = migrationcert.MigrationNodeSecretName(dstNode)).
+func dstStunnelVolumes(dstSecretName string) []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: stunnelConfigVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: stunnelConfigMapName},
+				},
+			},
+		},
+		{
+			Name: stunnelCertVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: dstSecretName,
+				},
+			},
+		},
+	}
+}
+
+// injectDstStunnelSidecar appends the destination stunnel sidecar
+// container and its two volumes to the dst pod. Idempotent: a pod that
+// already carries a container named stunnelSidecarContainerName is left
+// untouched (defensive against a future DeepCopy bringing a sidecar
+// over — though in PR 3 the src pod has no sidecar yet).
+//
+// srcNodeName is the SOURCE node (the dst pins its SAN as the expected
+// peer); dstNodeName is the DESTINATION node (whose identity Secret the
+// sidecar presents).
+func injectDstStunnelSidecar(pod *corev1.Pod, srcNodeName, dstNodeName string) {
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == stunnelSidecarContainerName {
+			return
+		}
+	}
+	pod.Spec.Containers = append(pod.Spec.Containers,
+		dstStunnelSidecar(migrationcert.MigrationNodeCertSAN(srcNodeName)))
+	pod.Spec.Volumes = append(pod.Spec.Volumes,
+		dstStunnelVolumes(migrationcert.MigrationNodeSecretName(dstNodeName))...)
+}

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -25,14 +25,21 @@ import (
 // missed events.
 const stopAndCopyLivePollInterval = 2 * time.Second
 
-// migrationListenPort is the TCP port both src and dst CH use for
-// the migration channel. Phase 2 manual demo uses 6789
-// (docs/design/live-migration-phase-2.md §2 example flow); Phase 3a
-// PR 1 keeps the same fixed port. mTLS sidecar (Phase 3b) may move
-// the port to localhost-proxy semantics — the design note in Phase 2
-// §spike "Decision 2" calls this out, so callers should NOT bake-in
-// assumptions about whether the port is direct CH or via a proxy.
+// migrationListenPort is the cross-pod TCP port for the migration
+// channel. In the plaintext path (mTLS off) it is the port CH itself
+// binds/dials. In the Phase 3c mTLS path it is the port the stunnel
+// SERVER sidecar binds on the destination pod (0.0.0.0:6789); CH then
+// receives on the localhost plaintext port behind it.
 const migrationListenPort = 6789
+
+// migrationLocalPlaintextPort is the loopback port the destination CH
+// receiver listens on when mTLS is enabled (Phase 3c). The dst stunnel
+// server accepts cross-pod TLS on migrationListenPort and forwards
+// decrypted bytes to 127.0.0.1:migrationLocalPlaintextPort, where CH's
+// vm.receive-migration listens. Localhost-only — no plaintext leaves
+// the pod. The SOURCE-side counterpart (CH sends to 127.0.0.1:6790 via
+// the src stunnel client) lands in PR 3b.
+const migrationLocalPlaintextPort = 6790
 
 // migrationActionTimeoutSeconds is the per-action HTTP timeout the
 // controller passes to swiftletd via migration-action-args. Phase 2
@@ -331,8 +338,18 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 		if srcArg != nil {
 			guestIP = srcArg.Annotations[AnnotationGuestIP]
 		}
+		// Phase 3c: when mTLS is enabled the dst CH receives on the
+		// loopback plaintext port behind the stunnel server sidecar
+		// (which terminates cross-pod TLS on migrationListenPort and
+		// forwards here). swiftletd is handed a localhost URL and stays
+		// TLS-unaware (design §5 opacity contract). With mTLS off, CH
+		// binds the cross-pod port directly exactly as in Phase 3a/3b.
+		listenURL := fmt.Sprintf("tcp:0.0.0.0:%d", migrationListenPort)
+		if r.MigrationMTLSEnabled {
+			listenURL = fmt.Sprintf("tcp:127.0.0.1:%d", migrationLocalPlaintextPort)
+		}
 		args := migrationReceiveArgs{
-			ListenURL:      fmt.Sprintf("tcp:0.0.0.0:%d", migrationListenPort),
+			ListenURL:      listenURL,
 			TimeoutSeconds: migrationActionTimeoutSeconds,
 			GuestIP:        guestIP,
 		}

--- a/internal/controller/swiftmigration/stopandcopy_live_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_live_test.go
@@ -278,6 +278,34 @@ func TestStopAndCopyLive_PreRecv_WritesReceiveAction(t *testing.T) {
 	}
 }
 
+// TestStopAndCopyLive_PreRecv_MTLS_RepointsListenToLocalhost verifies the
+// Phase 3c destination repoint: with mTLS enabled, the dst CH receive
+// listen_url targets the loopback plaintext port (behind the stunnel
+// server sidecar), not the cross-pod port. CH stays TLS-unaware.
+func TestStopAndCopyLive_PreRecv_MTLS_RepointsListenToLocalhost(t *testing.T) {
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+	r.MigrationMTLSEnabled = true
+
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.Err != nil || res.FailureMsg != "" {
+		t.Fatalf("unexpected failure: err=%v msg=%q", res.Err, res.FailureMsg)
+	}
+
+	var got corev1.Pod
+	if err := r.Get(context.Background(), key(dst), &got); err != nil {
+		t.Fatalf("re-get dst: %v", err)
+	}
+	var args migrationReceiveArgs
+	if err := json.Unmarshal([]byte(got.Annotations[AnnotationMigrationActionArgs]), &args); err != nil {
+		t.Fatalf("unmarshal args: %v", err)
+	}
+	if args.ListenURL != "tcp:127.0.0.1:6790" {
+		t.Errorf("mTLS listen_url: want tcp:127.0.0.1:6790 (loopback behind stunnel), got %q", args.ListenURL)
+	}
+}
+
 // W13 regression: substatePreRecv must patch src pod with BOTH the
 // migration-name label (informer observability per architect F-3) AND
 // the Phase 2 plaintext-ack annotation. Without the ack, swiftletd's

--- a/internal/controller/swiftmigration/validating_live.go
+++ b/internal/controller/swiftmigration/validating_live.go
@@ -11,6 +11,7 @@ import (
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/migrationcert"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
 )
 
@@ -179,6 +180,33 @@ func (r *SwiftMigrationReconciler) handleValidatingLive(
 	}
 
 	// CPU pre-flight: silent success per design §7.3.
+
+	// Phase 3c (Option B) mTLS precondition (§4.4). When live-migration
+	// mTLS is enabled, BOTH participating nodes' per-node identity
+	// Secrets must already be provisioned (cert-manager precondition) and
+	// are distributed into this guest namespace so the launcher pods can
+	// mount them. This is DISTRIBUTION, not issuance — no cert-manager
+	// call sits on the migration path; EnsureMigrationIdentitySecret
+	// copies an already-issued Secret and returns an error when the
+	// source Secret is absent. Failing fast here keeps a missing/expired
+	// node identity from ever reaching the cutover window. The dst
+	// sidecar mounts the dst-node Secret (PR 3); the src sidecar mounts
+	// the src-node Secret (PR 3b) — both are ensured up front so PR 3b
+	// needs no Validating-phase change.
+	if r.MigrationMTLSEnabled {
+		for _, n := range []string{status.SourceNode, status.DestinationNode} {
+			if n == "" {
+				return phaseFailure(
+					"migration mTLS enabled but a participating node name is empty; cannot resolve per-node identity",
+					migrationv1alpha1.FailureReasonMigrationIdentityNotReady)
+			}
+			if err := migrationcert.EnsureMigrationIdentitySecret(ctx, r.Client, r.SystemNamespace, guest.Namespace, n); err != nil {
+				return phaseFailure(
+					fmt.Sprintf("migration identity Secret for node %q not ready: %v", n, err),
+					migrationv1alpha1.FailureReasonMigrationIdentityNotReady)
+			}
+		}
+	}
 
 	// Compatible=True, advance to Preparing.
 	setCondition(status, migrationv1alpha1.SwiftMigrationConditionCompatible,

--- a/internal/controller/swiftmigration/validating_live_test.go
+++ b/internal/controller/swiftmigration/validating_live_test.go
@@ -9,12 +9,32 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/migrationcert"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
 )
+
+// migrationNodeIdentitySecret builds a per-node identity Secret fixture
+// (the shape cert-manager writes into the system namespace) for the
+// Phase 3c Validating-live precondition tests.
+func migrationNodeIdentitySecret(systemNS, node string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      migrationcert.MigrationNodeSecretName(node),
+			Namespace: systemNS,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": []byte("crt-" + node),
+			"tls.key": []byte("key-" + node),
+			"ca.crt":  []byte("ca"),
+		},
+	}
+}
 
 // newSourcePodWithLauncherImage builds a source pod with a launcher
 // container whose image is set explicitly. Used by image-tag-match
@@ -86,6 +106,123 @@ func TestValidatingLive_HappyPath_AdvancesToPreparing(t *testing.T) {
 	}
 	if status.DestinationNode != "miles" {
 		t.Errorf("DestinationNode: want miles, got %q", status.DestinationNode)
+	}
+}
+
+// TestValidatingLive_MTLS_IdentitiesPresent_Advances verifies the
+// Phase 3c precondition: with mTLS enabled and both node identity
+// Secrets present in the system namespace, Validating-live advances AND
+// distributes both Secrets into the guest namespace so the launcher
+// pods can mount them.
+func TestValidatingLive_MTLS_IdentitiesPresent_Advances(t *testing.T) {
+	scheme := validatingScheme(t)
+	const sysNS = "kubeswift-system"
+	guest := newGuestForValidating("guest", "default", "class-default")
+	class := newGuestClass("class-default", 2, 2048)
+	node := newSpaciousNode("miles", 8, 65536)
+	srcPod := newSourcePod("guest", "default", "src-pod-uid-1") // src node "boba"
+	mig := newMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
+	mig.Spec.Timeout = &metav1.Duration{Duration: 5 * 60 * 1e9}
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
+
+	srcSecret := migrationNodeIdentitySecret(sysNS, "boba")
+	dstSecret := migrationNodeIdentitySecret(sysNS, "miles")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest, class, node, srcPod, srcSecret, dstSecret).
+		WithStatusSubresource(mig).
+		Build()
+	r := &SwiftMigrationReconciler{
+		Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10),
+		MigrationMTLSEnabled: true, SystemNamespace: sysNS,
+	}
+
+	status := mig.Status.DeepCopy()
+	result := r.handleValidatingLive(context.Background(), mig, status)
+	if result.Err != nil || result.FailureMsg != "" {
+		t.Fatalf("handleValidatingLive failure: err=%v msg=%q reason=%q", result.Err, result.FailureMsg, result.FailureReason)
+	}
+	if !result.Advanced {
+		t.Fatal("expected Advanced=true with both identities present")
+	}
+	// Both node identity Secrets copied into the guest namespace.
+	for _, n := range []string{"boba", "miles"} {
+		var s corev1.Secret
+		if err := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: migrationcert.MigrationNodeSecretName(n)}, &s); err != nil {
+			t.Errorf("identity Secret for node %q not distributed into guest namespace: %v", n, err)
+		}
+	}
+}
+
+// TestValidatingLive_MTLS_IdentityMissing_FailsNotReady verifies the
+// precondition fails fast (before Preparing) when a participating node's
+// identity Secret has not been provisioned.
+func TestValidatingLive_MTLS_IdentityMissing_FailsNotReady(t *testing.T) {
+	scheme := validatingScheme(t)
+	const sysNS = "kubeswift-system"
+	guest := newGuestForValidating("guest", "default", "class-default")
+	class := newGuestClass("class-default", 2, 2048)
+	node := newSpaciousNode("miles", 8, 65536)
+	srcPod := newSourcePod("guest", "default", "src-pod-uid-1")
+	mig := newMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
+	mig.Spec.Timeout = &metav1.Duration{Duration: 5 * 60 * 1e9}
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
+
+	// Only the source-node Secret present; destination-node Secret missing.
+	srcSecret := migrationNodeIdentitySecret(sysNS, "boba")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest, class, node, srcPod, srcSecret).
+		WithStatusSubresource(mig).
+		Build()
+	r := &SwiftMigrationReconciler{
+		Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10),
+		MigrationMTLSEnabled: true, SystemNamespace: sysNS,
+	}
+
+	status := mig.Status.DeepCopy()
+	result := r.handleValidatingLive(context.Background(), mig, status)
+	if result.FailureReason != migrationv1alpha1.FailureReasonMigrationIdentityNotReady {
+		t.Fatalf("want FailureReason=%q, got reason=%q msg=%q advanced=%v err=%v",
+			migrationv1alpha1.FailureReasonMigrationIdentityNotReady, result.FailureReason, result.FailureMsg, result.Advanced, result.Err)
+	}
+	if status.Phase == migrationv1alpha1.SwiftMigrationPhasePreparing {
+		t.Errorf("must not advance to Preparing when an identity Secret is missing")
+	}
+}
+
+// TestValidatingLive_MTLSDisabled_SkipsPrecondition verifies the default
+// (plaintext) path is unchanged: no identity Secrets, mTLS off → advances.
+func TestValidatingLive_MTLSDisabled_SkipsPrecondition(t *testing.T) {
+	scheme := validatingScheme(t)
+	guest := newGuestForValidating("guest", "default", "class-default")
+	class := newGuestClass("class-default", 2, 2048)
+	node := newSpaciousNode("miles", 8, 65536)
+	srcPod := newSourcePod("guest", "default", "src-pod-uid-1")
+	mig := newMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
+	mig.Spec.Timeout = &metav1.Duration{Duration: 5 * 60 * 1e9}
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest, class, node, srcPod).
+		WithStatusSubresource(mig).
+		Build()
+	// MigrationMTLSEnabled left false; SystemNamespace irrelevant.
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	status := mig.Status.DeepCopy()
+	result := r.handleValidatingLive(context.Background(), mig, status)
+	if result.Err != nil || result.FailureMsg != "" {
+		t.Fatalf("mTLS-off Validating must not fail on missing identities: err=%v msg=%q", result.Err, result.FailureMsg)
+	}
+	if !result.Advanced {
+		t.Fatal("expected Advanced=true on the plaintext path")
 	}
 }
 

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -1264,6 +1264,42 @@ edit on a Ready image is allowed while a genuine spec change is still
 rejected. Deferred from branch fix/tfu-17 to keep that change scoped to
 the HIGH-severity trap (TFU #17). Surfaced 2026-05-29 by the PR C recon.
 
+### 24. W-3c-1 `lifecycle: run` freeze on the migration dst pod — deferred (defense-in-depth, not needed by the current live flow)
+
+Phase 3c PR 3 (destination-side mTLS wiring, PR #81) deliberately did
+NOT implement the design doc §4.1 / §8-invariant-#4 `lifecycle: run`
+freeze on the destination launcher pod. The freeze guards against a
+narrow poisoning: if the controller patched the source guest to
+`runPolicy: Stopped` mid-migration, the SwiftGuest controller would
+rewrite `<guest>-runtime-intent` to `lifecycle: stop`, and swiftletd's
+launch gate (`main.rs:201`) honors that for ALL launch paths including
+`migration_receiver_mode` (receiver role is an env var, not an
+exemption) — poisoning the dst receiver.
+
+**Why it cannot fire in the controller-driven live flow:**
+[`cutover.go`](internal/controller/swiftmigration/cutover.go) commits
+cutover by **`Delete`-ing the src pod** (step 2) and patching
+`SwiftGuest.status.podRef.name` (step 1); it **never patches
+`runPolicy: Stopped`** on the source guest. And the dst receiver reads
+its runtime intent **once at boot during Preparing-live** — long before
+any cutover action — so the `<guest>-runtime-intent` CM cannot flip to
+`lifecycle: stop` while the dst depends on it (RestartPolicy: Never, no
+re-read). The W-3c-1 finding originated in the Phase 3c **spike**, whose
+manual flow patched `runPolicy: Stopped` directly.
+
+Implementing the freeze now would be a speculative, non-trivial change
+(minting a frozen per-migration intent CM and repointing the dst pod's
+volume) against Design Principle #1 (minimal changes) / #7 (no
+speculative fixes). **Tracked as defense-in-depth** for a hypothetical
+future stop-during-migration path — most plausibly **Phase 4 drain
+integration**, where an eviction-triggered stop could coincide with a
+live migration. If/when such a path lands, the freeze (or an equivalent
+guard ensuring the dst intent stays `lifecycle: run`) must land with it.
+Documented in [`dst_pod.go::newDstPod`](internal/controller/swiftmigration/dst_pod.go)
+at the injection site so a future maintainer sees the constraint before
+adding a source-stop to the live path. Severity: LOW (latent; not
+reachable today). Surfaced 2026-06-01 during PR 3 planning.
+
 ---
 
 ## Phase 2 Decisions Resolved (live migration)


### PR DESCRIPTION
## Summary

PR 3 of Phase 3c (live-migration mTLS transport, **Option B**: per-node identity + SAN pinning). Wires the **destination side** of the stunnel sidecar (PR 2) into the SwiftMigration controller. Builds on PR 1 (#79 cert provisioning) + PR 2 (#80 sidecar image + ConfigMap).

**Gated entirely on `--migration-mtls-enabled`.** With the flag off (the default), the dst pod, receive `listen_url`, and the Validating phase are **byte-for-byte unchanged** — tests assert this explicitly. Per the agreed split, this PR is **destination-only**; the source side is PR 3b.

## What's in it

- **Reconciler plumbing** — `SwiftMigrationReconciler` gains `MigrationMTLSEnabled` + `SystemNamespace`, wired in `main.go` from the existing flag + leader-election namespace.
- **`newDstPod` sidecar injection** — when mTLS is on, appends the stunnel **server** sidecar (`STUNNEL_ROLE=server`, `CHECK_HOST` pinned to the **source** node's SAN — W-3c-4) plus the `kubeswift-migration-stunnel` ConfigMap volume and the **destination** node's identity Secret at `/etc/migration-tls/`. Role/peer are env-parameterized, never image-baked (W-3c-2). Guards empty node names.
- **Dst `listen_url` repoint** — `tcp:127.0.0.1:6790` (loopback, behind the sidecar) when mTLS is on; CH stays TLS-unaware (design §5 opacity contract). New `migrationLocalPlaintextPort = 6790`; the cross-pod `migrationListenPort = 6789` is now the stunnel server's port.
- **Validating-live precondition (§4.4)** — distributes **both** participating nodes' identity Secrets into the guest namespace via `EnsureMigrationIdentitySecret` (distribution, not issuance — no cert-manager call on the migration path); fails fast with new `FailureReasonMigrationIdentityNotReady` if a source Secret is missing.
- **Opportunistic fix** — stale `verify = 4` comment in the merged `migrationcert/certificate.go` → `verifyChain` + `checkHost`.

## Test plan

- [x] `gofmt` clean · `go build ./...` · `go vet ./...` · full `go test ./...` (exit 0).
- [x] No CRD regen — `FailureReason` is a free-string field, not an enum.
- [x] New unit tests: dst sidecar shape (mTLS on injects server+volumes / off injects nothing / empty node name errors), `listen_url` repoint to loopback, Validating precondition (identities present → advance + distribute / missing → `MigrationIdentityNotReady` / mTLS-off → skip).
- [ ] End-to-end cross-node mTLS migration — **deferred to PR 5** (requires the source sidecar from PR 3b).

## Deliberately deferred (documented in code + commit)

- **Source side → PR 3b** (downward-API + poll): the source launcher pod is pre-existing and immutable, so the design's "stamp `DST_POD_IP` onto the src sidecar env" (§4.2) isn't implementable on a running pod. PR 3b adds the src sidecar at launcher-pod creation, an entrypoint that polls a downward-API annotation file for `DST_POD_IP`/`CHECK_HOST`, and the `target_url` repoint. **End-to-end mTLS is therefore not functional between PR 3 and PR 3b** — enabling the flag yields a half-wired channel (dst expects TLS, src still sends plaintext) — which is safe because mTLS is off by default and is validated in PR 5.
- **W-3c-1 `lifecycle: run` freeze → not needed in this flow.** `cutover.go` Deletes the src pod and never patches `runPolicy: Stopped`, and the dst receiver reads its runtime intent once at boot during Preparing-live (before any cutover action), so the `<guest>-runtime-intent` CM cannot flip to `lifecycle: stop` while the dst depends on it. Kept as a tracked defense-in-depth item for a future stop-during-migration path (Phase 4 drain integration).

## Composition notes

- Both **mTLS** and **S1** (URLs-from-CR) remain required; neither subsumes the other (design §6.1). S1 lands in PR 4.
- Retiring the `migration-phase2-unsafe-plaintext: ack` gate is PR 4 work; this PR leaves it in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)