### PR TITLE
feat(migration): Phase 4 PR 1 — drain-integration design + spec.migration.drainPolicy

### DIFF
--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -127,6 +127,22 @@ type MigrationSpec struct {
 	// +kubebuilder:default=auto
 	// +optional
 	PreferredMode string `json:"preferredMode,omitempty"`
+	// DrainPolicy controls how kubectl drain / the eviction API evacuates
+	// this guest off a node (Phase 4 drain integration):
+	//   Migrate (default): mode=auto — live-migrate where possible,
+	//     offline-migrate (bounded downtime) for VFIO/GPU guests. Drain
+	//     always succeeds for an eligible guest.
+	//   LiveMigrate: live only; if the guest cannot live-migrate
+	//     (VFIO/GPU), deny the drain rather than incur downtime.
+	//   Block: always deny the drain; the operator handles the guest
+	//     manually.
+	// Orthogonal to Enabled (Enabled=false disables migration entirely and
+	// also denies drain). Has no effect until the Phase 4 eviction webhook
+	// + drain controller ship.
+	// +kubebuilder:validation:Enum=Migrate;LiveMigrate;Block
+	// +kubebuilder:default=Migrate
+	// +optional
+	DrainPolicy string `json:"drainPolicy,omitempty"`
 }
 
 // DataDiskRef references either a SwiftImage or a PVC for a data disk.

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
@@ -301,6 +301,25 @@ spec:
                           migration.enabled=false to pin a guest in place — the SwiftMigration
                           validation webhook rejects migrations of pinned guests.
                         properties:
+                          drainPolicy:
+                            default: Migrate
+                            description: |-
+                              DrainPolicy controls how kubectl drain / the eviction API evacuates
+                              this guest off a node (Phase 4 drain integration):
+                                Migrate (default): mode=auto — live-migrate where possible,
+                                  offline-migrate (bounded downtime) for VFIO/GPU guests. Drain
+                                  always succeeds for an eligible guest.
+                                LiveMigrate: live only; if the guest cannot live-migrate
+                                  (VFIO/GPU), deny the drain rather than incur downtime.
+                                Block: always deny the drain; the operator handles the guest
+                                  manually.
+                              Orthogonal to Enabled (Enabled=false disables migration entirely and
+                              also denies drain). Has no effect until the Phase 4 eviction webhook
+                            enum:
+                            - Migrate
+                            - LiveMigrate
+                            - Block
+                            type: string
                           enabled:
                             default: true
                             description: |-

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -233,6 +233,25 @@ spec:
                   migration.enabled=false to pin a guest in place — the SwiftMigration
                   validation webhook rejects migrations of pinned guests.
                 properties:
+                  drainPolicy:
+                    default: Migrate
+                    description: |-
+                      DrainPolicy controls how kubectl drain / the eviction API evacuates
+                      this guest off a node (Phase 4 drain integration):
+                        Migrate (default): mode=auto — live-migrate where possible,
+                          offline-migrate (bounded downtime) for VFIO/GPU guests. Drain
+                          always succeeds for an eligible guest.
+                        LiveMigrate: live only; if the guest cannot live-migrate
+                          (VFIO/GPU), deny the drain rather than incur downtime.
+                        Block: always deny the drain; the operator handles the guest
+                          manually.
+                      Orthogonal to Enabled (Enabled=false disables migration entirely and
+                      also denies drain). Has no effect until the Phase 4 eviction webhook
+                    enum:
+                    - Migrate
+                    - LiveMigrate
+                    - Block
+                    type: string
                   enabled:
                     default: true
                     description: |-

--- a/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
@@ -301,6 +301,25 @@ spec:
                           migration.enabled=false to pin a guest in place — the SwiftMigration
                           validation webhook rejects migrations of pinned guests.
                         properties:
+                          drainPolicy:
+                            default: Migrate
+                            description: |-
+                              DrainPolicy controls how kubectl drain / the eviction API evacuates
+                              this guest off a node (Phase 4 drain integration):
+                                Migrate (default): mode=auto — live-migrate where possible,
+                                  offline-migrate (bounded downtime) for VFIO/GPU guests. Drain
+                                  always succeeds for an eligible guest.
+                                LiveMigrate: live only; if the guest cannot live-migrate
+                                  (VFIO/GPU), deny the drain rather than incur downtime.
+                                Block: always deny the drain; the operator handles the guest
+                                  manually.
+                              Orthogonal to Enabled (Enabled=false disables migration entirely and
+                              also denies drain). Has no effect until the Phase 4 eviction webhook
+                            enum:
+                            - Migrate
+                            - LiveMigrate
+                            - Block
+                            type: string
                           enabled:
                             default: true
                             description: |-

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -233,6 +233,25 @@ spec:
                   migration.enabled=false to pin a guest in place — the SwiftMigration
                   validation webhook rejects migrations of pinned guests.
                 properties:
+                  drainPolicy:
+                    default: Migrate
+                    description: |-
+                      DrainPolicy controls how kubectl drain / the eviction API evacuates
+                      this guest off a node (Phase 4 drain integration):
+                        Migrate (default): mode=auto — live-migrate where possible,
+                          offline-migrate (bounded downtime) for VFIO/GPU guests. Drain
+                          always succeeds for an eligible guest.
+                        LiveMigrate: live only; if the guest cannot live-migrate
+                          (VFIO/GPU), deny the drain rather than incur downtime.
+                        Block: always deny the drain; the operator handles the guest
+                          manually.
+                      Orthogonal to Enabled (Enabled=false disables migration entirely and
+                      also denies drain). Has no effect until the Phase 4 eviction webhook
+                    enum:
+                    - Migrate
+                    - LiveMigrate
+                    - Block
+                    type: string
                   enabled:
                     default: true
                     description: |-

--- a/docs/design/live-migration-phase-4.md
+++ b/docs/design/live-migration-phase-4.md
@@ -1,0 +1,197 @@
+# Live Migration Phase 4 — Drain Integration (Design)
+
+> Status: design-locked (decisions resolved 2026-06-02). Spike COMPLETE.
+> Implementation pending across the PRs in §9.
+
+## 1. Goal & non-goals
+
+**Goal.** `kubectl drain <node>` (and any eviction-API caller — cluster-
+autoscaler, node upgrades) **automatically and safely evacuates SwiftGuest
+VMs**: the guest is migrated off the node (live where possible, offline for
+VFIO/GPU), and the eviction is blocked until the guest is gone. A VM is
+**never evicted-to-death**.
+
+**Non-goals.**
+- No new migration *transport* (Phase 4 reuses the Phase 1 offline and
+  Phase 3a/b/c live paths verbatim).
+- No scheduler replacement — target selection is a simple capacity pick.
+- No multi-guest batch orchestration beyond "evacuate each guest on the
+  node independently."
+
+## 2. Spike findings (validated on cluster, miles/boba)
+
+A throwaway `pods/eviction` deny-webhook (`spike/phase-4-eviction-webhook`,
+NOT for merge) validated the core mechanism:
+
+- A `ValidatingWebhook` on `pods/eviction` **does** intercept `kubectl
+  drain`'s evictions.
+- **Denying with `429 TooManyRequests` makes drain retry every 5s** — the
+  same code path the eviction API uses for PodDisruptionBudget blocks —
+  cleanly, with no hard failure. drain output: `error when evicting ...
+  (will retry after 5s): admission webhook denied the request`.
+- Drain's default `--timeout` is **infinite** (retries until the pod is
+  gone), so a ~38s live migration + cutover fits comfortably; the webhook
+  just keeps denying until cutover deletes the source pod, after which the
+  next retry sees `pod not found` → allow → drain proceeds.
+- The webhook fires on **every** eviction cluster-wide; the handler
+  fast-allows non-guest pods via a cheap cached `Get`.
+
+These shape the design below (5s retry granularity is plenty; deny-with-429
+is the right primitive; the allow-after-cutover transition is automatic).
+
+## 3. Architecture — webhook marks, controller creates, PDB guarantees
+
+Three pieces:
+
+```
+ kubectl drain node-A
+        │  POST pods/eviction (every 5s)
+        ▼
+ ┌──────────────────────────┐    stamp drain-requested      ┌─────────────────────┐
+ │ Eviction webhook         │ ───────────────────────────►  │ SwiftGuest           │
+ │ (pods/eviction, CREATE)  │    on the SwiftGuest           │ (annotation marker)  │
+ │ - guest pod? deny(429)   │                               └──────────┬──────────┘
+ │ - non-guest/gone? allow  │                                          │ watch
+ └──────────────────────────┘                                          ▼
+        ▲  (eviction also blocked by)                        ┌─────────────────────┐
+        │                                                    │ Drain controller    │
+ ┌──────┴───────────────────┐                                │ - create Migration  │
+ │ per-guest PodDisruption  │                                │   (auto/live/offline)│
+ │ Budget (maxUnavailable:0)│                                │ - clear marker when  │
+ │ — the HARD guarantee     │                                │   guest off the node │
+ └──────────────────────────┘                                └─────────────────────┘
+```
+
+1. **Eviction webhook** (`pods/eviction` CREATE; `failurePolicy: Ignore`;
+   `sideEffects: NoneOnDryRun`). For a SwiftGuest launcher pod:
+   - migratable (`drainPolicy` ∈ {Migrate, LiveMigrate}, `migration.enabled
+     != false`) → stamp `kubeswift.io/drain-requested: <node>` on the
+     SwiftGuest (skip the patch on dry-run) and **deny (429, retry)**.
+   - `drainPolicy: Block` or `migration.enabled: false` → **deny (429)**
+     with a "cannot auto-migrate; handle manually" message (no marker, no
+     migration).
+   - not a SwiftGuest pod, or pod already gone → **allow**.
+
+2. **Drain controller** (watches SwiftGuests). On `drain-requested`
+   present and no migration in flight for the guest → create a
+   `SwiftMigration` (deterministic name) with the mode resolved from
+   `drainPolicy` (§4.3) and the target node from §4.2. Clears the marker
+   once the guest is off the draining node (migration Completed / source
+   pod gone).
+
+3. **Per-guest PodDisruptionBudget** (`maxUnavailable: 0`), created by the
+   SwiftGuest controller for protected guests. This is the **hard
+   guarantee, independent of the webhook**: the eviction API blocks on it.
+   The migration's cutover **`Delete`s** the source pod (a direct Delete,
+   not an eviction), which bypasses the PDB — so the guest moves and drain
+   proceeds. Failure modes (§7): webhook up → smart auto-migrate; webhook
+   DOWN → drain stalls **safely** (PDB still blocks; VM protected).
+
+## 4. Decisions resolved
+
+### 4.1 Webhook-marks / controller-creates (not webhook-creates)
+
+The webhook is a thin admission gate that persists a marker; all
+`SwiftMigration` creation lives in a controller. Keeps the webhook's
+side-effect minimal (one annotation patch, `NoneOnDryRun`) and the
+CR-creation logic in the reconcile loop where retries/races are natural.
+
+### 4.2 Defense-in-depth: webhook + per-guest PDB, `failurePolicy: Ignore`
+
+`failurePolicy: Ignore` so a webhook outage **never** breaks cluster-wide
+evictions. The `maxUnavailable: 0` PDB is the floor that protects the VM
+even when the webhook is down. (Rejected: webhook-only — a webhook outage
+either kills the VM (`Ignore`) or breaks all evictions (`Fail`).)
+
+### 4.3 Per-guest `spec.migration.drainPolicy`
+
+New field `spec.migration.drainPolicy`, enum, default `Migrate`:
+
+| Value | Drain behaviour |
+|---|---|
+| `Migrate` (default) | `mode=auto` — live where possible, **offline** (bounded downtime) for VFIO/GPU. Drain always succeeds. |
+| `LiveMigrate` | live only; if the guest can't live-migrate (VFIO/GPU), **deny the drain** (block) rather than incur downtime. |
+| `Block` | always deny the drain; operator handles the guest manually. |
+
+`migration.enabled: false` is orthogonal and stronger — it disables
+migration entirely; drain denies with a manual-handling message.
+
+### 4.4 Target-node selection
+
+The drain controller picks the schedulable peer node (excluding the
+draining/cordoned node) with the most headroom, reusing the offline-path
+`checkNodeCapacity`. **No schedulable target** → keep denying with a "no
+target with capacity" message (drain stalls safely; operator frees
+capacity or `--force`s).
+
+### 4.5 Consumes TFU #24 (the `lifecycle: run` freeze)
+
+Drain is the canonical **stop-during-migration** path: an eviction-driven
+stop could coincide with a live migration's dst receiver. The W-3c-1
+`lifecycle: run` freeze on the dst intent (tracked as TFU #24, deferred
+through Phase 3c as not-reachable) **must land here** — Phase 4 is where it
+becomes reachable. See TFU #24 + `dst_pod.go::newDstPod`.
+
+## 5. CRD change
+
+`api/swift/v1alpha1` — add to `MigrationSpec`:
+
+```go
+// DrainPolicy controls how kubectl drain / the eviction API evacuates
+// this guest. +kubebuilder:validation:Enum=Migrate;LiveMigrate;Block
+// +kubebuilder:default=Migrate
+DrainPolicy string `json:"drainPolicy,omitempty"`
+```
+
+Requires `make generate` + chart CRD sync (per the recurring lesson:
+enum fields must be regenerated, not just constant-added — Phase 3c PR 5).
+
+## 6. RBAC
+
+- Webhook: `pods/eviction` admission; `get` pods; `get,patch` swiftguests
+  (the marker).
+- Drain controller: `get,list,watch,patch` swiftguests; `create,get,list`
+  swiftmigrations; `get,list,watch` nodes + pods (target capacity);
+  `create,get,update,delete` poddisruptionbudgets (policy/v1).
+- Cached-client `list,watch` on every GET-ed resource (the W7/W8 lesson —
+  poddisruptionbudgets + nodes need `list,watch`, not just `get`).
+
+## 7. Failure modes
+
+| Mode | Behaviour |
+|---|---|
+| Webhook up, migratable guest | mark → migrate → cutover deletes src → drain proceeds |
+| Webhook **down** (`Ignore`) | admission skipped → PDB still blocks the eviction (429) → drain stalls safely; VM protected; no auto-migration (operator notices, investigates) |
+| No schedulable target | webhook keeps denying with a clear message; drain stalls; operator frees capacity |
+| Migration fails mid-drain | marker stays; controller surfaces the failure on the SwiftMigration; webhook keeps denying (VM unharmed — live pre-copy never pauses the source) |
+| `drainPolicy: Block` / `migration.enabled=false` | deny with manual-handling message; operator `--force`s or moves manually |
+| Dry-run eviction (`drain --dry-run`) | webhook denies (shows it would block) but skips the marker patch (`NoneOnDryRun`) |
+
+## 8. Open implementation sub-decisions
+
+- **PDB scope:** create for migratable guests (and `Block` guests, for the
+  same hard protection) — but NOT before the launcher pod exists, and
+  clean up via ownerRef on guest delete. SwiftGuestPool replicas: per-pod
+  PDB vs pool-level; per-pod is simpler and uniform.
+- **Marker on the SwiftGuest vs the pod:** the SwiftGuest (survives the
+  cutover pod rename; the controller already reconciles it).
+- **Re-drain idempotency:** the deterministic SwiftMigration name +
+  `migration-in-progress` annotation (Phase 1) prevent duplicate
+  migrations across the 5s eviction retries.
+
+## 9. Implementation plan (PRs)
+
+1. **PR 1** — this design doc + the `drainPolicy` CRD field (+ generate +
+   chart sync). Design + API surface only; reviewable in isolation.
+2. **PR 2** — the TFU #24 `lifecycle: run` freeze on the dst intent (now
+   reachable: Phase 4 introduces the stop-during-migration path). Split
+   out because it touches `newDstPod` / dst-pod construction and is
+   logically independent of drain. Can land in parallel with PR 3.
+3. **PR 3** — the eviction webhook (`pods/eviction` admission handler, VWC
+   rule, `failurePolicy: Ignore`, marker patch with dry-run skip) + RBAC.
+   Unit-tested; no controller yet (marker is inert).
+4. **PR 4** — the drain controller (marker → SwiftMigration → clear) +
+   per-guest PDB creation in the SwiftGuest controller + target selection.
+5. **PR 5** — cluster walkthrough (drain miles → guest live-migrates to
+   boba → drain completes; VFIO-offline path; Block deny; webhook-down PDB
+   safety) + operator runbook (`docs/migration/phase-4.md`).


### PR DESCRIPTION
## Summary

PR 1 of **Phase 4 (drain integration)** — the next live-migration phase, now that Phase 3c (mTLS, #79–86) is landed. Design + API surface only; reviewable in isolation.

`kubectl drain <node>` (and any eviction-API caller) will **auto-evacuate SwiftGuest VMs** by migrating them off the node, blocking the eviction until the guest is gone — a VM is **never evicted-to-death**.

## What's in it

- **`docs/design/live-migration-phase-4.md`** — the design doc. Architecture (decisions resolved with the maintainer):
  - **Webhook-marks / controller-creates:** a `pods/eviction` webhook stamps a `drain-requested` marker on the SwiftGuest + denies (429, retry); a drain controller reconciles the marker into a `SwiftMigration`.
  - **Per-guest PDB defense-in-depth:** a `maxUnavailable: 0` PodDisruptionBudget is the hard guarantee independent of the webhook. The migration's cutover `Delete`s the source pod (bypasses the PDB), so the guest moves and drain proceeds.
  - **`failurePolicy: Ignore`** so a webhook outage never breaks cluster-wide evictions — the PDB still protects the VM (drain stalls *safely*).
  - **Consumes TFU #24** (the `lifecycle: run` freeze — drain is exactly the stop-during-migration path it defends).
- **`spec.migration.drainPolicy`** enum (`Migrate` default / `LiveMigrate` / `Block`): `Migrate` = auto (live, offline for VFIO); `LiveMigrate` = live-only-or-deny; `Block` = always deny the drain. Inert until the webhook + controller ship. CRD regenerated + chart synced (the enum-field lesson from Phase 3c PR 5).

## Spike (validated, not in this PR)

A throwaway `pods/eviction` deny-webhook (`spike/phase-4-eviction-webhook`, **not for merge**) validated the core mechanism on the cluster: the webhook **does** intercept `kubectl drain`, and denying with `429 TooManyRequests` makes drain **retry every 5s** cleanly; drain's default `--timeout` is infinite, so a ~38s migration fits, and the allow-after-cutover transition is automatic. Findings folded into design §2.

## Implementation plan (design §9)

1. **PR 1 (this)** — design + `drainPolicy` CRD field.
2. PR 2 — TFU #24 `lifecycle: run` freeze (now reachable).
3. PR 3 — eviction webhook + RBAC (marker inert until PR 4).
4. PR 4 — drain controller + per-guest PDB + target selection.
5. PR 5 — cluster walkthrough + operator runbook.

## Test plan

- [x] `make generate` + chart sync; `verify-crd-sync` passes; `drainPolicy` present in the swiftguests + swiftguestpools CRDs.
- [x] `go build ./...` / `go test ./...` pass.

## Note for review

The design's **universal `maxUnavailable: 0` PDB** is a real behavior change for protected guests: they become un-evictable except via migration (cluster-autoscaler / node-upgrade evictions of VMs block until a migration moves them). That's the correct VM-platform posture (a VM platform shouldn't let infra churn kill VMs), but it's a notable default worth a deliberate ack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)