### PR TITLE
feat(migration): Phase 4 PR 2 — freeze dst intent to lifecycle:run (TFU #24 / W-3c-1)

### DIFF
--- a/internal/controller/swiftmigration/dst_pod.go
+++ b/internal/controller/swiftmigration/dst_pod.go
@@ -167,6 +167,7 @@ func newDstPod(
 	srcPod *corev1.Pod,
 	scheme *runtime.Scheme,
 	sidecar dstSidecarConfig,
+	frozenIntentCMName string,
 ) (*corev1.Pod, error) {
 	name, err := dstPodName(mig, guest.Name)
 	if err != nil {
@@ -200,6 +201,15 @@ func newDstPod(
 	// Add KUBESWIFT_MIGRATION_ROLE=receiver to the launcher container.
 	if err := addReceiverEnvToLauncher(pod); err != nil {
 		return nil, err
+	}
+
+	// W-3c-1 / TFU #24: repoint the runtime-intent volume at the FROZEN
+	// per-migration intent CM (lifecycle: start), so a stop-during-migration
+	// flip of the live `<guest>-runtime-intent` CM cannot poison the dst
+	// receiver's launch gate. Empty name (tests / pre-freeze callers) leaves
+	// the inherited live CM in place.
+	if frozenIntentCMName != "" {
+		repointRuntimeIntentVolume(pod, frozenIntentCMName)
 	}
 
 	// Phase 3c (Option B): inject the destination stunnel sidecar (TLS

--- a/internal/controller/swiftmigration/dst_pod_test.go
+++ b/internal/controller/swiftmigration/dst_pod_test.go
@@ -113,7 +113,7 @@ func TestNewDstPod_SetsNameLabelsAnnotationsEnvNodeName(t *testing.T) {
 	}
 	src := templateSrcPod("guest", "default")
 
-	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{})
+	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, "")
 	if err != nil {
 		t.Fatalf("newDstPod: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestNewDstPod_NoLauncherContainer_Errors(t *testing.T) {
 	src := templateSrcPod("guest", "default")
 	src.Spec.Containers[0].Name = "not-launcher"
 
-	if _, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}); err == nil {
+	if _, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, ""); err == nil {
 		t.Errorf("expected error when launcher container is missing")
 	}
 }
@@ -234,7 +234,7 @@ func TestNewDstPod_MTLS_InjectsServerSidecar(t *testing.T) {
 		mtlsEnabled: true,
 		srcNodeName: "boba",  // source node — dst pins this SAN
 		dstNodeName: "miles", // destination node — dst presents this identity
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("newDstPod (mTLS): %v", err)
 	}
@@ -327,7 +327,7 @@ func TestNewDstPod_MTLS_FlipsInheritedClientSidecarToServer(t *testing.T) {
 
 	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
 		mtlsEnabled: true, srcNodeName: "boba", dstNodeName: "miles",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("newDstPod: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestNewDstPod_MTLS_OmitsPlaintextAck(t *testing.T) {
 	}
 	src := templateSrcPod("guest", "default")
 
-	off, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{})
+	off, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, "")
 	if err != nil {
 		t.Fatalf("newDstPod (plaintext): %v", err)
 	}
@@ -394,7 +394,7 @@ func TestNewDstPod_MTLS_OmitsPlaintextAck(t *testing.T) {
 
 	on, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
 		mtlsEnabled: true, srcNodeName: "boba", dstNodeName: "miles",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("newDstPod (mTLS): %v", err)
 	}
@@ -416,7 +416,7 @@ func TestNewDstPod_MTLS_EmptyNode_Errors(t *testing.T) {
 		mtlsEnabled: true,
 		srcNodeName: "", // unresolved
 		dstNodeName: "miles",
-	}); err == nil {
+	}, ""); err == nil {
 		t.Errorf("expected error when mTLS enabled but source node name empty")
 	}
 }

--- a/internal/controller/swiftmigration/frozen_intent.go
+++ b/internal/controller/swiftmigration/frozen_intent.go
@@ -1,0 +1,172 @@
+package swiftmigration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
+)
+
+// W-3c-1 / TFU #24 — freeze the destination runtime intent to lifecycle:run.
+//
+// The destination launcher pod is built by srcPod.DeepCopy() (newDstPod),
+// so it inherits the source pod's runtime-intent volume pointing at the
+// LIVE, controller-managed `<guest>-runtime-intent` ConfigMap. If the
+// SwiftGuest is stopped (runPolicy: Stopped) while a migration is in flight
+// — the canonical stop-during-migration race that Phase 4 drain makes
+// reachable — the SwiftGuest controller rewrites that CM to lifecycle:stop,
+// and swiftletd's launch gate (main.rs:201) honors `lifecycle == "stop"`
+// for ALL launch paths, INCLUDING migration_receiver_mode (the receiver
+// role is an env var, not an exemption). The dst receiver would then skip
+// its launch and the migration's receive would fail.
+//
+// The fix: the dst pod mounts a FROZEN per-migration intent ConfigMap with
+// lifecycle forced to "start", which the SwiftGuest controller never
+// writes (it manages only `<guest>-runtime-intent`). A later flip of the
+// live CM to lifecycle:stop cannot reach the dst receiver.
+//
+// Post-cutover correctness is unaffected: swiftletd reads the intent once
+// at boot, so a post-migration stop takes effect via pod deletion (graceful
+// stop), not via re-reading the intent — the frozen CM is a boot-time-only
+// artifact. Pod recreations after the migration use the live CM
+// (guest.Name pods mount `<guest>-runtime-intent`).
+
+// runtimeIntentVolumeName is the launcher pod's runtime-intent ConfigMap
+// volume name (matches swiftguest/pod.go's literal). The dst pod inherits
+// it via DeepCopy; the freeze repoints it.
+const runtimeIntentVolumeName = "runtime-intent"
+
+// repointRuntimeIntentVolume sets the pod's runtime-intent ConfigMap volume
+// to mount frozenCMName instead of the inherited live
+// `<guest>-runtime-intent`. No-op if the pod has no such volume (defensive;
+// every launcher pod has one).
+func repointRuntimeIntentVolume(pod *corev1.Pod, frozenCMName string) {
+	for i := range pod.Spec.Volumes {
+		v := &pod.Spec.Volumes[i]
+		if v.Name == runtimeIntentVolumeName && v.ConfigMap != nil {
+			v.ConfigMap.Name = frozenCMName
+			return
+		}
+	}
+}
+
+// frozenDstIntentCMName returns the deterministic name of the frozen
+// per-migration intent ConfigMap for a given destination pod. Keyed off the
+// dst pod name (itself deterministic from the SwiftMigration UID), so
+// re-entry on leader handover ensures/repoints the same CM.
+func frozenDstIntentCMName(dstPodName string) string {
+	return dstPodName + swiftguest.IntentConfigMapSuffix
+}
+
+// ensureFrozenDstIntent mints (idempotently) the frozen destination intent
+// ConfigMap: a copy of the guest's live `<guest>-runtime-intent` with the
+// runtime-intent.json `lifecycle` field forced to "start". Owned by the
+// SwiftGuest (GC'd on guest delete). Returns the frozen CM name for
+// newDstPod to repoint the dst pod's runtime-intent volume at.
+//
+// Must be called BEFORE the dst pod is created (the pod mounts this CM).
+func (r *SwiftMigrationReconciler) ensureFrozenDstIntent(
+	ctx context.Context,
+	guest *swiftv1alpha1.SwiftGuest,
+	dstPodName string,
+) (string, error) {
+	liveName := guest.Name + swiftguest.IntentConfigMapSuffix
+	var live corev1.ConfigMap
+	if err := r.Get(ctx, types.NamespacedName{Namespace: guest.Namespace, Name: liveName}, &live); err != nil {
+		if apierrors.IsNotFound(err) {
+			// No live intent CM to copy (shouldn't happen for a running
+			// guest). Skip the freeze gracefully: return "" so newDstPod
+			// leaves the inherited volume in place (pre-freeze behaviour).
+			// The freeze is defense-in-depth; not blocking the migration on
+			// a missing CM is preferable, and the inherited volume points
+			// at the same name anyway.
+			logf.FromContext(ctx).Info("frozen dst intent skipped: live runtime-intent CM not found",
+				"configMap", liveName, "guest", guest.Name)
+			return "", nil
+		}
+		return "", fmt.Errorf("get live runtime-intent ConfigMap %q: %w", liveName, err)
+	}
+
+	frozenData, err := forceLifecycleStart(live.Data)
+	if err != nil {
+		return "", fmt.Errorf("freeze runtime intent lifecycle: %w", err)
+	}
+
+	frozenName := frozenDstIntentCMName(dstPodName)
+	key := types.NamespacedName{Namespace: guest.Namespace, Name: frozenName}
+	var existing corev1.ConfigMap
+	gerr := r.Get(ctx, key, &existing)
+	if gerr == nil {
+		if equality.Semantic.DeepEqual(existing.Data, frozenData) {
+			return frozenName, nil
+		}
+		existing.Data = frozenData
+		if uerr := r.Update(ctx, &existing); uerr != nil {
+			return "", fmt.Errorf("update frozen intent ConfigMap %q: %w", frozenName, uerr)
+		}
+		return frozenName, nil
+	}
+	if !apierrors.IsNotFound(gerr) {
+		return "", fmt.Errorf("get frozen intent ConfigMap %q: %w", frozenName, gerr)
+	}
+
+	frozen := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      frozenName,
+			Namespace: guest.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "kubeswift",
+				"app.kubernetes.io/component":  "migration",
+				"app.kubernetes.io/managed-by": "kubeswift-controller-manager",
+			},
+		},
+		Data: frozenData,
+	}
+	if serr := controllerutil.SetControllerReference(guest, frozen, r.Scheme); serr != nil {
+		return "", fmt.Errorf("set ownerRef on frozen intent ConfigMap %q: %w", frozenName, serr)
+	}
+	if cerr := r.Create(ctx, frozen); cerr != nil {
+		if apierrors.IsAlreadyExists(cerr) {
+			return frozenName, nil
+		}
+		return "", fmt.Errorf("create frozen intent ConfigMap %q: %w", frozenName, cerr)
+	}
+	return frozenName, nil
+}
+
+// forceLifecycleStart returns a copy of the intent ConfigMap data with the
+// runtime-intent.json `lifecycle` field set to "start" (the canonical run
+// value; swiftletd's gate only skips on "stop"). Other keys/fields are
+// preserved verbatim. The intent is parsed as a generic object so this does
+// not depend on the full RuntimeIntent struct shape.
+func forceLifecycleStart(data map[string]string) (map[string]string, error) {
+	out := make(map[string]string, len(data))
+	for k, v := range data {
+		out[k] = v
+	}
+	raw, ok := out[swiftguest.IntentFile]
+	if !ok {
+		return nil, fmt.Errorf("live intent ConfigMap missing key %q", swiftguest.IntentFile)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
+		return nil, fmt.Errorf("unmarshal %q: %w", swiftguest.IntentFile, err)
+	}
+	obj["lifecycle"] = json.RawMessage(`"start"`)
+	frozen, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("marshal frozen intent: %w", err)
+	}
+	out[swiftguest.IntentFile] = string(frozen)
+	return out, nil
+}

--- a/internal/controller/swiftmigration/frozen_intent_test.go
+++ b/internal/controller/swiftmigration/frozen_intent_test.go
@@ -1,0 +1,148 @@
+package swiftmigration
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
+)
+
+func TestForceLifecycleStart_ForcesStartPreservesRest(t *testing.T) {
+	in := map[string]string{
+		swiftguest.IntentFile: `{"lifecycle":"stop","cpu":2,"network":true}`,
+		"unrelated":           "x",
+	}
+	out, err := forceLifecycleStart(in)
+	if err != nil {
+		t.Fatalf("forceLifecycleStart: %v", err)
+	}
+	if out["unrelated"] != "x" {
+		t.Errorf("unrelated key not preserved")
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(out[swiftguest.IntentFile]), &obj); err != nil {
+		t.Fatalf("unmarshal frozen: %v", err)
+	}
+	if obj["lifecycle"] != "start" {
+		t.Errorf("lifecycle: want start, got %v", obj["lifecycle"])
+	}
+	if obj["cpu"] != float64(2) {
+		t.Errorf("cpu field not preserved: %v", obj["cpu"])
+	}
+	if obj["network"] != true {
+		t.Errorf("network field not preserved: %v", obj["network"])
+	}
+	// Input not mutated.
+	if in[swiftguest.IntentFile] != `{"lifecycle":"stop","cpu":2,"network":true}` {
+		t.Errorf("input map was mutated")
+	}
+}
+
+func TestForceLifecycleStart_MissingKey_Errors(t *testing.T) {
+	if _, err := forceLifecycleStart(map[string]string{"x": "y"}); err == nil {
+		t.Errorf("expected error when the intent key is absent")
+	}
+}
+
+func TestEnsureFrozenDstIntent_CreatesFrozenStartCM(t *testing.T) {
+	scheme := testScheme(t)
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"}}
+	live := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest" + swiftguest.IntentConfigMapSuffix, Namespace: "default"},
+		Data:       map[string]string{swiftguest.IntentFile: `{"lifecycle":"stop","cpu":2}`},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, live).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme}
+	ctx := context.Background()
+
+	name, err := r.ensureFrozenDstIntent(ctx, guest, "guest-mig-abcdef")
+	if err != nil {
+		t.Fatalf("ensureFrozenDstIntent: %v", err)
+	}
+	want := "guest-mig-abcdef" + swiftguest.IntentConfigMapSuffix
+	if name != want {
+		t.Errorf("frozen CM name: want %q, got %q", want, name)
+	}
+
+	var frozen corev1.ConfigMap
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "default", Name: name}, &frozen); err != nil {
+		t.Fatalf("get frozen CM: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(frozen.Data[swiftguest.IntentFile]), &obj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if obj["lifecycle"] != "start" {
+		t.Errorf("frozen lifecycle: want start (not the live's stop), got %v", obj["lifecycle"])
+	}
+	if len(frozen.OwnerReferences) != 1 || frozen.OwnerReferences[0].Name != "guest" {
+		t.Errorf("frozen CM must be guest-owned; got %+v", frozen.OwnerReferences)
+	}
+	// Idempotent.
+	if _, err := r.ensureFrozenDstIntent(ctx, guest, "guest-mig-abcdef"); err != nil {
+		t.Errorf("idempotent ensure errored: %v", err)
+	}
+}
+
+func TestEnsureFrozenDstIntent_MissingLiveCM_SkipsGracefully(t *testing.T) {
+	scheme := testScheme(t)
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme}
+
+	name, err := r.ensureFrozenDstIntent(context.Background(), guest, "guest-mig-abcdef")
+	if err != nil {
+		t.Fatalf("missing live CM must not error (graceful skip); got %v", err)
+	}
+	if name != "" {
+		t.Errorf("missing live CM must skip the freeze (empty name); got %q", name)
+	}
+}
+
+func TestNewDstPod_RepointsRuntimeIntentVolume(t *testing.T) {
+	scheme := testScheme(t)
+	mig := newMigrationWithUID("mig-a", "default", "abcdef1234567890abcdef1234567890")
+	mig.Spec.Target.NodeName = "miles"
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"}}
+	src := templateSrcPod("guest", "default")
+	// Source carries the runtime-intent volume pointing at the live CM.
+	src.Spec.Volumes = append(src.Spec.Volumes, corev1.Volume{
+		Name: runtimeIntentVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "guest" + swiftguest.IntentConfigMapSuffix},
+			},
+		},
+	})
+
+	frozenName := "guest-mig-abcdef" + swiftguest.IntentConfigMapSuffix
+	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, frozenName)
+	if err != nil {
+		t.Fatalf("newDstPod: %v", err)
+	}
+	if got := intentVolumeCM(dst); got != frozenName {
+		t.Errorf("runtime-intent volume should be repointed to the frozen CM %q; got %q", frozenName, got)
+	}
+
+	// Empty frozen name leaves the inherited live CM in place.
+	dst2, _ := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, "")
+	if got := intentVolumeCM(dst2); got != "guest"+swiftguest.IntentConfigMapSuffix {
+		t.Errorf("empty frozen name must leave the live CM; got %q", got)
+	}
+}
+
+func intentVolumeCM(pod *corev1.Pod) string {
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == runtimeIntentVolumeName && v.ConfigMap != nil {
+			return v.ConfigMap.Name
+		}
+	}
+	return ""
+}

--- a/internal/controller/swiftmigration/preparing_live.go
+++ b/internal/controller/swiftmigration/preparing_live.go
@@ -152,11 +152,19 @@ func (r *SwiftMigrationReconciler) handlePreparingLive(
 		// Validating-live verified the guest is scheduled and the target
 		// node exists, and (when mTLS is on) distributed both identity
 		// Secrets into this namespace.
+		// W-3c-1 / TFU #24: mint the frozen lifecycle:run intent CM the dst
+		// pod will mount, BEFORE creating the pod. A stop-during-migration
+		// flip of the live `<guest>-runtime-intent` CM then cannot poison
+		// the dst receiver's launch gate.
+		frozenIntentCM, frozenErr := r.ensureFrozenDstIntent(ctx, &guest, expectedDstName)
+		if frozenErr != nil {
+			return phaseTransient(fmt.Errorf("ensure frozen dst intent: %w", frozenErr))
+		}
 		dst, buildErr := newDstPod(mig, &guest, &srcPod, r.Scheme, dstSidecarConfig{
 			mtlsEnabled: r.MigrationMTLSEnabled,
 			srcNodeName: guest.Status.NodeName,
 			dstNodeName: mig.Spec.Target.NodeName,
-		})
+		}, frozenIntentCM)
 		if buildErr != nil {
 			return phaseFailure(
 				fmt.Sprintf("construct dst pod: %v", buildErr),

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -1264,7 +1264,19 @@ edit on a Ready image is allowed while a genuine spec change is still
 rejected. Deferred from branch fix/tfu-17 to keep that change scoped to
 the HIGH-severity trap (TFU #17). Surfaced 2026-05-29 by the PR C recon.
 
-### 24. W-3c-1 `lifecycle: run` freeze on the migration dst pod — deferred (defense-in-depth, not needed by the current live flow)
+### 24. W-3c-1 `lifecycle: run` freeze on the migration dst pod — RESOLVED in Phase 4 PR 2
+
+**RESOLVED** (Phase 4 PR 2, `feat/phase-4-intent-freeze`). The freeze
+landed once Phase 4 made the stop-during-migration path reachable. The
+migration controller now mints a frozen per-migration intent ConfigMap
+(`<dstpod>-runtime-intent`, lifecycle forced to `start`, owned by the
+SwiftGuest) at Preparing-live via `ensureFrozenDstIntent`, and `newDstPod`
+repoints the dst pod's `runtime-intent` volume at it
+([`frozen_intent.go`](internal/controller/swiftmigration/frozen_intent.go)).
+A stop-during-migration flip of the live `<guest>-runtime-intent` CM can no
+longer poison the dst receiver's launch gate. Graceful skip if the live CM
+is absent (defense-in-depth, not a blocker). Original deferral rationale
+preserved below for context.
 
 Phase 3c PR 3 (destination-side mTLS wiring, PR #81) deliberately did
 NOT implement the design doc §4.1 / §8-invariant-#4 `lifecycle: run`


### PR DESCRIPTION
## Summary

PR 2 of Phase 4. Implements the **W-3c-1 / TFU #24** `lifecycle: run` freeze on the destination intent — deferred through Phase 3c as "not reachable in the controller-driven flow," now landed because **Phase 4 drain introduces the stop-during-migration path** it defends against.

## The bug it closes

The dst launcher pod is built by `srcPod.DeepCopy()` (`newDstPod`), so it inherits the `runtime-intent` volume pointing at the **live**, controller-managed `<guest>-runtime-intent` ConfigMap. If the guest is stopped (`runPolicy: Stopped`) **mid-migration** (e.g. a drain-coincident stop), the SwiftGuest controller rewrites that CM to `lifecycle: stop`, and swiftletd's launch gate (`main.rs:201`) honors `lifecycle == "stop"` for **all** launch paths **including `migration_receiver_mode`** (the receiver role is an env var, not an exemption — confirmed in the source). The dst receiver would skip its launch and the migration's receive would fail.

## The fix

- **`ensureFrozenDstIntent`** (called at Preparing-live, before the dst pod is created): mints a frozen per-migration intent CM `<dstpod>-runtime-intent`, a copy of the live CM with `lifecycle` forced to `"start"`, owned by the SwiftGuest (GC'd on delete). Idempotent; **gracefully skips** if the live CM is absent (defense-in-depth, never blocks the migration).
- **`newDstPod`** repoints the dst pod's `runtime-intent` volume at the frozen CM. A later flip of the live CM to `lifecycle: stop` can no longer reach the dst receiver.
- **Post-cutover correctness unaffected:** swiftletd reads the intent once at boot, so a post-migration stop takes effect via pod deletion (graceful stop), not via re-reading the intent — the frozen CM is a boot-time-only artifact, and pod recreations after the migration use the live CM.

## Test plan

- [x] `gofmt` / `go vet` / `go build ./...` / `go test ./...` pass.
- [x] No RBAC change (configmaps verbs already present).
- [x] New tests: `forceLifecycleStart` (forces `start`, preserves other fields, no input mutation, errors on missing key); `ensureFrozenDstIntent` (creates a frozen `start` CM owned by the guest, idempotent, graceful skip on missing live CM); `newDstPod` repoints the `runtime-intent` volume (and leaves it on `""`).
- [x] Existing dst-pod / preparing-live tests updated for the new `newDstPod` arg.

## Phase 4 progress

- ✅ PR 1 (#87) — design + `drainPolicy` CRD field.
- ✅ **PR 2 (this)** — TFU #24 freeze.
- ⬜ PR 3 — eviction webhook + RBAC.
- ⬜ PR 4 — drain controller + per-guest PDB + target selection.
- ⬜ PR 5 — cluster walkthrough + operator runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)