### PR TITLE
feat(gpu): SwiftGPUNode.status.vfioReady + GPUNodeHasCapacity pre-flight

### DIFF
--- a/api/gpu/v1alpha1/types_gpunode.go
+++ b/api/gpu/v1alpha1/types_gpunode.go
@@ -12,6 +12,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:printcolumn:name="GPUs",type=integer,JSONPath=`.status.gpuCount`
 // +kubebuilder:printcolumn:name="Free",type=integer,JSONPath=`.status.freeGPUs`
 // +kubebuilder:printcolumn:name="Model",type=string,JSONPath=`.status.gpuModel`
+// +kubebuilder:printcolumn:name="VfioReady",type=boolean,JSONPath=`.status.vfioReady`
 type SwiftGPUNode struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -38,6 +39,17 @@ type SwiftGPUNodeStatus struct {
 
 	// GPUVendor is the vendor of the GPUs (assumes homogeneous node): "NVIDIA", "AMD", "Intel".
 	GPUVendor string `json:"gpuVendor,omitempty"`
+
+	// VfioReady is true when the vfio-pci driver is loaded on this node
+	// (/sys/bus/pci/drivers/vfio-pci exists), so GPU passthrough can bind
+	// devices. When false, gpu-init would fail to bind the GPU to vfio-pci.
+	// GPU allocation and the migration GPU target pre-flight refuse a node
+	// that is not VfioReady (rather than allocate and let gpu-init fail).
+	// Loading vfio-pci is a host responsibility (e.g. /etc/modules-load.d);
+	// the minimal-capability gpu-discovery DaemonSet only DETECTS and reports
+	// it (it cannot modprobe — drop ALL, no CAP_SYS_MODULE).
+	// +optional
+	VfioReady bool `json:"vfioReady,omitempty"`
 
 	// Host describes the physical host topology.
 	Host HostTopology `json:"host,omitempty"`

--- a/charts/kubeswift/crds/gpu.kubeswift.io_swiftgpunodes.yaml
+++ b/charts/kubeswift/crds/gpu.kubeswift.io_swiftgpunodes.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.gpuModel
       name: Model
       type: string
+    - jsonPath: .status.vfioReady
+      name: VfioReady
+      type: boolean
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -255,6 +258,17 @@ spec:
               phase:
                 description: 'Phase of discovery: Discovering | Ready | Error'
                 type: string
+              vfioReady:
+                description: |-
+                  VfioReady is true when the vfio-pci driver is loaded on this node
+                  (/sys/bus/pci/drivers/vfio-pci exists), so GPU passthrough can bind
+                  devices. When false, gpu-init would fail to bind the GPU to vfio-pci.
+                  GPU allocation and the migration GPU target pre-flight refuse a node
+                  that is not VfioReady (rather than allocate and let gpu-init fail).
+                  Loading vfio-pci is a host responsibility (e.g. /etc/modules-load.d);
+                  the minimal-capability gpu-discovery DaemonSet only DETECTS and reports
+                  it (it cannot modprobe — drop ALL, no CAP_SYS_MODULE).
+                type: boolean
             type: object
         type: object
     served: true

--- a/cmd/gpu-discovery/discover.go
+++ b/cmd/gpu-discovery/discover.go
@@ -342,6 +342,18 @@ func isIOMMUEnabled() bool {
 	return len(entries) > 0
 }
 
+// isVfioPciLoaded reports whether the vfio-pci driver is registered on this
+// node (the driver directory exists in sysfs), which is required for GPU
+// passthrough: gpu-init binds devices to vfio-pci, and that fails if the
+// module is not loaded. This is a READ-ONLY check — the gpu-discovery
+// DaemonSet runs with drop-ALL capabilities and a read-only /sys, so it
+// reports readiness but cannot load the module; loading vfio-pci is a host
+// responsibility (e.g. /etc/modules-load.d/vfio.conf).
+func isVfioPciLoaded() bool {
+	info, err := os.Stat("/sys/bus/pci/drivers/vfio-pci")
+	return err == nil && info.IsDir()
+}
+
 func discoverHugepages() gpuv1alpha1.HugepageInfo {
 	total := readIntFile("/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages")
 	free := readIntFile("/sys/kernel/mm/hugepages/hugepages-1048576kB/free_hugepages")

--- a/cmd/gpu-discovery/discover_test.go
+++ b/cmd/gpu-discovery/discover_test.go
@@ -573,3 +573,13 @@ func TestParseIntList(t *testing.T) {
 		}
 	}
 }
+
+func TestMergeStatus_VfioReady(t *testing.T) {
+	for _, ready := range []bool{true, false} {
+		discovered := &SwiftGPUNodeStatus{VfioReady: ready}
+		merged := mergeStatus(discovered, &gpuv1alpha1.SwiftGPUNodeStatus{})
+		if merged.VfioReady != ready {
+			t.Errorf("VfioReady = %v, want %v (must carry through from discovery)", merged.VfioReady, ready)
+		}
+	}
+}

--- a/cmd/gpu-discovery/main.go
+++ b/cmd/gpu-discovery/main.go
@@ -135,6 +135,7 @@ func mergeStatus(discovered *SwiftGPUNodeStatus, existing *gpuv1alpha1.SwiftGPUN
 		LastDiscovery: &now,
 		Host:          discovered.Host,
 		NVSwitches:    discovered.NVSwitches,
+		VfioReady:     discovered.VfioReady,
 	}
 
 	// Build a map of existing GPU allocations keyed by PCI address.
@@ -230,6 +231,7 @@ type SwiftGPUNodeStatus struct {
 	GPUs          []gpuv1alpha1.GPUDevice
 	NVSwitches    []gpuv1alpha1.NVSwitchDevice
 	FabricManager *gpuv1alpha1.FabricManagerStatus
+	VfioReady     bool
 }
 
 // discoverHardware reads GPU inventory, NUMA topology, and Fabric Manager state
@@ -270,5 +272,6 @@ func discoverHardware() (*SwiftGPUNodeStatus, error) {
 		GPUs:          gpus,
 		NVSwitches:    nvSwitches,
 		FabricManager: fm,
+		VfioReady:     isVfioPciLoaded(),
 	}, nil
 }

--- a/config/crd/bases/gpu.kubeswift.io_swiftgpunodes.yaml
+++ b/config/crd/bases/gpu.kubeswift.io_swiftgpunodes.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.gpuModel
       name: Model
       type: string
+    - jsonPath: .status.vfioReady
+      name: VfioReady
+      type: boolean
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -255,6 +258,17 @@ spec:
               phase:
                 description: 'Phase of discovery: Discovering | Ready | Error'
                 type: string
+              vfioReady:
+                description: |-
+                  VfioReady is true when the vfio-pci driver is loaded on this node
+                  (/sys/bus/pci/drivers/vfio-pci exists), so GPU passthrough can bind
+                  devices. When false, gpu-init would fail to bind the GPU to vfio-pci.
+                  GPU allocation and the migration GPU target pre-flight refuse a node
+                  that is not VfioReady (rather than allocate and let gpu-init fail).
+                  Loading vfio-pci is a host responsibility (e.g. /etc/modules-load.d);
+                  the minimal-capability gpu-discovery DaemonSet only DETECTS and reports
+                  it (it cannot modprobe — drop ALL, no CAP_SYS_MODULE).
+                type: boolean
             type: object
         type: object
     served: true

--- a/docs/design/vfio-release-reallocate.md
+++ b/docs/design/vfio-release-reallocate.md
@@ -93,17 +93,22 @@ on **both** the source (status.GPU.NodeName=S, the running pod) and the target
 
 ### 4.2 Node vfio-readiness
 
-`SwiftGPUNode.status` gains a `vfioReady` condition (or boolean), set by the
-gpu-discovery DaemonSet (already privileged, already per-GPU-node):
-- gpu-discovery checks `/sys/bus/pci/drivers/vfio-pci` exists (module loaded)
-  and, if missing, **`modprobe vfio-pci`** (it has the privilege; gpu-init
-  does not — minimal caps). Surfaces the result on `SwiftGPUNode.status`.
+`SwiftGPUNode.status` gains a `vfioReady` boolean (PR 1, shipped):
+- gpu-discovery **detects and reports** vfio-readiness — a read-only check
+  that `/sys/bus/pci/drivers/vfio-pci` exists (module loaded). It does **NOT**
+  load the module: the gpu-discovery DaemonSet runs with `privileged: false`,
+  `drop: ALL`, and a read-only `/sys` (verified — an earlier design draft
+  wrongly assumed it was privileged), so it has neither `CAP_SYS_MODULE` nor a
+  writable sysfs / `/lib/modules`.
+- **Loading `vfio-pci` is a host responsibility** — `/etc/modules-load.d/
+  vfio.conf` (persistent) or `modprobe vfio-pci` (transient). Documented as a
+  GPU-node prerequisite. A future opt-in privileged loader (a separate
+  minimal, dedicated DaemonSet, NOT gpu-discovery) could automate it if
+  operators want it; out of scope for this sub-phase.
 - `ReserveOnNode` and the GPU target pre-flight **refuse a node that is not
   vfioReady**, turning a silent gpu-init `Init:Error` into a clear, early
-  rejection.
-- Operators should also load `vfio-pci` persistently
-  (`/etc/modules-load.d/vfio.conf`); the modprobe is a safety net, documented
-  as such.
+  rejection — this is the value the surface delivers regardless of who loads
+  the module.
 
 ### 4.3 GPU target pre-flight (a GPU analogue of `NodeHasCapacity`)
 
@@ -199,9 +204,10 @@ status, shipped explicitly labeled. Tier 1 (the validatable case) has no FM.
 2. **vfioReady representation.** A `SwiftGPUNode.status.conditions[vfioReady]`
    vs a boolean `status.vfioReady`. Conditions are the kube-idiomatic choice;
    confirm with the discovery DaemonSet's existing status shape.
-3. **modprobe in gpu-discovery: opt-in?** Auto-modprobe vs only-report. Lean
-   auto (it is the safety net) but gate behind a discovery flag if operators
-   want host config to be authoritative.
+3. **modprobe — RESOLVED (PR 1): only-report.** gpu-discovery is minimal-cap
+   (drop ALL, read-only /sys) and cannot modprobe; it detects + reports
+   vfioReady. Loading `vfio-pci` is a host responsibility. A future opt-in
+   privileged loader (separate DaemonSet) is the path if auto-load is wanted.
 4. **Same-node migration semantics.** `boba->boba` is degenerate (source ==
    target). The migration webhook today rejects same-node; the validation path
    needs a test-only allowance OR the design treats `boba->boba` as a

--- a/internal/controller/swiftgpu/preflight.go
+++ b/internal/controller/swiftgpu/preflight.go
@@ -1,0 +1,50 @@
+package swiftgpu
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
+)
+
+// GPUNodeHasCapacity is the GPU analogue of swiftmigration.NodeHasCapacity: it
+// reports whether nodeName's SwiftGPUNode can host a guest using profile — the
+// node is vfio-ready AND has at least profile.Count free GPUs matching the
+// profile's model (and, for shared partition mode, a free Fabric Manager
+// partition).
+//
+// Read-only (it allocates nothing). Intended for the VFIO release-and-
+// reallocate sub-phase: the drain controller's GPU target selection and the
+// migration GPU target pre-flight call this so a VFIO guest only ever targets
+// a node that can actually host it — turning a would-be gpu-init Init:Error
+// (e.g. vfio-pci not loaded) into an early, clear rejection. Returns nil when
+// the node fits; a descriptive error otherwise.
+func GPUNodeHasCapacity(ctx context.Context, c client.Client, nodeName string, profile *gpuv1alpha1.SwiftGPUProfile) error {
+	var node gpuv1alpha1.SwiftGPUNode
+	if err := c.Get(ctx, client.ObjectKey{Name: nodeName}, &node); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("node %q has no SwiftGPUNode (not a GPU node, or discovery has not run)", nodeName)
+		}
+		return fmt.Errorf("get SwiftGPUNode %q: %w", nodeName, err)
+	}
+
+	if !node.Status.VfioReady {
+		return fmt.Errorf("GPU node %q is not vfio-ready (vfio-pci not loaded); load vfio-pci on the host", nodeName)
+	}
+	if node.Status.FreeGPUs < profile.Spec.Count {
+		return fmt.Errorf("GPU node %q has %d free GPU(s), need %d", nodeName, node.Status.FreeGPUs, profile.Spec.Count)
+	}
+	if profile.Spec.Model != "" && !strings.Contains(node.Status.GPUModel, profile.Spec.Model) {
+		return fmt.Errorf("GPU node %q model %q does not match profile model %q", nodeName, node.Status.GPUModel, profile.Spec.Model)
+	}
+	if profile.Spec.PartitionMode == "shared" {
+		if _, err := findFMPartition(node.Status.FabricManager, profile.Spec.Count); err != nil {
+			return fmt.Errorf("GPU node %q has no free Fabric Manager partition for %d GPU(s): %w", nodeName, profile.Spec.Count, err)
+		}
+	}
+	return nil
+}

--- a/internal/controller/swiftgpu/preflight_test.go
+++ b/internal/controller/swiftgpu/preflight_test.go
@@ -1,0 +1,97 @@
+package swiftgpu
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/scheme"
+)
+
+func gpuNode(name string, vfioReady bool, free int, model string) *gpuv1alpha1.SwiftGPUNode {
+	return &gpuv1alpha1.SwiftGPUNode{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: gpuv1alpha1.SwiftGPUNodeStatus{
+			VfioReady: vfioReady,
+			FreeGPUs:  free,
+			GPUModel:  model,
+		},
+	}
+}
+
+func profile(count int, model, mode string) *gpuv1alpha1.SwiftGPUProfile {
+	return &gpuv1alpha1.SwiftGPUProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+		Spec:       gpuv1alpha1.SwiftGPUProfileSpec{Count: count, Model: model, PartitionMode: mode},
+	}
+}
+
+func TestGPUNodeHasCapacity(t *testing.T) {
+	tests := []struct {
+		name    string
+		node    *gpuv1alpha1.SwiftGPUNode // nil => not present
+		profile *gpuv1alpha1.SwiftGPUProfile
+		wantErr bool
+	}{
+		{
+			name:    "node missing",
+			node:    nil,
+			profile: profile(1, "", "isolated"),
+			wantErr: true,
+		},
+		{
+			name:    "not vfio-ready",
+			node:    gpuNode("boba", false, 1, "GeForce GTX 1080"),
+			profile: profile(1, "", "isolated"),
+			wantErr: true,
+		},
+		{
+			name:    "insufficient free GPUs",
+			node:    gpuNode("boba", true, 0, "GeForce GTX 1080"),
+			profile: profile(1, "", "isolated"),
+			wantErr: true,
+		},
+		{
+			name:    "model mismatch",
+			node:    gpuNode("boba", true, 1, "GeForce GTX 1080"),
+			profile: profile(1, "H200", "isolated"),
+			wantErr: true,
+		},
+		{
+			name:    "fits (empty model matches any)",
+			node:    gpuNode("boba", true, 1, "GeForce GTX 1080"),
+			profile: profile(1, "", "isolated"),
+			wantErr: false,
+		},
+		{
+			name:    "fits (model substring match)",
+			node:    gpuNode("boba", true, 2, "NVIDIA Corporation GP104 [GeForce GTX 1080]"),
+			profile: profile(2, "GTX 1080", "isolated"),
+			wantErr: false,
+		},
+		{
+			name:    "shared mode without FM partition",
+			node:    gpuNode("boba", true, 4, "H200 SXM"),
+			profile: profile(2, "", "shared"),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+			if tc.node != nil {
+				b = b.WithObjects(tc.node)
+			}
+			c := b.Build()
+
+			err := GPUNodeHasCapacity(context.Background(), c, "boba", tc.profile)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("GPUNodeHasCapacity err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Release-and-reallocate sub-phase (TFU #27) — PR 1 of 5

The node-vfio-readiness surface + the GPU target pre-flight helper. **No migration wiring yet** — these are the foundation later PRs consume (the reserve primitive, the migration GPU sequence, the drain GPU target selection).

### Why
The spike's **blocker #2** was a silent gpu-init `Init:Error` when `vfio-pci` isn't loaded on the GPU node. This surfaces vfio-readiness so it's gated *early*, not discovered at gpu-init time.

### What
- **`SwiftGPUNode.status.vfioReady`** (bool) + printcolumn. `make generate` + chart CRD sync.
- **gpu-discovery** `isVfioPciLoaded()` — a **read-only** check that `/sys/bus/pci/drivers/vfio-pci` exists, carried through `discoverHardware → mergeStatus → status`. gpu-discovery **detects and reports**; it does **not** load the module (`privileged: false`, `drop: ALL`, read-only `/sys` — no `CAP_SYS_MODULE`). Loading `vfio-pci` stays a host responsibility.
- **`GPUNodeHasCapacity(ctx, c, nodeName, profile)`** — the GPU analogue of `swiftmigration.NodeHasCapacity`. Read-only; node must be `vfioReady` **and** have ≥ `profile.Count` free GPUs matching model (+ a free FM partition for shared mode). Turns a would-be gpu-init failure into an early, clear rejection.

### Design correction (W5 again)
An earlier draft of the design doc assumed gpu-discovery was privileged and could `modprobe`. The recon showed it's minimal-cap — so it only **reports**. Design doc §4.2/§10.3 corrected; a future opt-in privileged loader (a *separate* DaemonSet, not gpu-discovery) is the path if auto-load is wanted.

### Tests
`GPUNodeHasCapacity` matrix (missing / not-ready / insufficient / model-mismatch / fits / shared-without-partition); `mergeStatus` carries `vfioReady`. Full `go test ./...` green; vet + fmt clean; verify-crd-sync OK.

**Cluster validation is post-merge** (the gpu-discovery image builds on main): after merge I'll apply the CRD + bump the gpu-discovery DaemonSet and confirm `kubectl get swiftgpunode boba` shows `VfioReady=true` (vfio-pci is currently loaded on boba from the spike).

### Sub-phase progress
- ✅ Spike (#94), gpu-init fix (#93), design (#95)
- ▶️ **PR 1 (this)** — vfioReady surface + pre-flight
- ⬜ PR 2 — ReserveOnNode / ReleaseFromNode primitives
- ⬜ PR 3 — migration GPU offline sequence + webhook lift
- ⬜ PR 4 — drain controller GPU wiring
- ⬜ PR 5 — cluster walkthrough + runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)