### PR TITLE
Phase 4 PR 5 — drain-integration walkthrough + operator runbook

### DIFF
--- a/config/samples/migration/phase-4/swiftguest-drainpolicy-block.yaml
+++ b/config/samples/migration/phase-4/swiftguest-drainpolicy-block.yaml
@@ -1,0 +1,25 @@
+# Phase 4 drain integration — a guest that BLOCKS `kubectl drain`.
+#
+# drainPolicy: Block — the eviction webhook denies the eviction with a
+# manual-handling message and never stamps the drain marker, so the guest is
+# never auto-migrated. The per-guest maxUnavailable:0 PDB also blocks the
+# eviction. Draining the node stalls until the operator moves/stops the guest
+# manually (or `kubectl drain --force`, which deletes the VM).
+#
+# Use for pinned/stateful guests that must not move automatically.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: phase4-block
+  namespace: default
+spec:
+  kernelRef:
+    name: faas-minimal
+  guestClassRef:
+    name: default
+  kernelCmdline: "console=ttyS0 root=/dev/ram0 rdinit=/init"
+  runPolicy: Running
+  nodeName: miles
+  migration:
+    enabled: true
+    drainPolicy: Block

--- a/config/samples/migration/phase-4/swiftguest-drainpolicy-migrate.yaml
+++ b/config/samples/migration/phase-4/swiftguest-drainpolicy-migrate.yaml
@@ -1,0 +1,26 @@
+# Phase 4 drain integration — a guest that auto-migrates on `kubectl drain`.
+#
+# drainPolicy: Migrate (the default) — when the guest's node is drained, the
+# eviction webhook blocks the eviction (429, retry) and the drain controller
+# creates a SwiftMigration (mode=auto: live-migrate where possible) to
+# evacuate it. Drain completes once the guest has moved.
+#
+# Kernel-boot guest (faas-minimal) — live-migration-capable with no storage
+# gymnastics. Requires: SwiftKernel "faas-minimal" Ready, SwiftGuestClass
+# "default", and the target/source nodes labeled kubeswift.io/kernel-node=true.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: phase4-migrate
+  namespace: default
+spec:
+  kernelRef:
+    name: faas-minimal
+  guestClassRef:
+    name: default
+  kernelCmdline: "console=ttyS0 root=/dev/ram0 rdinit=/init"
+  runPolicy: Running
+  nodeName: miles          # start on miles so `kubectl drain miles` moves it
+  migration:
+    enabled: true
+    drainPolicy: Migrate    # Migrate | LiveMigrate | Block

--- a/docs/design/live-migration-phase-4.md
+++ b/docs/design/live-migration-phase-4.md
@@ -213,20 +213,22 @@ enum fields must be regenerated, not just constant-added — Phase 3c PR 5).
 3. **PR 3** (#89, merged) — the eviction webhook (`pods/eviction` admission
    handler, VWC rule, `failurePolicy: Ignore`, marker patch with dry-run
    skip). Unit-tested; marker inert until PR 4a.
-4. **PR 4a** — the drain controller (marker → SwiftMigration → clear +
-   target selection). Handles **non-VFIO** guests; VFIO/GPU guests are
-   denied-without-marking by the eviction webhook (VFIO correctness fix
+4. **PR 4a** (#90, merged) — the drain controller (marker → SwiftMigration →
+   clear + target selection). Handles **non-VFIO** guests; VFIO/GPU guests
+   are denied-without-marking by the eviction webhook (VFIO correctness fix
    folded in here, since 4a makes the marker live). Reuses the migration
    Validating phase's `NodeHasCapacity` gate. Unit-tested.
    *(Split from the original single PR 4 per the same Design-Principle-#1
    reviewability discipline used throughout Phase 4.)*
-5. **PR 4b** — per-guest `maxUnavailable: 0` PodDisruptionBudget creation in
-   the SwiftGuest controller (the hard floor, independent of the
-   webhook/controller; §4.2). Logically independent of 4a.
-6. **PR 5** — cluster walkthrough (drain miles → guest live-migrates to
-   boba → drain completes; `Block` deny; webhook-down PDB safety) +
-   operator runbook (`docs/migration/phase-4.md`). VFIO-offline is **not**
-   in this walkthrough (deferred to the release-and-reallocate sub-phase).
+5. **PR 4b** (#91, merged) — universal per-guest `maxUnavailable: 0`
+   PodDisruptionBudget creation in the SwiftGuest controller (the hard floor,
+   independent of the webhook/controller; §4.2). Logically independent of 4a.
+6. **PR 5** (SHIPPED) — cluster walkthrough + operator runbook
+   (`docs/migration/phase-4.md`) + drainPolicy samples. Validated on
+   miles/boba (image sha-04c054d): drain → live-migrate to boba
+   (observedDowntime 2.30s) → drain completes; `Block` deny; webhook-down PDB
+   safety; per-guest PDB. All PASS, no bugs. VFIO-offline deferred to the
+   release-and-reallocate sub-phase.
 
 ### Follow-on sub-phase — VFIO/GPU release-and-reallocate
 

--- a/docs/migration/phase-4.md
+++ b/docs/migration/phase-4.md
@@ -1,0 +1,164 @@
+# Live Migration Phase 4 — Drain Integration (Operator Guide)
+
+> Status: SHIPPED (non-VFIO). `kubectl drain` automatically evacuates
+> SwiftGuest VMs off a node instead of killing them. VFIO/GPU guests block
+> the drain (manual handling) pending the release-and-reallocate sub-phase
+> (TFU #27).
+
+## What it does
+
+`kubectl drain <node>` (and any eviction-API caller — cluster-autoscaler,
+node upgrades) now **safely evacuates SwiftGuest VMs**: each guest is
+migrated off the node (live where possible), and the eviction is blocked
+until the guest is gone. **A VM is never evicted-to-death.**
+
+Three pieces cooperate:
+
+1. **Eviction webhook** (`pods/eviction`, `failurePolicy: Ignore`) — denies
+   the eviction of a SwiftGuest launcher pod with `429 TooManyRequests` (so
+   drain retries every 5s) and stamps `kubeswift.io/drain-requested:<node>`
+   on the SwiftGuest.
+2. **Drain controller** — sees the marker, creates a `SwiftMigration`
+   (`reason: node-drain`, mode from the guest's `drainPolicy`, target node
+   chosen by capacity), and clears the marker once the guest has moved.
+   The migration's cutover `Delete`s the source pod (a Delete, not an
+   Eviction), so the guest moves and the next drain retry proceeds.
+3. **Per-guest PodDisruptionBudget** (`maxUnavailable: 0`) — the **hard
+   floor**: it protects the VM even if the webhook is down. Created by the
+   SwiftGuest controller for every guest with a launcher pod.
+
+## Per-guest drain policy
+
+Set `spec.migration.drainPolicy` on a SwiftGuest (default `Migrate`):
+
+| Value | On drain |
+|---|---|
+| `Migrate` (default) | `mode=auto` — live-migrate where possible, offline otherwise. Drain succeeds (non-VFIO). |
+| `LiveMigrate` | live only; if the guest can't live-migrate, **deny the drain** rather than incur downtime. |
+| `Block` | always **deny the drain**; handle the guest manually. |
+
+`spec.migration.enabled: false` is stronger — it disables migration entirely;
+drain denies with a manual-handling message.
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: web-1
+spec:
+  # ...
+  migration:
+    enabled: true
+    drainPolicy: Migrate   # Migrate | LiveMigrate | Block
+```
+
+## VFIO/GPU guests — NOT auto-evacuated (yet)
+
+Guests with VFIO devices (`gpuProfileRef`, or any `sriov` interface) **cannot
+be auto-migrated** in this release: cross-node VFIO migration needs a
+release-and-reallocate primitive that does not exist yet (TFU #27). Under any
+`drainPolicy`, the eviction webhook denies their eviction with a
+manual-handling message and does **not** stamp the marker. To drain a node
+with a VFIO/GPU guest, move or stop the guest manually first, or
+`kubectl drain --force` (which deletes the pod — **the VM is lost**; only do
+this if the guest is disposable).
+
+## Deploying
+
+Phase 4 requires the eviction webhook, so deploy with a webhook overlay
+(cert-manager required):
+
+```bash
+# webhook only:
+make deploy-with-webhook
+# webhook + live-migration mTLS (Phase 3c):
+make deploy-with-webhook-and-mtls
+```
+
+The drain controller and the per-guest PDB ship in the controller-manager
+and are always active; only the eviction webhook needs the overlay. With the
+minimal `make deploy` (no webhook), the **PDB still protects** VMs (drain
+stalls safely), but there is no automatic migration — drain a node and the
+guest's eviction is blocked by the PDB with no auto-evacuation.
+
+> **Upgrade note (stale-CRD strip).** `spec.migration.drainPolicy` is a new
+> CRD field. If you upgrade via a custom pipeline that doesn't re-apply the
+> CRDs, the apiserver silently strips it. `make deploy*` / `helm upgrade`
+> re-apply the CRDs; verify with
+> `kubectl explain swiftguest.spec.migration.drainPolicy`.
+
+## Walking through a drain
+
+```bash
+# 1. Drain a worker; SwiftGuest VMs evacuate automatically.
+kubectl drain miles --ignore-daemonsets --delete-emptydir-data
+#   evicting pod default/web-1
+#   error when evicting pod "web-1" (will retry after 5s): admission webhook
+#     "veviction.kubeswift.io" denied the request: SwiftGuest "web-1" on node
+#     "miles" is being migrated off before eviction; retry
+#   ... (the guest live-migrates to boba) ...
+#   pod/web-1 evicted
+#   node/miles drained
+
+# 2. Watch the auto-created migration.
+kubectl get swiftmigration -w        # <guest>-drain-<hash>, reason=node-drain
+
+# 3. Confirm the guest landed on the other node.
+kubectl get swiftguest web-1 -o jsonpath='{.status.nodeName}{"\n"}'   # boba
+
+# 4. Done; uncordon.
+kubectl uncordon miles
+```
+
+## Empirical results (dev cluster, miles/boba, CH v51.1, image sha-04c054d)
+
+PR 5 cluster walkthrough (2026-06-02), kernel-boot guest, default node-local
+networking, live-migration mTLS enabled:
+
+| Scenario | Result |
+|---|---|
+| **Drain → auto-migrate** (`drainPolicy: Migrate`) | `kubectl drain miles` → eviction denied 429 (~6 retries at 5s) → drain controller created `phase4-migrate-drain-96888133` (`reason=node-drain`, resolved **mode=live**, target=boba, `allowIPChange=true`) → guest live-migrated to boba, marker cleared → **`node/miles drained`** (exit 0). **observedDowntime 2.30s**, observedTransferDuration 38.48s. |
+| **Block** (`drainPolicy: Block`) | eviction denied `... drainPolicy=Block ... handle this guest manually`; **no marker, no migration**; guest stayed Running on miles; drain stalls (operator `--force`s or moves manually). |
+| **Webhook down** (controller scaled to 0) | webhook skipped (`failurePolicy: Ignore`) → the `maxUnavailable:0` PDB denied the eviction (`Cannot evict pod as it would violate the pod's disruption budget`) → drain stalls **safely**, VM protected. |
+| **Per-guest PDB** | every guest got a `maxUnavailable:0` PDB (ALLOWED DISRUPTIONS 0), owned by the SwiftGuest, selecting its launcher pod; GC'd with the guest. |
+
+> **Drain SwiftGuest nodes with `--delete-emptydir-data`.** The launcher pod
+> uses `emptyDir` volumes (runtime dir, serial socket), so a plain
+> `kubectl drain <node>` refuses with *"cannot delete Pods with local storage
+> (use --delete-emptydir-data to override)"* **before** the eviction webhook
+> ever fires — the guest is not migrated. Always include
+> `--delete-emptydir-data --ignore-daemonsets`:
+> ```bash
+> kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
+> ```
+
+## Failure modes
+
+| Mode | Behaviour |
+|---|---|
+| Webhook up, migratable guest | mark → migrate → cutover deletes src → drain proceeds |
+| Webhook **down** (`Ignore`) | admission skipped → the `maxUnavailable:0` PDB still blocks the eviction (429) → drain stalls **safely**; VM protected; no auto-migration (investigate the controller) |
+| No schedulable target | webhook keeps denying with a clear message; drain stalls; free capacity or `--force` |
+| Migration fails mid-drain | marker stays; `SwiftMigration` shows the failure; webhook keeps denying (VM unharmed — live pre-copy never pauses the source). `kubectl delete swiftmigration <name>` to retry, or handle manually |
+| `drainPolicy: Block` / `migration.enabled=false` | deny with a manual-handling message; move the guest manually or `--force` |
+| VFIO/GPU guest | deny with a manual-handling message (no marker); not auto-evacuated yet (TFU #27) |
+| `drain --dry-run` | webhook denies (shows it would block) but skips the marker patch (`sideEffects: NoneOnDryRun`) |
+
+## Troubleshooting
+
+- **Drain hangs forever, no migration created.** Check the SwiftGuest for a
+  `DrainNoTarget` event (`kubectl describe swiftguest <g>`): no peer node has
+  capacity. Free capacity on another worker, or `--force`.
+- **Drain hangs, `DrainUnsupported` event.** The guest is VFIO/GPU — not
+  auto-evacuated yet. Handle manually.
+- **Drain hangs, controller is down.** Expected (PDB hard floor). Bring the
+  controller back; the drain then auto-migrates. Or `--force` to delete the
+  VM (data loss).
+- **A guest won't migrate** but should: `kubectl describe swiftmigration
+  <guest>-drain-*` for the `Failed` reason (often a capacity or storage
+  gate). Delete the migration to retry.
+
+## See also
+
+- Design: [`docs/design/live-migration-phase-4.md`](../design/live-migration-phase-4.md)
+- Live migration (Phase 3a/b/c): [`phase-3a.md`](phase-3a.md), [`phase-3b.md`](phase-3b.md), [`phase-3c.md`](phase-3c.md)

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -1465,6 +1465,51 @@ apiserver-enum-vs-Go-constant mismatch, the CPU-throttle resource bug,
 and the ghcr package-visibility gap. PR 5 runbook:
 [`docs/migration/phase-3c.md`](docs/migration/phase-3c.md).
 
+### Phase 4 — Drain Integration (non-VFIO) — SHIPPED + cluster-validated
+
+Phase 4 makes `kubectl drain` automatically and safely evacuate SwiftGuest
+VMs (webhook-marks / controller-creates / PDB-guarantees). Design:
+[`docs/design/live-migration-phase-4.md`](docs/design/live-migration-phase-4.md);
+operator runbook: [`docs/migration/phase-4.md`](docs/migration/phase-4.md).
+Shipped across 6 PRs:
+
+- **PR 1 (#87)** — design doc + `spec.migration.drainPolicy` enum
+  (Migrate|LiveMigrate|Block, default Migrate) + generate + chart sync.
+- **PR 2 (#88)** — TFU #24 `lifecycle: run` freeze on the dst intent (now
+  reachable: Phase 4 introduces the stop-during-migration path). RESOLVED.
+- **PR 3 (#89)** — `pods/eviction` admission webhook (`veviction`,
+  `failurePolicy: Ignore`, `sideEffects: NoneOnDryRun`): denies a guest
+  launcher pod's eviction with 429 + stamps `kubeswift.io/drain-requested`.
+- **PR 4a (#90)** — drain controller (`internal/controller/swiftdrain`):
+  marker → guest-owned SwiftMigration (mode from drainPolicy, target by
+  capacity reusing the exported `swiftmigration.NodeHasCapacity`) → clear on
+  move. Plus the VFIO correctness fix (VFIO guests denied-without-marking
+  under any policy) and the canonical `SwiftGuest.HasVFIODevices` predicate.
+- **PR 4b (#91)** — universal per-guest `maxUnavailable: 0` PDB in the
+  SwiftGuest controller (the hard floor; protects VMs even when the webhook
+  is down). policy/poddisruptionbudgets RBAC (get,list,watch,...).
+- **PR 5** — cluster walkthrough + operator runbook + drainPolicy samples.
+
+**PR 5 cluster walkthrough (2026-06-02, image sha-04c054d, kernel-boot
+guest, miles/boba). All four scenarios PASS; no bugs surfaced** (the
+pre-spiked eviction mechanism held — a rare clean cluster walkthrough):
+
+| Scenario | Result |
+|---|---|
+| Drain → auto-migrate (Migrate) | 6× 429 deny (5s retry) → drain controller created `*-drain-*` (resolved **mode=live**, reason=node-drain, target=boba) → live-migrated → `node/miles drained` (exit 0). **observedDowntime 2.30s**, transfer 38.48s. |
+| Block | denied with manual-handling message, **no marker, no migration**, drain stalls, guest stayed put. |
+| Webhook down (controller→0) | webhook Ignored → the maxUnavailable:0 **PDB denied the eviction** ("would violate the pod's disruption budget") → drain stalls safely, VM protected. |
+| Per-guest PDB | every guest got a guest-owned maxUnavailable:0 PDB; GC'd (PDB + drain SwiftMigration both cascade on guest delete). |
+
+**Operator finding (documented in the runbook, not a bug):** draining a
+SwiftGuest node needs `--delete-emptydir-data` (the launcher pod uses
+emptyDir) — a plain `kubectl drain` refuses on local-storage **before** the
+eviction webhook fires, so the guest is not migrated.
+
+**VFIO/GPU guests are NOT auto-evacuated yet** — they block the drain
+(manual handling). The release-and-reallocate primitive is the next sub-phase
+(**TFU #27**).
+
 ---
 
 ## Phase 2 Decisions Resolved (live migration)


### PR DESCRIPTION
## Phase 4 drain integration — PR 5 of 5 (final)

Operator-facing docs + drainPolicy samples + the **cluster validation** that closes Phase 4 (non-VFIO). No code — the stack shipped in #87–#91.

### Cluster walkthrough (2026-06-02, image `sha-04c054d`, kernel-boot guest, miles/boba, mTLS on)
**All four scenarios PASS — no bugs surfaced** (the pre-spiked eviction mechanism held; a rare clean cluster walkthrough):

| Scenario | Result |
|---|---|
| **Drain → auto-migrate** (`Migrate`) | `kubectl drain miles` → 6× `429` deny (5s retry) → drain controller created `phase4-migrate-drain-96888133` (resolved **mode=live**, `reason=node-drain`, target=boba, `allowIPChange=true`) → live-migrated → `node/miles drained` (exit 0). **observedDowntime 2.30s**, transfer 38.48s. |
| **Block** | denied with `drainPolicy=Block ... handle this guest manually`; **no marker, no migration**; guest stayed Running; drain stalls. |
| **Webhook down** (controller→0) | webhook Ignored → the `maxUnavailable:0` **PDB denied the eviction** (`would violate the pod's disruption budget`) → drain stalls **safely**, VM protected. |
| **Per-guest PDB** | every guest got a guest-owned `maxUnavailable:0` PDB; PDB **and** the drain SwiftMigration both GC on guest delete. |

### Operator finding (documented, not a bug)
Draining a SwiftGuest node needs **`--delete-emptydir-data`** — the launcher pod uses `emptyDir`, so a plain `kubectl drain` refuses on local-storage *before* the eviction webhook fires (the guest wouldn't migrate). Captured in the runbook.

### Contents
- `docs/migration/phase-4.md` — operator runbook (what it does, drainPolicy, VFIO caveat, deploy, worked example, empirical results, failure modes, troubleshooting).
- `config/samples/migration/phase-4/` — `Migrate` + `Block` kernel-boot samples.
- Design doc §9 + context doc updated to SHIPPED.

### Cleanup
Test guests deleted; PDBs + drain migration cascaded via ownerRef; miles uncordoned. Cluster left on the legitimate `sha-04c054d` Phase 4 release.

### Phase 4 status — non-VFIO drain integration SHIPPED ✅
- ✅ PR 1 (#87) design + `drainPolicy` · ✅ PR 2 (#88) freeze · ✅ PR 3 (#89) eviction webhook · ✅ PR 4a (#90) drain controller · ✅ PR 4b (#91) per-guest PDB · ▶️ **PR 5 (this)** walkthrough + runbook
- ⬜ Follow-on — VFIO/GPU release-and-reallocate sub-phase (TFU #27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)