### PR TITLE
feat(migration): Phase 3c PR 3b — source pod carries an idle stunnel client

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -138,6 +138,13 @@ func main() {
 	if err = (&swiftguest.SwiftGuestReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		// Phase 3c (Option B): when mTLS is enabled, migration-eligible
+		// launcher pods carry an idle source-side stunnel client sidecar so
+		// a later live migration has its TLS client already in the
+		// immutable source pod. SystemNamespace is where the stunnel
+		// ConfigMap + per-node identity Secrets live.
+		MigrationMTLSEnabled: *migrationMTLSEnabled,
+		SystemNamespace:      leaderElectionNS,
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftGuest controller")
 		os.Exit(1)

--- a/images/migration-stunnel/entrypoint.sh
+++ b/images/migration-stunnel/entrypoint.sh
@@ -1,26 +1,50 @@
 #!/bin/sh
 # KubeSwift live-migration mTLS stunnel sidecar entrypoint (Phase 3c).
 #
-# Selects the server-vs-client stunnel config by STUNNEL_ROLE and injects the
-# per-migration parameters (peer IP, peer SAN) from env. Role and peer are
-# env-parameterized, NEVER image-baked - W-3c-2 load-bearing property: the
-# controller DeepCopies the source pod's sidecar onto the destination and
-# flips STUNNEL_ROLE rather than maintaining two images.
+# Selects the server-vs-client stunnel config by STUNNEL_ROLE and renders
+# the per-migration parameters (peer IP, peer SAN) into the active config.
+# Role and peer are env/file-parameterized, NEVER image-baked - W-3c-2
+# load-bearing property: the controller picks role + peer per migration
+# rather than maintaining two images.
 #
-# Env contract (stamped by the SwiftMigration controller in PR 3):
-#   STUNNEL_ROLE   server | client          (required)
-#   CHECK_HOST     expected peer node SAN    (required, both roles)
-#   DST_POD_IP     destination pod IP        (required, client role only)
+# Two input models, by role:
 #
-# The mounted ConfigMap (STUNNEL_CONFIG_DIR) carries server.conf + client.conf
-# with __CHECK_HOST__ / __DST_POD_IP__ placeholders; this script renders the
-# active config into a writable runtime path and execs stunnel on it.
+#   server (DESTINATION pod): created fresh by the SwiftMigration
+#     controller at migration time, so CHECK_HOST and the identity Secret
+#     are available at container start. Inputs come from ENV + the mounted
+#     per-node identity Secret. Starts immediately.
+#
+#   client (SOURCE pod): lives inside the pre-existing, immutable launcher
+#     pod, born long before any migration. Its inputs (peer IP, peer SAN,
+#     and this guest's identity) are unknown at pod creation and arrive
+#     only when a migration starts: the controller stamps pod annotations
+#     (surfaced here via a downward-API volume) and populates the per-guest
+#     identity Secret. So the client IDLE-POLLS for those inputs and only
+#     then starts stunnel. Idling keeps the launcher pod Running/Ready at
+#     rest (no migration in flight) instead of crash-looping.
+#
+# Env contract:
+#   STUNNEL_ROLE        server | client                 (required)
+#   CHECK_HOST          expected peer node SAN           (server: required)
+#   STUNNEL_CONFIG_DIR  server.conf/client.conf dir      (default /etc/stunnel-config)
+#   STUNNEL_INPUT_DIR   downward-API input dir (client)  (default /etc/migration-input)
+#   STUNNEL_TLS_DIR     identity Secret mount            (default /etc/migration-tls)
+#   STUNNEL_RUNTIME_DIR writable dir for rendered config (default /tmp)
+#   STUNNEL_POLL_SECONDS client idle-poll interval       (default 2)
+#
+# Client inputs arrive as files (controller-stamped, downward-API + Secret):
+#   ${STUNNEL_INPUT_DIR}/dst-ip    destination pod IP   (TLS connect target)
+#   ${STUNNEL_INPUT_DIR}/peer-san  destination node SAN (checkHost pin)
+#   ${STUNNEL_TLS_DIR}/tls.crt, tls.key, ca.crt          (this guest's identity)
 #
 # Pure ASCII; explicit interpreter; POSIX sh (BusyBox-compatible).
 set -eu
 
 CONFIG_DIR="${STUNNEL_CONFIG_DIR:-/etc/stunnel-config}"
 RUNTIME_DIR="${STUNNEL_RUNTIME_DIR:-/tmp}"
+INPUT_DIR="${STUNNEL_INPUT_DIR:-/etc/migration-input}"
+TLS_DIR="${STUNNEL_TLS_DIR:-/etc/migration-tls}"
+POLL_SECONDS="${STUNNEL_POLL_SECONDS:-2}"
 ROLE="${STUNNEL_ROLE:-}"
 
 case "${ROLE}" in
@@ -41,32 +65,54 @@ if [ ! -f "${SRC_CONF}" ]; then
   exit 1
 fi
 
-# CHECK_HOST (expected peer node SAN) is required for BOTH roles. It is the
-# subject-check that closes the W-3c-4 gap: verifyChain alone proves "chains
-# to the migration CA"; checkHost pins the peer to the specific node the
-# controller chose from the SwiftMigration CR. Fail fast if unset rather than
-# render a config that would accept any CA-signed peer.
-if [ -z "${CHECK_HOST:-}" ]; then
-  echo "stunnel-sidecar: CHECK_HOST (expected peer node SAN) is required" >&2
-  exit 1
-fi
+# read_file prints a file's contents with trailing newlines stripped, or an
+# empty string when the file is absent. Used to read controller-stamped
+# downward-API inputs without tripping 'set -e' on a missing file.
+read_file() {
+  if [ -f "$1" ]; then
+    tr -d '\n\r' < "$1"
+  else
+    printf ''
+  fi
+}
 
-# DST_POD_IP is the TLS connect target; required only for the client (source)
-# sidecar. It is known only after the destination pod is scheduled, so the
-# controller stamps it during Preparing-live (W-3c-2 sequencing).
-if [ "${ROLE}" = "client" ] && [ -z "${DST_POD_IP:-}" ]; then
-  echo "stunnel-sidecar: DST_POD_IP is required for client role" >&2
-  exit 1
+EFF_DST_POD_IP=""
+
+if [ "${ROLE}" = "server" ]; then
+  # Destination: CHECK_HOST (expected SOURCE node SAN) arrives by env at
+  # container start; the identity Secret is mounted populated. The SAN pin
+  # closes the W-3c-4 subject-check gap - fail fast rather than render a
+  # config that would accept any CA-signed peer.
+  if [ -z "${CHECK_HOST:-}" ]; then
+    echo "stunnel-sidecar: CHECK_HOST (expected peer node SAN) is required for server role" >&2
+    exit 1
+  fi
+  EFF_CHECK_HOST="${CHECK_HOST}"
+else
+  # Source: idle-poll for the controller-stamped inputs (downward-API
+  # annotations) and the populated per-guest identity Secret. Stays in this
+  # loop - container Running, pod Ready - until a migration starts.
+  echo "stunnel-sidecar: client idle; waiting for migration inputs (dst-ip, peer-san, identity) under ${INPUT_DIR} + ${TLS_DIR}" >&2
+  while : ; do
+    EFF_CHECK_HOST="$(read_file "${INPUT_DIR}/peer-san")"
+    EFF_DST_POD_IP="$(read_file "${INPUT_DIR}/dst-ip")"
+    if [ -n "${EFF_CHECK_HOST}" ] && [ -n "${EFF_DST_POD_IP}" ] && \
+       [ -s "${TLS_DIR}/tls.crt" ] && [ -s "${TLS_DIR}/tls.key" ] && [ -s "${TLS_DIR}/ca.crt" ]; then
+      break
+    fi
+    sleep "${POLL_SECONDS}"
+  done
+  echo "stunnel-sidecar: inputs ready (peer-san=${EFF_CHECK_HOST} dst-ip=${EFF_DST_POD_IP}); starting" >&2
 fi
 
 ACTIVE_CONF="${RUNTIME_DIR}/stunnel.conf"
 # The mounted ConfigMap is read-only; render the substituted config into a
 # writable runtime path.
 cp "${SRC_CONF}" "${ACTIVE_CONF}"
-sed -i "s|__CHECK_HOST__|${CHECK_HOST}|g" "${ACTIVE_CONF}"
+sed -i "s|__CHECK_HOST__|${EFF_CHECK_HOST}|g" "${ACTIVE_CONF}"
 if [ "${ROLE}" = "client" ]; then
-  sed -i "s|__DST_POD_IP__|${DST_POD_IP}|g" "${ACTIVE_CONF}"
+  sed -i "s|__DST_POD_IP__|${EFF_DST_POD_IP}|g" "${ACTIVE_CONF}"
 fi
 
-echo "stunnel-sidecar: starting role=${ROLE} peer-SAN=${CHECK_HOST}${DST_POD_IP:+ dst-ip=${DST_POD_IP}}" >&2
+echo "stunnel-sidecar: starting role=${ROLE} peer-san=${EFF_CHECK_HOST}${EFF_DST_POD_IP:+ dst-ip=${EFF_DST_POD_IP}}" >&2
 exec stunnel "${ACTIVE_CONF}"

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -57,6 +57,23 @@ const (
 type SwiftGuestReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	// MigrationMTLSEnabled mirrors the controller-manager's
+	// --migration-mtls-enabled flag (Phase 3c, Option B). When true, every
+	// migration-eligible launcher pod is born with an idle source-side
+	// stunnel client sidecar (plus its downward-API input volume and a
+	// per-guest identity Secret), so that a future live migration has the
+	// TLS client already in place inside the immutable, already-running
+	// source pod. When false (default) the launcher pod is byte-for-byte
+	// unchanged from Phase 3a/3b.
+	MigrationMTLSEnabled bool
+
+	// SystemNamespace is the controller-manager's own namespace, where the
+	// migration CA Issuer, the per-node identity Secrets, and the
+	// kubeswift-migration-stunnel ConfigMap live. Used to copy the stunnel
+	// ConfigMap into guest namespaces. Only consulted when
+	// MigrationMTLSEnabled.
+	SystemNamespace string
 }
 
 // Reconcile implements the reconcile loop.
@@ -341,6 +358,23 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Override the PVC name to use the clone instead of the shared image PVC.
 		rg.PreparedImage.PVCName = res.PVCName
 	}
+	// Phase 3c (Option B): when mTLS is enabled, the launcher pod for a
+	// migration-eligible guest mounts the stunnel-config ConfigMap and a
+	// per-guest identity Secret (see applyMigrationSourceSidecar). Ensure
+	// both exist in the guest namespace BEFORE building/creating the pod —
+	// a pod that references a missing ConfigMap/Secret never starts. These
+	// are idempotent and never clobber a migration-populated identity.
+	if r.MigrationMTLSEnabled && migrationEligible(&guest) {
+		if err := EnsureMigrationStunnelConfig(ctx, r.Client, r.SystemNamespace, guest.Namespace); err != nil {
+			logger.Error(err, "failed to ensure migration stunnel ConfigMap")
+			return ctrl.Result{}, err
+		}
+		if err := EnsurePerGuestMigrationIdentitySecret(ctx, r.Client, r.Scheme, &guest); err != nil {
+			logger.Error(err, "failed to ensure per-guest migration identity Secret")
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Build and create/update pod
 	desiredPod, err := r.buildPod(ctx, &guest, rg, seedConfigMapName, intentConfigMapName, rootDiskClone)
 	if err != nil {

--- a/internal/controller/swiftguest/gpu.go
+++ b/internal/controller/swiftguest/gpu.go
@@ -256,7 +256,29 @@ func expandCPURange(s string) ([]int, error) {
 // rootDiskClone is non-nil for disk-boot guests after EnsureRootDiskClone
 // has succeeded. It controls whether a clone-grow-init init container is
 // added on the snapshot clone strategy.
+// buildPod resolves the launcher pod and, when Phase 3c mTLS is enabled,
+// injects the idle source-side stunnel client sidecar for migration-
+// eligible guests. The base-pod construction lives in buildBasePod; this
+// thin wrapper keeps the sidecar concern (and the r-scoped mTLS flag) out
+// of the three boot-path branches.
 func (r *SwiftGuestReconciler) buildPod(
+	ctx context.Context,
+	guest *swiftv1alpha1.SwiftGuest,
+	rg *resolved.ResolvedGuest,
+	seedConfigMapName, intentConfigMapName string,
+	rootDiskClone *RootDiskCloneResult,
+) (*corev1.Pod, error) {
+	pod, err := r.buildBasePod(ctx, guest, rg, seedConfigMapName, intentConfigMapName, rootDiskClone)
+	if err != nil {
+		return nil, err
+	}
+	if r.MigrationMTLSEnabled && migrationEligible(guest) {
+		applyMigrationSourceSidecar(pod, guest)
+	}
+	return pod, nil
+}
+
+func (r *SwiftGuestReconciler) buildBasePod(
 	ctx context.Context,
 	guest *swiftv1alpha1.SwiftGuest,
 	rg *resolved.ResolvedGuest,

--- a/internal/controller/swiftguest/migration_sidecar.go
+++ b/internal/controller/swiftguest/migration_sidecar.go
@@ -1,0 +1,301 @@
+package swiftguest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/migrationsidecar"
+)
+
+// Phase 3c (Option B) SOURCE-side live-migration mTLS stunnel sidecar.
+//
+// Unlike the destination sidecar (injected by the SwiftMigration controller
+// at migration time, when the target node is known), the source sidecar
+// must live inside the pre-existing, immutable launcher pod — you cannot
+// add a container or env to a running pod. So when mTLS is enabled, EVERY
+// migration-eligible launcher pod is born with an IDLE stunnel client
+// sidecar. It idle-polls a downward-API volume + the per-guest identity
+// Secret for the inputs a migration stamps later (design §4.2, corrected by
+// the PR 3 walkthrough: the source pod's node may not even be known at
+// creation time, which is why the identity arrives via a per-guest Secret
+// populated at migration time rather than a per-node Secret mounted here).
+//
+// This file (PR 3b) only wires the IDLE sidecar. The SwiftMigration
+// controller activates it (PR 3d) by populating the per-guest identity
+// Secret and stamping the dst-ip / peer-san annotations.
+
+// migrationIdentitySecretSuffix forms the per-guest identity Secret name.
+const migrationIdentitySecretSuffix = "-migration-identity"
+
+// PerGuestMigrationIdentitySecretName returns the name of the per-guest
+// Secret that holds the SOURCE guest's migration identity (tls.crt /
+// tls.key / ca.crt). The SwiftGuest controller ensures it exists (empty)
+// at pod creation; the SwiftMigration controller (PR 3d) populates it with
+// the source node's issued identity at migration time.
+func PerGuestMigrationIdentitySecretName(guestName string) string {
+	return guestName + migrationIdentitySecretSuffix
+}
+
+// migrationEligible reports whether SwiftMigrations may target this guest.
+// Mirrors the SwiftMigration webhook's eligibility rule: migration is
+// enabled unless explicitly disabled (spec.migration.enabled=false). Only
+// eligible guests get the source sidecar — pinned-in-place guests
+// (enabled=false) never migrate, so the idle sidecar would be dead weight.
+func migrationEligible(guest *swiftv1alpha1.SwiftGuest) bool {
+	if guest.Spec.Migration == nil || guest.Spec.Migration.Enabled == nil {
+		return true
+	}
+	return *guest.Spec.Migration.Enabled
+}
+
+// sourceStunnelSidecar builds the source-side stunnel client sidecar.
+// It carries NO peer SAN / dst IP in env: those are per-migration and
+// unknown at pod creation, so the entrypoint idle-polls the downward-API
+// input volume (and the per-guest identity Secret) and only starts stunnel
+// once a migration stamps them. Role/peer are env/file-parameterized,
+// never image-baked (W-3c-2).
+func sourceStunnelSidecar() corev1.Container {
+	noEsc := false
+	nonRoot := true
+	return corev1.Container{
+		Name:            migrationsidecar.ContainerName,
+		Image:           migrationsidecar.Image(),
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Env: []corev1.EnvVar{
+			{Name: migrationsidecar.EnvRole, Value: migrationsidecar.RoleClient},
+			{Name: migrationsidecar.EnvConfigDir, Value: migrationsidecar.ConfigDir},
+			{Name: migrationsidecar.EnvInputDir, Value: migrationsidecar.InputDir},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: migrationsidecar.ConfigVolumeName, MountPath: migrationsidecar.ConfigDir, ReadOnly: true},
+			{Name: migrationsidecar.CertVolumeName, MountPath: migrationsidecar.TLSDir, ReadOnly: true},
+			{Name: migrationsidecar.InputVolumeName, MountPath: migrationsidecar.InputDir, ReadOnly: true},
+		},
+		// Idle-poll is cheap; cap it small. No readinessProbe: the sidecar
+		// is "ready" (running) at rest, and a data-port probe would mark the
+		// launcher pod NotReady whenever no migration is in flight.
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(10, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(16*1024*1024, resource.BinarySI),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(64*1024*1024, resource.BinarySI),
+			},
+		},
+		// Minimal privilege: a TLS proxy needs no Linux capabilities. The
+		// image already runs as USER 65534; making it explicit prevents a
+		// node default-policy change from silently granting more.
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: &noEsc,
+			RunAsNonRoot:             &nonRoot,
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		},
+	}
+}
+
+// sourceStunnelVolumes returns the three volumes the source sidecar mounts:
+//   - the shared stunnel-config ConfigMap (server.conf/client.conf),
+//   - the per-guest identity Secret (empty until a migration populates it),
+//   - a downward-API volume projecting the controller-stamped dst-ip /
+//     peer-san annotations into files the entrypoint polls.
+func sourceStunnelVolumes(guestName string) []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: migrationsidecar.ConfigVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: migrationsidecar.ConfigMapName},
+				},
+			},
+		},
+		{
+			Name: migrationsidecar.CertVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: PerGuestMigrationIdentitySecretName(guestName),
+				},
+			},
+		},
+		{
+			Name: migrationsidecar.InputVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				DownwardAPI: &corev1.DownwardAPIVolumeSource{
+					Items: []corev1.DownwardAPIVolumeFile{
+						{
+							Path:     migrationsidecar.InputFileDstIP,
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: fmt.Sprintf("metadata.annotations['%s']", migrationsidecar.AnnotationDstPodIP)},
+						},
+						{
+							Path:     migrationsidecar.InputFilePeerSAN,
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: fmt.Sprintf("metadata.annotations['%s']", migrationsidecar.AnnotationPeerSAN)},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// applyMigrationSourceSidecar appends the idle source stunnel client
+// sidecar and its three volumes to the launcher pod. Idempotent: a pod that
+// already carries the sidecar container is left untouched.
+func applyMigrationSourceSidecar(pod *corev1.Pod, guest *swiftv1alpha1.SwiftGuest) {
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == migrationsidecar.ContainerName {
+			return
+		}
+	}
+	pod.Spec.Containers = append(pod.Spec.Containers, sourceStunnelSidecar())
+	pod.Spec.Volumes = append(pod.Spec.Volumes, sourceStunnelVolumes(guest.Name)...)
+}
+
+// EnsureMigrationStunnelConfig copies the kubeswift-migration-stunnel
+// ConfigMap (server.conf + client.conf) from the system namespace into the
+// guest namespace so the source sidecar can mount it. Same-namespace
+// fast-path: when the guest runs in the system namespace, the chart/overlay
+// already provisioned it there.
+//
+// The source ConfigMap missing in the system namespace is a precondition
+// failure (operator enabled mTLS without installing the migration-mtls
+// overlay / Helm value) — surfaced as an error so the reconcile requeues
+// and the gap is visible, rather than creating a pod that mounts a missing
+// ConfigMap and never starts. Create-if-absent, update-if-differs keeps the
+// copy current. No ownerRef: like the swiftletd-reporter RoleBinding it is
+// shared across all guests in the namespace and must outlive any one of them.
+func EnsureMigrationStunnelConfig(ctx context.Context, c client.Client, systemNamespace, targetNamespace string) error {
+	if targetNamespace == systemNamespace {
+		return nil
+	}
+	srcKey := types.NamespacedName{Namespace: systemNamespace, Name: migrationsidecar.ConfigMapName}
+	var source corev1.ConfigMap
+	if err := c.Get(ctx, srcKey, &source); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("migration stunnel ConfigMap %s not found (install the migration-mtls overlay / Helm value before enabling mTLS): %w", srcKey, err)
+		}
+		return fmt.Errorf("get source migration stunnel ConfigMap %s: %w", srcKey, err)
+	}
+
+	targetKey := types.NamespacedName{Namespace: targetNamespace, Name: migrationsidecar.ConfigMapName}
+	var existing corev1.ConfigMap
+	err := c.Get(ctx, targetKey, &existing)
+	if err == nil {
+		if configMapDataEqual(existing.Data, source.Data) && configMapBinaryEqual(existing.BinaryData, source.BinaryData) {
+			return nil
+		}
+		existing.Data = source.Data
+		existing.BinaryData = source.BinaryData
+		if uerr := c.Update(ctx, &existing); uerr != nil {
+			return fmt.Errorf("update copied migration stunnel ConfigMap %s: %w", targetKey, uerr)
+		}
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get target migration stunnel ConfigMap %s: %w", targetKey, err)
+	}
+
+	copyCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      migrationsidecar.ConfigMapName,
+			Namespace: targetNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "kubeswift",
+				"app.kubernetes.io/component":  "migration-mtls",
+				"app.kubernetes.io/managed-by": "kubeswift-controller-manager",
+			},
+		},
+		Data:       source.Data,
+		BinaryData: source.BinaryData,
+	}
+	if cerr := c.Create(ctx, copyCM); cerr != nil {
+		if apierrors.IsAlreadyExists(cerr) {
+			return nil
+		}
+		return fmt.Errorf("create copied migration stunnel ConfigMap %s: %w", targetKey, cerr)
+	}
+	return nil
+}
+
+// EnsurePerGuestMigrationIdentitySecret idempotently ensures the per-guest
+// identity Secret EXISTS (so the launcher pod's sidecar volume can mount
+// it). It is created EMPTY and owned by the SwiftGuest (GC on guest delete).
+// The SwiftMigration controller (PR 3d) populates it with the source node's
+// issued cert/key/ca at migration time.
+//
+// Critically, this never clobbers an existing Secret's Data: a migration in
+// flight may have just populated it, and a SwiftGuest reconcile must not
+// wipe the identity out from under the sidecar.
+func EnsurePerGuestMigrationIdentitySecret(ctx context.Context, c client.Client, scheme *runtime.Scheme, guest *swiftv1alpha1.SwiftGuest) error {
+	key := types.NamespacedName{Namespace: guest.Namespace, Name: PerGuestMigrationIdentitySecretName(guest.Name)}
+	var existing corev1.Secret
+	err := c.Get(ctx, key, &existing)
+	if err == nil {
+		return nil // exists — do not touch its Data (may be migration-populated)
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get per-guest migration identity Secret %s: %w", key, err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "kubeswift",
+				"app.kubernetes.io/component":  "migration-mtls",
+				"app.kubernetes.io/managed-by": "kubeswift-controller-manager",
+				"swift.kubeswift.io/guest":     guest.Name,
+			},
+		},
+		// Opaque + empty: a kubernetes.io/tls Secret would require tls.crt
+		// and tls.key at creation, but the placeholder has neither until a
+		// migration populates it. stunnel reads files by path, type-agnostic.
+		Type: corev1.SecretTypeOpaque,
+	}
+	if err := controllerutil.SetControllerReference(guest, secret, scheme); err != nil {
+		return fmt.Errorf("set ownerRef on per-guest migration identity Secret %s: %w", key, err)
+	}
+	if cerr := c.Create(ctx, secret); cerr != nil {
+		if apierrors.IsAlreadyExists(cerr) {
+			return nil
+		}
+		return fmt.Errorf("create per-guest migration identity Secret %s: %w", key, cerr)
+	}
+	return nil
+}
+
+func configMapDataEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		if bv, ok := b[k]; !ok || av != bv {
+			return false
+		}
+	}
+	return true
+}
+
+func configMapBinaryEqual(a, b map[string][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		if bv, ok := b[k]; !ok || !bytes.Equal(av, bv) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/swiftguest/migration_sidecar_test.go
+++ b/internal/controller/swiftguest/migration_sidecar_test.go
@@ -1,0 +1,230 @@
+package swiftguest
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/migrationsidecar"
+)
+
+func migrationSidecarScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("clientgoscheme: %v", err)
+	}
+	gvSwift := schema.GroupVersion{Group: "swift.kubeswift.io", Version: "v1alpha1"}
+	s.AddKnownTypes(gvSwift, &swiftv1alpha1.SwiftGuest{}, &swiftv1alpha1.SwiftGuestList{})
+	metav1.AddToGroupVersion(s, gvSwift)
+	return s
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestMigrationEligible(t *testing.T) {
+	cases := []struct {
+		name string
+		spec *swiftv1alpha1.MigrationSpec
+		want bool
+	}{
+		{"nil migration block", nil, true},
+		{"enabled unset", &swiftv1alpha1.MigrationSpec{}, true},
+		{"enabled true", &swiftv1alpha1.MigrationSpec{Enabled: boolPtr(true)}, true},
+		{"enabled false", &swiftv1alpha1.MigrationSpec{Enabled: boolPtr(false)}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{Migration: tc.spec}}
+			if got := migrationEligible(g); got != tc.want {
+				t.Errorf("migrationEligible=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// podWithLauncher is a minimal launcher pod for sidecar-injection tests.
+func podWithLauncher() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "launcher", Image: "swiftletd:latest"}},
+		},
+	}
+}
+
+func TestApplyMigrationSourceSidecar_InjectsIdleClient(t *testing.T) {
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a"}}
+	pod := podWithLauncher()
+
+	applyMigrationSourceSidecar(pod, guest)
+
+	// Launcher still first; sidecar appended.
+	if pod.Spec.Containers[0].Name != "launcher" {
+		t.Fatalf("launcher must remain first container; got %q", pod.Spec.Containers[0].Name)
+	}
+	var sc *corev1.Container
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == migrationsidecar.ContainerName {
+			sc = &pod.Spec.Containers[i]
+		}
+	}
+	if sc == nil {
+		t.Fatalf("source sidecar %q not injected", migrationsidecar.ContainerName)
+	}
+
+	env := map[string]string{}
+	for _, e := range sc.Env {
+		env[e.Name] = e.Value
+	}
+	if env[migrationsidecar.EnvRole] != migrationsidecar.RoleClient {
+		t.Errorf("sidecar role: want %q, got %q", migrationsidecar.RoleClient, env[migrationsidecar.EnvRole])
+	}
+	// Idle client: peer SAN + dst IP are NOT env (they arrive via files).
+	if _, ok := env[migrationsidecar.EnvCheckHost]; ok {
+		t.Errorf("client sidecar must NOT set CHECK_HOST in env (reads from downward-API file)")
+	}
+	if _, ok := env[migrationsidecar.EnvDstPodIP]; ok {
+		t.Errorf("client sidecar must NOT set DST_POD_IP in env (reads from downward-API file)")
+	}
+	if env[migrationsidecar.EnvInputDir] != migrationsidecar.InputDir {
+		t.Errorf("client sidecar must set STUNNEL_INPUT_DIR=%q", migrationsidecar.InputDir)
+	}
+
+	// Volumes: config CM, per-guest identity Secret, downward-API input.
+	vols := map[string]corev1.Volume{}
+	for _, v := range pod.Spec.Volumes {
+		vols[v.Name] = v
+	}
+	cfg, ok := vols[migrationsidecar.ConfigVolumeName]
+	if !ok || cfg.ConfigMap == nil || cfg.ConfigMap.Name != migrationsidecar.ConfigMapName {
+		t.Errorf("config volume must mount ConfigMap %q; got %+v", migrationsidecar.ConfigMapName, cfg.ConfigMap)
+	}
+	cert, ok := vols[migrationsidecar.CertVolumeName]
+	if !ok || cert.Secret == nil || cert.Secret.SecretName != "guest-migration-identity" {
+		t.Errorf("identity volume must mount Secret guest-migration-identity; got %+v", cert.Secret)
+	}
+	in, ok := vols[migrationsidecar.InputVolumeName]
+	if !ok || in.DownwardAPI == nil {
+		t.Fatalf("input volume must be a downward-API volume; got %+v", in)
+	}
+	wantPaths := map[string]string{
+		migrationsidecar.InputFileDstIP:   "metadata.annotations['" + migrationsidecar.AnnotationDstPodIP + "']",
+		migrationsidecar.InputFilePeerSAN: "metadata.annotations['" + migrationsidecar.AnnotationPeerSAN + "']",
+	}
+	gotPaths := map[string]string{}
+	for _, it := range in.DownwardAPI.Items {
+		if it.FieldRef != nil {
+			gotPaths[it.Path] = it.FieldRef.FieldPath
+		}
+	}
+	for path, field := range wantPaths {
+		if gotPaths[path] != field {
+			t.Errorf("downward-API item %q: want fieldPath %q, got %q", path, field, gotPaths[path])
+		}
+	}
+
+	// Idempotent: second call does not duplicate.
+	nContainers := len(pod.Spec.Containers)
+	nVolumes := len(pod.Spec.Volumes)
+	applyMigrationSourceSidecar(pod, guest)
+	if len(pod.Spec.Containers) != nContainers || len(pod.Spec.Volumes) != nVolumes {
+		t.Errorf("applyMigrationSourceSidecar not idempotent: containers %d->%d, volumes %d->%d",
+			nContainers, len(pod.Spec.Containers), nVolumes, len(pod.Spec.Volumes))
+	}
+}
+
+func TestEnsureMigrationStunnelConfig_CopiesAcrossNamespaces(t *testing.T) {
+	scheme := migrationSidecarScheme(t)
+	const sysNS = "kubeswift-system"
+	src := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: migrationsidecar.ConfigMapName, Namespace: sysNS},
+		Data:       map[string]string{"server.conf": "S", "client.conf": "C"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(src).Build()
+	ctx := context.Background()
+
+	if err := EnsureMigrationStunnelConfig(ctx, c, sysNS, "team-a"); err != nil {
+		t.Fatalf("EnsureMigrationStunnelConfig: %v", err)
+	}
+	var got corev1.ConfigMap
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: migrationsidecar.ConfigMapName}, &got); err != nil {
+		t.Fatalf("copied ConfigMap not found in team-a: %v", err)
+	}
+	if got.Data["server.conf"] != "S" || got.Data["client.conf"] != "C" {
+		t.Errorf("copied ConfigMap data mismatch: %+v", got.Data)
+	}
+}
+
+func TestEnsureMigrationStunnelConfig_SameNamespaceFastPath(t *testing.T) {
+	scheme := migrationSidecarScheme(t)
+	// No source ConfigMap seeded; same-namespace must be a no-op (no error).
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	if err := EnsureMigrationStunnelConfig(context.Background(), c, "kubeswift-system", "kubeswift-system"); err != nil {
+		t.Errorf("same-namespace fast path must be a no-op; got %v", err)
+	}
+}
+
+func TestEnsureMigrationStunnelConfig_MissingSourceErrors(t *testing.T) {
+	scheme := migrationSidecarScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	if err := EnsureMigrationStunnelConfig(context.Background(), c, "kubeswift-system", "team-a"); err == nil {
+		t.Errorf("missing source ConfigMap must error (operator misconfig); got nil")
+	}
+}
+
+func TestEnsurePerGuestMigrationIdentitySecret_CreatesEmptyOwnedPlaceholder(t *testing.T) {
+	scheme := migrationSidecarScheme(t)
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a", UID: "guest-uid"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest).Build()
+	ctx := context.Background()
+
+	if err := EnsurePerGuestMigrationIdentitySecret(ctx, c, scheme, guest); err != nil {
+		t.Fatalf("EnsurePerGuestMigrationIdentitySecret: %v", err)
+	}
+	var s corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "guest-migration-identity"}, &s); err != nil {
+		t.Fatalf("placeholder Secret not created: %v", err)
+	}
+	if s.Type != corev1.SecretTypeOpaque {
+		t.Errorf("placeholder must be Opaque (TLS type requires keys); got %q", s.Type)
+	}
+	if len(s.Data) != 0 {
+		t.Errorf("placeholder must be empty; got %d keys", len(s.Data))
+	}
+	if len(s.OwnerReferences) != 1 || s.OwnerReferences[0].Name != "guest" {
+		t.Errorf("placeholder must be owned by the SwiftGuest; got %+v", s.OwnerReferences)
+	}
+}
+
+func TestEnsurePerGuestMigrationIdentitySecret_DoesNotClobberPopulated(t *testing.T) {
+	scheme := migrationSidecarScheme(t)
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a", UID: "guest-uid"}}
+	// Simulate a migration having populated the identity.
+	populated := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest-migration-identity", Namespace: "team-a"},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{"tls.crt": []byte("CRT"), "tls.key": []byte("KEY"), "ca.crt": []byte("CA")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, populated).Build()
+	ctx := context.Background()
+
+	if err := EnsurePerGuestMigrationIdentitySecret(ctx, c, scheme, guest); err != nil {
+		t.Fatalf("EnsurePerGuestMigrationIdentitySecret: %v", err)
+	}
+	var s corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "guest-migration-identity"}, &s); err != nil {
+		t.Fatalf("Secret missing after ensure: %v", err)
+	}
+	if string(s.Data["tls.crt"]) != "CRT" {
+		t.Errorf("ensure must NOT clobber a migration-populated identity; tls.crt=%q", s.Data["tls.crt"])
+	}
+}

--- a/internal/controller/swiftmigration/sidecar.go
+++ b/internal/controller/swiftmigration/sidecar.go
@@ -1,11 +1,10 @@
 package swiftmigration
 
 import (
-	"os"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/projectbeskar/kubeswift/internal/controller/migrationcert"
+	"github.com/projectbeskar/kubeswift/internal/migrationsidecar"
 )
 
 // Phase 3c (Option B) live-migration mTLS stunnel sidecar wiring.
@@ -28,65 +27,32 @@ import (
 // the kubeswift-migration-stunnel ConfigMap (charts + kustomize overlay,
 // PR 2). The entrypoint self-selects by STUNNEL_ROLE and pins the peer
 // via CHECK_HOST (verifyChain + checkHost — W-3c-4).
+// The sidecar contract (image, container name, mount paths, env keys,
+// roles) lives in internal/migrationsidecar so the SwiftGuest controller
+// (source sidecar) and this controller (destination sidecar + PR 3d
+// stamping) share one source of truth. These file-local aliases keep the
+// destination code + tests reading the same short names introduced in
+// PR 3 while sourcing the values from the shared package.
 const (
-	// MigrationStunnelImageEnv overrides the sidecar image. Mirrors
-	// swiftguest.LauncherImageEnv. The release pipeline sets this to the
-	// version-stamped tag; local dev and tests fall back to the default.
-	MigrationStunnelImageEnv = "KUBESWIFT_MIGRATION_STUNNEL_IMAGE"
-	// MigrationStunnelImageDefault is the default sidecar image.
-	MigrationStunnelImageDefault = "ghcr.io/projectbeskar/kubeswift/migration-stunnel:latest"
+	stunnelSidecarContainerName = migrationsidecar.ContainerName
+	stunnelConfigMapName        = migrationsidecar.ConfigMapName
+	stunnelConfigDir            = migrationsidecar.ConfigDir
+	migrationTLSDir             = migrationsidecar.TLSDir
+	stunnelConfigVolumeName     = migrationsidecar.ConfigVolumeName
+	stunnelCertVolumeName       = migrationsidecar.CertVolumeName
 
-	// stunnelSidecarContainerName is the dst pod's sidecar container.
-	// Distinct from LauncherContainerName so dstPodMatches and the
-	// launcher-container lookups (addReceiverEnvToLauncher,
-	// launcherContainerImage) never mistake it for the swiftletd
-	// container.
-	stunnelSidecarContainerName = "migration-stunnel"
+	envStunnelRole      = migrationsidecar.EnvRole
+	envStunnelConfigDir = migrationsidecar.EnvConfigDir
+	envStunnelCheckHost = migrationsidecar.EnvCheckHost
+	envStunnelDstPodIP  = migrationsidecar.EnvDstPodIP
 
-	// stunnelConfigMapName is the ConfigMap carrying server.conf +
-	// client.conf (PR 2: charts/kubeswift/templates/migration/
-	// stunnel-configmap.yaml + config/overlays/migration-mtls). Must
-	// exist in the guest namespace for the sidecar to start; the Helm
-	// chart/overlay provision it in .Values.namespace, and operators
-	// running migrations in other namespaces must replicate it (PR 5
-	// documents this — same shape as the migration identity Secret copy).
-	stunnelConfigMapName = "kubeswift-migration-stunnel"
-
-	// stunnelConfigDir is where the ConfigMap mounts (matches the PR 2
-	// entrypoint's STUNNEL_CONFIG_DIR default).
-	stunnelConfigDir = "/etc/stunnel-config"
-	// migrationTLSDir is where the per-node identity Secret mounts
-	// (matches the cert/key/CAfile paths baked into the PR 2 configs).
-	migrationTLSDir = "/etc/migration-tls"
-
-	// stunnelConfigVolumeName / stunnelCertVolumeName name the two
-	// sidecar volumes on the dst pod.
-	stunnelConfigVolumeName = "migration-stunnel-config"
-	stunnelCertVolumeName   = "migration-tls"
-
-	// Env keys the entrypoint reads (PR 2 entrypoint.sh contract).
-	envStunnelRole      = "STUNNEL_ROLE"
-	envStunnelConfigDir = "STUNNEL_CONFIG_DIR"
-	envStunnelCheckHost = "CHECK_HOST"
-	// envStunnelDstPodIP is the client-only connect target. Destination
-	// sidecars (server role) do not set it; PR 3b stamps it on the src
-	// sidecar via downward API.
-	envStunnelDstPodIP = "DST_POD_IP"
-
-	// stunnelRoleServer is the dst sidecar role (TLS server: accept
-	// 0.0.0.0:6789, forward to the local CH receiver on 127.0.0.1:6790).
-	stunnelRoleServer = "server"
-	// stunnelRoleClient is the src sidecar role (PR 3b).
-	stunnelRoleClient = "client"
+	stunnelRoleServer = migrationsidecar.RoleServer
+	stunnelRoleClient = migrationsidecar.RoleClient
 )
 
-// MigrationStunnelImage returns the stunnel sidecar image, from
-// KUBESWIFT_MIGRATION_STUNNEL_IMAGE env or MigrationStunnelImageDefault.
+// MigrationStunnelImage returns the stunnel sidecar image (shared helper).
 func MigrationStunnelImage() string {
-	if img := os.Getenv(MigrationStunnelImageEnv); img != "" {
-		return img
-	}
-	return MigrationStunnelImageDefault
+	return migrationsidecar.Image()
 }
 
 // dstStunnelSidecar builds the destination-side stunnel sidecar

--- a/internal/migrationsidecar/sidecar.go
+++ b/internal/migrationsidecar/sidecar.go
@@ -1,0 +1,80 @@
+// Package migrationsidecar is the single source of truth for the Phase 3c
+// live-migration mTLS stunnel sidecar contract: the image, container name,
+// mount paths, env keys, role values, and the controller<->sidecar
+// annotation keys.
+//
+// It exists because the two controllers that touch the sidecar cannot
+// import each other:
+//   - the SwiftMigration controller injects the DESTINATION sidecar and
+//     (PR 3d) stamps the source pod's dst-ip / peer-san annotations,
+//   - the SwiftGuest controller injects the SOURCE sidecar and the
+//     downward-API volume that surfaces those annotations to it,
+//
+// and swiftmigration already imports swiftguest (a cycle the other way).
+// Centralising the contract here keeps the annotation keys the controller
+// WRITES identical to the files the sidecar READS — a drift here would
+// silently break mTLS (the sidecar would idle forever waiting on a key the
+// controller never sets).
+package migrationsidecar
+
+import "os"
+
+const (
+	// ImageEnv overrides the sidecar image; ImageDefault is the fallback.
+	// The release pipeline sets ImageEnv to the version-stamped tag.
+	ImageEnv     = "KUBESWIFT_MIGRATION_STUNNEL_IMAGE"
+	ImageDefault = "ghcr.io/projectbeskar/kubeswift/migration-stunnel:latest"
+
+	// ContainerName is the sidecar container name on both src and dst pods.
+	// Distinct from the launcher container so launcher-by-name lookups
+	// never mistake it.
+	ContainerName = "migration-stunnel"
+
+	// ConfigMapName carries server.conf + client.conf (PR 2). Provisioned
+	// in the system namespace by the Helm chart / kustomize overlay and
+	// copied into guest namespaces by the SwiftGuest controller.
+	ConfigMapName = "kubeswift-migration-stunnel"
+
+	// Mount paths (match the PR 2 entrypoint defaults + the cert/key/CAfile
+	// paths baked into the PR 2 stunnel configs).
+	ConfigDir = "/etc/stunnel-config"  // ConfigMap (server.conf/client.conf)
+	TLSDir    = "/etc/migration-tls"   // identity Secret (tls.crt/key/ca.crt)
+	InputDir  = "/etc/migration-input" // downward-API inputs (client only)
+
+	// Pod volume names.
+	ConfigVolumeName = "migration-stunnel-config"
+	CertVolumeName   = "migration-tls"
+	InputVolumeName  = "migration-input"
+
+	// Env keys the entrypoint reads.
+	EnvRole      = "STUNNEL_ROLE"
+	EnvConfigDir = "STUNNEL_CONFIG_DIR"
+	EnvInputDir  = "STUNNEL_INPUT_DIR"
+	EnvCheckHost = "CHECK_HOST" // server: peer SAN by env; client reads InputDir
+	EnvDstPodIP  = "DST_POD_IP" // server never sets it; client reads InputDir
+
+	// Role values.
+	RoleServer = "server" // destination: TLS server, inputs by env at start
+	RoleClient = "client" // source: TLS client, idle-polls InputDir + TLSDir
+
+	// Controller-stamped SOURCE-pod annotations. The SwiftGuest controller's
+	// downward-API volume projects these into InputFileDstIP / InputFilePeerSAN
+	// under InputDir; the SwiftMigration controller (PR 3d) writes them when a
+	// migration starts. These two keys are the load-bearing contract — keep
+	// the writer (swiftmigration) and the reader (this volume) in lockstep.
+	AnnotationDstPodIP = "kubeswift.io/migration-dst-ip"
+	AnnotationPeerSAN  = "kubeswift.io/migration-peer-san"
+
+	// Downward-API projected file names under InputDir (what the entrypoint
+	// reads).
+	InputFileDstIP   = "dst-ip"
+	InputFilePeerSAN = "peer-san"
+)
+
+// Image returns the sidecar image, from ImageEnv or ImageDefault.
+func Image() string {
+	if img := os.Getenv(ImageEnv); img != "" {
+		return img
+	}
+	return ImageDefault
+}


### PR DESCRIPTION
## Summary

PR 3b of Phase 3c (live-migration mTLS transport, **Option B**: per-node identity + SAN pinning). Wires the **source side** of the stunnel sidecar into the SwiftGuest launcher pod. Symmetric to PR 3 (#81), which wired the destination — this PR wires the source and is likewise **inert until activated** (PR 3d).

**Gated on `--migration-mtls-enabled`.** Flag off (the default) → the launcher pod is **byte-for-byte unchanged** (tests assert this).

## Why the source side is different

The destination sidecar is injected by the SwiftMigration controller at migration time, when the target node is known. The **source** is the pre-existing, **immutable** launcher pod running the live VM — you can't add a container or env to it at migration time, and an unpinned guest's node isn't even known at pod creation. So, when mTLS is enabled, **every migration-eligible launcher pod is born with an idle stunnel client** that idle-polls for the inputs a migration stamps later, and its TLS identity arrives via a **per-guest Secret populated at migration time** (decided with the maintainer) rather than a per-node Secret mounted at creation.

## What's in it

- **`internal/migrationsidecar/`** *(new shared package)* — single source of truth for the sidecar contract: image, container name, mount paths, env keys, roles, **and the controller↔sidecar `migration-dst-ip`/`migration-peer-san` annotation keys**. The two controllers can't import each other (swiftmigration already imports swiftguest); centralising keeps the keys the controller *writes* identical to the files the sidecar *reads* — a drift would silently hang mTLS.
- **Entrypoint v2** (`images/migration-stunnel/entrypoint.sh`) — client role becomes *wait-for-input*: idle-polls the downward-API files (`dst-ip`, `peer-san`) and the identity Secret, then execs stunnel. Stays Running/Ready at rest (no crash-loop, no data-port readinessProbe). Server (dst) keeps the env path unchanged.
- **SwiftGuest controller** — plumb `MigrationMTLSEnabled` + `SystemNamespace`; before pod build, `EnsureMigrationStunnelConfig` (copy the stunnel ConfigMap into the guest namespace) and `EnsurePerGuestMigrationIdentitySecret` (empty, guest-owned placeholder, **never clobbers** a migration-populated identity); a `buildPod` wrapper injects the idle client sidecar + downward-API volume for migration-eligible guests.
- **`swiftmigration/sidecar.go`** — aliased its PR 3 constants to the shared package (no dst-test churn).

## Test plan

- [x] `gofmt` clean · `go build ./...` · `go vet ./...` · full `go test ./...` (exit 0).
- [x] No CRD change; RBAC already sufficient (secrets+configmaps verbs present since PR 1).
- [x] New tests: `migrationEligible` matrix; idle-client sidecar shape (role=client, **no** peer SAN/dst-IP in env, downward-API items map to the right annotations, idempotent); ConfigMap copy (cross-ns / same-ns fast-path / missing-source errors); identity placeholder (empty+Opaque+owned, and no-clobber of a populated identity).
- [x] Entrypoint `sh -n` + pure-ASCII clean.
- [ ] End-to-end cross-node mTLS — **PR 5** (after PR 3d activates the source path).

## Deferred to PR 3d (migration controller activation)

Populate `<guest>-migration-identity` at Validating-live · stamp `dst-ip`/`peer-san` early at Preparing-live · repoint `target_url` → `127.0.0.1:6790` · bounded mTLS-only send retry on connect-refused. End-to-end mTLS is not functional until then; safe because the flag is off by default.

## Operator notes (for PR 5 docs)

- **Fail-loud prerequisite:** enabling mTLS requires the `migration-mtls` overlay / Helm value installed (it provisions the stunnel ConfigMap + cert-manager PKI). Without it, `EnsureMigrationStunnelConfig` errors and the guest pod isn't created — a clear requeue error rather than a pod stuck on a missing mount.
- **Immutable-pod limitation:** enabling mTLS adds the sidecar only to *newly created* launcher pods. Already-running guests need a pod recycle (stop/start, or a migration) to gain the source sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)