### PR TITLE
Phase 4 PR 3 — pods/eviction webhook (drain marks guest)

### DIFF
--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -145,6 +145,52 @@ type MigrationSpec struct {
 	DrainPolicy string `json:"drainPolicy,omitempty"`
 }
 
+// DrainPolicy values for MigrationSpec.DrainPolicy (Phase 4 drain
+// integration). Kept in sync with the +kubebuilder:validation:Enum marker
+// above.
+const (
+	// DrainPolicyMigrate (default) evacuates the guest with mode=auto: live
+	// where possible, offline (bounded downtime) for VFIO/GPU. Drain always
+	// succeeds for an eligible guest.
+	DrainPolicyMigrate = "Migrate"
+	// DrainPolicyLiveMigrate evacuates live only; a guest that cannot
+	// live-migrate (VFIO/GPU) blocks the drain rather than incur downtime.
+	DrainPolicyLiveMigrate = "LiveMigrate"
+	// DrainPolicyBlock always blocks the drain; the operator handles the
+	// guest manually.
+	DrainPolicyBlock = "Block"
+)
+
+// AnnotationDrainRequested, when present on a SwiftGuest, carries the name
+// of the node being drained. The Phase 4 eviction webhook stamps it when it
+// intercepts an eviction of the guest's launcher pod; the Phase 4 drain
+// controller consumes it to create a SwiftMigration off that node and
+// clears it once the guest has moved. Inert until the drain controller
+// ships.
+const AnnotationDrainRequested = "kubeswift.io/drain-requested"
+
+// HasVFIODevices reports whether the guest references VFIO passthrough
+// devices (GPU via gpuProfileRef, or any SR-IOV interface). VFIO devices
+// cannot live-migrate cross-node — the destination Cloud Hypervisor has no
+// equivalent host device to receive the guest's device state — so a guest
+// with VFIO devices can only be moved by an offline (release-and-reallocate)
+// migration.
+//
+// This is the canonical predicate. The SwiftMigration controller
+// (auto_mode.go) and validation webhook (validator.go) carry the same check
+// inline (a package-cycle workaround that predates this method).
+func (g *SwiftGuest) HasVFIODevices() bool {
+	if g.Spec.GPUProfileRef != nil {
+		return true
+	}
+	for _, iface := range g.Spec.Interfaces {
+		if iface.Type == InterfaceTypeSRIOV {
+			return true
+		}
+	}
+	return false
+}
+
 // DataDiskRef references either a SwiftImage or a PVC for a data disk.
 type DataDiskRef struct {
 	// Name identifies this data disk (used for volume naming).

--- a/charts/kubeswift/templates/webhook/validating-webhook.yaml
+++ b/charts/kubeswift/templates/webhook/validating-webhook.yaml
@@ -95,4 +95,26 @@ webhooks:
         apiGroups: ["migration.kubeswift.io"]
         apiVersions: ["v1alpha1"]
         resources: ["swiftmigrations"]
+  # Phase 4 drain integration. Fires on EVERY pod eviction cluster-wide; the
+  # handler fast-allows any pod that is not a SwiftGuest launcher pod.
+  # failurePolicy: Ignore so a webhook outage never breaks evictions (the
+  # per-guest PodDisruptionBudget is the hard floor). sideEffects:
+  # NoneOnDryRun because the handler stamps a drain-requested marker on the
+  # SwiftGuest (skipped on dry-run).
+  - name: veviction.kubeswift.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: NoneOnDryRun
+    failurePolicy: Ignore
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    clientConfig:
+      service:
+        namespace: {{ .Values.namespace }}
+        name: kubeswift-webhook-service
+        path: /validate-pods-eviction
+    rules:
+      - operations: [CREATE]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods/eviction"]
 {{- end }}

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftsnapshot"
 	"github.com/projectbeskar/kubeswift/internal/scheme"
 	"github.com/projectbeskar/kubeswift/internal/version"
+	evictionwebhook "github.com/projectbeskar/kubeswift/internal/webhook/eviction"
 	swiftguestwebhook "github.com/projectbeskar/kubeswift/internal/webhook/swiftguest"
 	swiftimagewebhook "github.com/projectbeskar/kubeswift/internal/webhook/swiftimage"
 	swiftmigrationwebhook "github.com/projectbeskar/kubeswift/internal/webhook/swiftmigration"
@@ -262,6 +263,14 @@ func main() {
 			klog.ErrorS(err, "unable to create SwiftMigration webhook")
 			os.Exit(1)
 		}
+		// Phase 4 drain integration: raw admission handler on pods/eviction
+		// (not a CRD validator, so registered directly on the webhook-server
+		// path). The VWC entry uses failurePolicy: Ignore — a webhook outage
+		// must never break cluster-wide evictions; the per-guest PDB is the
+		// hard floor that protects VMs when the webhook is down.
+		mgr.GetWebhookServer().Register("/validate-pods-eviction",
+			&webhook.Admission{Handler: &evictionwebhook.Handler{Client: mgr.GetClient()}})
+		klog.InfoS("registered pods/eviction webhook at /validate-pods-eviction")
 	}
 
 	klog.InfoS("starting manager", "version", version.Version, "git", version.GitCommit)

--- a/config/webhook/validating-webhook.yaml
+++ b/config/webhook/validating-webhook.yaml
@@ -66,3 +66,25 @@ webhooks:
         apiGroups: ["migration.kubeswift.io"]
         apiVersions: ["v1alpha1"]
         resources: ["swiftmigrations"]
+  # Phase 4 drain integration. Fires on EVERY pod eviction cluster-wide; the
+  # handler fast-allows any pod that is not a SwiftGuest launcher pod.
+  # failurePolicy: Ignore so a webhook outage never breaks evictions (the
+  # per-guest PodDisruptionBudget is the hard floor). sideEffects:
+  # NoneOnDryRun because the handler stamps a drain-requested marker on the
+  # SwiftGuest (skipped on dry-run).
+  - name: veviction.kubeswift.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: NoneOnDryRun
+    failurePolicy: Ignore
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    clientConfig:
+      service:
+        namespace: kubeswift-system
+        name: kubeswift-webhook-service
+        path: /validate-pods-eviction
+    rules:
+      - operations: [CREATE]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods/eviction"]

--- a/internal/controller/swiftmigration/auto_mode.go
+++ b/internal/controller/swiftmigration/auto_mode.go
@@ -97,17 +97,9 @@ func (r *SwiftMigrationReconciler) resolveAutoMode(
 // node; the receiver CH would have no equivalent device on the
 // destination.
 //
-// Mirrors the webhook's check (validator.go line 418-424). Duplicated
-// rather than imported because the webhook lives in a separate package
-// and importing the webhook from the controller would create a cycle.
+// Delegates to the canonical SwiftGuest.HasVFIODevices predicate in
+// api/swift/v1alpha1 (the cycle-free home). Kept as a package-local thunk
+// so existing call sites and tests are unaffected.
 func hasVFIODevices(guest *swiftv1alpha1.SwiftGuest) bool {
-	if guest.Spec.GPUProfileRef != nil {
-		return true
-	}
-	for _, iface := range guest.Spec.Interfaces {
-		if iface.Type == swiftv1alpha1.InterfaceTypeSRIOV {
-			return true
-		}
-	}
-	return false
+	return guest.HasVFIODevices()
 }

--- a/internal/webhook/eviction/handler.go
+++ b/internal/webhook/eviction/handler.go
@@ -1,0 +1,184 @@
+// Package eviction is the Phase 4 drain-integration eviction webhook.
+//
+// It is a raw admission handler on pods/eviction (NOT a CRD validator) that
+// makes `kubectl drain` (and any eviction-API caller — cluster-autoscaler,
+// node upgrades) safely evacuate SwiftGuest VMs instead of killing them.
+//
+// For a SwiftGuest launcher pod the handler, per the guest's drain policy:
+//   - migratable (drainPolicy Migrate/LiveMigrate, migration.enabled != false)
+//     → stamps the kubeswift.io/drain-requested marker on the SwiftGuest
+//     (skipping the patch on dry-run) and DENIES the eviction with 429
+//     TooManyRequests so drain retries every 5s. The Phase 4 drain
+//     controller reads the marker and creates the SwiftMigration; once the
+//     migration's cutover Deletes the source pod, the next eviction retry
+//     finds the pod gone and is allowed — drain proceeds.
+//   - drainPolicy Block, migration.enabled=false, or LiveMigrate on a
+//     VFIO/GPU guest → DENIES (429) with a manual-handling message and does
+//     NOT stamp a marker (no auto-migration).
+//   - not a SwiftGuest launcher pod, or pod already gone → ALLOWS.
+//
+// The marker is inert until the drain controller ships (Phase 4 PR 4): this
+// PR wires the webhook only. The webhook is registered with
+// failurePolicy: Ignore so a webhook outage never breaks cluster-wide
+// evictions; the per-guest PodDisruptionBudget (PR 4) is the hard floor that
+// protects the VM when the webhook is down.
+package eviction
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// guestLabelKey marks a SwiftGuest launcher pod. Matches the label written
+// by the SwiftGuest controller's pod builder (swiftguest/pod.go).
+const guestLabelKey = "swift.kubeswift.io/guest"
+
+// Handler is the pods/eviction admission handler.
+type Handler struct {
+	Client client.Client
+}
+
+// Handle implements admission.Handler. For pods/eviction the AdmissionRequest
+// Name/Namespace identify the pod being evicted (the policy/v1 Eviction
+// object is named after the pod), so the handler fetches the pod by that
+// name rather than decoding the Eviction body.
+func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	log := logf.FromContext(ctx)
+
+	var pod corev1.Pod
+	if err := h.Client.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: req.Name}, &pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Pod gone (a prior eviction succeeded, or a migration cutover
+			// already deleted it): nothing to protect — let drain proceed.
+			return admission.Allowed("pod not found")
+		}
+		// Transient read error: deny-with-retry (429) rather than a 500 so
+		// drain keeps looping safely instead of hard-failing. (failurePolicy
+		// Ignore covers webhook-CALL failures at the apiserver; this is a
+		// handler-internal read error, which we choose to surface as
+		// retryable so we never accidentally allow a guest eviction.)
+		return denyRetry(fmt.Sprintf("transient error reading pod %s/%s; retry", req.Namespace, req.Name))
+	}
+
+	guestName := pod.Labels[guestLabelKey]
+	if guestName == "" {
+		return admission.Allowed("not a SwiftGuest launcher pod")
+	}
+
+	var guest swiftv1alpha1.SwiftGuest
+	if err := h.Client.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: guestName}, &guest); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Labeled pod but no SwiftGuest CR (orphaned/already-deleted
+			// guest): nothing to migrate and no policy to honor — allow the
+			// eviction so the orphan is cleaned up and drain proceeds.
+			return admission.Allowed(fmt.Sprintf("SwiftGuest %q not found; nothing to protect", guestName))
+		}
+		return denyRetry(fmt.Sprintf("transient error reading SwiftGuest %q; retry", guestName))
+	}
+
+	node := pod.Spec.NodeName
+
+	// Resolve the per-guest migration enablement + drain policy (defaults:
+	// enabled=true, drainPolicy=Migrate).
+	enabled := true
+	policy := swiftv1alpha1.DrainPolicyMigrate
+	if guest.Spec.Migration != nil {
+		if guest.Spec.Migration.Enabled != nil {
+			enabled = *guest.Spec.Migration.Enabled
+		}
+		if guest.Spec.Migration.DrainPolicy != "" {
+			policy = guest.Spec.Migration.DrainPolicy
+		}
+	}
+
+	// migration.enabled=false is the strongest pin: no auto-migration, no
+	// marker — deny with a manual-handling message.
+	if !enabled {
+		return denyRetry(fmt.Sprintf(
+			"SwiftGuest %q has migration disabled (migration.enabled=false); it will not be auto-migrated off node %q — drain it manually or set migration.enabled=true",
+			guestName, node))
+	}
+
+	switch policy {
+	case swiftv1alpha1.DrainPolicyBlock:
+		return denyRetry(fmt.Sprintf(
+			"SwiftGuest %q has drainPolicy=Block; it will not be auto-migrated off node %q — handle this guest manually",
+			guestName, node))
+	case swiftv1alpha1.DrainPolicyLiveMigrate:
+		if guest.HasVFIODevices() {
+			// LiveMigrate forbids incurring downtime; a VFIO/GPU guest can
+			// only migrate offline, so block the drain rather than evacuate
+			// it with downtime.
+			return denyRetry(fmt.Sprintf(
+				"SwiftGuest %q has drainPolicy=LiveMigrate but uses VFIO/GPU devices that cannot live-migrate; it will not be evacuated off node %q — handle it manually or set drainPolicy=Migrate to allow offline migration",
+				guestName, node))
+		}
+	case swiftv1alpha1.DrainPolicyMigrate:
+		// auto: live where possible, offline for VFIO/GPU — always migratable.
+	default:
+		// Unknown/unvalidated policy: treat as Migrate (the CRD enum should
+		// have rejected anything else at admission of the SwiftGuest).
+	}
+
+	// Migratable. Stamp the drain-requested marker (skip on dry-run) and
+	// deny-with-retry. The Phase 4 drain controller reads the marker and
+	// creates the SwiftMigration; until then the marker is inert.
+	dryRun := req.DryRun != nil && *req.DryRun
+	if !dryRun {
+		if err := h.markDrainRequested(ctx, &guest, node); err != nil {
+			log.Error(err, "failed to stamp drain-requested marker; denying (retry)",
+				"guest", guestName, "node", node)
+			// Still deny (retry): the marker write can succeed on the next 5s
+			// eviction retry. Never allow the VM to be evicted-to-death
+			// because a marker patch flaked.
+			return denyRetry(fmt.Sprintf(
+				"SwiftGuest %q: could not record drain request (will retry)", guestName))
+		}
+	}
+	return denyRetry(fmt.Sprintf(
+		"SwiftGuest %q on node %q is being migrated off before eviction; retry", guestName, node))
+}
+
+// markDrainRequested idempotently stamps the drain-requested marker (the
+// draining node name) on the SwiftGuest via a merge patch. No-op when the
+// marker already records this node.
+func (h *Handler) markDrainRequested(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, node string) error {
+	if guest.Annotations[swiftv1alpha1.AnnotationDrainRequested] == node {
+		return nil
+	}
+	patch := client.MergeFrom(guest.DeepCopy())
+	if guest.Annotations == nil {
+		guest.Annotations = map[string]string{}
+	}
+	guest.Annotations[swiftv1alpha1.AnnotationDrainRequested] = node
+	return h.Client.Patch(ctx, guest, patch)
+}
+
+// denyRetry denies an eviction with 429 TooManyRequests so kubectl drain
+// treats it as retryable (the same status the eviction API returns for a
+// PodDisruptionBudget block) and retries every 5s rather than hard-failing.
+func denyRetry(msg string) admission.Response {
+	return admission.Response{
+		AdmissionResponse: admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    http.StatusTooManyRequests,
+				Reason:  metav1.StatusReasonTooManyRequests,
+				Message: msg,
+			},
+		},
+	}
+}

--- a/internal/webhook/eviction/handler_test.go
+++ b/internal/webhook/eviction/handler_test.go
@@ -1,0 +1,224 @@
+package eviction
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/scheme"
+)
+
+func guestPod(name, ns, guest, node string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{guestLabelKey: guest},
+		},
+		Spec: corev1.PodSpec{NodeName: node},
+	}
+}
+
+func plainPod(name, ns, node string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec:       corev1.PodSpec{NodeName: node},
+	}
+}
+
+func swiftGuest(name, ns string, mig *swiftv1alpha1.MigrationSpec) *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec:       swiftv1alpha1.SwiftGuestSpec{Migration: mig},
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func evictReq(ns, name string, dryRun bool) admission.Request {
+	r := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Name:      name,
+			Namespace: ns,
+		},
+	}
+	if dryRun {
+		r.DryRun = boolPtr(true)
+	}
+	return r
+}
+
+func markerOf(t *testing.T, c client.Client, ns, name string) string {
+	t.Helper()
+	var g swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, &g); err != nil {
+		t.Fatalf("get guest %q: %v", name, err)
+	}
+	return g.Annotations[swiftv1alpha1.AnnotationDrainRequested]
+}
+
+func TestHandle(t *testing.T) {
+	const ns = "default"
+	vfioGuestSpec := func(name string) *swiftv1alpha1.SwiftGuest {
+		g := swiftGuest(name, ns, &swiftv1alpha1.MigrationSpec{DrainPolicy: swiftv1alpha1.DrainPolicyLiveMigrate})
+		g.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu"}
+		return g
+	}
+
+	tests := []struct {
+		name        string
+		objects     []client.Object
+		req         admission.Request
+		wantAllowed bool
+		wantMarked  string // expected drain-requested marker value ("" = absent)
+	}{
+		{
+			name:        "pod not found allows",
+			objects:     nil,
+			req:         evictReq(ns, "ghost", false),
+			wantAllowed: true,
+		},
+		{
+			name:        "non-guest pod allows",
+			objects:     []client.Object{plainPod("app", ns, "miles")},
+			req:         evictReq(ns, "app", false),
+			wantAllowed: true,
+		},
+		{
+			name:        "guest pod without SwiftGuest CR allows (orphan)",
+			objects:     []client.Object{guestPod("g-pod", ns, "g", "miles")},
+			req:         evictReq(ns, "g-pod", false),
+			wantAllowed: true,
+		},
+		{
+			name: "migratable default policy denies and marks",
+			objects: []client.Object{
+				guestPod("g-pod", ns, "g", "miles"),
+				swiftGuest("g", ns, nil), // nil migration → defaults (enabled, Migrate)
+			},
+			req:         evictReq(ns, "g-pod", false),
+			wantAllowed: false,
+			wantMarked:  "miles",
+		},
+		{
+			name: "dry-run denies but does not mark",
+			objects: []client.Object{
+				guestPod("g-pod", ns, "g", "miles"),
+				swiftGuest("g", ns, nil),
+			},
+			req:         evictReq(ns, "g-pod", true),
+			wantAllowed: false,
+			wantMarked:  "",
+		},
+		{
+			name: "migration disabled denies without marking",
+			objects: []client.Object{
+				guestPod("g-pod", ns, "g", "miles"),
+				swiftGuest("g", ns, &swiftv1alpha1.MigrationSpec{Enabled: boolPtr(false)}),
+			},
+			req:         evictReq(ns, "g-pod", false),
+			wantAllowed: false,
+			wantMarked:  "",
+		},
+		{
+			name: "drainPolicy Block denies without marking",
+			objects: []client.Object{
+				guestPod("g-pod", ns, "g", "miles"),
+				swiftGuest("g", ns, &swiftv1alpha1.MigrationSpec{DrainPolicy: swiftv1alpha1.DrainPolicyBlock}),
+			},
+			req:         evictReq(ns, "g-pod", false),
+			wantAllowed: false,
+			wantMarked:  "",
+		},
+		{
+			name: "LiveMigrate on VFIO guest denies without marking",
+			objects: []client.Object{
+				guestPod("g-pod", ns, "g", "miles"),
+				vfioGuestSpec("g"),
+			},
+			req:         evictReq(ns, "g-pod", false),
+			wantAllowed: false,
+			wantMarked:  "",
+		},
+		{
+			name: "LiveMigrate on non-VFIO guest denies and marks",
+			objects: []client.Object{
+				guestPod("g-pod", ns, "g", "miles"),
+				swiftGuest("g", ns, &swiftv1alpha1.MigrationSpec{DrainPolicy: swiftv1alpha1.DrainPolicyLiveMigrate}),
+			},
+			req:         evictReq(ns, "g-pod", false),
+			wantAllowed: false,
+			wantMarked:  "miles",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := scheme.Scheme
+			c := fake.NewClientBuilder().WithScheme(s).WithObjects(tc.objects...).Build()
+			h := &Handler{Client: c}
+
+			resp := h.Handle(context.Background(), tc.req)
+
+			if resp.Allowed != tc.wantAllowed {
+				t.Fatalf("Allowed = %v, want %v (msg=%q)", resp.Allowed, tc.wantAllowed, respMsg(resp))
+			}
+			if !tc.wantAllowed {
+				if resp.Result == nil || resp.Result.Code != http.StatusTooManyRequests {
+					t.Errorf("deny must use 429 TooManyRequests so drain retries; got %+v", resp.Result)
+				}
+			}
+			// Marker assertion only when a SwiftGuest exists.
+			if hasGuest(tc.objects) {
+				if got := markerOf(t, c, ns, "g"); got != tc.wantMarked {
+					t.Errorf("drain-requested marker = %q, want %q", got, tc.wantMarked)
+				}
+			}
+		})
+	}
+}
+
+// TestHandle_MarkerIdempotent verifies a second eviction (marker already set
+// to this node) is still denied and does not error.
+func TestHandle_MarkerIdempotent(t *testing.T) {
+	const ns = "default"
+	s := scheme.Scheme
+	g := swiftGuest("g", ns, nil)
+	g.Annotations = map[string]string{swiftv1alpha1.AnnotationDrainRequested: "miles"}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(guestPod("g-pod", ns, "g", "miles"), g).Build()
+	h := &Handler{Client: c}
+
+	resp := h.Handle(context.Background(), evictReq(ns, "g-pod", false))
+	if resp.Allowed {
+		t.Fatalf("already-marked migratable guest must still be denied; got allowed")
+	}
+	if got := markerOf(t, c, ns, "g"); got != "miles" {
+		t.Errorf("marker = %q, want miles (unchanged)", got)
+	}
+}
+
+func hasGuest(objs []client.Object) bool {
+	for _, o := range objs {
+		if _, ok := o.(*swiftv1alpha1.SwiftGuest); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func respMsg(r admission.Response) string {
+	if r.Result == nil {
+		return ""
+	}
+	return r.Result.Message
+}

--- a/internal/webhook/swiftmigration/validator.go
+++ b/internal/webhook/swiftmigration/validator.go
@@ -415,13 +415,7 @@ func (v *Validator) validateClusterState(ctx context.Context, mig *migrationv1al
 	//   - If sourceNode == target: the same-node check above already
 	//     rejected; this branch wouldn't be reached.
 	// So: reject any GPU SwiftMigration in Phase 1, period.
-	hasGPUWorkload := guest.Spec.GPUProfileRef != nil
-	for _, iface := range guest.Spec.Interfaces {
-		if iface.Type == swiftv1alpha1.InterfaceTypeSRIOV {
-			hasGPUWorkload = true
-			break
-		}
-	}
+	hasGPUWorkload := guest.HasVFIODevices()
 	if hasGPUWorkload {
 		return nil, fmt.Errorf("SwiftGuest %q has VFIO devices (gpuProfileRef or sriov interface); cross-node migration is not supported in Phase 1 — Phase 4+ work pending a release-and-reallocate primitive",
 			guest.Name)


### PR DESCRIPTION
## Phase 4 drain integration — PR 3 of 5

Wires the **eviction admission webhook** that makes `kubectl drain` (and any eviction-API caller — cluster-autoscaler, node upgrades) **safely evacuate SwiftGuest VMs** instead of killing them. Per design doc §3, §4.3, §9.

### What this PR does
`internal/webhook/eviction.Handler` — a raw admission handler on `pods/eviction` (not a CRD validator). For a SwiftGuest launcher pod, resolved against the guest's migration policy:

| Condition | Behaviour |
|---|---|
| migratable (`drainPolicy` ∈ {Migrate, LiveMigrate}, `migration.enabled != false`) | stamp `kubeswift.io/drain-requested:<node>` on the SwiftGuest (skipped on dry-run) + **deny 429** (drain retries every 5s) |
| `drainPolicy: Block` / `migration.enabled: false` / `LiveMigrate` on a VFIO·GPU guest | **deny 429** with a manual-handling message, **no marker** |
| not a guest pod, or pod already gone | **allow** (drain proceeds) |

The **marker is inert this PR** — the drain controller that reads it and creates the `SwiftMigration` lands in **PR 4**. This is the webhook half only.

### Defense-in-depth posture
- `failurePolicy: Ignore` — a webhook outage **never** breaks cluster-wide evictions. The per-guest PDB (PR 4) is the hard floor that protects the VM when the webhook is down.
- `sideEffects: NoneOnDryRun` — the marker patch is the only side effect; skipped on `drain --dry-run`.
- Deny uses **429 TooManyRequests** (the PDB-block status) so drain retries cleanly rather than hard-failing — validated by the Phase 4 spike.

Replaces the throwaway deny-only spike handler.

### Consolidation (anti-drift)
Promotes a canonical `SwiftGuest.HasVFIODevices()` predicate into `api/swift/v1alpha1` (the cycle-free home) and points the two equivalent inline copies — swiftmigration controller `auto_mode.go` and webhook `validator.go` — at it. This **removes** the duplication that `auto_mode.go`'s own comment lamented ("Duplicated rather than imported because the webhook lives in a separate package"), rather than adding a third copy for the new `LiveMigrate` branch.

### CRD / RBAC
- **No CRD change** — the `drainPolicy` field + `make generate` + chart sync landed in **PR 1 (#87)**. This PR adds only Go constants (`DrainPolicy{Migrate,LiveMigrate,Block}`, `AnnotationDrainRequested`) + a method.
- **No new RBAC** — the in-process controller-manager already holds `get,list,watch,patch` on swiftguests and `get,list,watch` on pods.
- VWC entry added to **both** `config/webhook/validating-webhook.yaml` and the Helm chart (parity).

### Tests
- `TestHandle` — 9-case table: allow/deny matrix, marker-stamped-vs-not, dry-run skip, VFIO `LiveMigrate` block, orphan-pod allow.
- `TestHandle_MarkerIdempotent` — re-eviction with marker already set stays denied, marker unchanged.
- Full `go test ./...` green; helm template renders the eviction webhook.

### Phase 4 progress
- ✅ PR 1 (#87) — design + `drainPolicy` CRD field
- ✅ PR 2 (#88) — TFU #24 `lifecycle: run` freeze
- ▶️ **PR 3 (this)** — eviction webhook + RBAC *(marker inert)*
- ⬜ PR 4 — drain controller (marker → SwiftMigration → clear) + per-guest PDB + target selection
- ⬜ PR 5 — cluster walkthrough + operator runbook (`docs/migration/phase-4.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)