### PR TITLE
feat(migration): Phase 3c PR 3d — activate source mTLS path end-to-end

### DIFF
--- a/api/migration/v1alpha1/swiftmigration_types.go
+++ b/api/migration/v1alpha1/swiftmigration_types.go
@@ -199,6 +199,15 @@ const (
 	// window. Untyped string (TFU #21) for consistency with the rest of
 	// this enum.
 	FailureReasonMigrationIdentityNotReady = "MigrationIdentityNotReady"
+	// FailureReasonSourceSidecarNotReady — set by Validating-live (Phase
+	// 3c, Option B) when live-migration mTLS is enabled but the source pod
+	// lacks a client-role migration-stunnel sidecar. Happens when the
+	// source pod predates mTLS enablement (the sidecar is only injected on
+	// newly created launcher pods) or is a post-cutover destination pod
+	// from a prior migration (server-role sidecar; chain migrations under
+	// mTLS need a pod recycle). Operators recycle the guest's pod and
+	// retry. Untyped string (TFU #21).
+	FailureReasonSourceSidecarNotReady = "SourceSidecarNotReady"
 )
 
 // Phase 3a phaseDetail vocabulary additions (live mode only). These

--- a/internal/controller/swiftmigration/dst_pod_test.go
+++ b/internal/controller/swiftmigration/dst_pod_test.go
@@ -295,6 +295,79 @@ func TestNewDstPod_MTLS_InjectsServerSidecar(t *testing.T) {
 	}
 }
 
+// TestNewDstPod_MTLS_FlipsInheritedClientSidecarToServer verifies W-3c-2:
+// when the source pod already carries a CLIENT sidecar (PR 3b), newDstPod's
+// DeepCopy brings it over and the dst construction must FLIP it to a SERVER
+// (and replace the client-only volumes: drop the downward-API input volume,
+// swap the per-guest identity Secret for the dst per-node Secret). Without
+// this, the dst would run a misconfigured client and mTLS would break even
+// for the first migration.
+func TestNewDstPod_MTLS_FlipsInheritedClientSidecarToServer(t *testing.T) {
+	scheme := testScheme(t)
+	mig := newMigrationWithUID("mig-a", "default", "abcdef1234567890abcdef1234567890")
+	mig.Spec.Target.NodeName = "miles"
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
+	}
+	src := templateSrcPod("guest", "default")
+	// Source carries a CLIENT sidecar + the client-only volumes (as PR 3b
+	// produces): config, per-guest identity Secret, downward-API input.
+	src.Spec.Containers = append(src.Spec.Containers, corev1.Container{
+		Name: stunnelSidecarContainerName,
+		Env: []corev1.EnvVar{
+			{Name: envStunnelRole, Value: stunnelRoleClient},
+			{Name: "STUNNEL_INPUT_DIR", Value: "/etc/migration-input"},
+		},
+	})
+	src.Spec.Volumes = append(src.Spec.Volumes,
+		corev1.Volume{Name: stunnelConfigVolumeName},
+		corev1.Volume{Name: stunnelCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "guest-migration-identity"}}},
+		corev1.Volume{Name: "migration-input", VolumeSource: corev1.VolumeSource{DownwardAPI: &corev1.DownwardAPIVolumeSource{}}},
+	)
+
+	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
+		mtlsEnabled: true, srcNodeName: "boba", dstNodeName: "miles",
+	})
+	if err != nil {
+		t.Fatalf("newDstPod: %v", err)
+	}
+
+	// Exactly ONE migration-stunnel container, role=server.
+	var count int
+	var sc *corev1.Container
+	for i := range dst.Spec.Containers {
+		if dst.Spec.Containers[i].Name == stunnelSidecarContainerName {
+			count++
+			sc = &dst.Spec.Containers[i]
+		}
+	}
+	if count != 1 {
+		t.Fatalf("want exactly 1 stunnel sidecar after flip, got %d", count)
+	}
+	role := ""
+	for _, e := range sc.Env {
+		if e.Name == envStunnelRole {
+			role = e.Value
+		}
+	}
+	if role != stunnelRoleServer {
+		t.Errorf("inherited client sidecar must be flipped to server; got role %q", role)
+	}
+
+	// The downward-API input volume must be gone; the cert volume must now
+	// point at the dst per-node Secret, not the inherited per-guest one.
+	for _, v := range dst.Spec.Volumes {
+		if v.Name == "migration-input" {
+			t.Errorf("dst must not carry the client downward-API input volume")
+		}
+		if v.Name == stunnelCertVolumeName {
+			if v.Secret == nil || v.Secret.SecretName != "kubeswift-migration-node-miles" {
+				t.Errorf("dst cert volume must be the dst per-node Secret; got %+v", v.Secret)
+			}
+		}
+	}
+}
+
 // TestNewDstPod_MTLS_EmptyNode_Errors verifies the guard: mTLS enabled
 // with an unresolved node name is a clean construction error rather than
 // a sidecar with an empty SAN pin / unresolvable identity Secret.

--- a/internal/controller/swiftmigration/preparing_live.go
+++ b/internal/controller/swiftmigration/preparing_live.go
@@ -12,6 +12,7 @@ import (
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/migrationcert"
 )
 
 // preparingLiveReadyBudget is the wall-clock window for the dst pod
@@ -196,6 +197,19 @@ func (r *SwiftMigrationReconciler) handlePreparingLive(
 		// been lost across leader handover or status patches).
 		if status.DestinationPodRef == nil || status.DestinationPodRef.Name != existingDst.Name {
 			status.DestinationPodRef = &migrationv1alpha1.SwiftMigrationPodRef{Name: existingDst.Name}
+		}
+		// PR 3d: as soon as the dst pod has an IP, stamp the dst-ip /
+		// peer-san annotations on the SOURCE pod. The SwiftGuest
+		// controller's downward-API volume surfaces them to the idle
+		// client sidecar, which then renders its config and brings stunnel
+		// up — giving it the full Preparing-Ready window to start before
+		// StopAndCopy issues the send ("stamp early" — design §4.2). The
+		// dst node's SAN is what the source client pins via checkHost.
+		if r.MigrationMTLSEnabled && existingDst.Status.PodIP != "" {
+			dstNodeSAN := migrationcert.MigrationNodeCertSAN(mig.Spec.Target.NodeName)
+			if err := r.stampSourceMigrationInputs(ctx, &srcPod, existingDst.Status.PodIP, dstNodeSAN); err != nil {
+				return phaseTransient(fmt.Errorf("stamp source migration inputs: %w", err))
+			}
 		}
 	}
 

--- a/internal/controller/swiftmigration/sidecar.go
+++ b/internal/controller/swiftmigration/sidecar.go
@@ -114,23 +114,53 @@ func dstStunnelVolumes(dstSecretName string) []corev1.Volume {
 	}
 }
 
-// injectDstStunnelSidecar appends the destination stunnel sidecar
-// container and its two volumes to the dst pod. Idempotent: a pod that
-// already carries a container named stunnelSidecarContainerName is left
-// untouched (defensive against a future DeepCopy bringing a sidecar
-// over — though in PR 3 the src pod has no sidecar yet).
+// injectDstStunnelSidecar makes the dst pod's stunnel sidecar authoritative
+// as the TLS SERVER. It is W-3c-2's "flip role post-DeepCopy": newDstPod
+// builds the dst by srcPod.DeepCopy(), and since PR 3b the source pod
+// carries a CLIENT-role sidecar (+ a downward-API input volume + a
+// per-GUEST identity Secret). The dst must instead run a SERVER (+ its
+// per-NODE identity Secret, no input volume). So we STRIP any inherited
+// sidecar container and the three sidecar volumes, then add the server
+// sidecar + server volumes. Correct whether or not the src had a sidecar,
+// and idempotent on re-entry.
 //
-// srcNodeName is the SOURCE node (the dst pins its SAN as the expected
-// peer); dstNodeName is the DESTINATION node (whose identity Secret the
-// sidecar presents).
+// srcNodeName is the SOURCE node (the dst pins its SAN via checkHost);
+// dstNodeName is the DESTINATION node (whose per-node identity Secret the
+// server sidecar presents).
 func injectDstStunnelSidecar(pod *corev1.Pod, srcNodeName, dstNodeName string) {
-	for i := range pod.Spec.Containers {
-		if pod.Spec.Containers[i].Name == stunnelSidecarContainerName {
-			return
-		}
-	}
+	pod.Spec.Containers = removeContainerByName(pod.Spec.Containers, stunnelSidecarContainerName)
+	pod.Spec.Volumes = removeVolumesByName(pod.Spec.Volumes,
+		migrationsidecar.ConfigVolumeName, migrationsidecar.CertVolumeName, migrationsidecar.InputVolumeName)
 	pod.Spec.Containers = append(pod.Spec.Containers,
 		dstStunnelSidecar(migrationcert.MigrationNodeCertSAN(srcNodeName)))
 	pod.Spec.Volumes = append(pod.Spec.Volumes,
 		dstStunnelVolumes(migrationcert.MigrationNodeSecretName(dstNodeName))...)
+}
+
+// removeContainerByName returns containers with any entry named `name`
+// removed (preserving order).
+func removeContainerByName(containers []corev1.Container, name string) []corev1.Container {
+	out := containers[:0:0]
+	for _, c := range containers {
+		if c.Name != name {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// removeVolumesByName returns volumes with any entry whose name is in
+// `names` removed (preserving order).
+func removeVolumesByName(volumes []corev1.Volume, names ...string) []corev1.Volume {
+	drop := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		drop[n] = struct{}{}
+	}
+	out := volumes[:0:0]
+	for _, v := range volumes {
+		if _, ok := drop[v.Name]; !ok {
+			out = append(out, v)
+		}
+	}
+	return out
 }

--- a/internal/controller/swiftmigration/source_mtls.go
+++ b/internal/controller/swiftmigration/source_mtls.go
@@ -1,0 +1,190 @@
+package swiftmigration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/migrationcert"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
+	"github.com/projectbeskar/kubeswift/internal/migrationsidecar"
+)
+
+// Phase 3c PR 3d — SOURCE-side activation of the live-migration mTLS path.
+//
+// The source launcher pod was born (PR 3b) with an IDLE stunnel client
+// sidecar that idle-polls for three inputs. This file is where the
+// SwiftMigration controller provides them when a migration runs:
+//   - populateSourceIdentity copies the source node's issued identity into
+//     the per-guest Secret the sidecar mounts (Validating-live),
+//   - stampSourceMigrationInputs writes the dst-ip / peer-san annotations
+//     the sidecar reads via its downward-API volume (Preparing-live, as
+//     early as the dst pod has an IP, per the "stamp early" decision),
+//   - the bounded send retry (isLocalStunnelNotReady + maxMTLSSendRetries,
+//     consumed in stopandcopy_live) is the residual-race safety net.
+
+// maxMTLSSendRetries bounds how many times the controller re-issues the
+// send-action while the source mTLS sidecar is still coming up. Each retry
+// is one substatePreSend->substateSendPending cycle (a few reconciles at
+// stopAndCopyLivePollInterval); ~10 covers kubelet downward-API + Secret
+// propagation on a slow-sync cluster. spec.timeout is the hard outer cap.
+const maxMTLSSendRetries = 10
+
+// sourcePodMTLSReady reports whether the source pod is ready to act as the
+// TLS CLIENT for an mTLS migration: it must carry a migration-stunnel
+// sidecar whose STUNNEL_ROLE is "client". Two cases fail this:
+//
+//   - the source pod predates mTLS enablement (no sidecar at all — the
+//     SwiftGuest controller only injects it on newly created pods), or
+//   - the source pod is a post-cutover DESTINATION pod from a prior
+//     migration (it carries a SERVER-role sidecar; chain migrations under
+//     mTLS need a pod recycle first — the role is immutable).
+//
+// Failing fast here turns a confusing ~60s retry-then-timeout (the source
+// CH would keep hitting a local port with no client listening) into a
+// single clear admission-time failure with a recycle hint.
+func sourcePodMTLSReady(srcPod *corev1.Pod) bool {
+	for i := range srcPod.Spec.Containers {
+		c := &srcPod.Spec.Containers[i]
+		if c.Name != migrationsidecar.ContainerName {
+			continue
+		}
+		for _, e := range c.Env {
+			if e.Name == migrationsidecar.EnvRole {
+				return e.Value == migrationsidecar.RoleClient
+			}
+		}
+		return false // sidecar present but no role env (treat as not client-ready)
+	}
+	return false // no sidecar
+}
+
+// isLocalStunnelNotReady reports whether a src-side migration-status-detail
+// indicates the LOCAL stunnel client (127.0.0.1:6790) was not yet
+// listening when the src CH tried to send — i.e. the source sidecar hasn't
+// finished idle-polling its inputs and started stunnel.
+//
+// Reliable signal ONLY under mTLS: with mTLS on, target_url is the local
+// client, so a CH "connection_refused" means localhost had nothing
+// listening yet. A dst-side disappearance surfaces as transport_error (CH
+// connected to the up local client, which then failed reaching the dst),
+// NOT connection_refused — so this never misfires on a genuine dst failure.
+// Callers MUST additionally gate on r.MigrationMTLSEnabled.
+func isLocalStunnelNotReady(detail string) bool {
+	d := strings.ToLower(strings.TrimSpace(detail))
+	return strings.HasPrefix(d, "send_migration:") && strings.Contains(d, "connection_refused")
+}
+
+// stampSourceMigrationInputs idempotently patches the dst-ip / peer-san
+// annotations onto the source pod. The SwiftGuest controller's downward-API
+// volume projects these into files the idle client sidecar polls; stamping
+// them is what unblocks the sidecar and lets it bring stunnel up.
+//
+// dstIP is the destination pod IP (the TLS connect target); dstNodeSAN is
+// the destination node's SAN (the client pins it via checkHost). Stamped as
+// early as the dst pod has an IP (Preparing-live) to maximise the
+// propagation window before the send is issued.
+func (r *SwiftMigrationReconciler) stampSourceMigrationInputs(ctx context.Context, srcPod *corev1.Pod, dstIP, dstNodeSAN string) error {
+	if srcPod.Annotations[migrationsidecar.AnnotationDstPodIP] == dstIP &&
+		srcPod.Annotations[migrationsidecar.AnnotationPeerSAN] == dstNodeSAN {
+		return nil // already stamped with the same values
+	}
+	patch := client.MergeFrom(srcPod.DeepCopy())
+	if srcPod.Annotations == nil {
+		srcPod.Annotations = map[string]string{}
+	}
+	srcPod.Annotations[migrationsidecar.AnnotationDstPodIP] = dstIP
+	srcPod.Annotations[migrationsidecar.AnnotationPeerSAN] = dstNodeSAN
+	return r.Patch(ctx, srcPod, patch)
+}
+
+// populateSourceIdentity copies the SOURCE node's issued migration identity
+// (cert-manager Secret kubeswift-migration-node-<srcNode> in the system
+// namespace) into the per-guest identity Secret the source sidecar mounts
+// (<guest>-migration-identity, created empty by the SwiftGuest controller).
+//
+// This is distribution, not issuance — the per-node cert is a long-lived
+// precondition (Validating-live already verified it exists). Upsert: update
+// the placeholder's Data when present, create it (guest-owned) if the
+// SwiftGuest controller hasn't yet. Never errors the migration on an
+// already-equal Secret (idempotent across reconciles).
+func (r *SwiftMigrationReconciler) populateSourceIdentity(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, srcNode string) error {
+	srcKey := types.NamespacedName{Namespace: r.SystemNamespace, Name: migrationcert.MigrationNodeSecretName(srcNode)}
+	var source corev1.Secret
+	if err := r.Get(ctx, srcKey, &source); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("source node migration identity %s not provisioned (cert-manager precondition not ready): %w", srcKey, err)
+		}
+		return fmt.Errorf("get source node migration identity %s: %w", srcKey, err)
+	}
+	data := map[string][]byte{}
+	for _, k := range []string{"tls.crt", "tls.key", "ca.crt"} {
+		if v, ok := source.Data[k]; ok {
+			data[k] = v
+		}
+	}
+
+	name := swiftguest.PerGuestMigrationIdentitySecretName(guest.Name)
+	key := types.NamespacedName{Namespace: guest.Namespace, Name: name}
+	var existing corev1.Secret
+	err := r.Get(ctx, key, &existing)
+	if err == nil {
+		if secretBytesEqual(existing.Data, data) {
+			return nil
+		}
+		existing.Data = data
+		if uerr := r.Update(ctx, &existing); uerr != nil {
+			return fmt.Errorf("update per-guest migration identity %s: %w", key, uerr)
+		}
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get per-guest migration identity %s: %w", key, err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: guest.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "kubeswift",
+				"app.kubernetes.io/component":  "migration-mtls",
+				"app.kubernetes.io/managed-by": "kubeswift-controller-manager",
+				"swift.kubeswift.io/guest":     guest.Name,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+	if serr := controllerutil.SetControllerReference(guest, secret, r.Scheme); serr != nil {
+		return fmt.Errorf("set ownerRef on per-guest migration identity %s: %w", key, serr)
+	}
+	if cerr := r.Create(ctx, secret); cerr != nil {
+		if apierrors.IsAlreadyExists(cerr) {
+			return nil
+		}
+		return fmt.Errorf("create per-guest migration identity %s: %w", key, cerr)
+	}
+	return nil
+}
+
+func secretBytesEqual(a, b map[string][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		if bv, ok := b[k]; !ok || !bytes.Equal(av, bv) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/swiftmigration/source_mtls_test.go
+++ b/internal/controller/swiftmigration/source_mtls_test.go
@@ -1,0 +1,261 @@
+package swiftmigration
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/migrationcert"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
+	"github.com/projectbeskar/kubeswift/internal/migrationsidecar"
+)
+
+func TestIsLocalStunnelNotReady(t *testing.T) {
+	cases := []struct {
+		detail string
+		want   bool
+	}{
+		{"send_migration: connection_refused", true},
+		{"SEND_MIGRATION: CONNECTION_REFUSED", true},     // case-insensitive
+		{"send_migration: transport_error", false},       // dst-gone, not local-not-ready
+		{"receive_migration: connection_refused", false}, // dst side, not src-local
+		{"", false},
+		{"some other error", false},
+	}
+	for _, tc := range cases {
+		if got := isLocalStunnelNotReady(tc.detail); got != tc.want {
+			t.Errorf("isLocalStunnelNotReady(%q)=%v, want %v", tc.detail, got, tc.want)
+		}
+	}
+}
+
+// --- target_url repoint (substatePreSend) --------------------------------
+
+func setupPreSend(t *testing.T, mtls bool) (*SwiftMigrationReconciler, *corev1.Pod) {
+	t.Helper()
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
+	mig.Status.RecvAttempts = 1
+	// dst is receive-ready; src has no send yet => substatePreSend.
+	stamp(dst, migrationActionVerbReceive, recvActionID(mig), migrationStatusReceiveReady, recvActionID(mig), "")
+	dst.Status.PodIP = "10.0.0.9"
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+	r.MigrationMTLSEnabled = mtls
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.Err != nil || res.FailureMsg != "" {
+		t.Fatalf("unexpected failure: err=%v msg=%q", res.Err, res.FailureMsg)
+	}
+	var gotSrc corev1.Pod
+	if err := r.Get(context.Background(), key(src), &gotSrc); err != nil {
+		t.Fatalf("re-get src: %v", err)
+	}
+	return r, &gotSrc
+}
+
+func preSendTargetURL(t *testing.T, src *corev1.Pod) string {
+	t.Helper()
+	var args migrationSendArgs
+	if err := json.Unmarshal([]byte(src.Annotations[AnnotationMigrationActionArgs]), &args); err != nil {
+		t.Fatalf("unmarshal send args %q: %v", src.Annotations[AnnotationMigrationActionArgs], err)
+	}
+	return args.TargetURL
+}
+
+func TestStopAndCopyLive_PreSend_MTLS_TargetLocalhost(t *testing.T) {
+	_, src := setupPreSend(t, true)
+	if got := preSendTargetURL(t, src); got != "tcp:127.0.0.1:6790" {
+		t.Errorf("mTLS target_url: want tcp:127.0.0.1:6790 (local stunnel client), got %q", got)
+	}
+}
+
+func TestStopAndCopyLive_PreSend_Plaintext_TargetDstIP(t *testing.T) {
+	_, src := setupPreSend(t, false)
+	if got := preSendTargetURL(t, src); got != "tcp:10.0.0.9:6789" {
+		t.Errorf("plaintext target_url: want tcp:10.0.0.9:6789, got %q", got)
+	}
+}
+
+// --- bounded send retry (substateSrcFailed) ------------------------------
+
+func srcFailedReconciler(t *testing.T, mtls bool, sendAttempts int32, detail string, dstTerminating bool) (*SwiftMigrationReconciler, *migrationv1alpha1.SwiftMigration) {
+	t.Helper()
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
+	mig.Status.RecvAttempts = 1
+	mig.Status.SendAttempts = sendAttempts
+	stamp(src, migrationActionVerbSend, sendActionID(mig), MigrationStatusFailed, sendActionID(mig), detail)
+	if dstTerminating {
+		now := metav1.Now()
+		dst.DeletionTimestamp = &now
+		dst.Finalizers = []string{"kubernetes.io/grace-period"}
+	}
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+	r.MigrationMTLSEnabled = mtls
+	return r, mig
+}
+
+func TestStopAndCopyLive_SrcFailed_MTLS_ConnRefused_RetriesSend(t *testing.T) {
+	r, mig := srcFailedReconciler(t, true, 1, "send_migration: connection_refused", false)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureMsg != "" || res.FailureReason != "" {
+		t.Fatalf("expected retry (no failure); got msg=%q reason=%q", res.FailureMsg, res.FailureReason)
+	}
+	if res.Requeue == 0 {
+		t.Errorf("expected requeue on retry")
+	}
+	if status.SendAttempts != 2 {
+		t.Errorf("SendAttempts: want 2 (bumped for retry), got %d", status.SendAttempts)
+	}
+}
+
+func TestStopAndCopyLive_SrcFailed_MTLS_ConnRefused_BudgetExhausted_Fails(t *testing.T) {
+	r, mig := srcFailedReconciler(t, true, maxMTLSSendRetries, "send_migration: connection_refused", false)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason == "" {
+		t.Fatalf("expected terminal failure at budget; got retry (reason empty, requeue=%v)", res.Requeue)
+	}
+	if res.FailureReason != migrationv1alpha1.FailureReasonReceiveDisconnect {
+		t.Errorf("FailureReason at budget: want ReceiveDisconnect (connection_refused classifier), got %q", res.FailureReason)
+	}
+}
+
+func TestStopAndCopyLive_SrcFailed_MTLS_TransportError_NoRetry(t *testing.T) {
+	// transport_error == dst-gone mid-stream, NOT local-not-ready: must fail, not retry.
+	r, mig := srcFailedReconciler(t, true, 1, "send_migration: transport_error", false)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason == "" {
+		t.Fatalf("transport_error must not be retried; expected failure")
+	}
+}
+
+func TestStopAndCopyLive_SrcFailed_MTLSOff_ConnRefused_NoRetry(t *testing.T) {
+	// With mTLS off, connection_refused is a real dst-unreachable failure.
+	r, mig := srcFailedReconciler(t, false, 1, "send_migration: connection_refused", false)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason == "" {
+		t.Fatalf("mTLS-off connection_refused must not be retried; expected failure")
+	}
+}
+
+func TestStopAndCopyLive_SrcFailed_MTLS_DstTerminating_NoRetry(t *testing.T) {
+	// Even with connection_refused, a terminating dst is a genuine failure.
+	r, mig := srcFailedReconciler(t, true, 1, "send_migration: connection_refused", true)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason == "" {
+		t.Fatalf("terminating dst must not be retried; expected failure")
+	}
+}
+
+// --- stampSourceMigrationInputs ------------------------------------------
+
+func TestStampSourceMigrationInputs_PatchesAndIsIdempotent(t *testing.T) {
+	scheme := testScheme(t)
+	src := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(src).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(5)}
+	ctx := context.Background()
+
+	if err := r.stampSourceMigrationInputs(ctx, src, "10.0.0.9", "miles"); err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+	var got corev1.Pod
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "guest"}, &got); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if got.Annotations[migrationsidecar.AnnotationDstPodIP] != "10.0.0.9" {
+		t.Errorf("dst-ip annotation: got %q", got.Annotations[migrationsidecar.AnnotationDstPodIP])
+	}
+	if got.Annotations[migrationsidecar.AnnotationPeerSAN] != "miles" {
+		t.Errorf("peer-san annotation: got %q", got.Annotations[migrationsidecar.AnnotationPeerSAN])
+	}
+	// Idempotent: second call with same values is a no-op (no error).
+	if err := r.stampSourceMigrationInputs(ctx, &got, "10.0.0.9", "miles"); err != nil {
+		t.Errorf("idempotent stamp errored: %v", err)
+	}
+}
+
+// --- populateSourceIdentity ----------------------------------------------
+
+func TestPopulateSourceIdentity_CopiesNodeIdentityIntoPerGuestSecret(t *testing.T) {
+	scheme := testScheme(t)
+	const sysNS = "kubeswift-system"
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a", UID: "guest-uid"}}
+	srcNodeSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: migrationcert.MigrationNodeSecretName("boba"), Namespace: sysNS},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": []byte("CRT"), "tls.key": []byte("KEY"), "ca.crt": []byte("CA")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, srcNodeSecret).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
+	ctx := context.Background()
+
+	if err := r.populateSourceIdentity(ctx, guest, "boba"); err != nil {
+		t.Fatalf("populateSourceIdentity: %v", err)
+	}
+	var s corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: swiftguest.PerGuestMigrationIdentitySecretName("guest")}, &s); err != nil {
+		t.Fatalf("per-guest identity not created: %v", err)
+	}
+	if string(s.Data["tls.crt"]) != "CRT" || string(s.Data["tls.key"]) != "KEY" || string(s.Data["ca.crt"]) != "CA" {
+		t.Errorf("per-guest identity data mismatch: %+v", s.Data)
+	}
+	if len(s.OwnerReferences) != 1 || s.OwnerReferences[0].Name != "guest" {
+		t.Errorf("per-guest identity must be guest-owned; got %+v", s.OwnerReferences)
+	}
+	// Idempotent: second call with identical source is a no-op.
+	if err := r.populateSourceIdentity(ctx, guest, "boba"); err != nil {
+		t.Errorf("idempotent populate errored: %v", err)
+	}
+}
+
+func TestPopulateSourceIdentity_UpdatesExistingPlaceholder(t *testing.T) {
+	scheme := testScheme(t)
+	const sysNS = "kubeswift-system"
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a", UID: "guest-uid"}}
+	srcNodeSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: migrationcert.MigrationNodeSecretName("boba"), Namespace: sysNS},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": []byte("CRT"), "tls.key": []byte("KEY"), "ca.crt": []byte("CA")},
+	}
+	// Empty placeholder already created by the SwiftGuest controller.
+	placeholder := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: swiftguest.PerGuestMigrationIdentitySecretName("guest"), Namespace: "team-a"},
+		Type:       corev1.SecretTypeOpaque,
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, srcNodeSecret, placeholder).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
+	ctx := context.Background()
+
+	if err := r.populateSourceIdentity(ctx, guest, "boba"); err != nil {
+		t.Fatalf("populateSourceIdentity: %v", err)
+	}
+	var s corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: swiftguest.PerGuestMigrationIdentitySecretName("guest")}, &s); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(s.Data["tls.crt"]) != "CRT" {
+		t.Errorf("placeholder not populated; tls.crt=%q", s.Data["tls.crt"])
+	}
+}
+
+func TestPopulateSourceIdentity_MissingSourceErrors(t *testing.T) {
+	scheme := testScheme(t)
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a", UID: "guest-uid"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, SystemNamespace: "kubeswift-system"}
+	if err := r.populateSourceIdentity(context.Background(), guest, "boba"); err == nil {
+		t.Errorf("missing source node identity must error; got nil")
+	}
+}

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -393,8 +393,16 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 			// Requeue briefly.
 			return phaseRequeue(stopAndCopyLivePollInterval)
 		}
+		// Phase 3c: when mTLS is enabled the src CH sends to the LOCAL
+		// stunnel client (127.0.0.1:6790), which tunnels over TLS to the
+		// dst sidecar; swiftletd stays TLS-unaware (design §5). With mTLS
+		// off, CH dials the dst pod IP directly exactly as in Phase 3a/3b.
+		targetURL := fmt.Sprintf("tcp:%s:%d", dstPod.Status.PodIP, migrationListenPort)
+		if r.MigrationMTLSEnabled {
+			targetURL = fmt.Sprintf("tcp:127.0.0.1:%d", migrationLocalPlaintextPort)
+		}
 		args := migrationSendArgs{
-			TargetURL:      fmt.Sprintf("tcp:%s:%d", dstPod.Status.PodIP, migrationListenPort),
+			TargetURL:      targetURL,
 			TimeoutSeconds: migrationActionTimeoutSeconds,
 			GuestRAMMiB:    guestRAMMiB(ctx, r, &guest),
 		}
@@ -405,7 +413,12 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 		if err := r.writeMigrationAction(ctx, &srcPod, migrationActionVerbSend, sendActionID(mig), string(argsJSON)); err != nil {
 			return phaseTransient(fmt.Errorf("write send-action on src pod: %w", err))
 		}
-		status.SendAttempts = 1
+		// Persist the SAME attempt number sendActionID just used (NOT a
+		// hard-coded 1) so the mTLS retry counter is preserved across
+		// reconciles: a retry bumps mig.Status.SendAttempts at
+		// substateSrcFailed, and re-entering substatePreSend with the new
+		// id must not reset it.
+		status.SendAttempts = sendAttemptNumber(mig)
 		setPhaseDetail(status, migrationv1alpha1.PhaseDetailLiveIssuingSend)
 		setReadyCondition(status, metav1.ConditionFalse, ReasonStopAndCopy,
 			"issuing send action on source pod")
@@ -460,6 +473,32 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 		detail := ""
 		if srcArg != nil {
 			detail = srcArg.Annotations[AnnotationMigrationStatusDtl]
+		}
+		// Phase 3d — bounded retry for the mTLS source-sidecar readiness
+		// race. With mTLS on, target_url is the LOCAL stunnel client
+		// (127.0.0.1:6790); a "send_migration: connection_refused" means
+		// the client sidecar hasn't finished idle-polling its inputs and
+		// brought stunnel up yet (CH couldn't connect to localhost). The
+		// src CH never reached the dst, so NO migration data flowed and
+		// re-issuing is safe. The dst is still receive-ready (it never saw
+		// a connection), so bumping SendAttempts yields a fresh $SEND_ID
+		// that re-drives substatePreSend on the next reconcile. Bounded by
+		// maxMTLSSendRetries; the overall spec.timeout is the hard cap.
+		// Gated on dst NOT terminating so a genuine dst-gone failure (which
+		// surfaces as transport_error, not connection_refused) is never
+		// mistaken for sidecar-not-ready.
+		if r.MigrationMTLSEnabled && isLocalStunnelNotReady(detail) &&
+			dstPod.DeletionTimestamp == nil && sendAttemptNumber(mig) < maxMTLSSendRetries {
+			status.SendAttempts = sendAttemptNumber(mig) + 1
+			setPhaseDetail(status, "source mTLS sidecar not ready; retrying send")
+			setReadyCondition(status, metav1.ConditionFalse, ReasonStopAndCopy,
+				"waiting for source mTLS sidecar to become ready; retrying send")
+			if r.Recorder != nil {
+				r.Recorder.Eventf(mig, corev1.EventTypeNormal, "SendRetry",
+					"source mTLS sidecar not yet listening (attempt %d/%d); re-issuing send",
+					sendAttemptNumber(mig), maxMTLSSendRetries)
+			}
+			return phaseRequeue(stopAndCopyLivePollInterval)
 		}
 		// W18 (PR #46 Scenario 4): when dst pod is being K8s-
 		// terminated mid-StopAndCopy, src CH's vm.send-migration

--- a/internal/controller/swiftmigration/stopandcopy_substate.go
+++ b/internal/controller/swiftmigration/stopandcopy_substate.go
@@ -134,17 +134,28 @@ func recvActionID(mig *migrationv1alpha1.SwiftMigration) string {
 	return fmt.Sprintf("%s:recv:%d", mig.Name, n)
 }
 
+// sendAttemptNumber returns the current send attempt number, clamped to a
+// minimum of 1. Phase 3a kept this at 1 (no retry). Phase 3d's mTLS
+// source-sidecar readiness retry increments mig.Status.SendAttempts, so
+// the attempt number (and thus $SEND_ID) advances; this helper is the one
+// place that derives it, shared by sendActionID and the substatePreSend
+// counter write so the written action-id and the persisted counter never
+// disagree.
+func sendAttemptNumber(mig *migrationv1alpha1.SwiftMigration) int32 {
+	n := int32(1)
+	if mig.Status.SendAttempts > n {
+		n = mig.Status.SendAttempts
+	}
+	return n
+}
+
 // sendActionID returns the deterministic $SEND_ID per design F1.8:
 //
 //	$SEND_ID = "<swiftmigration.Name>:send:<SendAttempts>"
 //
 // Same min-clamp semantics as recvActionID.
 func sendActionID(mig *migrationv1alpha1.SwiftMigration) string {
-	n := int32(1)
-	if mig.Status.SendAttempts > n {
-		n = mig.Status.SendAttempts
-	}
-	return fmt.Sprintf("%s:send:%d", mig.Name, n)
+	return fmt.Sprintf("%s:send:%d", mig.Name, sendAttemptNumber(mig))
 }
 
 // migrationActionVerbReceive is the action verb the controller writes

--- a/internal/controller/swiftmigration/validating_live.go
+++ b/internal/controller/swiftmigration/validating_live.go
@@ -194,6 +194,16 @@ func (r *SwiftMigrationReconciler) handleValidatingLive(
 	// the src-node Secret (PR 3b) — both are ensured up front so PR 3b
 	// needs no Validating-phase change.
 	if r.MigrationMTLSEnabled {
+		// Fail fast if the source pod can't act as the TLS client: a pod
+		// that predates mTLS enablement (no sidecar) or a post-cutover
+		// destination pod (server-role sidecar) would otherwise retry the
+		// send for ~60s and then time out. A clear admission-time failure
+		// with a recycle hint is far better.
+		if !sourcePodMTLSReady(&srcPod) {
+			return phaseFailure(
+				fmt.Sprintf("source pod %q is not mTLS-source-ready (no client-role migration-stunnel sidecar); it predates mTLS enablement or is a post-cutover destination pod — recycle the guest's pod before live-migrating with mTLS", srcPod.Name),
+				migrationv1alpha1.FailureReasonSourceSidecarNotReady)
+		}
 		for _, n := range []string{status.SourceNode, status.DestinationNode} {
 			if n == "" {
 				return phaseFailure(
@@ -205,6 +215,16 @@ func (r *SwiftMigrationReconciler) handleValidatingLive(
 					fmt.Sprintf("migration identity Secret for node %q not ready: %v", n, err),
 					migrationv1alpha1.FailureReasonMigrationIdentityNotReady)
 			}
+		}
+		// PR 3d: populate the per-guest identity Secret the SOURCE sidecar
+		// mounts with the source node's issued identity, so the idle client
+		// sidecar (PR 3b) has its cert/key/ca well before the send. Done
+		// here (early) to give kubelet time to propagate the Secret into the
+		// mounted volume before StopAndCopy.
+		if err := r.populateSourceIdentity(ctx, &guest, status.SourceNode); err != nil {
+			return phaseFailure(
+				fmt.Sprintf("populate source migration identity: %v", err),
+				migrationv1alpha1.FailureReasonMigrationIdentityNotReady)
 		}
 	}
 

--- a/internal/controller/swiftmigration/validating_live_test.go
+++ b/internal/controller/swiftmigration/validating_live_test.go
@@ -16,7 +16,19 @@ import (
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
 	"github.com/projectbeskar/kubeswift/internal/controller/migrationcert"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
+	"github.com/projectbeskar/kubeswift/internal/migrationsidecar"
 )
+
+// withClientStunnelSidecar adds a client-role migration-stunnel sidecar to a
+// source pod so it passes the Phase 3c sourcePodMTLSReady fail-fast (the
+// SwiftGuest controller injects this on real migration-eligible pods).
+func withClientStunnelSidecar(p *corev1.Pod) *corev1.Pod {
+	p.Spec.Containers = append(p.Spec.Containers, corev1.Container{
+		Name: migrationsidecar.ContainerName,
+		Env:  []corev1.EnvVar{{Name: migrationsidecar.EnvRole, Value: migrationsidecar.RoleClient}},
+	})
+	return p
+}
 
 // migrationNodeIdentitySecret builds a per-node identity Secret fixture
 // (the shape cert-manager writes into the system namespace) for the
@@ -120,7 +132,7 @@ func TestValidatingLive_MTLS_IdentitiesPresent_Advances(t *testing.T) {
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
 	node := newSpaciousNode("miles", 8, 65536)
-	srcPod := newSourcePod("guest", "default", "src-pod-uid-1") // src node "boba"
+	srcPod := withClientStunnelSidecar(newSourcePod("guest", "default", "src-pod-uid-1")) // src node "boba"
 	mig := newMigration("m", "default")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	mig.Spec.Timeout = &metav1.Duration{Duration: 5 * 60 * 1e9}
@@ -165,7 +177,7 @@ func TestValidatingLive_MTLS_IdentityMissing_FailsNotReady(t *testing.T) {
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
 	node := newSpaciousNode("miles", 8, 65536)
-	srcPod := newSourcePod("guest", "default", "src-pod-uid-1")
+	srcPod := withClientStunnelSidecar(newSourcePod("guest", "default", "src-pod-uid-1"))
 	mig := newMigration("m", "default")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	mig.Spec.Timeout = &metav1.Duration{Duration: 5 * 60 * 1e9}
@@ -192,6 +204,42 @@ func TestValidatingLive_MTLS_IdentityMissing_FailsNotReady(t *testing.T) {
 	}
 	if status.Phase == migrationv1alpha1.SwiftMigrationPhasePreparing {
 		t.Errorf("must not advance to Preparing when an identity Secret is missing")
+	}
+}
+
+// TestValidatingLive_MTLS_SourceNotSidecarReady_Fails verifies the fail-fast
+// for a source pod that lacks a client-role stunnel sidecar (predates mTLS
+// enablement, or is a post-cutover dst pod). Even with both identities
+// present, it must fail with SourceSidecarNotReady rather than advance and
+// later retry-then-timeout.
+func TestValidatingLive_MTLS_SourceNotSidecarReady_Fails(t *testing.T) {
+	scheme := validatingScheme(t)
+	const sysNS = "kubeswift-system"
+	guest := newGuestForValidating("guest", "default", "class-default")
+	class := newGuestClass("class-default", 2, 2048)
+	node := newSpaciousNode("miles", 8, 65536)
+	srcPod := newSourcePod("guest", "default", "src-pod-uid-1") // NO sidecar
+	mig := newMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
+	mig.Spec.Timeout = &metav1.Duration{Duration: 5 * 60 * 1e9}
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mig, guest, class, node, srcPod,
+			migrationNodeIdentitySecret(sysNS, "boba"), migrationNodeIdentitySecret(sysNS, "miles")).
+		WithStatusSubresource(mig).
+		Build()
+	r := &SwiftMigrationReconciler{
+		Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10),
+		MigrationMTLSEnabled: true, SystemNamespace: sysNS,
+	}
+
+	status := mig.Status.DeepCopy()
+	result := r.handleValidatingLive(context.Background(), mig, status)
+	if result.FailureReason != migrationv1alpha1.FailureReasonSourceSidecarNotReady {
+		t.Fatalf("want FailureReason=%q, got reason=%q msg=%q",
+			migrationv1alpha1.FailureReasonSourceSidecarNotReady, result.FailureReason, result.FailureMsg)
 	}
 }
 

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -1300,6 +1300,46 @@ at the injection site so a future maintainer sees the constraint before
 adding a source-stop to the live path. Severity: LOW (latent; not
 reachable today). Surfaced 2026-06-01 during PR 3 planning.
 
+### 25. Chain migrations under live-migration mTLS require a pod recycle
+
+Phase 3c PR 3d (source-side mTLS activation, PR #83) ships with a known
+limitation around back-to-back ("chain") live migrations when mTLS is
+enabled. The source sidecar is a TLS **client** and the destination
+sidecar is a TLS **server**; the role is an immutable env on an immutable
+pod. After a migration's cutover, the destination pod becomes the guest's
+running pod — carrying a **server**-role sidecar. If that guest is then
+live-migrated again, it is the *source* of the next migration but cannot
+act as a TLS client (wrong-role sidecar). The same applies to any guest
+whose launcher pod predates mTLS enablement (no sidecar at all — the
+SwiftGuest controller only injects the sidecar on newly created pods).
+
+**Current behaviour (fail-fast, not silent):** Validating-live's
+`sourcePodMTLSReady` check fails such a migration immediately with
+`FailureReason=SourceSidecarNotReady` and a message hinting the operator
+to recycle the guest's pod (stop/start), rather than letting it run the
+~60s bounded-send-retry and then time out. The source VM is never harmed
+(live-migration pre-copy does not pause the source).
+
+**Operator workaround:** recycle the guest's launcher pod between chained
+mTLS migrations (a stop/start, which recreates the pod via the SwiftGuest
+controller with a fresh client-role sidecar). PR 5 documents this.
+
+**Possible future fixes (not scoped):**
+- Give the destination pod BOTH a server sidecar (for the inbound
+  migration) AND a client sidecar (for a future outbound migration) —
+  heavier per-pod footprint, but removes the limitation.
+- A controller-driven post-cutover pod recycle (invasive: recreating a
+  running VM pod is downtime; likely not worth it).
+- Revisit once a single stunnel instance / config can serve both roles on
+  the localhost port pair (not possible with the current stunnel model).
+
+Severity: LOW-MEDIUM (operators doing rapid chained rebalancing under
+mTLS hit it; the fail-fast makes it diagnosable). Surfaced 2026-06-01
+during PR 3d implementation. Cross-reference: the W-3c-2 "flip role
+post-DeepCopy" fix in
+[`sidecar.go::injectDstStunnelSidecar`](internal/controller/swiftmigration/sidecar.go)
+is what makes the FIRST migration correct; this TFU is about the SECOND.
+
 ---
 
 ## Phase 2 Decisions Resolved (live migration)


### PR DESCRIPTION
## Summary

PR 3d of Phase 3c (live-migration mTLS, **Option B**). The SwiftMigration controller now provides the three inputs the **idle source sidecar** (PR 3b, #82) waits for — making cross-node mTLS migration **end-to-end** for the first time. Builds on PR 1 (#79), PR 2 (#80), PR 3 (#81), PR 3b (#82).

**Gated on `--migration-mtls-enabled`.** Flag off (default) → byte-for-byte unchanged (tests assert).

## What activates the source path

- **Validating-live** — populate the per-guest identity Secret the source sidecar mounts with the source node's issued identity (copied from the system namespace). **Fail fast** (`SourceSidecarNotReady`) if the source pod lacks a client-role sidecar.
- **Preparing-live** — as soon as the dst pod has an IP, stamp the `migration-dst-ip` / `migration-peer-san` annotations on the source pod (surfaced to the sidecar via its downward-API volume), so it brings stunnel up with the full Preparing→Ready window before the send (the **"stamp early"** decision).
- **StopAndCopy** — repoint the send `target_url` → `tcp:127.0.0.1:6790` (the local stunnel client) under mTLS; CH stays TLS-unaware.
- **Bounded send retry** — a `send_migration: connection_refused` under mTLS means the source sidecar's stunnel isn't listening yet (CH couldn't reach localhost), **distinct** from a dst failure (`transport_error`). No data flowed and the dst is still `receive-ready`, so re-issue with a fresh `$SEND_ID`, bounded by `maxMTLSSendRetries=10`; `spec.timeout` is the hard cap. Extracted `sendAttemptNumber` so the counter survives reconciles.

## ⚠️ Correctness fix (required, not just activation)

PR 3's `newDstPod` **skipped** sidecar injection when the DeepCopied pod already had one — written when the source had no sidecar. **PR 3b gave the source a *client* sidecar**, so the dst inherited a client and ran misconfigured, breaking mTLS **even for the first migration** (the W-3c-2 "flip role post-DeepCopy" the design mandated). `injectDstStunnelSidecar` is now **authoritative**: strip any inherited sidecar + the three client volumes, then add the **server** sidecar + the dst per-node identity Secret. (Latent on main but harmless — mTLS is off by default and wasn't end-to-end until this PR.)

## Known limitation — chain migrations under mTLS (TFU #25)

The source sidecar is a TLS **client**, the dst is a **server**, and the role is an immutable env on an immutable pod. After cutover, the dst pod (server-role) becomes the running guest; live-migrating it *again* makes it a source that can't act as a client. Same for pods predating mTLS enablement (no sidecar). The `SourceSidecarNotReady` fail-fast surfaces this clearly with a **recycle hint**, instead of a ~60s retry-then-timeout. The source VM is never harmed. Workaround: recycle the guest's pod between chained mTLS migrations. Tracked in `kubeswift_context.md` TFU #25; PR 5 documents it.

## Test plan

- [x] `gofmt` clean · `go build ./...` · `go vet ./...` · full `go test ./...` (exit 0).
- [x] No CRD change (`FailureReason` is a free-string field).
- [x] New/updated tests: `target_url` repoint (mtls/plaintext); bounded-retry matrix (conn-refused retries / budget-exhausted fails / transport_error no-retry / mtls-off no-retry / dst-terminating no-retry); `stampSourceMigrationInputs` + `populateSourceIdentity` (create/update/missing); the dst sidecar **flip**; the Validating **fail-fast**; `isLocalStunnelNotReady` table.
- [ ] End-to-end cross-node mTLS migration on the cluster — **PR 5** (this PR makes it possible).

## Next

PR 4 (S1 URLs-from-CR + ack-gate retirement + audit Events) and PR 5 (cluster walkthrough + `docs/migration/phase-3c.md` + THREAT-MODEL). mTLS is now end-to-end behind the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)