### PR TITLE
feat(migration): Phase 3c cleanup — stop emitting plaintext-ack on the secured path

### DIFF
--- a/docs/design/THREAT-MODEL.md
+++ b/docs/design/THREAT-MODEL.md
@@ -66,9 +66,13 @@ actual posture is recorded here:
   loopback mitigation.
 - **Plaintext-ack gate — RETIRED on the secured path.** swiftletd bypasses
   the `migration-phase2-unsafe-plaintext: ack` requirement in secured
-  mode (the channel is TLS). The controller still emits the ack (harmless,
-  ignored) to avoid a rolling-upgrade version-skew window; the
-  stop-emitting + key-deletion cleanup is a tracked follow-up.
+  mode (the channel is TLS), and the controller **no longer emits** the
+  ack on the secured path (Phase 3c cleanup) — an "unsafe-plaintext"
+  annotation on a TLS-secured pod is misleading. The annotation key is
+  **retained** (not deleted): the plaintext path still uses it as the
+  operator's "I acknowledge cleartext" gate. Safe from version skew
+  because mTLS only ever runs against the Phase 3c swiftletd that added
+  the secured-mode bypass.
 - **Audit events — DONE.** An `MTLSChannel` Kubernetes Event names the
   pinned per-node peer identities (`src`/`dst`) at Validating; the
   handshake outcome surfaces via the Completed event or the failure

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -30,6 +30,22 @@ helm install kubeswift oci://ghcr.io/projectbeskar/charts/kubeswift --version 0.
 
 Each workflow builds images, pushes to ghcr.io, packages the Helm chart, and pushes to OCI (`oci://ghcr.io/projectbeskar/charts` — parent repo; Helm appends chart name). `release-stable` also creates a GitHub Release. See [Helm OCI](install/helm-oci.md#push-vs-install-reference) for push vs install reference.
 
+### Adding a NEW image to the build/push matrix — one-time publicize step
+
+New ghcr container packages are created **private** by default (GitHub's
+default for org packages), and **GitHub provides no REST API to change
+package visibility** — the release workflow cannot automate it. After the
+first push of a new image, a maintainer must publicize the package **once**:
+
+> `https://github.com/orgs/projectbeskar/packages/container/<package>/settings`
+> → **Danger Zone → Change visibility → Public** (confirm by typing the name).
+
+Otherwise pods pulling the image stick at `ImagePullBackOff` / `401
+Unauthorized`. The existing public packages (`controller-manager`,
+`swiftletd`, `gpu-discovery`, `migration-stunnel`) each went through this
+once. (Alternatively, deploy an `imagePullSecret` — but publicizing matches
+the other packages.) Surfaced by the Phase 3c PR 5 walkthrough (TFU #26).
+
 ## Manual release
 
 ```bash

--- a/internal/controller/swiftmigration/dst_pod.go
+++ b/internal/controller/swiftmigration/dst_pod.go
@@ -181,7 +181,7 @@ func newDstPod(
 	// useful labels (guest, etc) by starting from src.Labels and
 	// adding migration-specific keys.
 	preservedLabels := mergeLabelsForDst(srcPod.Labels, guest.Name, mig.Name)
-	preservedAnnotations := mergeAnnotationsForDst(srcPod.Annotations)
+	preservedAnnotations := mergeAnnotationsForDst(srcPod.Annotations, sidecar.mtlsEnabled)
 
 	pod.ObjectMeta = metav1.ObjectMeta{
 		Name:        name,
@@ -255,11 +255,21 @@ func mergeLabelsForDst(srcLabels map[string]string, guestName, migName string) m
 // runtime status the dst's swiftletd will repopulate, plus operator
 // annotations that don't transfer to the dst pod cleanly.
 //
-// Future B3 / B2.4 may extend this to copy specific allowlisted keys
-// (e.g., a label-selector indexer might want a subset of the src
-// pod's labels copied as annotations on the dst). For B2.2 the only
-// required annotation is the Phase 2 ack-gate; nothing else.
-func mergeAnnotationsForDst(srcAnnotations map[string]string) map[string]string {
+// The Phase 2 plaintext-ack annotation is set ONLY on the plaintext
+// path. Under mTLS (Phase 3c) the channel is TLS, swiftletd bypasses the
+// ack gate in secured mode (KUBESWIFT_MIGRATION_MTLS=1), and emitting an
+// "unsafe-plaintext: ack" annotation on a TLS-secured pod is misleading.
+// So when mtlsEnabled we omit it. This is safe from version skew: mTLS
+// only ever runs against the Phase 3c swiftletd (same release that added
+// the secured-mode bypass), so no in-flight migration sees an old
+// swiftletd that still requires the ack.
+//
+// The key is NOT deleted outright: the plaintext path still uses the ack
+// gate as the THREAT-MODEL's "operator acknowledged cleartext" guard.
+func mergeAnnotationsForDst(srcAnnotations map[string]string, mtlsEnabled bool) map[string]string {
+	if mtlsEnabled {
+		return map[string]string{}
+	}
 	return map[string]string{
 		AnnotationMigrationPhase2Ack: AnnotationMigrationPhase2AckValue,
 	}

--- a/internal/controller/swiftmigration/dst_pod_test.go
+++ b/internal/controller/swiftmigration/dst_pod_test.go
@@ -371,6 +371,38 @@ func TestNewDstPod_MTLS_FlipsInheritedClientSidecarToServer(t *testing.T) {
 // TestNewDstPod_MTLS_EmptyNode_Errors verifies the guard: mTLS enabled
 // with an unresolved node name is a clean construction error rather than
 // a sidecar with an empty SAN pin / unresolvable identity Secret.
+// TestNewDstPod_MTLS_OmitsPlaintextAck verifies the Phase 3c cleanup: the
+// plaintext-ack annotation is set on the dst pod ONLY on the plaintext
+// path. Under mTLS swiftletd bypasses the ack gate, so the annotation is
+// omitted (and would be misleading on a TLS-secured pod).
+func TestNewDstPod_MTLS_OmitsPlaintextAck(t *testing.T) {
+	scheme := testScheme(t)
+	mig := newMigrationWithUID("mig-a", "default", "abcdef1234567890abcdef1234567890")
+	mig.Spec.Target.NodeName = "miles"
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
+	}
+	src := templateSrcPod("guest", "default")
+
+	off, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{})
+	if err != nil {
+		t.Fatalf("newDstPod (plaintext): %v", err)
+	}
+	if off.Annotations[AnnotationMigrationPhase2Ack] != AnnotationMigrationPhase2AckValue {
+		t.Errorf("plaintext dst must carry the ack annotation")
+	}
+
+	on, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
+		mtlsEnabled: true, srcNodeName: "boba", dstNodeName: "miles",
+	})
+	if err != nil {
+		t.Fatalf("newDstPod (mTLS): %v", err)
+	}
+	if _, present := on.Annotations[AnnotationMigrationPhase2Ack]; present {
+		t.Errorf("mTLS dst must NOT carry the plaintext-ack annotation; got %q", on.Annotations[AnnotationMigrationPhase2Ack])
+	}
+}
+
 func TestNewDstPod_MTLS_EmptyNode_Errors(t *testing.T) {
 	scheme := testScheme(t)
 	mig := newMigrationWithUID("m", "default", "abcdef1234567890abcdef1234567890")

--- a/internal/controller/swiftmigration/source_mtls_test.go
+++ b/internal/controller/swiftmigration/source_mtls_test.go
@@ -83,6 +83,31 @@ func TestStopAndCopyLive_PreSend_Plaintext_TargetDstIP(t *testing.T) {
 	}
 }
 
+// TestStopAndCopyLive_PreRecv_MTLS_SkipsAckPatch verifies the Phase 3c
+// cleanup: under mTLS the src pod is NOT patched with the plaintext-ack
+// annotation (swiftletd bypasses the gate in secured mode) — but the
+// migration-name label IS still applied (informer observability).
+func TestStopAndCopyLive_PreRecv_MTLS_SkipsAckPatch(t *testing.T) {
+	mig, guest, src, dst := stopAndCopyFixture(t, "uid-1")
+	r := newStopAndCopyReconciler(t, mig, guest, src, dst)
+	r.MigrationMTLSEnabled = true
+
+	status := mig.Status.DeepCopy()
+	_ = r.handleStopAndCopyLive(context.Background(), mig, status)
+
+	var got corev1.Pod
+	if err := r.Get(context.Background(), key(src), &got); err != nil {
+		t.Fatalf("re-get src: %v", err)
+	}
+	if _, present := got.Annotations[AnnotationMigrationPhase2Ack]; present {
+		t.Errorf("mTLS src must NOT be patched with the plaintext-ack annotation; got %q",
+			got.Annotations[AnnotationMigrationPhase2Ack])
+	}
+	if got.Labels[LabelMigrationName] != mig.Name {
+		t.Errorf("src must still get the migration-name label under mTLS; got %q", got.Labels[LabelMigrationName])
+	}
+}
+
 // --- bounded send retry (substateSrcFailed) ------------------------------
 
 func srcFailedReconciler(t *testing.T, mtls bool, sendAttempts int32, detail string, dstTerminating bool) (*SwiftMigrationReconciler, *migrationv1alpha1.SwiftMigration) {

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -309,7 +309,14 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 		// src pod is the existing SwiftGuest launcher pod which
 		// predates the migration, so the controller must add it.
 		needLabelPatch := srcPodPresent && srcPod.Labels[LabelMigrationName] != mig.Name
-		needAckPatch := srcPodPresent && srcPod.Annotations[AnnotationMigrationPhase2Ack] != AnnotationMigrationPhase2AckValue
+		// Phase 3c cleanup: only stamp the plaintext-ack annotation on the
+		// plaintext path. Under mTLS swiftletd bypasses the ack gate
+		// (secured mode), so the patch is unnecessary and the annotation
+		// would be misleading on a TLS-secured pod. Safe from version skew
+		// (mTLS implies the Phase 3c swiftletd). The key is retained for the
+		// plaintext path's THREAT-MODEL acknowledgement gate.
+		needAckPatch := !r.MigrationMTLSEnabled && srcPodPresent &&
+			srcPod.Annotations[AnnotationMigrationPhase2Ack] != AnnotationMigrationPhase2AckValue
 		if needLabelPatch || needAckPatch {
 			patch := client.MergeFrom(srcPod.DeepCopy())
 			if srcPod.Labels == nil {


### PR DESCRIPTION
## Summary

Phase 3c cleanup batch (the item the maintainer chose before Phase 4). Ties off the ack-gate retirement deferred from PR 4 (#84) and documents the new-image release step.

## What's in it

- **Controller stops emitting the plaintext-ack under mTLS.** PR 4 made swiftletd *bypass* the `migration-phase2-unsafe-plaintext: ack` gate in secured mode but kept the controller *emitting* the annotation (conservative, to dodge a rolling-upgrade skew window). Now that mTLS is shipped, both emission sites are gated on `mtlsEnabled`:
  - `mergeAnnotationsForDst` (destination pod construction)
  - the `substatePreRecv` source-pod patch
  
  An "unsafe-plaintext: ack" annotation on a TLS-secured pod was misleading; under mTLS it's now omitted. **The plaintext path is unchanged** — it still stamps the ack as the THREAT-MODEL operator-acknowledged-cleartext gate.
- **The annotation key is NOT deleted.** The plaintext path still uses it. (Full key deletion would only be appropriate if/when the plaintext migration path is removed.)
- **Version-skew safe:** mTLS only ever runs against the Phase 3c swiftletd that added the secured-mode bypass (sidecar + secured mode shipped together), so no in-flight migration sees an old swiftletd that still requires the ack.
- **Docs:** `docs/releases.md` gains a "new image → one-time publicize" step (TFU #26 — GitHub has no API for container-package visibility); THREAT-MODEL Phase 3c status updated.

## Test plan

- [x] `gofmt` / `go vet` / `go build ./...` / `go test ./...` all pass.
- [x] New tests: dst pod **omits** the ack under mTLS / **carries** it on plaintext; `substatePreRecv` **skips** the ack patch under mTLS but still applies the migration-name label.
- [x] Existing plaintext-path tests unchanged (the default reconciler is mTLS-off) — backward compatible.

## Not in this batch

- The dev-cluster redeploy onto the CI-built image (operational, separate).
- Phase 4 (drain integration) — next, per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)