### PR TITLE
feat(migration): Phase 3c PR 4 — S1 enforcement, ack retirement, audit events

### DIFF
--- a/internal/controller/swiftguest/migration_sidecar.go
+++ b/internal/controller/swiftguest/migration_sidecar.go
@@ -150,9 +150,17 @@ func sourceStunnelVolumes(guestName string) []corev1.Volume {
 }
 
 // applyMigrationSourceSidecar appends the idle source stunnel client
-// sidecar and its three volumes to the launcher pod. Idempotent: a pod that
+// sidecar and its three volumes to the launcher pod, and sets the
+// secured-mode env on the launcher container. Idempotent: a pod that
 // already carries the sidecar container is left untouched.
 func applyMigrationSourceSidecar(pod *corev1.Pod, guest *swiftv1alpha1.SwiftGuest) {
+	// Secured-mode signal for swiftletd (PR 4): set on the launcher
+	// container, NOT the sidecar. The dst launcher inherits it via
+	// newDstPod's DeepCopy. Set first so it lands even on the idempotent
+	// re-entry guard below (a pod created before this code shipped that
+	// already has the sidecar still gets the env on the next reconcile-
+	// driven rebuild).
+	setLauncherMTLSEnv(pod)
 	for i := range pod.Spec.Containers {
 		if pod.Spec.Containers[i].Name == migrationsidecar.ContainerName {
 			return
@@ -160,6 +168,29 @@ func applyMigrationSourceSidecar(pod *corev1.Pod, guest *swiftv1alpha1.SwiftGues
 	}
 	pod.Spec.Containers = append(pod.Spec.Containers, sourceStunnelSidecar())
 	pod.Spec.Volumes = append(pod.Spec.Volumes, sourceStunnelVolumes(guest.Name)...)
+}
+
+// setLauncherMTLSEnv sets KUBESWIFT_MIGRATION_MTLS=1 on the launcher
+// container so swiftletd enters secured mode (S1 loopback enforcement +
+// plaintext-ack bypass). Idempotent: replaces any existing entry.
+func setLauncherMTLSEnv(pod *corev1.Pod) {
+	for i := range pod.Spec.Containers {
+		c := &pod.Spec.Containers[i]
+		if c.Name != "launcher" {
+			continue
+		}
+		filtered := c.Env[:0]
+		for _, e := range c.Env {
+			if e.Name != migrationsidecar.EnvMTLSEnabled {
+				filtered = append(filtered, e)
+			}
+		}
+		c.Env = append(filtered, corev1.EnvVar{
+			Name:  migrationsidecar.EnvMTLSEnabled,
+			Value: migrationsidecar.EnvMTLSEnabledValue,
+		})
+		return
+	}
 }
 
 // EnsureMigrationStunnelConfig copies the kubeswift-migration-stunnel

--- a/internal/controller/swiftguest/migration_sidecar_test.go
+++ b/internal/controller/swiftguest/migration_sidecar_test.go
@@ -142,6 +142,54 @@ func TestApplyMigrationSourceSidecar_InjectsIdleClient(t *testing.T) {
 	}
 }
 
+// TestApplyMigrationSourceSidecar_SetsLauncherMTLSEnv verifies the PR 4
+// secured-mode signal: the launcher container gets KUBESWIFT_MIGRATION_MTLS=1
+// so swiftletd enters secured mode (S1 loopback enforcement + ack bypass).
+// The env goes on the launcher, NOT the stunnel sidecar.
+func TestApplyMigrationSourceSidecar_SetsLauncherMTLSEnv(t *testing.T) {
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a"}}
+	pod := podWithLauncher()
+
+	applyMigrationSourceSidecar(pod, guest)
+
+	var launcher *corev1.Container
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == "launcher" {
+			launcher = &pod.Spec.Containers[i]
+		}
+	}
+	if launcher == nil {
+		t.Fatal("launcher container missing")
+	}
+	var got string
+	var count int
+	for _, e := range launcher.Env {
+		if e.Name == migrationsidecar.EnvMTLSEnabled {
+			got = e.Value
+			count++
+		}
+	}
+	if got != migrationsidecar.EnvMTLSEnabledValue {
+		t.Errorf("launcher %s: want %q, got %q", migrationsidecar.EnvMTLSEnabled, migrationsidecar.EnvMTLSEnabledValue, got)
+	}
+	// Idempotent: re-applying must not duplicate the env var.
+	applyMigrationSourceSidecar(pod, guest)
+	count = 0
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name != "launcher" {
+			continue
+		}
+		for _, e := range pod.Spec.Containers[i].Env {
+			if e.Name == migrationsidecar.EnvMTLSEnabled {
+				count++
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("KUBESWIFT_MIGRATION_MTLS must appear exactly once after re-apply; got %d", count)
+	}
+}
+
 func TestEnsureMigrationStunnelConfig_CopiesAcrossNamespaces(t *testing.T) {
 	scheme := migrationSidecarScheme(t)
 	const sysNS = "kubeswift-system"

--- a/internal/controller/swiftmigration/validating_live.go
+++ b/internal/controller/swiftmigration/validating_live.go
@@ -226,6 +226,16 @@ func (r *SwiftMigrationReconciler) handleValidatingLive(
 				fmt.Sprintf("populate source migration identity: %v", err),
 				migrationv1alpha1.FailureReasonMigrationIdentityNotReady)
 		}
+		// PR 4 audit event (§6.3): record that this migration's channel is
+		// mTLS-secured and which per-node identities are pinned, so an
+		// operator can see WHICH identity the channel will authenticate.
+		// The handshake OUTCOME surfaces later as the Completed event
+		// (success) or the failure event's TLS-related detail.
+		if r.Recorder != nil {
+			r.Recorder.Eventf(mig, corev1.EventTypeNormal, "MTLSChannel",
+				"live-migration channel secured with mTLS; pinned peers src=%q dst=%q (SAN-pinned per-node identities)",
+				status.SourceNode, status.DestinationNode)
+		}
 	}
 
 	// Compatible=True, advance to Preparing.

--- a/internal/migrationsidecar/sidecar.go
+++ b/internal/migrationsidecar/sidecar.go
@@ -57,6 +57,17 @@ const (
 	RoleServer = "server" // destination: TLS server, inputs by env at start
 	RoleClient = "client" // source: TLS client, idle-polls InputDir + TLSDir
 
+	// EnvMTLSEnabled is set on the LAUNCHER container (not the sidecar) by
+	// the SwiftGuest controller when mTLS is enabled; the dst launcher
+	// inherits it via newDstPod's DeepCopy. swiftletd reads it at startup
+	// to enter "secured mode" (Phase 3c PR 4): it then (a) validates the
+	// migration target_url/listen_url is a loopback address and rejects
+	// otherwise (S1 — the URL becomes untrusted), and (b) bypasses the
+	// plaintext-ack gate (the channel is TLS). The string MUST match the
+	// constant swiftletd reads (rust/swiftletd/src/action.rs).
+	EnvMTLSEnabled      = "KUBESWIFT_MIGRATION_MTLS"
+	EnvMTLSEnabledValue = "1"
+
 	// Controller-stamped SOURCE-pod annotations. The SwiftGuest controller's
 	// downward-API volume projects these into InputFileDstIP / InputFilePeerSAN
 	// under InputDir; the SwiftMigration controller (PR 3d) writes them when a

--- a/rust/swiftletd/src/action.rs
+++ b/rust/swiftletd/src/action.rs
@@ -280,6 +280,88 @@ pub static MIGRATION_KEYS: KeySet = KeySet {
     namespace: "migration",
 };
 
+/// Env var the SwiftGuest controller sets on the launcher container when
+/// live-migration mTLS is enabled (Phase 3c PR 4). When set, swiftletd runs
+/// in "secured mode": it validates the migration URL is a loopback address
+/// (S1) and bypasses the plaintext-ack gate (the channel is TLS). Must
+/// match `internal/migrationsidecar.EnvMTLSEnabled` on the Go side.
+pub const MIGRATION_MTLS_ENV: &str = "KUBESWIFT_MIGRATION_MTLS";
+
+/// True when the launcher is running in secured (mTLS) migration mode.
+pub fn secured_migration_mode() -> bool {
+    secured_from(std::env::var(MIGRATION_MTLS_ENV).ok().as_deref())
+}
+
+/// Pure helper for [`secured_migration_mode`] — secured when the value is
+/// exactly "1" or "true".
+fn secured_from(v: Option<&str>) -> bool {
+    matches!(v, Some("1") | Some("true"))
+}
+
+/// Returns the migration [`KeySet`], dropping the plaintext-ack requirement
+/// when secured mode is active. Under mTLS the channel is authenticated, so
+/// the `migration-phase2-unsafe-plaintext: ack` escape-hatch is moot and
+/// must not gate the secured flow (design §6.2). The controller KEEPS
+/// emitting the ack for now (harmless — we ignore it here), so there is no
+/// version-skew window during a rolling upgrade.
+pub fn migration_keys() -> KeySet {
+    migration_keys_for(secured_migration_mode())
+}
+
+/// Pure helper for [`migration_keys`].
+fn migration_keys_for(secured: bool) -> KeySet {
+    let mut k = MIGRATION_KEYS;
+    if secured {
+        k.ack_key = None;
+    }
+    k
+}
+
+/// Validates that a CH migration URL targets a loopback address. Under
+/// secured mode the controller writes `tcp:127.0.0.1:<port>` (the local
+/// stunnel proxy); an attacker who rewrote the operator-writable
+/// `migration-action-args` to a remote IP would otherwise make CH stream
+/// the guest in cleartext to that endpoint — the S1 risk mTLS does not
+/// close on its own (design §6.1). `unix:` sockets are inherently local and
+/// always pass. Only invoked under secured mode (the plaintext path still
+/// targets the remote dst IP directly).
+pub fn validate_loopback_url(url: &str) -> Result<(), String> {
+    if url.strip_prefix("unix:").is_some() {
+        return Ok(());
+    }
+    let rest = url.strip_prefix("tcp:").ok_or_else(|| {
+        format!(
+            "secured migration: unsupported URL scheme (want tcp:/unix:): {}",
+            url
+        )
+    })?;
+    let host = if let Some(after) = rest.strip_prefix('[') {
+        // [ipv6]:port
+        let end = after
+            .find(']')
+            .ok_or_else(|| format!("secured migration: malformed bracketed host: {}", url))?;
+        &after[..end]
+    } else {
+        match rest.rfind(':') {
+            Some(i) => &rest[..i],
+            None => rest,
+        }
+    };
+    let loopback = host == "localhost"
+        || host
+            .parse::<std::net::IpAddr>()
+            .map(|ip| ip.is_loopback())
+            .unwrap_or(false);
+    if loopback {
+        Ok(())
+    } else {
+        Err(format!(
+            "secured migration: refusing non-loopback host {:?} (S1: migration URL must be localhost under mTLS): {}",
+            host, url
+        ))
+    }
+}
+
 /// Maps a snapshot-namespace verb string to an [`ActionKind`].
 fn parse_snapshot_verb(verb: &str) -> ActionKind {
     match verb {
@@ -809,13 +891,28 @@ async fn dispatch_migration_send(
     action: &PendingAction,
     api_socket: &Path,
 ) -> Result<ActionOutcome, String> {
-    // SECURITY-S1: target_url is read from operator-set pod annotation
-    // args (Phase 2 manual path ONLY). In Phase 3, this read is replaced
-    // by reading from the SwiftMigration CR via kube-rs to mitigate the
-    // annotation-trust-boundary issue. See
-    // docs/design/live-migration-phase-2.md §8.2.3.
+    // SECURITY-S1: target_url is read from the operator-writable pod
+    // annotation args. Phase 3c PR 4 mitigates the annotation-trust-boundary
+    // issue under mTLS by validating the URL is loopback below (a tampered
+    // remote URL is rejected, not dialed) rather than reading from the
+    // SwiftMigration CR — under the sidecar architecture the URL is always
+    // the local stunnel proxy, so loopback-validation is the equivalent and
+    // simpler mitigation. See docs/design/live-migration-phase-3c.md §6.1.
     let args: MigrationSendArgs = serde_json::from_value(action.args.clone())
         .map_err(|e| format!("parse migration_send args: {}", e))?;
+
+    // S1 (secured mode): the target_url comes from the operator-writable
+    // action-args annotation. Under mTLS it MUST be the local stunnel proxy
+    // (loopback); refuse a non-loopback target so a tampered annotation
+    // cannot redirect the plaintext CH stream to an attacker endpoint. The
+    // "secured migration:" detail is NOT a connection_refused token, so the
+    // controller does not retry it (it is a real rejection, not a sidecar-
+    // not-ready race).
+    if secured_migration_mode() {
+        if let Err(e) = validate_loopback_url(&args.target_url) {
+            return Err(format!("send_migration: {}", e));
+        }
+    }
 
     log::info!(
         "dispatch_migration_send id={} target={}",
@@ -906,10 +1003,22 @@ async fn dispatch_migration_receive(
     action: &PendingAction,
     api_socket: &Path,
 ) -> Result<ActionOutcome, String> {
-    // SECURITY-S1: listen_url is read from operator-set pod annotation
-    // args (Phase 2 manual path ONLY). Phase 3 replaces this read.
+    // SECURITY-S1: listen_url is read from the operator-writable pod
+    // annotation args. Phase 3c PR 4 validates it is loopback below under
+    // secured mode (same mitigation as the send path). See
+    // docs/design/live-migration-phase-3c.md §6.1.
     let args: MigrationReceiveArgs = serde_json::from_value(action.args.clone())
         .map_err(|e| format!("parse migration_receive args: {}", e))?;
+
+    // S1 (secured mode): same as the send path — the listen_url must bind a
+    // loopback address (CH receives behind the local stunnel server);
+    // refuse anything else so a tampered annotation cannot make CH accept a
+    // cleartext connection over the pod network.
+    if secured_migration_mode() {
+        if let Err(e) = validate_loopback_url(&args.listen_url) {
+            return Err(format!("receive_migration: {}", e));
+        }
+    }
 
     log::info!(
         "dispatch_migration_receive id={} listen={}",
@@ -1873,13 +1982,17 @@ async fn handle_pod_state(
     )
     .await;
 
+    // Secured mode drops the ack-gate from the migration KeySet (PR 4 §6.2):
+    // under mTLS the plaintext-ack escape-hatch is moot, so decide() must
+    // not reject the secured flow for a missing ack.
+    let mig_keys = migration_keys();
     handle_namespace(
         client,
         namespace,
         pod_name,
         api_socket,
         &mut state.migration,
-        &MIGRATION_KEYS,
+        &mig_keys,
         annotations,
         write_migration_status_fn,
     )
@@ -2894,6 +3007,73 @@ mod tests {
         // lands.
         assert!(SNAPSHOT_KEYS.ack_key.is_none());
         assert_eq!(MIGRATION_KEYS.ack_key, Some(MIGRATION_PHASE2_ACK_KEY));
+    }
+
+    // --- Phase 3c PR 4: secured-mode (mTLS) ----------------------------
+
+    #[test]
+    fn secured_from_recognises_truthy_values() {
+        assert!(secured_from(Some("1")));
+        assert!(secured_from(Some("true")));
+        assert!(!secured_from(Some("0")));
+        assert!(!secured_from(Some("false")));
+        assert!(!secured_from(Some("")));
+        assert!(!secured_from(Some("yes")));
+        assert!(!secured_from(None));
+    }
+
+    #[test]
+    fn migration_keys_for_drops_ack_gate_when_secured() {
+        // Plaintext: ack gate present. Secured: ack gate bypassed.
+        assert_eq!(
+            migration_keys_for(false).ack_key,
+            Some(MIGRATION_PHASE2_ACK_KEY)
+        );
+        assert!(migration_keys_for(true).ack_key.is_none());
+        // All other fields are untouched by the flip.
+        assert_eq!(
+            migration_keys_for(true).action_key,
+            MIGRATION_KEYS.action_key
+        );
+        assert_eq!(migration_keys_for(true).namespace, MIGRATION_KEYS.namespace);
+    }
+
+    #[test]
+    fn validate_loopback_url_accepts_loopback() {
+        for url in [
+            "tcp:127.0.0.1:6790",
+            "tcp:127.5.5.5:6790",
+            "tcp:localhost:6790",
+            "tcp:[::1]:6790",
+            "unix:/var/run/ch/migration.sock",
+        ] {
+            assert!(
+                validate_loopback_url(url).is_ok(),
+                "expected {} to be accepted as loopback",
+                url
+            );
+        }
+    }
+
+    #[test]
+    fn validate_loopback_url_rejects_remote_and_bad_scheme() {
+        for url in [
+            "tcp:1.2.3.4:6789",
+            "tcp:10.0.0.9:6789",
+            "tcp:example.com:6789",
+            "tcp:[2001:db8::1]:6789",
+            "http://127.0.0.1:6790",
+        ] {
+            let res = validate_loopback_url(url);
+            assert!(res.is_err(), "expected {} to be rejected", url);
+            // The rejection detail must NOT contain a connection_refused
+            // token (the controller must not retry an S1 rejection).
+            assert!(
+                !res.unwrap_err().contains("connection_refused"),
+                "S1 rejection detail must not look retryable: {}",
+                url
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR 4 of Phase 3c (live-migration mTLS, **Option B**). Composes the three security workstreams the spike confirmed mTLS is **necessary but not sufficient** for (design §6). **Cross-component** — Go controllers + Rust swiftletd. Builds on PR 1–3d (#79, #80, #81, #82, #83).

Every new behavior is gated on a secured-mode signal that's only set when mTLS is enabled, so the **plaintext path is unchanged** (tests assert).

## Secured-mode signal

The SwiftGuest controller sets `KUBESWIFT_MIGRATION_MTLS=1` on the **launcher** container when mTLS is enabled (the dst launcher inherits it via `newDstPod`'s DeepCopy). swiftletd reads it at startup. The constant lives once in `internal/migrationsidecar` and is string-matched in `rust/swiftletd/src/action.rs`.

## The three workstreams

- **S1 — validate-loopback (§6.1).** swiftletd reads `target_url`/`listen_url` from the operator-writable `migration-action-args` annotation. Under secured mode it now **rejects a non-loopback URL** (`validate_loopback_url`): an attacker who rewrites `target_url` to a remote IP can no longer make CH stream the guest **in cleartext** to that endpoint — the exfil risk mTLS doesn't close on its own. The rejection detail deliberately avoids a `connection_refused` token so the controller treats it as **terminal**, not a retryable sidecar-not-ready race. `unix:` sockets always pass. Keeps the port controller-driven (no hardcoded constant).
- **Ack retirement (§6.2).** `migration_keys()` drops the `migration-phase2-unsafe-plaintext` ack gate from the migration KeySet **in secured mode** (the channel is TLS, so the plaintext escape-hatch is moot). The controller **keeps emitting** the ack for now — harmless (swiftletd ignores it) and **zero version-skew risk** during a rolling upgrade (a new-controller/old-swiftletd window still sees the ack it expects). The stop-emitting + key-deletion cleanup is a deferred follow-up once a swiftletd version floor exists.
- **Audit events (§6.3).** Validating-live emits an `MTLSChannel` Event naming the pinned per-node peer identities (`src`/`dst`); the handshake **outcome** surfaces via the existing Completed Event (success) or the failure Event's TLS-related detail.

## Test plan

- [x] Go: `gofmt` / `go vet ./...` / full `go test ./...` (exit 0).
- [x] Rust: `cargo fmt --check` clean · `cargo test -p swiftletd` 97 passed.
- [x] New tests: `secured_from` value matrix; `migration_keys_for` ack-drop; `validate_loopback_url` (accepts loopback/localhost/`::1`/`unix:`, rejects remote/bad-scheme, detail not retryable); launcher secured-mode env (set + idempotent).
- [x] Plaintext path unchanged: still requires the ack, still dials the remote dst IP (gated on the env).
- [ ] End-to-end on cluster — **PR 5**.

## Decision record (forks resolved with the maintainer)

- **S1**: validate-loopback (vs. ignore-annotation/hardcode-constant) — keeps the port controller-driven, minimal Rust change, closes the exfil.
- **Ack**: swiftletd-bypasses-while-controller-keeps-emitting (vs. controller-stops-now) — eliminates the rolling-upgrade skew window.

## Deferred

- **THREAT-MODEL.md update** (§6.2 references it) — documentation, belongs with the PR 5 docs pass.
- **Ack-key deletion** (controller stops emitting + key removed) — needs a swiftletd version floor; follow-up.

## Next

PR 5 — cluster mini-walkthrough (first end-to-end mTLS migration validation) + `docs/migration/phase-3c.md` + THREAT-MODEL update. mTLS is now feature-complete behind `--migration-mtls-enabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)