### PR TITLE
feat(gpu): ReserveOnNode / ReleaseFromNode primitives

### DIFF
--- a/internal/controller/swiftgpu/allocate.go
+++ b/internal/controller/swiftgpu/allocate.go
@@ -7,9 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
 )
@@ -130,36 +127,10 @@ func (r *SwiftGPUReconciler) deallocateGPUs(ctx context.Context, guest *swiftv1a
 	if guest.Status.GPU == nil || guest.Status.GPU.NodeName == "" {
 		return nil
 	}
-
-	var gpuNode gpuv1alpha1.SwiftGPUNode
-	if err := r.Get(ctx, client.ObjectKey{Name: guest.Status.GPU.NodeName}, &gpuNode); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Node is gone; nothing to clean up.
-			return nil
-		}
-		return err
-	}
-
-	allocatedTo := guest.Namespace + "/" + guest.Name
-
-	for i := range gpuNode.Status.GPUs {
-		if gpuNode.Status.GPUs[i].AllocatedTo == allocatedTo {
-			gpuNode.Status.GPUs[i].Allocated = false
-			gpuNode.Status.GPUs[i].AllocatedTo = ""
-		}
-	}
-
-	if gpuNode.Status.FabricManager != nil {
-		for i := range gpuNode.Status.FabricManager.Partitions {
-			if gpuNode.Status.FabricManager.Partitions[i].AllocatedTo == allocatedTo {
-				gpuNode.Status.FabricManager.Partitions[i].AllocatedTo = ""
-			}
-		}
-	}
-
-	gpuNode.Status.FreeGPUs = countFreeGPUs(gpuNode.Status.GPUs)
-
-	return r.Status().Update(ctx, &gpuNode)
+	// Delegate to the exported ReleaseFromNode primitive (the same one the
+	// migration release-and-reallocate path uses), keyed on the guest's
+	// currently-allocated node.
+	return ReleaseFromNode(ctx, r.Client, guest, guest.Status.GPU.NodeName)
 }
 
 // selectGPUs picks count free GPUs from gpus, preferring GPUs on the same NUMA

--- a/internal/controller/swiftgpu/primitives.go
+++ b/internal/controller/swiftgpu/primitives.go
@@ -1,0 +1,149 @@
+package swiftgpu
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// ReserveOnNode reserves profile.Count GPUs (+ an FM partition for shared
+// mode) for the guest on a SPECIFIC node, marking them AllocatedTo the guest
+// on that node's SwiftGPUNode WITHOUT touching guest.Status.GPU. Returns the
+// selected devices / NUMA nodes / FM partition id for the caller to stamp into
+// status.GPU at migration cutover. Idempotent: a re-reserve returns the
+// existing reservation on this node.
+//
+// This is the "reserve target before stopping the source" primitive for VFIO
+// release-and-reallocate: the source keeps its own allocation + status.GPU
+// while the target GPUs are held here. Because it does NOT write status.GPU,
+// the SwiftGPU controller (which only allocates when status.GPU is nil) stays
+// idle and the pod builder (which keys on status.GPU) is unaffected — but
+// findAndAllocate for OTHER guests sees these GPUs as AllocatedTo this guest,
+// so the reservation holds. Mirrors findAndAllocate's per-node selection
+// (selectGPUs / findFMPartition / countFreeGPUs) constrained to one node.
+//
+// Callers should GPUNodeHasCapacity-pre-flight first; this re-checks (vfio-
+// ready, free matching GPUs) so a stale pre-flight cannot over-commit.
+func ReserveOnNode(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest, profile *gpuv1alpha1.SwiftGPUProfile, nodeName string) (devices []gpuv1alpha1.GPUDevice, numaNodes []int, partitionID int, err error) {
+	allocatedTo := guest.Namespace + "/" + guest.Name
+
+	var node gpuv1alpha1.SwiftGPUNode
+	if gerr := c.Get(ctx, client.ObjectKey{Name: nodeName}, &node); gerr != nil {
+		return nil, nil, -1, fmt.Errorf("get SwiftGPUNode %q: %w", nodeName, gerr)
+	}
+
+	// Idempotency: an existing reservation for this guest on this node.
+	var existing []gpuv1alpha1.GPUDevice
+	numaSet := map[int]bool{}
+	existingPart := -1
+	for _, g := range node.Status.GPUs {
+		if g.AllocatedTo == allocatedTo {
+			existing = append(existing, g)
+			numaSet[g.NUMANode] = true
+		}
+	}
+	if node.Status.FabricManager != nil {
+		for _, p := range node.Status.FabricManager.Partitions {
+			if p.AllocatedTo == allocatedTo {
+				existingPart = p.ID
+			}
+		}
+	}
+	if len(existing) > 0 {
+		return existing, numaSetToSlice(numaSet), existingPart, nil
+	}
+
+	if !node.Status.VfioReady {
+		return nil, nil, -1, fmt.Errorf("GPU node %q is not vfio-ready (vfio-pci not loaded)", nodeName)
+	}
+	if node.Status.FreeGPUs < profile.Spec.Count {
+		return nil, nil, -1, fmt.Errorf("GPU node %q has %d free GPU(s), need %d", nodeName, node.Status.FreeGPUs, profile.Spec.Count)
+	}
+	if profile.Spec.Model != "" && !strings.Contains(node.Status.GPUModel, profile.Spec.Model) {
+		return nil, nil, -1, fmt.Errorf("GPU node %q model %q does not match profile model %q", nodeName, node.Status.GPUModel, profile.Spec.Model)
+	}
+
+	gpus, numa := selectGPUs(node.Status.GPUs, profile.Spec.Count, profile.Spec.Model)
+	if gpus == nil {
+		return nil, nil, -1, fmt.Errorf("GPU node %q could not select %d matching GPU(s)", nodeName, profile.Spec.Count)
+	}
+
+	partID := -1
+	if profile.Spec.PartitionMode == "shared" {
+		partID, err = findFMPartition(node.Status.FabricManager, profile.Spec.Count)
+		if err != nil {
+			return nil, nil, -1, fmt.Errorf("GPU node %q: no free FM partition for %d GPU(s): %w", nodeName, profile.Spec.Count, err)
+		}
+	}
+
+	for _, g := range gpus {
+		for j := range node.Status.GPUs {
+			if node.Status.GPUs[j].PCIAddress == g.PCIAddress {
+				node.Status.GPUs[j].Allocated = true
+				node.Status.GPUs[j].AllocatedTo = allocatedTo
+			}
+		}
+	}
+	if partID >= 0 && node.Status.FabricManager != nil {
+		for j := range node.Status.FabricManager.Partitions {
+			if node.Status.FabricManager.Partitions[j].ID == partID {
+				node.Status.FabricManager.Partitions[j].AllocatedTo = allocatedTo
+			}
+		}
+	}
+	node.Status.FreeGPUs = countFreeGPUs(node.Status.GPUs)
+
+	if uerr := c.Status().Update(ctx, &node); uerr != nil {
+		return nil, nil, -1, fmt.Errorf("reserve GPUs on %q: %w", nodeName, uerr)
+	}
+	return gpus, numa, partID, nil
+}
+
+// ReleaseFromNode clears the guest's GPU (+ FM partition) reservation/
+// allocation on a SPECIFIC node's SwiftGPUNode. Idempotent; no-op if the node
+// is gone or nothing is allocated to the guest there.
+//
+// deallocateGPUs delegates here (releasing status.GPU.NodeName on guest
+// delete); migration release-and-reallocate uses it to drop a pre-cutover
+// reservation on the target (failure path) or to free the source at cutover.
+func ReleaseFromNode(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest, nodeName string) error {
+	if nodeName == "" {
+		return nil
+	}
+	var node gpuv1alpha1.SwiftGPUNode
+	if err := c.Get(ctx, client.ObjectKey{Name: nodeName}, &node); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil // node gone; nothing to clean up
+		}
+		return err
+	}
+
+	allocatedTo := guest.Namespace + "/" + guest.Name
+	changed := false
+	for i := range node.Status.GPUs {
+		if node.Status.GPUs[i].AllocatedTo == allocatedTo {
+			node.Status.GPUs[i].Allocated = false
+			node.Status.GPUs[i].AllocatedTo = ""
+			changed = true
+		}
+	}
+	if node.Status.FabricManager != nil {
+		for i := range node.Status.FabricManager.Partitions {
+			if node.Status.FabricManager.Partitions[i].AllocatedTo == allocatedTo {
+				node.Status.FabricManager.Partitions[i].AllocatedTo = ""
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return nil
+	}
+	node.Status.FreeGPUs = countFreeGPUs(node.Status.GPUs)
+	return c.Status().Update(ctx, &node)
+}

--- a/internal/controller/swiftgpu/primitives_test.go
+++ b/internal/controller/swiftgpu/primitives_test.go
@@ -1,0 +1,165 @@
+package swiftgpu
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/scheme"
+)
+
+func dev(idx int, pci string, numa int) gpuv1alpha1.GPUDevice {
+	return gpuv1alpha1.GPUDevice{Index: idx, PCIAddress: pci, NUMANode: numa, Model: "GeForce GTX 1080"}
+}
+
+func gpuNodeWithDevices(name string, vfioReady bool, devs ...gpuv1alpha1.GPUDevice) *gpuv1alpha1.SwiftGPUNode {
+	n := &gpuv1alpha1.SwiftGPUNode{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: gpuv1alpha1.SwiftGPUNodeStatus{
+			VfioReady: vfioReady,
+			GPUModel:  "NVIDIA Corporation GP104 [GeForce GTX 1080]",
+			GPUs:      devs,
+		},
+	}
+	n.Status.FreeGPUs = countFreeGPUs(devs)
+	return n
+}
+
+func gpuGuest(name string) *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: types.UID(name + "-uid")}}
+}
+
+func newClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithStatusSubresource(&gpuv1alpha1.SwiftGPUNode{}).
+		WithObjects(objs...).Build()
+}
+
+func getNode(t *testing.T, c client.Client, name string) *gpuv1alpha1.SwiftGPUNode {
+	t.Helper()
+	var n gpuv1alpha1.SwiftGPUNode
+	if err := c.Get(context.Background(), types.NamespacedName{Name: name}, &n); err != nil {
+		t.Fatalf("get node %q: %v", name, err)
+	}
+	return &n
+}
+
+func allocatedTo(n *gpuv1alpha1.SwiftGPUNode, pci string) string {
+	for _, g := range n.Status.GPUs {
+		if g.PCIAddress == pci {
+			return g.AllocatedTo
+		}
+	}
+	return "<no-such-gpu>"
+}
+
+func TestReserveOnNode_MarksWithoutTouchingStatus(t *testing.T) {
+	g := gpuGuest("g")
+	n := gpuNodeWithDevices("boba", true, dev(0, "0000:01:00.0", 0))
+	c := newClient(n, g)
+
+	devs, _, partID, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "boba")
+	if err != nil {
+		t.Fatalf("ReserveOnNode: %v", err)
+	}
+	if len(devs) != 1 || devs[0].PCIAddress != "0000:01:00.0" {
+		t.Errorf("returned devices = %+v, want the GTX 1080", devs)
+	}
+	if partID != -1 {
+		t.Errorf("partitionID = %d, want -1 (isolated)", partID)
+	}
+
+	got := getNode(t, c, "boba")
+	if allocatedTo(got, "0000:01:00.0") != "default/g" {
+		t.Errorf("GPU must be AllocatedTo default/g; got %q", allocatedTo(got, "0000:01:00.0"))
+	}
+	if got.Status.FreeGPUs != 0 {
+		t.Errorf("FreeGPUs = %d, want 0 after reserve", got.Status.FreeGPUs)
+	}
+	// status.GPU on the guest must be UNTOUCHED (reserve never writes it).
+	var gg swiftv1alpha1.SwiftGuest
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "g"}, &gg)
+	if gg.Status.GPU != nil {
+		t.Errorf("ReserveOnNode must not write guest.status.GPU; got %+v", gg.Status.GPU)
+	}
+}
+
+func TestReserveOnNode_Idempotent(t *testing.T) {
+	g := gpuGuest("g")
+	n := gpuNodeWithDevices("boba", true, dev(0, "0000:01:00.0", 0))
+	c := newClient(n, g)
+
+	if _, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "boba"); err != nil {
+		t.Fatalf("first reserve: %v", err)
+	}
+	devs, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "boba")
+	if err != nil {
+		t.Fatalf("re-reserve must be idempotent, not error: %v", err)
+	}
+	if len(devs) != 1 {
+		t.Errorf("re-reserve returned %d devices, want the existing 1", len(devs))
+	}
+	if got := getNode(t, c, "boba"); got.Status.FreeGPUs != 0 {
+		t.Errorf("FreeGPUs = %d, want 0 (no double-allocation on re-reserve)", got.Status.FreeGPUs)
+	}
+}
+
+func TestReserveOnNode_NotVfioReady(t *testing.T) {
+	c := newClient(gpuNodeWithDevices("boba", false, dev(0, "0000:01:00.0", 0)), gpuGuest("g"))
+	if _, _, _, err := ReserveOnNode(context.Background(), c, gpuGuest("g"), profile(1, "", "isolated"), "boba"); err == nil {
+		t.Errorf("expected error reserving on a non-vfio-ready node")
+	}
+}
+
+func TestReserveOnNode_Insufficient(t *testing.T) {
+	c := newClient(gpuNodeWithDevices("boba", true), gpuGuest("g")) // no GPUs
+	if _, _, _, err := ReserveOnNode(context.Background(), c, gpuGuest("g"), profile(1, "", "isolated"), "boba"); err == nil {
+		t.Errorf("expected error reserving when no GPUs are free")
+	}
+}
+
+// TestReserveOnNode_HoldsAgainstOtherGuests proves the reservation holds: once
+// guest A reserves the only GPU, guest B cannot reserve on the same node.
+func TestReserveOnNode_HoldsAgainstOtherGuests(t *testing.T) {
+	gA, gB := gpuGuest("a"), gpuGuest("b")
+	c := newClient(gpuNodeWithDevices("boba", true, dev(0, "0000:01:00.0", 0)), gA, gB)
+
+	if _, _, _, err := ReserveOnNode(context.Background(), c, gA, profile(1, "", "isolated"), "boba"); err != nil {
+		t.Fatalf("guest A reserve: %v", err)
+	}
+	if _, _, _, err := ReserveOnNode(context.Background(), c, gB, profile(1, "", "isolated"), "boba"); err == nil {
+		t.Errorf("guest B must NOT be able to reserve the GPU A holds")
+	}
+}
+
+func TestReleaseFromNode(t *testing.T) {
+	g := gpuGuest("g")
+	c := newClient(gpuNodeWithDevices("boba", true, dev(0, "0000:01:00.0", 0)), g)
+
+	if _, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "boba"); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := ReleaseFromNode(context.Background(), c, g, "boba"); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	got := getNode(t, c, "boba")
+	if allocatedTo(got, "0000:01:00.0") != "" {
+		t.Errorf("GPU must be freed; AllocatedTo = %q", allocatedTo(got, "0000:01:00.0"))
+	}
+	if got.Status.FreeGPUs != 1 {
+		t.Errorf("FreeGPUs = %d, want 1 after release", got.Status.FreeGPUs)
+	}
+}
+
+func TestReleaseFromNode_NodeGone_NoError(t *testing.T) {
+	c := newClient(gpuGuest("g")) // no node
+	if err := ReleaseFromNode(context.Background(), c, gpuGuest("g"), "ghost"); err != nil {
+		t.Errorf("release on a missing node must be a no-op, not an error: %v", err)
+	}
+}


### PR DESCRIPTION
## Release-and-reallocate sub-phase (TFU #27) — PR 2 of 5

The SwiftGPU primitives the migration controller will orchestrate. **No migration wiring yet** — these are exported for PR 3.

### `ReserveOnNode(ctx, c, guest, profile, nodeName)`
Reserves `profile.Count` GPUs (+ an FM partition for shared mode) on a **specific** node, marking them `AllocatedTo` the guest on the node's SwiftGPUNode **without touching `guest.Status.GPU`**. Returns the selected devices / NUMA / partition for the caller to stamp into `status.GPU` at cutover. Idempotent; re-checks `vfioReady` + free matching GPUs.

This is the **"reserve target before stopping the source"** primitive: the source keeps its allocation + `status.GPU` while the target GPUs are held. Because it never writes `status.GPU`, the SwiftGPU controller (allocates only when `status.GPU` is nil) stays idle and the pod builder (keys on `status.GPU`) is unaffected — but `findAndAllocate` for *other* guests sees these GPUs as taken, so **the reservation holds** (tested).

### `ReleaseFromNode(ctx, c, guest, nodeName)`
Clears the guest's GPU (+ FM partition) allocation on a **specific** node. Idempotent; no-op if the node is gone. **`deallocateGPUs` now delegates to it** (keyed on `status.GPU.NodeName`) — removing the duplicated free logic. Migration uses it to drop a pre-cutover target reservation (failure) or free the source (cutover).

Both primitives reuse the existing per-node selection helpers (`selectGPUs` / `findFMPartition` / `countFreeGPUs`) — one selection/free implementation, no drift.

### Tests
Reserve: marks-without-touching-status, idempotent, not-vfio-ready, insufficient, **reservation-holds-against-other-guests**. Release: frees, node-gone-no-op. Full `go test ./...` green — the `deallocateGPUs` refactor leaves existing swiftgpu controller tests passing.

### Sub-phase progress
- ✅ Spike (#94), gpu-init fix (#93), design (#95), PR 1 vfioReady surface (#96)
- ▶️ **PR 2 (this)** — Reserve/Release primitives
- ⬜ PR 3 — migration GPU offline sequence + precedence-rule change + webhook lift
- ⬜ PR 4 — drain controller GPU wiring
- ⬜ PR 5 — cluster walkthrough (same-node `boba→boba`) + runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)