### PR TITLE
Phase 4 PR 4b — per-guest PodDisruptionBudget (hard floor)

### DIFF
--- a/charts/kubeswift/templates/controller-manager/rbac.yaml
+++ b/charts/kubeswift/templates/controller-manager/rbac.yaml
@@ -45,6 +45,13 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # poddisruptionbudgets — Phase 4 drain integration: the SwiftGuest
+  # controller creates a per-guest maxUnavailable:0 PDB (the hard floor that
+  # protects VMs from drain even when the eviction webhook is down). list,watch
+  # alongside get because the cached client opens an informer on GET (W7/W8).
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # secrets — get,list,watch for general reads; create,update added for
   # the Phase 3c live-migration mTLS path (migration.mtls.enabled): the
   # migrationcert controller copies a node's cert-manager-issued identity

--- a/config/manager/controller-manager-rbac.yaml
+++ b/config/manager/controller-manager-rbac.yaml
@@ -97,6 +97,14 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # poddisruptionbudgets — Phase 4 drain integration: the SwiftGuest
+  # controller creates a per-guest maxUnavailable:0 PDB (the hard floor that
+  # protects VMs from drain even when the eviction webhook is down). list,watch
+  # alongside get because the controller-runtime cached client opens an
+  # informer on every GET-ed resource (the W7/W8 lesson).
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # secrets — get,list,watch for general reads; create,update added for
   # the Phase 3c live-migration mTLS path (--migration-mtls-enabled): the
   # migrationcert controller copies a node's cert-manager-issued identity

--- a/docs/design/live-migration-phase-4.md
+++ b/docs/design/live-migration-phase-4.md
@@ -185,10 +185,17 @@ enum fields must be regenerated, not just constant-added — Phase 3c PR 5).
 
 ## 8. Open implementation sub-decisions
 
-- **PDB scope:** create for migratable guests (and `Block` guests, for the
-  same hard protection) — but NOT before the launcher pod exists, and
-  clean up via ownerRef on guest delete. SwiftGuestPool replicas: per-pod
-  PDB vs pool-level; per-pod is simpler and uniform.
+- **PDB scope (RESOLVED: universal, per-guest).** Shipped in PR 4b: the
+  SwiftGuest controller creates a `maxUnavailable: 0` PDB for **every** guest
+  with a launcher pod (migratable, `Block`, and `migration.enabled: false`
+  alike — a VM is never evicted-to-death regardless of policy). Created only
+  past the pod-ensure block (NOT before the launcher pod exists); selects the
+  launcher pod by `swift.kubeswift.io/guest` (so protection follows the guest
+  across a live-migration pod rename); owned by the guest (GC on delete).
+  SwiftGuestPool replicas get a per-pod PDB each (uniform, simpler than
+  pool-level). The PDB does not impede the happy-path drain — the webhook
+  denies and the migration cutover `Delete`s the source pod (a Delete, not an
+  Eviction); the PDB only bites when the webhook is down.
 - **Marker on the SwiftGuest vs the pod:** the SwiftGuest (survives the
   cutover pod rename; the controller already reconciles it).
 - **Re-drain idempotency:** the deterministic SwiftMigration name +

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -7,6 +7,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -436,6 +437,15 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	// Phase 4 drain integration: ensure the per-guest PodDisruptionBudget
+	// (maxUnavailable: 0). The hard floor that protects the VM from drain even
+	// when the eviction webhook is down. Reached only past the pod-ensure
+	// block above, so the launcher pod exists; owned by the guest (GC on
+	// delete). See ensureMigrationPDB.
+	if err := r.ensureMigrationPDB(ctx, &guest); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
 }
 
@@ -531,6 +541,7 @@ func (r *SwiftGuestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Pod{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&batchv1.Job{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Watches(&imagev1alpha1.SwiftImage{}, handler.EnqueueRequestsFromMapFunc(r.swiftImageToSwiftGuests)).
 		Complete(r)
 }

--- a/internal/controller/swiftguest/ensure_pdb.go
+++ b/internal/controller/swiftguest/ensure_pdb.go
@@ -1,0 +1,79 @@
+package swiftguest
+
+import (
+	"context"
+	"fmt"
+
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// guestPodLabelKey is the launcher-pod label the per-guest PDB selects on.
+// Matches the label written by the pod builder (pod.go).
+const guestPodLabelKey = "swift.kubeswift.io/guest"
+
+// ensureMigrationPDB creates (idempotently) the per-guest PodDisruptionBudget
+// with maxUnavailable: 0 — the Phase 4 "hard floor" that protects the VM from
+// voluntary eviction (kubectl drain / the eviction API) EVEN WHEN the eviction
+// webhook is down (design §3, §4.2). Universal: every guest with a launcher
+// pod gets one.
+//
+// It selects the guest's launcher pod by the swift.kubeswift.io/guest label
+// (which both the steady-state guest.Name pod and a post-migration
+// <guest>-mig-<uid> pod carry, so protection follows the guest across a live
+// migration), and is owned by the SwiftGuest so it is garbage-collected on
+// guest delete.
+//
+// A maxUnavailable:0 PDB does NOT impede the happy-path drain: the eviction
+// webhook denies (429, retry) and the migration's cutover Deletes the source
+// pod directly (a Delete, not an Eviction — PDBs gate only the eviction API),
+// so the guest moves and drain proceeds. The PDB only bites when the webhook
+// is unavailable — exactly the failure mode it backstops.
+//
+// Called past the pod-ensure block, so the launcher pod exists (§8: "not
+// before the launcher pod exists"). The spec is deterministic (selector keyed
+// on the immutable guest name, constant maxUnavailable), so this is
+// create-if-absent and leaves an existing PDB untouched.
+func (r *SwiftGuestReconciler) ensureMigrationPDB(ctx context.Context, guest *swiftv1alpha1.SwiftGuest) error {
+	name := guest.Name
+	var existing policyv1.PodDisruptionBudget
+	err := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: name}, &existing)
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get PodDisruptionBudget %q: %w", name, err)
+	}
+
+	zero := intstr.FromInt32(0)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: guest.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "kubeswift",
+				"app.kubernetes.io/component":  "guest",
+				"app.kubernetes.io/managed-by": "kubeswift-controller-manager",
+			},
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MaxUnavailable: &zero,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{guestPodLabelKey: guest.Name},
+			},
+		},
+	}
+	if err := controllerutil.SetControllerReference(guest, pdb, r.Scheme); err != nil {
+		return fmt.Errorf("set ownerRef on PodDisruptionBudget %q: %w", name, err)
+	}
+	if err := r.Create(ctx, pdb); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create PodDisruptionBudget %q: %w", name, err)
+	}
+	return nil
+}

--- a/internal/controller/swiftguest/ensure_pdb_test.go
+++ b/internal/controller/swiftguest/ensure_pdb_test.go
@@ -1,0 +1,72 @@
+package swiftguest
+
+import (
+	"context"
+	"testing"
+
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/scheme"
+)
+
+func pdbTestGuest() *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "default", UID: "g-uid"},
+	}
+}
+
+func TestEnsureMigrationPDB_Creates(t *testing.T) {
+	g := pdbTestGuest()
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(g).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme}
+
+	if err := r.ensureMigrationPDB(context.Background(), g); err != nil {
+		t.Fatalf("ensureMigrationPDB: %v", err)
+	}
+
+	var pdb policyv1.PodDisruptionBudget
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "g"}, &pdb); err != nil {
+		t.Fatalf("PDB not created: %v", err)
+	}
+	if pdb.Spec.MaxUnavailable == nil || *pdb.Spec.MaxUnavailable != intstr.FromInt32(0) {
+		t.Errorf("maxUnavailable must be 0 (the hard floor); got %v", pdb.Spec.MaxUnavailable)
+	}
+	if pdb.Spec.MinAvailable != nil {
+		t.Errorf("minAvailable must be unset (maxUnavailable:0 is the model); got %v", pdb.Spec.MinAvailable)
+	}
+	if pdb.Spec.Selector == nil || pdb.Spec.Selector.MatchLabels[guestPodLabelKey] != "g" {
+		t.Errorf("selector must match launcher pod label %s=g; got %+v", guestPodLabelKey, pdb.Spec.Selector)
+	}
+	if len(pdb.OwnerReferences) != 1 ||
+		pdb.OwnerReferences[0].Name != "g" ||
+		pdb.OwnerReferences[0].Controller == nil || !*pdb.OwnerReferences[0].Controller {
+		t.Errorf("PDB must be controller-owned by the guest (GC on delete); got %+v", pdb.OwnerReferences)
+	}
+}
+
+func TestEnsureMigrationPDB_Idempotent(t *testing.T) {
+	g := pdbTestGuest()
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(g).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme}
+	ctx := context.Background()
+
+	if err := r.ensureMigrationPDB(ctx, g); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	if err := r.ensureMigrationPDB(ctx, g); err != nil {
+		t.Fatalf("second ensure must be a no-op, not an error: %v", err)
+	}
+
+	var list policyv1.PodDisruptionBudgetList
+	if err := c.List(ctx, &list); err != nil {
+		t.Fatalf("list PDBs: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Errorf("expected exactly 1 PDB after two ensures; got %d", len(list.Items))
+	}
+}


### PR DESCRIPTION
## Phase 4 drain integration — PR 4b of 5

The **PDB-guarantees** leg of webhook-marks / controller-creates / PDB-guarantees (design §3, §4.2, §8). The **hard floor** that protects a VM from voluntary eviction **even when the eviction webhook is down** — independent of both the webhook and the drain controller.

### What this PR does
The SwiftGuest controller now creates a `maxUnavailable: 0` PodDisruptionBudget for **every** guest with a launcher pod (`ensureMigrationPDB`, called past the pod-ensure block so the pod exists — §8):

- **Universal** — migratable, `Block`, and `migration.enabled: false` guests all get one. A VM is never evicted-to-death regardless of policy.
- **Selector** = `swift.kubeswift.io/guest=<name>` — the label both the steady-state `guest.Name` pod and a post-migration `<guest>-mig-<uid>` pod carry, so protection **follows the guest across a live-migration pod rename**.
- **Owned by the guest** → GC'd on guest delete. `Owns(PodDisruptionBudget)` in SetupWithManager so a manually-deleted PDB self-heals.
- **Create-if-absent** — the spec is deterministic (immutable selector + constant `maxUnavailable`).

### Why it doesn't break the happy-path drain
PDBs gate **only** the eviction API. On drain: the eviction webhook denies (429, retry) and the migration cutover **`Delete`s** the source pod directly (a Delete, not an Eviction), so the guest moves and drain proceeds. The PDB only bites when the webhook is **unavailable** — exactly the failure mode it backstops (§7: *"webhook down → drain stalls safely; VM protected"*).

### CRD / RBAC
- **No CRD change.**
- **New RBAC**: `policy/poddisruptionbudgets` `get,list,watch,create,update,patch,delete` (config/manager + Helm). `list,watch` alongside `get` because the cached client opens an informer on every GET-ed resource (the **W7/W8 lesson** — avoid the reconcile-queue starvation that bit StorageClass/RoleBinding).

### Tests
- PDB created with `maxUnavailable: 0`, correct selector, controller ownerRef, no `minAvailable`.
- Idempotent: two ensures → exactly one PDB.
- Full `go test ./...` green; vet + fmt clean; helm renders the RBAC rule.

### Phase 4 progress
- ✅ PR 1 (#87) — design + `drainPolicy` field
- ✅ PR 2 (#88) — TFU #24 freeze
- ✅ PR 3 (#89) — eviction webhook
- ✅ PR 4a (#90) — drain controller (non-VFIO)
- ▶️ **PR 4b (this)** — per-guest PDB (hard floor)
- ⬜ PR 5 — cluster walkthrough + operator runbook (`docs/migration/phase-4.md`)
- ⬜ Follow-on — VFIO/GPU release-and-reallocate sub-phase (TFU #27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)