### PR TITLE
Phase 4 PR 4a — drain controller (non-VFIO)

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -21,6 +21,7 @@ import (
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
 	"github.com/projectbeskar/kubeswift/internal/controller/migrationcert"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftdrain"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftgpu"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftguestpool"
@@ -202,6 +203,20 @@ func main() {
 		SystemNamespace:      leaderElectionNS,
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftMigration controller")
+		os.Exit(1)
+	}
+
+	// Phase 4 drain controller: the "controller creates" half of drain
+	// integration. Watches SwiftGuests for the kubeswift.io/drain-requested
+	// marker (stamped by the eviction webhook) and creates a SwiftMigration to
+	// evacuate the guest. Always registered — it is a no-op until a marker
+	// appears (which only the eviction webhook stamps).
+	if err = (&swiftdrain.Reconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("swiftdrain-controller"),
+	}).SetupWithManager(mgr); err != nil {
+		klog.ErrorS(err, "unable to create SwiftDrain controller")
 		os.Exit(1)
 	}
 

--- a/docs/design/live-migration-phase-4.md
+++ b/docs/design/live-migration-phase-4.md
@@ -109,12 +109,28 @@ New field `spec.migration.drainPolicy`, enum, default `Migrate`:
 
 | Value | Drain behaviour |
 |---|---|
-| `Migrate` (default) | `mode=auto` — live where possible, **offline** (bounded downtime) for VFIO/GPU. Drain always succeeds. |
-| `LiveMigrate` | live only; if the guest can't live-migrate (VFIO/GPU), **deny the drain** (block) rather than incur downtime. |
+| `Migrate` (default) | `mode=auto` — live where possible, **offline** (bounded downtime) otherwise. Drain always succeeds **for non-VFIO guests**. |
+| `LiveMigrate` | live only; if the guest can't live-migrate, **deny the drain** (block) rather than incur downtime. |
 | `Block` | always deny the drain; operator handles the guest manually. |
 
 `migration.enabled: false` is orthogonal and stronger — it disables
 migration entirely; drain denies with a manual-handling message.
+
+> **VFIO/GPU scope correction (initial Phase 4).** The original §4.3 text
+> promised `Migrate` does "offline for VFIO/GPU." That is **not deliverable
+> in the initial Phase 4**: the SwiftMigration webhook still rejects ALL
+> VFIO/GPU cross-node migration (`internal/webhook/swiftmigration/validator.go`
+> — "Phase 4+ work pending a release-and-reallocate primitive"), and that
+> primitive (SwiftGPU deallocate-on-source + reallocate-on-target) does not
+> exist. Until it ships, **VFIO/GPU guests block the drain under ANY
+> drainPolicy** (the eviction webhook denies them with a manual-handling
+> message and does NOT mark them — a marker would drive the drain controller
+> to create a webhook-rejected migration every 5s). Building the
+> release-and-reallocate primitive is a follow-on sub-phase (decision
+> 2026-06-02: build it next, after the non-VFIO drain ships); it cannot be
+> cross-node-validated on the current single-GPU-node cluster (validation:
+> same-node release→reacquire on boba + mocked second SwiftGPUNode in
+> unit/envtest). Tracked in `kubeswift_context.md`.
 
 ### 4.4 Target-node selection
 
@@ -181,17 +197,50 @@ enum fields must be regenerated, not just constant-added — Phase 3c PR 5).
 
 ## 9. Implementation plan (PRs)
 
-1. **PR 1** — this design doc + the `drainPolicy` CRD field (+ generate +
-   chart sync). Design + API surface only; reviewable in isolation.
-2. **PR 2** — the TFU #24 `lifecycle: run` freeze on the dst intent (now
-   reachable: Phase 4 introduces the stop-during-migration path). Split
-   out because it touches `newDstPod` / dst-pod construction and is
-   logically independent of drain. Can land in parallel with PR 3.
-3. **PR 3** — the eviction webhook (`pods/eviction` admission handler, VWC
-   rule, `failurePolicy: Ignore`, marker patch with dry-run skip) + RBAC.
-   Unit-tested; no controller yet (marker is inert).
-4. **PR 4** — the drain controller (marker → SwiftMigration → clear) +
-   per-guest PDB creation in the SwiftGuest controller + target selection.
-5. **PR 5** — cluster walkthrough (drain miles → guest live-migrates to
-   boba → drain completes; VFIO-offline path; Block deny; webhook-down PDB
-   safety) + operator runbook (`docs/migration/phase-4.md`).
+1. **PR 1** (#87, merged) — this design doc + the `drainPolicy` CRD field
+   (+ generate + chart sync). Design + API surface only.
+2. **PR 2** (#88, merged) — the TFU #24 `lifecycle: run` freeze on the dst
+   intent (now reachable: Phase 4 introduces the stop-during-migration
+   path). Split out because it touches `newDstPod` / dst-pod construction
+   and is logically independent of drain.
+3. **PR 3** (#89, merged) — the eviction webhook (`pods/eviction` admission
+   handler, VWC rule, `failurePolicy: Ignore`, marker patch with dry-run
+   skip). Unit-tested; marker inert until PR 4a.
+4. **PR 4a** — the drain controller (marker → SwiftMigration → clear +
+   target selection). Handles **non-VFIO** guests; VFIO/GPU guests are
+   denied-without-marking by the eviction webhook (VFIO correctness fix
+   folded in here, since 4a makes the marker live). Reuses the migration
+   Validating phase's `NodeHasCapacity` gate. Unit-tested.
+   *(Split from the original single PR 4 per the same Design-Principle-#1
+   reviewability discipline used throughout Phase 4.)*
+5. **PR 4b** — per-guest `maxUnavailable: 0` PodDisruptionBudget creation in
+   the SwiftGuest controller (the hard floor, independent of the
+   webhook/controller; §4.2). Logically independent of 4a.
+6. **PR 5** — cluster walkthrough (drain miles → guest live-migrates to
+   boba → drain completes; `Block` deny; webhook-down PDB safety) +
+   operator runbook (`docs/migration/phase-4.md`). VFIO-offline is **not**
+   in this walkthrough (deferred to the release-and-reallocate sub-phase).
+
+### Follow-on sub-phase — VFIO/GPU release-and-reallocate
+
+Builds the missing primitive so VFIO/GPU guests can be offline-evacuated on
+drain (decision 2026-06-02: build it after the non-VFIO drain ships). Its
+own design doc + spike + PRs. Surface (from recon):
+- **New SwiftGPU capability**: allocate on a *specific* requested node (today
+  `findAndAllocate` auto-picks the first node with capacity) + release-from-
+  node, exposed for the migration controller to call.
+- **GPU target pre-flight**: target node must have free GPUs matching the
+  profile (count/model/tier/NUMA/FM partition) — a GPU analogue of
+  `NodeHasCapacity`, in both drain target-selection and the migration
+  Validating phase.
+- **Two-phase atomicity**: reserve target GPUs *before* stopping the source
+  (Phase 1's "drive-forward post-cutover, restore pre-cutover"), else a
+  failed realloc strands a stopped, GPU-less guest.
+- **Lift the webhook VFIO rejection** for offline mode only (live + VFIO
+  stays blocked).
+- **FM partition handoff** (Tier 2/3): deactivate on source, activate on
+  target.
+- **Validation**: same-node `boba→boba` release→reacquire on the real GTX
+  1080 + mocked second `SwiftGPUNode` in unit/envtest. Cross-node GPU
+  migration **cannot** be hardware-validated on the single-GPU-node cluster;
+  ships explicitly labeled as such.

--- a/internal/controller/swiftdrain/controller.go
+++ b/internal/controller/swiftdrain/controller.go
@@ -1,0 +1,219 @@
+// Package swiftdrain implements the Phase 4 drain controller: the "controller
+// creates" half of the webhook-marks / controller-creates / PDB-guarantees
+// architecture (design doc §3).
+//
+// The eviction webhook (internal/webhook/eviction) stamps
+// kubeswift.io/drain-requested:<node> on a SwiftGuest when an eviction of its
+// launcher pod is intercepted and the guest is auto-migratable. This
+// controller watches SwiftGuests and, for a marked guest still on the
+// draining node, creates a SwiftMigration (deterministic name, mode resolved
+// from drainPolicy, target node chosen by capacity) to evacuate it. Once the
+// guest is off the draining node, it clears the marker; the next eviction
+// retry then finds the pod gone (or moved) and is allowed, so drain proceeds.
+//
+// VFIO/GPU guests are NOT handled here: cross-node migration of VFIO devices
+// needs a release-and-reallocate primitive that does not exist yet (tracked
+// follow-up). The eviction webhook denies those without marking; this
+// controller guards defensively and surfaces a manual-handling event if a
+// VFIO guest is somehow marked.
+package swiftdrain
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// Reconciler drives drain-requested SwiftGuests to a SwiftMigration.
+type Reconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
+
+// Reconcile implements the drain state machine for one SwiftGuest.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	var guest swiftv1alpha1.SwiftGuest
+	if err := r.Get(ctx, req.NamespacedName, &guest); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	if guest.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	drainingNode := guest.Annotations[swiftv1alpha1.AnnotationDrainRequested]
+	if drainingNode == "" {
+		return ctrl.Result{}, nil // no drain in progress for this guest
+	}
+
+	// Guest already off the draining node → drain achieved; clear the marker.
+	if guest.Status.NodeName != "" && guest.Status.NodeName != drainingNode {
+		if err := r.clearMarker(ctx, &guest); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.event(&guest, corev1.EventTypeNormal, "DrainComplete",
+			fmt.Sprintf("guest evacuated from %q to %q; drain marker cleared", drainingNode, guest.Status.NodeName))
+		return ctrl.Result{}, nil
+	}
+
+	// VFIO/GPU guests cannot be auto-migrated yet (release-and-reallocate
+	// pending). The eviction webhook should not have marked them; guard
+	// defensively and surface a manual-handling event rather than create a
+	// migration the SwiftMigration webhook would reject.
+	if guest.HasVFIODevices() {
+		r.event(&guest, corev1.EventTypeWarning, "DrainUnsupported",
+			fmt.Sprintf("guest on node %q uses VFIO/GPU devices; automatic evacuation is not supported yet (release-and-reallocate pending) — handle manually", drainingNode))
+		return ctrl.Result{}, nil
+	}
+
+	migName := drainMigrationName(guest.Name, drainingNode)
+	var mig migrationv1alpha1.SwiftMigration
+	getErr := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: migName}, &mig)
+	if getErr == nil {
+		return r.observeMigration(ctx, &guest, &mig, drainingNode)
+	}
+	if !apierrors.IsNotFound(getErr) {
+		return ctrl.Result{}, fmt.Errorf("get drain migration %q: %w", migName, getErr)
+	}
+
+	// No drain migration yet. If some OTHER migration is already in flight for
+	// this guest (operator-initiated, or a prior drain of a different node),
+	// don't create a second — wait for it to settle.
+	if inflight := guest.Annotations[migrationv1alpha1.AnnotationMigrationInProgress]; inflight != "" {
+		log.Info("drain deferred: another migration is in flight for this guest",
+			"guest", guest.Name, "migration", inflight)
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	target, err := r.selectTarget(ctx, &guest, drainingNode)
+	if err != nil {
+		r.event(&guest, corev1.EventTypeWarning, "DrainNoTarget",
+			fmt.Sprintf("cannot evacuate %q from %q: %v — drain stalls safely until capacity frees up", guest.Name, drainingNode, err))
+		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+	}
+
+	if err := r.createDrainMigration(ctx, &guest, migName, target, drainingNode); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// observeMigration reacts to an existing drain migration's phase.
+func (r *Reconciler) observeMigration(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, mig *migrationv1alpha1.SwiftMigration, drainingNode string) (ctrl.Result, error) {
+	switch mig.Status.Phase {
+	case migrationv1alpha1.SwiftMigrationPhaseCompleted:
+		// Cutover done; status.NodeName should flip to the target shortly.
+		// Requeue so the top-of-reconcile node check clears the marker.
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	case migrationv1alpha1.SwiftMigrationPhaseFailed, migrationv1alpha1.SwiftMigrationPhaseCancelled:
+		// Don't retry-storm: leave the marker (the eviction webhook keeps
+		// denying — the VM is protected, never killed) and surface the
+		// failure. Operator deletes the SwiftMigration to retry, or handles
+		// the guest manually.
+		r.event(guest, corev1.EventTypeWarning, "DrainMigrationFailed",
+			fmt.Sprintf("migration %q evacuating %q from %q ended %s: %s — marker left (drain stays blocked); delete the SwiftMigration to retry or handle manually",
+				mig.Name, guest.Name, drainingNode, mig.Status.Phase, failureDetail(mig)))
+		return ctrl.Result{}, nil
+	default:
+		// In progress (Pending/Validating/Preparing/StopAndCopy/Resuming).
+		// The Owns watch re-triggers reconcile on the migration's status
+		// changes; nothing to do now.
+		return ctrl.Result{}, nil
+	}
+}
+
+// createDrainMigration creates the guest-owned SwiftMigration that evacuates
+// the guest to target.
+func (r *Reconciler) createDrainMigration(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, migName, target, drainingNode string) error {
+	mode := drainMode(drainPolicyOf(guest))
+	mig := &migrationv1alpha1.SwiftMigration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      migName,
+			Namespace: guest.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "kubeswift",
+				"app.kubernetes.io/component":  "migration",
+				"app.kubernetes.io/managed-by": "kubeswift-controller-manager",
+				"kubeswift.io/drain":           "true",
+			},
+		},
+		Spec: migrationv1alpha1.SwiftMigrationSpec{
+			GuestRef: migrationv1alpha1.SwiftMigrationGuestRef{Name: guest.Name},
+			Target:   migrationv1alpha1.SwiftMigrationTarget{NodeName: target},
+			Mode:     mode,
+			Reason:   "node-drain",
+			// Drain is an operator-initiated evacuation: the guest must move,
+			// so opt into the cross-node IP change inherent to default
+			// node-local networking. Without this the migration webhook
+			// rejects the cross-node move and the drain would stall.
+			AllowIPChange: true,
+		},
+	}
+	if err := ctrl.SetControllerReference(guest, mig, r.Scheme); err != nil {
+		return fmt.Errorf("set ownerRef on drain migration %q: %w", migName, err)
+	}
+	if err := r.Create(ctx, mig); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil // raced with another reconcile; next loop observes it
+		}
+		return fmt.Errorf("create drain migration %q: %w", migName, err)
+	}
+	r.event(guest, corev1.EventTypeNormal, "DrainMigrationCreated",
+		fmt.Sprintf("created migration %q (mode %s) to evacuate %q from %q to %q", migName, mode, guest.Name, drainingNode, target))
+	return nil
+}
+
+// clearMarker removes the drain-requested annotation via a merge patch.
+func (r *Reconciler) clearMarker(ctx context.Context, guest *swiftv1alpha1.SwiftGuest) error {
+	if _, ok := guest.Annotations[swiftv1alpha1.AnnotationDrainRequested]; !ok {
+		return nil
+	}
+	patch := client.MergeFrom(guest.DeepCopy())
+	delete(guest.Annotations, swiftv1alpha1.AnnotationDrainRequested)
+	if err := r.Patch(ctx, guest, patch); err != nil {
+		return fmt.Errorf("clear drain-requested marker on %q: %w", guest.Name, err)
+	}
+	return nil
+}
+
+func (r *Reconciler) event(obj client.Object, eventtype, reason, msg string) {
+	if r.Recorder != nil {
+		r.Recorder.Event(obj, eventtype, reason, msg)
+	}
+}
+
+// failureDetail returns the most specific failure description available.
+func failureDetail(mig *migrationv1alpha1.SwiftMigration) string {
+	if mig.Status.FailureMessage != "" {
+		return mig.Status.FailureMessage
+	}
+	if mig.Status.FailureReason != "" {
+		return mig.Status.FailureReason
+	}
+	return "no detail reported"
+}
+
+// SetupWithManager registers the drain controller. It watches SwiftGuests
+// (the marker lives there) and Owns the SwiftMigrations it creates (so a
+// migration's status changes re-trigger reconcile of the owning guest).
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("swiftdrain").
+		For(&swiftv1alpha1.SwiftGuest{}).
+		Owns(&migrationv1alpha1.SwiftMigration{}).
+		Complete(r)
+}

--- a/internal/controller/swiftdrain/controller_test.go
+++ b/internal/controller/swiftdrain/controller_test.go
@@ -1,0 +1,317 @@
+package swiftdrain
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/scheme"
+)
+
+const ns = "default"
+
+// --- builders ---
+
+func guest(name string, opts ...func(*swiftv1alpha1.SwiftGuest)) *swiftv1alpha1.SwiftGuest {
+	g := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, UID: types.UID(name + "-uid")},
+		Spec:       swiftv1alpha1.SwiftGuestSpec{GuestClassRef: corev1.LocalObjectReference{Name: "small"}},
+	}
+	for _, o := range opts {
+		o(g)
+	}
+	return g
+}
+
+func drain(node string) func(*swiftv1alpha1.SwiftGuest) {
+	return func(g *swiftv1alpha1.SwiftGuest) {
+		if g.Annotations == nil {
+			g.Annotations = map[string]string{}
+		}
+		g.Annotations[swiftv1alpha1.AnnotationDrainRequested] = node
+	}
+}
+
+func statusNode(node string) func(*swiftv1alpha1.SwiftGuest) {
+	return func(g *swiftv1alpha1.SwiftGuest) { g.Status.NodeName = node }
+}
+
+func policy(p string) func(*swiftv1alpha1.SwiftGuest) {
+	return func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.Migration = &swiftv1alpha1.MigrationSpec{DrainPolicy: p}
+	}
+}
+
+func vfio() func(*swiftv1alpha1.SwiftGuest) {
+	return func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu"}
+	}
+}
+
+func inProgress(migName string) func(*swiftv1alpha1.SwiftGuest) {
+	return func(g *swiftv1alpha1.SwiftGuest) {
+		if g.Annotations == nil {
+			g.Annotations = map[string]string{}
+		}
+		g.Annotations[migrationv1alpha1.AnnotationMigrationInProgress] = migName
+	}
+}
+
+func node(name string, opts ...func(*corev1.Node)) *corev1.Node {
+	n := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	n.Status.Conditions = []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}
+	n.Status.Allocatable = corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("8"),
+		corev1.ResourceMemory: resource.MustParse("16Gi"),
+	}
+	for _, o := range opts {
+		o(n)
+	}
+	return n
+}
+
+func cordoned(n *corev1.Node) { n.Spec.Unschedulable = true }
+func notReady(n *corev1.Node) { n.Status.Conditions[0].Status = corev1.ConditionFalse }
+func smallClass() *swiftv1alpha1.SwiftGuestClass {
+	return &swiftv1alpha1.SwiftGuestClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "small"},
+		Spec:       swiftv1alpha1.SwiftGuestClassSpec{CPU: resource.MustParse("1"), Memory: resource.MustParse("1Gi")},
+	}
+}
+
+func drainMig(name string, phase migrationv1alpha1.SwiftMigrationPhase) *migrationv1alpha1.SwiftMigration {
+	return &migrationv1alpha1.SwiftMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status:     migrationv1alpha1.SwiftMigrationStatus{Phase: phase},
+	}
+}
+
+func newR(objs ...client.Object) (*Reconciler, client.Client) {
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).Build()
+	return &Reconciler{Client: c, Scheme: scheme.Scheme, Recorder: record.NewFakeRecorder(32)}, c
+}
+
+func reconcileGuest(t *testing.T, r *Reconciler, name string) ctrl.Result {
+	t.Helper()
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: name}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	return res
+}
+
+func listMigs(t *testing.T, c client.Client) []migrationv1alpha1.SwiftMigration {
+	t.Helper()
+	var l migrationv1alpha1.SwiftMigrationList
+	if err := c.List(context.Background(), &l); err != nil {
+		t.Fatalf("list migrations: %v", err)
+	}
+	return l.Items
+}
+
+func getGuest(t *testing.T, c client.Client, name string) *swiftv1alpha1.SwiftGuest {
+	t.Helper()
+	var g swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, &g); err != nil {
+		t.Fatalf("get guest: %v", err)
+	}
+	return &g
+}
+
+// --- tests ---
+
+func TestReconcile_NoMarker_NoOp(t *testing.T) {
+	r, c := newR(guest("g"), node("miles"), node("boba"), smallClass())
+	reconcileGuest(t, r, "g")
+	if migs := listMigs(t, c); len(migs) != 0 {
+		t.Errorf("no marker → no migration; got %d", len(migs))
+	}
+}
+
+func TestReconcile_GuestMovedOff_ClearsMarker(t *testing.T) {
+	r, c := newR(guest("g", drain("miles"), statusNode("boba")), node("miles"), node("boba"), smallClass())
+	reconcileGuest(t, r, "g")
+	g := getGuest(t, c, "g")
+	if _, ok := g.Annotations[swiftv1alpha1.AnnotationDrainRequested]; ok {
+		t.Errorf("marker should be cleared once guest is off the draining node")
+	}
+	if migs := listMigs(t, c); len(migs) != 0 {
+		t.Errorf("moved-off guest must not get a new migration; got %d", len(migs))
+	}
+}
+
+func TestReconcile_VFIOGuest_NoMigration(t *testing.T) {
+	r, c := newR(guest("g", drain("miles"), statusNode("miles"), vfio()), node("miles"), node("boba"), smallClass())
+	reconcileGuest(t, r, "g")
+	if migs := listMigs(t, c); len(migs) != 0 {
+		t.Errorf("VFIO guest cannot auto-migrate yet; must create no migration, got %d", len(migs))
+	}
+	// Marker is left as-is (the controller doesn't clear it; the operator
+	// handles the guest manually).
+	g := getGuest(t, c, "g")
+	if g.Annotations[swiftv1alpha1.AnnotationDrainRequested] != "miles" {
+		t.Errorf("VFIO marker should be left for manual handling")
+	}
+}
+
+func TestReconcile_CreatesMigration(t *testing.T) {
+	r, c := newR(guest("g", drain("miles"), statusNode("miles")), node("miles"), node("boba"), smallClass())
+	reconcileGuest(t, r, "g")
+
+	migs := listMigs(t, c)
+	if len(migs) != 1 {
+		t.Fatalf("expected 1 migration created; got %d", len(migs))
+	}
+	m := migs[0]
+	if want := drainMigrationName("g", "miles"); m.Name != want {
+		t.Errorf("migration name = %q, want %q", m.Name, want)
+	}
+	if m.Spec.GuestRef.Name != "g" {
+		t.Errorf("guestRef = %q, want g", m.Spec.GuestRef.Name)
+	}
+	if m.Spec.Target.NodeName != "boba" {
+		t.Errorf("target = %q, want boba (the non-draining peer)", m.Spec.Target.NodeName)
+	}
+	if m.Spec.Mode != migrationv1alpha1.SwiftMigrationModeAuto {
+		t.Errorf("mode = %q, want auto (default Migrate policy)", m.Spec.Mode)
+	}
+	if m.Spec.Reason != "node-drain" {
+		t.Errorf("reason = %q, want node-drain", m.Spec.Reason)
+	}
+	if !m.Spec.AllowIPChange {
+		t.Errorf("drain migration must set allowIPChange=true to avoid stalling on default networking")
+	}
+	if len(m.OwnerReferences) != 1 || m.OwnerReferences[0].Name != "g" {
+		t.Errorf("migration must be guest-owned; got %+v", m.OwnerReferences)
+	}
+}
+
+func TestReconcile_LiveMigratePolicy_LiveMode(t *testing.T) {
+	r, c := newR(guest("g", drain("miles"), statusNode("miles"), policy(swiftv1alpha1.DrainPolicyLiveMigrate)),
+		node("miles"), node("boba"), smallClass())
+	reconcileGuest(t, r, "g")
+	migs := listMigs(t, c)
+	if len(migs) != 1 {
+		t.Fatalf("expected 1 migration; got %d", len(migs))
+	}
+	if migs[0].Spec.Mode != migrationv1alpha1.SwiftMigrationModeLive {
+		t.Errorf("LiveMigrate policy → mode=live; got %q", migs[0].Spec.Mode)
+	}
+}
+
+func TestReconcile_MigrationInFlight_NoDuplicate(t *testing.T) {
+	existing := drainMig(drainMigrationName("g", "miles"), migrationv1alpha1.SwiftMigrationPhaseValidating)
+	r, c := newR(guest("g", drain("miles"), statusNode("miles")), existing, node("miles"), node("boba"), smallClass())
+	reconcileGuest(t, r, "g")
+	if migs := listMigs(t, c); len(migs) != 1 {
+		t.Errorf("in-flight migration must not be duplicated; got %d", len(migs))
+	}
+}
+
+func TestReconcile_MigrationFailed_MarkerStays_NoNew(t *testing.T) {
+	failed := drainMig(drainMigrationName("g", "miles"), migrationv1alpha1.SwiftMigrationPhaseFailed)
+	failed.Status.FailureMessage = "boom"
+	r, c := newR(guest("g", drain("miles"), statusNode("miles")), failed, node("miles"), node("boba"), smallClass())
+	reconcileGuest(t, r, "g")
+	if migs := listMigs(t, c); len(migs) != 1 {
+		t.Errorf("failed migration must not trigger a new one (no retry storm); got %d", len(migs))
+	}
+	g := getGuest(t, c, "g")
+	if g.Annotations[swiftv1alpha1.AnnotationDrainRequested] != "miles" {
+		t.Errorf("marker must stay after a failed migration (VM stays protected)")
+	}
+}
+
+func TestReconcile_NoTarget_Requeue(t *testing.T) {
+	// Only the draining node exists → no schedulable peer.
+	r, c := newR(guest("g", drain("miles"), statusNode("miles")), node("miles"), smallClass())
+	res := reconcileGuest(t, r, "g")
+	if migs := listMigs(t, c); len(migs) != 0 {
+		t.Errorf("no target → no migration; got %d", len(migs))
+	}
+	if res.RequeueAfter == 0 {
+		t.Errorf("no-target should requeue to retry when capacity frees up")
+	}
+}
+
+func TestReconcile_CordonedPeer_NoTarget(t *testing.T) {
+	r, c := newR(guest("g", drain("miles"), statusNode("miles")), node("miles"), node("boba", cordoned), smallClass())
+	reconcileGuest(t, r, "g")
+	if migs := listMigs(t, c); len(migs) != 0 {
+		t.Errorf("cordoned peer is not a valid target; got %d migrations", len(migs))
+	}
+}
+
+func TestReconcile_NotReadyPeer_NoTarget(t *testing.T) {
+	r, c := newR(guest("g", drain("miles"), statusNode("miles")), node("miles"), node("boba", notReady), smallClass())
+	reconcileGuest(t, r, "g")
+	if migs := listMigs(t, c); len(migs) != 0 {
+		t.Errorf("not-Ready peer is not a valid target; got %d migrations", len(migs))
+	}
+}
+
+func TestReconcile_OtherMigrationInProgress_Defers(t *testing.T) {
+	r, c := newR(guest("g", drain("miles"), statusNode("miles"), inProgress("some-other-mig")),
+		node("miles"), node("boba"), smallClass())
+	res := reconcileGuest(t, r, "g")
+	if migs := listMigs(t, c); len(migs) != 0 {
+		t.Errorf("must not create a second migration while one is in flight; got %d", len(migs))
+	}
+	if res.RequeueAfter == 0 {
+		t.Errorf("should requeue while deferring to the in-flight migration")
+	}
+}
+
+func TestDrainMigrationName_DeterministicAndBounded(t *testing.T) {
+	a := drainMigrationName("guest", "miles")
+	if a != drainMigrationName("guest", "miles") {
+		t.Errorf("name must be deterministic for the same (guest, node)")
+	}
+	if a == drainMigrationName("guest", "boba") {
+		t.Errorf("name must differ across draining nodes")
+	}
+	long := ""
+	for i := 0; i < 80; i++ {
+		long += "x"
+	}
+	n := drainMigrationName(long, "miles")
+	if len(n) > maxMigrationNameLen {
+		t.Errorf("name %q (len %d) exceeds the %d-char label-value bound", n, len(n), maxMigrationNameLen)
+	}
+}
+
+func TestDrainMode(t *testing.T) {
+	if drainMode(swiftv1alpha1.DrainPolicyLiveMigrate) != migrationv1alpha1.SwiftMigrationModeLive {
+		t.Errorf("LiveMigrate → live")
+	}
+	if drainMode(swiftv1alpha1.DrainPolicyMigrate) != migrationv1alpha1.SwiftMigrationModeAuto {
+		t.Errorf("Migrate → auto")
+	}
+	if drainMode("") != migrationv1alpha1.SwiftMigrationModeAuto {
+		t.Errorf("empty → auto (default)")
+	}
+}
+
+// guard: a SwiftMigration get error other than NotFound is surfaced.
+func TestObserveMigration_InProgress_NoOp(t *testing.T) {
+	r, _ := newR()
+	g := guest("g", drain("miles"))
+	m := drainMig("x", migrationv1alpha1.SwiftMigrationPhasePreparing)
+	res, err := r.observeMigration(context.Background(), g, m, "miles")
+	if err != nil {
+		t.Fatalf("observeMigration: %v", err)
+	}
+	if res.RequeueAfter != 0 || res.Requeue {
+		t.Errorf("in-progress migration: rely on the Owns watch, no explicit requeue; got %+v", res)
+	}
+}

--- a/internal/controller/swiftdrain/name.go
+++ b/internal/controller/swiftdrain/name.go
@@ -1,0 +1,60 @@
+package swiftdrain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// maxMigrationNameLen bounds the generated SwiftMigration name. The name
+// becomes a pod LABEL VALUE (dst_pod.go LabelMigrationName), so it must be a
+// valid label value (<=63 chars, RFC1123). Mirrors swiftkernel/pull.go's
+// truncate-40 + sha256-8 naming discipline.
+const maxMigrationNameLen = 63
+
+// drainMigrationName returns the deterministic SwiftMigration name for
+// draining guestName off nodeName. Deterministic per (guest, node) so the
+// eviction API's 5s retries reuse the same migration object; a later drain
+// of a DIFFERENT node yields a different name (the node is folded into the
+// hash). Bounded to a valid label value.
+func drainMigrationName(guestName, nodeName string) string {
+	suffix := "-drain-" + shortHash(guestName+"|"+nodeName)
+	if len(guestName)+len(suffix) <= maxMigrationNameLen {
+		return guestName + suffix
+	}
+	// Guest name too long: truncate it so the whole name fits.
+	keep := maxMigrationNameLen - len(suffix)
+	if keep < 0 {
+		keep = 0
+	}
+	return guestName[:keep] + suffix
+}
+
+// shortHash returns the first 8 hex digits of sha256(s).
+func shortHash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+// drainMode maps a guest's drainPolicy to the SwiftMigration mode. Only
+// migratable policies reach the drain controller (the eviction webhook denies
+// Block / migration-disabled / VFIO without marking), so this handles the two
+// migratable cases:
+//   - Migrate (default): mode=auto — live where possible, offline otherwise.
+//   - LiveMigrate: mode=live — live only (the operator opted out of downtime).
+func drainMode(policy string) migrationv1alpha1.SwiftMigrationMode {
+	if policy == swiftv1alpha1.DrainPolicyLiveMigrate {
+		return migrationv1alpha1.SwiftMigrationModeLive
+	}
+	return migrationv1alpha1.SwiftMigrationModeAuto
+}
+
+// drainPolicyOf returns the guest's effective drain policy (default Migrate).
+func drainPolicyOf(guest *swiftv1alpha1.SwiftGuest) string {
+	if guest.Spec.Migration != nil && guest.Spec.Migration.DrainPolicy != "" {
+		return guest.Spec.Migration.DrainPolicy
+	}
+	return swiftv1alpha1.DrainPolicyMigrate
+}

--- a/internal/controller/swiftdrain/target.go
+++ b/internal/controller/swiftdrain/target.go
@@ -1,0 +1,97 @@
+package swiftdrain
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftmigration"
+)
+
+// selectTarget picks the destination node to evacuate the guest to: a node
+// that is Ready, schedulable (not cordoned), not the draining node, satisfies
+// the guest's node-class requirements (kernel-node label for kernel-boot),
+// and has capacity for the guest's class. Among fitting candidates it picks
+// the one with the most allocatable CPU (a cheap headroom proxy), breaking
+// ties by name for determinism.
+//
+// Returns an error (no target) when no candidate fits — the drain then stalls
+// safely (the eviction webhook keeps denying; the guest is never killed)
+// until the operator frees capacity. The SwiftMigration Validating phase
+// re-runs the authoritative capacity gate, so a transient race here only
+// costs a retry, never a bad cutover.
+func (r *Reconciler) selectTarget(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, drainingNode string) (string, error) {
+	var class swiftv1alpha1.SwiftGuestClass
+	if err := r.Get(ctx, client.ObjectKey{Name: guest.Spec.GuestClassRef.Name}, &class); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("SwiftGuestClass %q not found", guest.Spec.GuestClassRef.Name)
+		}
+		return "", fmt.Errorf("get SwiftGuestClass %q: %w", guest.Spec.GuestClassRef.Name, err)
+	}
+
+	var nodes corev1.NodeList
+	if err := r.List(ctx, &nodes); err != nil {
+		return "", fmt.Errorf("list nodes: %w", err)
+	}
+
+	type cand struct {
+		name     string
+		allocCPU int64 // milliCPU, headroom proxy
+	}
+	var fitting []cand
+	var skipped int
+	for i := range nodes.Items {
+		n := &nodes.Items[i]
+		if n.Name == drainingNode {
+			continue
+		}
+		if n.Spec.Unschedulable {
+			skipped++
+			continue
+		}
+		if !nodeReady(n) {
+			skipped++
+			continue
+		}
+		// Kernel-boot guests require a kernel-node-labeled target (the
+		// migration webhook enforces this; pre-filter to avoid a doomed
+		// migration object).
+		if guest.Spec.KernelRef != nil && n.Labels["kubeswift.io/kernel-node"] != "true" {
+			skipped++
+			continue
+		}
+		if err := swiftmigration.NodeHasCapacity(ctx, r.Client, n, &class); err != nil {
+			skipped++
+			continue
+		}
+		fitting = append(fitting, cand{name: n.Name, allocCPU: n.Status.Allocatable.Cpu().MilliValue()})
+	}
+
+	if len(fitting) == 0 {
+		return "", fmt.Errorf("no Ready, schedulable peer node has capacity for class %q (%d candidate node(s) rejected)",
+			class.Name, skipped)
+	}
+
+	sort.Slice(fitting, func(i, j int) bool {
+		if fitting[i].allocCPU != fitting[j].allocCPU {
+			return fitting[i].allocCPU > fitting[j].allocCPU // most headroom first
+		}
+		return fitting[i].name < fitting[j].name // deterministic tiebreak
+	})
+	return fitting[0].name, nil
+}
+
+// nodeReady reports whether the node's Ready condition is True.
+func nodeReady(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/internal/controller/swiftmigration/validating.go
+++ b/internal/controller/swiftmigration/validating.go
@@ -153,6 +153,20 @@ func (r *SwiftMigrationReconciler) checkNodeCapacity(
 	node *corev1.Node,
 	class *swiftv1alpha1.SwiftGuestClass,
 ) error {
+	return NodeHasCapacity(ctx, r.Client, node, class)
+}
+
+// NodeHasCapacity verifies the node has headroom for the guest's CPU +
+// memory (including launcher overhead). Exported so the Phase 4 drain
+// controller reuses the exact capacity gate the migration Validating phase
+// applies, instead of a second, drift-prone copy. Returns nil when the node
+// fits; a descriptive error otherwise.
+func NodeHasCapacity(
+	ctx context.Context,
+	c client.Client,
+	node *corev1.Node,
+	class *swiftv1alpha1.SwiftGuestClass,
+) error {
 	allocCPU, ok := node.Status.Allocatable[corev1.ResourceCPU]
 	if !ok {
 		return fmt.Errorf("target node %q has no Allocatable CPU reported", node.Name)
@@ -168,7 +182,7 @@ func (r *SwiftMigrationReconciler) checkNodeCapacity(
 	// doesn't provide by default). The filter by spec.nodeName is
 	// done manually below; the cluster is small enough this is cheap.
 	var pods corev1.PodList
-	if err := r.List(ctx, &pods); err != nil {
+	if err := c.List(ctx, &pods); err != nil {
 		return fmt.Errorf("list pods for capacity check: %w", err)
 	}
 	usedCPU := *resource.NewQuantity(0, resource.DecimalSI)

--- a/internal/webhook/eviction/handler.go
+++ b/internal/webhook/eviction/handler.go
@@ -111,22 +111,26 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 			guestName, node))
 	}
 
+	// VFIO/GPU guests cannot be auto-migrated yet — neither live nor offline
+	// cross-node migration of VFIO devices is supported (the SwiftGPU
+	// release-and-reallocate primitive is a tracked follow-up). Deny with a
+	// manual-handling message under ANY drainPolicy and do NOT mark: a marker
+	// would drive the drain controller to create a SwiftMigration the
+	// migration webhook rejects, looping a doomed object every 5s.
+	if guest.HasVFIODevices() {
+		return denyRetry(fmt.Sprintf(
+			"SwiftGuest %q uses VFIO/GPU devices that cannot be auto-migrated yet; it will not be evacuated off node %q — handle it manually (cross-node VFIO migration is pending the release-and-reallocate primitive)",
+			guestName, node))
+	}
+
 	switch policy {
 	case swiftv1alpha1.DrainPolicyBlock:
 		return denyRetry(fmt.Sprintf(
 			"SwiftGuest %q has drainPolicy=Block; it will not be auto-migrated off node %q — handle this guest manually",
 			guestName, node))
-	case swiftv1alpha1.DrainPolicyLiveMigrate:
-		if guest.HasVFIODevices() {
-			// LiveMigrate forbids incurring downtime; a VFIO/GPU guest can
-			// only migrate offline, so block the drain rather than evacuate
-			// it with downtime.
-			return denyRetry(fmt.Sprintf(
-				"SwiftGuest %q has drainPolicy=LiveMigrate but uses VFIO/GPU devices that cannot live-migrate; it will not be evacuated off node %q — handle it manually or set drainPolicy=Migrate to allow offline migration",
-				guestName, node))
-		}
-	case swiftv1alpha1.DrainPolicyMigrate:
-		// auto: live where possible, offline for VFIO/GPU — always migratable.
+	case swiftv1alpha1.DrainPolicyLiveMigrate, swiftv1alpha1.DrainPolicyMigrate:
+		// Non-VFIO + Migrate (auto: live where possible, offline otherwise)
+		// or LiveMigrate (live only) — migratable; fall through to mark.
 	default:
 		// Unknown/unvalidated policy: treat as Migrate (the CRD enum should
 		// have rejected anything else at admission of the SwiftGuest).

--- a/internal/webhook/eviction/handler_test.go
+++ b/internal/webhook/eviction/handler_test.go
@@ -68,8 +68,8 @@ func markerOf(t *testing.T, c client.Client, ns, name string) string {
 
 func TestHandle(t *testing.T) {
 	const ns = "default"
-	vfioGuestSpec := func(name string) *swiftv1alpha1.SwiftGuest {
-		g := swiftGuest(name, ns, &swiftv1alpha1.MigrationSpec{DrainPolicy: swiftv1alpha1.DrainPolicyLiveMigrate})
+	vfioGuestSpec := func(name, policy string) *swiftv1alpha1.SwiftGuest {
+		g := swiftGuest(name, ns, &swiftv1alpha1.MigrationSpec{DrainPolicy: policy})
 		g.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu"}
 		return g
 	}
@@ -140,10 +140,20 @@ func TestHandle(t *testing.T) {
 			wantMarked:  "",
 		},
 		{
-			name: "LiveMigrate on VFIO guest denies without marking",
+			name: "VFIO guest with LiveMigrate denies without marking",
 			objects: []client.Object{
 				guestPod("g-pod", ns, "g", "miles"),
-				vfioGuestSpec("g"),
+				vfioGuestSpec("g", swiftv1alpha1.DrainPolicyLiveMigrate),
+			},
+			req:         evictReq(ns, "g-pod", false),
+			wantAllowed: false,
+			wantMarked:  "",
+		},
+		{
+			name: "VFIO guest with Migrate denies without marking (cannot auto-migrate yet)",
+			objects: []client.Object{
+				guestPod("g-pod", ns, "g", "miles"),
+				vfioGuestSpec("g", swiftv1alpha1.DrainPolicyMigrate),
 			},
 			req:         evictReq(ns, "g-pod", false),
 			wantAllowed: false,

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -1374,6 +1374,55 @@ Document in the release runbook; cross-referenced from
 `docs/migration/phase-3c.md` §2. Severity: LOW (one-time per new image;
 fail-loud — ImagePullBackOff is obvious). Surfaced 2026-06-01.
 
+### 27. VFIO/GPU release-and-reallocate primitive (Phase 4 drain follow-on sub-phase)
+
+Surfaced 2026-06-02 during Phase 4 PR 4a recon. The Phase 4 design doc
+§4.3 promised `drainPolicy: Migrate` does "offline (bounded downtime) for
+VFIO/GPU." That is **NOT deliverable** in the initial Phase 4: the
+SwiftMigration validating webhook
+([`internal/webhook/swiftmigration/validator.go`](internal/webhook/swiftmigration/validator.go))
+still **unconditionally rejects ALL VFIO/GPU cross-node migration**
+("Phase 4+ work pending a release-and-reallocate primitive"), and that
+primitive does not exist. The SwiftGPU model is the blocker:
+`findAndAllocate` (allocate.go) **auto-picks** the first GPU node with
+matching free capacity and pins the guest there; `deallocateGPUs` frees by
+`guest.Status.GPU.NodeName`. There is **no "allocate on a specific
+requested node"** capability — exactly what migrating a GPU guest to a
+chosen target needs.
+
+**Initial-Phase-4 handling (shipped in PR 4a):** VFIO/GPU guests block the
+drain under ANY drainPolicy. The eviction webhook denies them with a
+manual-handling message and does NOT mark them (a marker would drive the
+drain controller to create a webhook-rejected SwiftMigration every 5s); the
+drain controller also guards defensively (`HasVFIODevices` → Warning event,
+no migration). Design doc §4.3 corrected with a prominent scope note.
+
+**Decision (2026-06-02):** build the release-and-reallocate primitive
+**next**, after the non-VFIO drain (PR 4a/4b/5) ships. Its own
+design→spike→multi-PR track. Surface (design doc §9 "Follow-on sub-phase"):
+1. New SwiftGPU capability: allocate-on-specific-node + release-from-node,
+   exposed for the migration controller.
+2. GPU target pre-flight (free GPUs matching profile count/model/tier/NUMA/
+   FM partition) — a GPU analogue of `swiftmigration.NodeHasCapacity`, in
+   drain target-selection AND the migration Validating phase.
+3. Two-phase atomicity: reserve target GPUs BEFORE stopping the source
+   (Phase 1's drive-forward-post-cutover / restore-pre-cutover), else a
+   failed realloc strands a stopped GPU-less guest.
+4. Lift the webhook VFIO rejection for **offline mode only** (live+VFIO
+   stays blocked).
+5. FM partition handoff (Tier 2/3): deactivate on source, activate on
+   target.
+
+**Hard validation constraint:** the cluster has **one GPU node** (boba,
+GTX 1080), so true cross-node GPU migration **cannot be hardware-validated**
+here. Validation strategy (decided 2026-06-02): degenerate same-node
+`boba→boba` release→reacquire of the real GTX 1080 (exercises the
+dealloc→realloc choreography) + a mocked second `SwiftGPUNode` in
+unit/envtest for the cross-node target-selection logic. Ship explicitly
+labeled "cross-node GPU migration not hardware-validated (needs 2nd GPU
+node)." Severity: MEDIUM (real operator value for GPU nodes; the W5 pattern
+again — the design under-constrained reality at the SwiftGPU boundary).
+
 ### Phase 3c PR 5 — cluster walkthrough COMPLETE (mTLS validated end-to-end)
 
 PR 5 deployed the combined webhook+mTLS overlay on the dev cluster


### PR DESCRIPTION
## Phase 4 drain integration — PR 4a of 5

The **"controller creates"** half of webhook-marks / controller-creates (design §3). Turns the inert PR-3 `kubeswift.io/drain-requested` marker into actual VM evacuation. *(Split from the original single PR 4 — PR 4b is the per-guest PDB — for reviewability, per the same discipline used across Phase 4.)*

### Drain controller (`internal/controller/swiftdrain`)
Watches SwiftGuests, `Owns` the SwiftMigrations it creates. For a marked guest:

| State | Action |
|---|---|
| already off the draining node (`status.NodeName` moved) | **clear the marker** (drain achieved), emit `DrainComplete` |
| non-VFIO, still on draining node, no migration in flight | select target + **create a guest-owned SwiftMigration** |
| migration `Failed`/`Cancelled` | leave the marker (webhook keeps denying — VM protected), surface failure, **no retry storm** |
| no schedulable target | requeue; **drain stalls safely** |
| another migration already in flight | defer (requeue) — no duplicate |

The created migration: deterministic **bounded** name (≤63 char label-value, sha256-suffixed), `mode` from `drainPolicy` (Migrate→auto, LiveMigrate→live), `Reason=node-drain`, `AllowIPChange=true` (so default-networking cross-node doesn't stall the drain), ownerRef→guest (GC).

Target selection: Ready + schedulable + non-draining peer with capacity — reusing the migration Validating phase's capacity gate (see below); kernel-boot guests require a `kernel-node` target. The migration Validating phase re-runs the **authoritative** capacity check, so a race here only costs a retry, never a bad cutover.

### VFIO correctness fix (folded in — 4a makes the marker live)
The design's "`Migrate` → offline for VFIO/GPU" was **undeliverable**: the SwiftMigration webhook still **rejects all VFIO/GPU migration** (no release-and-reallocate primitive exists). So:
- The **eviction webhook** now denies VFIO/GPU guests under **any** drainPolicy with a manual-handling message and does **not mark** them (a marker would loop a webhook-rejected migration every 5s).
- The **drain controller** guards defensively (`HasVFIODevices` → Warning event, no migration).
- Design doc **§4.3 corrected** with a prominent scope note.

Building the release-and-reallocate primitive is the **next sub-phase** (decision 2026-06-02), tracked as **TFU #27** + design §9 "Follow-on sub-phase". It can't be cross-node-validated on the single-GPU-node cluster (validation plan: same-node `boba→boba` reacquire + mocked 2nd `SwiftGPUNode`).

### Consolidation
Exports `swiftmigration.NodeHasCapacity` (was a private method) so target selection reuses the **exact** capacity gate the Validating phase applies — one source of truth, no drift (same ethos as PR 3's `HasVFIODevices`).

### CRD / RBAC
- **No CRD change.**
- **No new RBAC** — the controller-manager already holds `swiftmigrations` create + `nodes`/`pods`/`swiftguestclasses` get,list,watch + `swiftguests` patch. The controller is always registered (no-op until a marker appears).

### Tests
- 13-case state-machine table: create / clear-on-move / defer / no-target / cordoned-peer / not-Ready-peer / Failed-no-new / in-flight-no-dup / VFIO-no-migration / live-mode + name determinism+bound + mode mapping.
- Eviction tests gain VFIO-under-`Migrate` coverage.
- Full `go test ./...` green; vet + fmt clean.

### Phase 4 progress
- ✅ PR 1 (#87) — design + `drainPolicy` field
- ✅ PR 2 (#88) — TFU #24 freeze
- ✅ PR 3 (#89) — eviction webhook
- ▶️ **PR 4a (this)** — drain controller (non-VFIO)
- ⬜ PR 4b — per-guest `maxUnavailable:0` PDB
- ⬜ PR 5 — cluster walkthrough + operator runbook
- ⬜ Follow-on — VFIO/GPU release-and-reallocate sub-phase (TFU #27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)