### PR TITLE
feat(gpu): VFIO offline migration — release-and-reallocate sequence

### DIFF
--- a/internal/controller/swiftguest/gpu.go
+++ b/internal/controller/swiftguest/gpu.go
@@ -296,18 +296,24 @@ func (r *SwiftGuestReconciler) buildBasePod(
 	// restore with `bar 0 already used`), so the restore branch sits
 	// before the GPU branch and the two are mutually exclusive in
 	// practice.
-	// Precedence check: when both spec.NodeName and a GPU allocation are
-	// present, they MUST agree. The SwiftMigration validation webhook
-	// rejects cross-node GPU migrations in Phase 1 (no release-and-
-	// reallocate primitive yet — Phase 4+ work) so disagreement here is a
-	// either an operator bypass of the webhook OR a future Phase 4 bug.
-	// Either way: refuse to build, surface as Resolved=False via the
-	// controller's existing ResolutionError mapping.
+	// Precedence consistency assertion: when both spec.NodeName and a GPU
+	// allocation are present, they MUST agree (status.GPU.NodeName is the
+	// binding source for which GPUs gpu-init binds; spec.NodeName pins the
+	// pod). The VFIO release-and-reallocate offline migration cutover commits
+	// BOTH together (ReleaseFromNode(source) + stamp status.GPU=target, THEN
+	// patch spec.NodeName=target), so by the time the dst pod is built they
+	// agree. A disagreement here is therefore a real bug or an out-of-band
+	// edit — refuse to build, surfaced as Resolved=False via the controller's
+	// ResolutionError mapping.
+	//
+	// LOAD-BEARING (W26-class): do NOT weaken this to "trust spec.NodeName
+	// alone" — status.GPU.NodeName must stay the binding source, or a
+	// half-committed cutover could bind the wrong node's GPUs.
 	if guest.Spec.NodeName != "" &&
 		guest.Status.GPU != nil &&
 		guest.Status.GPU.NodeName != "" &&
 		guest.Status.GPU.NodeName != guest.Spec.NodeName {
-		return nil, fmt.Errorf("spec.nodeName=%q disagrees with status.gpu.nodeName=%q; cross-node GPU migration is not supported in Phase 1",
+		return nil, fmt.Errorf("spec.nodeName=%q disagrees with status.gpu.nodeName=%q; the GPU migration cutover must commit both together",
 			guest.Spec.NodeName, guest.Status.GPU.NodeName)
 	}
 

--- a/internal/controller/swiftguest/gpu_test.go
+++ b/internal/controller/swiftguest/gpu_test.go
@@ -494,8 +494,8 @@ func TestBuildPodDispatcher_NodeNameGPUDisagreement(t *testing.T) {
 	}
 	// Operators reading the Resolved=False condition need to see both
 	// node names in the message to diagnose; assert both appear.
-	if !strings.Contains(err.Error(), "cross-node GPU migration is not supported") {
-		t.Errorf("error message should mention cross-node GPU migration; got %q", err.Error())
+	if !strings.Contains(err.Error(), "must commit both together") {
+		t.Errorf("error message should mention the cutover-consistency assertion; got %q", err.Error())
 	}
 	if !strings.Contains(err.Error(), "boba") || !strings.Contains(err.Error(), "miles") {
 		t.Errorf("error message should name both spec.nodeName (boba) and status.gpu.nodeName (miles); got %q", err.Error())

--- a/internal/controller/swiftmigration/failure.go
+++ b/internal/controller/swiftmigration/failure.go
@@ -156,6 +156,18 @@ func (r *SwiftMigrationReconciler) cleanupSourceGuest(
 		}
 		return err
 	}
+
+	// GPU release-and-reallocate: on a pre-cutover failure (restoreRunPolicy),
+	// drop the target-node GPU reservation so a failed migration does not
+	// strand it. The source resumes on its own node with its existing GPUs
+	// (status.GPU is unchanged pre-cutover). Idempotent; no-op for non-GPU
+	// guests. Post-cutover failures drive forward, so the reservation has
+	// already become the live allocation — don't release it there.
+	if restoreRunPolicy && guest.HasVFIODevices() {
+		if err := r.releaseTargetReservation(ctx, mig, &guest); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/controller/swiftmigration/gpu_offline.go
+++ b/internal/controller/swiftmigration/gpu_offline.go
@@ -1,0 +1,153 @@
+package swiftmigration
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftgpu"
+)
+
+// GPU release-and-reallocate for offline migration of VFIO/GPU guests (the
+// Phase 4 drain follow-on, design doc vfio-release-reallocate.md §5). All of
+// this is gated on guest.HasVFIODevices() at the call sites, so non-GPU
+// offline migration is byte-for-byte unchanged.
+//
+// Sequence (migration-controller-orchestrated, reserve-before-stop):
+//   Validating  -> gpuPreflight: target node is vfio-ready + has free matching GPUs
+//   Preparing   -> reserveTargetGPUs(T) BEFORE the source is stopped
+//   StopAndCopy -> cutoverGPUs: ReleaseFromNode(S) + stamp status.GPU=T (so the
+//                  pod builder's precedence rule holds when the dst pod builds)
+//   Failed      -> releaseTargetReservation(T) on pre-cutover failure
+//
+// VFIO guests migrate OFFLINE only (CH cannot live-migrate a VFIO device); the
+// webhook still rejects mode=live for them.
+
+// resolveGPUProfile fetches the SwiftGPUProfile referenced by the guest.
+func (r *SwiftMigrationReconciler) resolveGPUProfile(ctx context.Context, guest *swiftv1alpha1.SwiftGuest) (*gpuv1alpha1.SwiftGPUProfile, error) {
+	if guest.Spec.GPUProfileRef == nil {
+		return nil, fmt.Errorf("guest %q has no gpuProfileRef", guest.Name)
+	}
+	var profile gpuv1alpha1.SwiftGPUProfile
+	if err := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: guest.Spec.GPUProfileRef.Name}, &profile); err != nil {
+		return nil, fmt.Errorf("get SwiftGPUProfile %q: %w", guest.Spec.GPUProfileRef.Name, err)
+	}
+	return &profile, nil
+}
+
+// gpuPreflight (Validating) verifies the target node can host the guest's GPUs
+// before the migration commits to anything — an early, clear rejection rather
+// than a Preparing-time reserve failure. Fails the migration on miss.
+func (r *SwiftMigrationReconciler) gpuPreflight(ctx context.Context, mig *migrationv1alpha1.SwiftMigration, guest *swiftv1alpha1.SwiftGuest) *phaseResult {
+	profile, err := r.resolveGPUProfile(ctx, guest)
+	if err != nil {
+		return phaseFailure(fmt.Sprintf("GPU pre-flight: %v", err), "")
+	}
+	if err := swiftgpu.GPUNodeHasCapacity(ctx, r.Client, mig.Spec.Target.NodeName, profile); err != nil {
+		return phaseFailure(fmt.Sprintf("GPU pre-flight: %v", err), "")
+	}
+	return nil
+}
+
+// reserveTargetGPUs (Preparing, BEFORE the source is stopped) reserves the
+// target GPUs. Idempotent across re-entries. On failure the source has not yet
+// been stopped, so failing here leaves it running and unharmed.
+func (r *SwiftMigrationReconciler) reserveTargetGPUs(ctx context.Context, mig *migrationv1alpha1.SwiftMigration, guest *swiftv1alpha1.SwiftGuest, status *migrationv1alpha1.SwiftMigrationStatus) *phaseResult {
+	profile, err := r.resolveGPUProfile(ctx, guest)
+	if err != nil {
+		return phaseFailure(fmt.Sprintf("reserve target GPUs: %v", err), "")
+	}
+	if _, _, _, rerr := swiftgpu.ReserveOnNode(ctx, r.Client, guest, profile, mig.Spec.Target.NodeName); rerr != nil {
+		// Reserve failed before the source was stopped — fail cleanly.
+		return phaseFailure(fmt.Sprintf("reserve target GPUs on %q: %v", mig.Spec.Target.NodeName, rerr), "")
+	}
+	setPhaseDetail(status, fmt.Sprintf("reserved target GPUs on %q", mig.Spec.Target.NodeName))
+	if r.Recorder != nil {
+		r.Recorder.Event(mig, corev1.EventTypeNormal, "GPUReserved",
+			fmt.Sprintf("reserved target GPUs on %q for %q", mig.Spec.Target.NodeName, guest.Name))
+	}
+	return nil
+}
+
+// cutoverGPUs (StopAndCopy, before the runPolicy+nodeName spec patch) frees the
+// source GPUs and stamps status.GPU=target so the precedence rule in the pod
+// builder holds when the destination pod is created. Idempotent: a no-op once
+// status.GPU already points at the target.
+func (r *SwiftMigrationReconciler) cutoverGPUs(ctx context.Context, mig *migrationv1alpha1.SwiftMigration, guest *swiftv1alpha1.SwiftGuest, status *migrationv1alpha1.SwiftMigrationStatus) *phaseResult {
+	target := mig.Spec.Target.NodeName
+
+	// Already cut over (re-entry): status.GPU points at the target.
+	if guest.Status.GPU != nil && guest.Status.GPU.NodeName == target {
+		return nil
+	}
+
+	profile, err := r.resolveGPUProfile(ctx, guest)
+	if err != nil {
+		return phaseTransient(fmt.Errorf("cutover GPUs: %w", err))
+	}
+	// Re-derive the reservation (idempotent) for the device/NUMA/partition set.
+	devices, numaNodes, partID, rerr := swiftgpu.ReserveOnNode(ctx, r.Client, guest, profile, target)
+	if rerr != nil {
+		return phaseTransient(fmt.Errorf("cutover: re-derive target reservation on %q: %w", target, rerr))
+	}
+
+	// Free the source GPUs (the guest's pre-cutover node).
+	sourceNode := ""
+	if guest.Status.GPU != nil {
+		sourceNode = guest.Status.GPU.NodeName
+	}
+	if sourceNode != "" && sourceNode != target {
+		if err := swiftgpu.ReleaseFromNode(ctx, r.Client, guest, sourceNode); err != nil {
+			return phaseTransient(fmt.Errorf("cutover: release source GPUs on %q: %w", sourceNode, err))
+		}
+	}
+
+	// Stamp status.GPU = target. Preserve the resolved hypervisor.
+	pciAddrs := make([]string, 0, len(devices))
+	for _, d := range devices {
+		pciAddrs = append(pciAddrs, d.PCIAddress)
+	}
+	hypervisor := ""
+	if guest.Status.GPU != nil {
+		hypervisor = guest.Status.GPU.Hypervisor
+	}
+	patch := client.MergeFrom(guest.DeepCopy())
+	guest.Status.GPU = &swiftv1alpha1.GPUStatus{
+		Devices:     pciAddrs,
+		PartitionID: partID,
+		NUMANodes:   numaNodes,
+		Hypervisor:  hypervisor,
+		NodeName:    target,
+	}
+	if err := r.Status().Patch(ctx, guest, patch); err != nil {
+		return phaseTransient(fmt.Errorf("cutover: stamp status.GPU=%q: %w", target, err))
+	}
+	if r.Recorder != nil {
+		r.Recorder.Event(mig, corev1.EventTypeNormal, "GPUCutover",
+			fmt.Sprintf("released source GPUs on %q, committed target GPUs on %q for %q", sourceNode, target, guest.Name))
+	}
+	return nil
+}
+
+// releaseTargetReservation drops the target-node GPU reservation. Called from
+// the pre-cutover failure/cleanup path so a failed migration does not strand a
+// reservation on the target; the source resumes on its own node with its
+// existing GPUs (status.GPU is unchanged pre-cutover). Idempotent.
+func (r *SwiftMigrationReconciler) releaseTargetReservation(ctx context.Context, mig *migrationv1alpha1.SwiftMigration, guest *swiftv1alpha1.SwiftGuest) error {
+	// Only release the target if it is NOT the guest's committed node (it is
+	// not, pre-cutover: status.GPU still points at the source). Guards against
+	// freeing the live allocation if called post-cutover by mistake.
+	if guest.Status.GPU != nil && guest.Status.GPU.NodeName == mig.Spec.Target.NodeName {
+		return nil
+	}
+	if err := swiftgpu.ReleaseFromNode(ctx, r.Client, guest, mig.Spec.Target.NodeName); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/controller/swiftmigration/gpu_offline_test.go
+++ b/internal/controller/swiftmigration/gpu_offline_test.go
@@ -1,0 +1,211 @@
+package swiftmigration
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/scheme"
+)
+
+func srcNode(name, guestKey, pci string) *gpuv1alpha1.SwiftGPUNode {
+	return &gpuv1alpha1.SwiftGPUNode{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: gpuv1alpha1.SwiftGPUNodeStatus{
+			VfioReady: true,
+			GPUModel:  "NVIDIA Corporation GP104 [GeForce GTX 1080]",
+			FreeGPUs:  0,
+			GPUs: []gpuv1alpha1.GPUDevice{
+				{Index: 0, PCIAddress: pci, NUMANode: 0, Allocated: true, AllocatedTo: guestKey},
+			},
+		},
+	}
+}
+
+func tgtNode(name, pci string, vfioReady bool) *gpuv1alpha1.SwiftGPUNode {
+	free := 0
+	if vfioReady {
+		free = 1
+	}
+	return &gpuv1alpha1.SwiftGPUNode{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: gpuv1alpha1.SwiftGPUNodeStatus{
+			VfioReady: vfioReady,
+			GPUModel:  "NVIDIA Corporation GP104 [GeForce GTX 1080]",
+			FreeGPUs:  free,
+			GPUs: []gpuv1alpha1.GPUDevice{
+				{Index: 0, PCIAddress: pci, NUMANode: 0},
+			},
+		},
+	}
+}
+
+func gpuProfileObj() *gpuv1alpha1.SwiftGPUProfile {
+	return &gpuv1alpha1.SwiftGPUProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+		Spec:       gpuv1alpha1.SwiftGPUProfileSpec{Count: 1, PartitionMode: "isolated"},
+	}
+}
+
+func gpuGuestOnSrc(srcNodeName, pci string) *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "default", UID: "g-uid"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			GPUProfileRef: &corev1.LocalObjectReference{Name: "p"},
+		},
+		Status: swiftv1alpha1.SwiftGuestStatus{
+			GPU: &swiftv1alpha1.GPUStatus{NodeName: srcNodeName, Devices: []string{pci}, Hypervisor: "cloud-hypervisor", PartitionID: -1},
+		},
+	}
+}
+
+func gpuMig() *migrationv1alpha1.SwiftMigration {
+	return &migrationv1alpha1.SwiftMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+		Spec: migrationv1alpha1.SwiftMigrationSpec{
+			GuestRef: migrationv1alpha1.SwiftMigrationGuestRef{Name: "g"},
+			Target:   migrationv1alpha1.SwiftMigrationTarget{NodeName: "boba"},
+			Mode:     migrationv1alpha1.SwiftMigrationModeOffline,
+		},
+	}
+}
+
+func gpuReconciler(objs ...client.Object) (*SwiftMigrationReconciler, client.Client) {
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithStatusSubresource(&gpuv1alpha1.SwiftGPUNode{}, &swiftv1alpha1.SwiftGuest{}).
+		WithObjects(objs...).Build()
+	return &SwiftMigrationReconciler{Client: c, Scheme: scheme.Scheme}, c
+}
+
+func nodeAllocTo(t *testing.T, c client.Client, node, pci string) string {
+	t.Helper()
+	var n gpuv1alpha1.SwiftGPUNode
+	if err := c.Get(context.Background(), types.NamespacedName{Name: node}, &n); err != nil {
+		t.Fatalf("get node %q: %v", node, err)
+	}
+	for _, g := range n.Status.GPUs {
+		if g.PCIAddress == pci {
+			return g.AllocatedTo
+		}
+	}
+	return "<no-such-gpu>"
+}
+
+func TestReserveTargetGPUs(t *testing.T) {
+	r, c := gpuReconciler(srcNode("miles", "default/g", "0000:aa:00.0"),
+		tgtNode("boba", "0000:bb:00.0", true), gpuProfileObj())
+	g := gpuGuestOnSrc("miles", "0000:aa:00.0")
+
+	if res := r.reserveTargetGPUs(context.Background(), gpuMig(), g, &migrationv1alpha1.SwiftMigrationStatus{}); res != nil {
+		t.Fatalf("reserveTargetGPUs returned a phaseResult (failure): %+v", res)
+	}
+	// Target GPU is now reserved for the guest; source is still allocated.
+	if got := nodeAllocTo(t, c, "boba", "0000:bb:00.0"); got != "default/g" {
+		t.Errorf("target GPU should be reserved for default/g; got %q", got)
+	}
+	if got := nodeAllocTo(t, c, "miles", "0000:aa:00.0"); got != "default/g" {
+		t.Errorf("source GPU must stay allocated to default/g pre-cutover; got %q", got)
+	}
+}
+
+func TestReserveTargetGPUs_NotVfioReady_Fails(t *testing.T) {
+	r, _ := gpuReconciler(srcNode("miles", "default/g", "0000:aa:00.0"),
+		tgtNode("boba", "0000:bb:00.0", false), gpuProfileObj())
+	g := gpuGuestOnSrc("miles", "0000:aa:00.0")
+
+	if res := r.reserveTargetGPUs(context.Background(), gpuMig(), g, &migrationv1alpha1.SwiftMigrationStatus{}); res == nil {
+		t.Errorf("reserve on a non-vfio-ready target must fail (before stopping the source)")
+	}
+}
+
+func TestCutoverGPUs_ReleasesSourceAndStampsTarget(t *testing.T) {
+	g := gpuGuestOnSrc("miles", "0000:aa:00.0")
+	r, c := gpuReconciler(srcNode("miles", "default/g", "0000:aa:00.0"),
+		tgtNode("boba", "0000:bb:00.0", true), gpuProfileObj(), g)
+	mig := gpuMig()
+
+	// Reserve first (as Preparing would), then cut over.
+	if res := r.reserveTargetGPUs(context.Background(), mig, g, &migrationv1alpha1.SwiftMigrationStatus{}); res != nil {
+		t.Fatalf("reserve: %+v", res)
+	}
+	if res := r.cutoverGPUs(context.Background(), mig, g, &migrationv1alpha1.SwiftMigrationStatus{}); res != nil {
+		t.Fatalf("cutoverGPUs returned a phaseResult: %+v", res)
+	}
+
+	// Source freed, target committed.
+	if got := nodeAllocTo(t, c, "miles", "0000:aa:00.0"); got != "" {
+		t.Errorf("source GPU must be freed at cutover; got %q", got)
+	}
+	if got := nodeAllocTo(t, c, "boba", "0000:bb:00.0"); got != "default/g" {
+		t.Errorf("target GPU must stay allocated to default/g; got %q", got)
+	}
+	// guest.status.GPU stamped to the target.
+	var gg swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "g"}, &gg); err != nil {
+		t.Fatalf("get guest: %v", err)
+	}
+	if gg.Status.GPU == nil || gg.Status.GPU.NodeName != "boba" {
+		t.Fatalf("status.GPU.NodeName must be boba after cutover; got %+v", gg.Status.GPU)
+	}
+	if len(gg.Status.GPU.Devices) != 1 || gg.Status.GPU.Devices[0] != "0000:bb:00.0" {
+		t.Errorf("status.GPU.Devices must be the target device; got %v", gg.Status.GPU.Devices)
+	}
+	if gg.Status.GPU.Hypervisor != "cloud-hypervisor" {
+		t.Errorf("hypervisor must be preserved; got %q", gg.Status.GPU.Hypervisor)
+	}
+}
+
+func TestCutoverGPUs_Idempotent(t *testing.T) {
+	g := gpuGuestOnSrc("miles", "0000:aa:00.0")
+	r, c := gpuReconciler(srcNode("miles", "default/g", "0000:aa:00.0"),
+		tgtNode("boba", "0000:bb:00.0", true), gpuProfileObj(), g)
+	mig := gpuMig()
+	_ = r.reserveTargetGPUs(context.Background(), mig, g, &migrationv1alpha1.SwiftMigrationStatus{})
+	_ = r.cutoverGPUs(context.Background(), mig, g, &migrationv1alpha1.SwiftMigrationStatus{})
+	// Re-fetch the guest (status.GPU now boba) and cut over again — no-op.
+	var gg swiftv1alpha1.SwiftGuest
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "g"}, &gg)
+	if res := r.cutoverGPUs(context.Background(), mig, &gg, &migrationv1alpha1.SwiftMigrationStatus{}); res != nil {
+		t.Errorf("cutover must be idempotent once status.GPU is on the target; got %+v", res)
+	}
+}
+
+func TestReleaseTargetReservation(t *testing.T) {
+	r, c := gpuReconciler(srcNode("miles", "default/g", "0000:aa:00.0"),
+		tgtNode("boba", "0000:bb:00.0", true), gpuProfileObj())
+	g := gpuGuestOnSrc("miles", "0000:aa:00.0")
+	mig := gpuMig()
+	if res := r.reserveTargetGPUs(context.Background(), mig, g, &migrationv1alpha1.SwiftMigrationStatus{}); res != nil {
+		t.Fatalf("reserve: %+v", res)
+	}
+	if err := r.releaseTargetReservation(context.Background(), mig, g); err != nil {
+		t.Fatalf("releaseTargetReservation: %v", err)
+	}
+	if got := nodeAllocTo(t, c, "boba", "0000:bb:00.0"); got != "" {
+		t.Errorf("target reservation must be released; got %q", got)
+	}
+	// Source untouched (the guest resumes there).
+	if got := nodeAllocTo(t, c, "miles", "0000:aa:00.0"); got != "default/g" {
+		t.Errorf("source must stay allocated after a pre-cutover release; got %q", got)
+	}
+}
+
+func TestGPUPreflight(t *testing.T) {
+	r, _ := gpuReconciler(tgtNode("boba", "0000:bb:00.0", true), gpuProfileObj())
+	if res := r.gpuPreflight(context.Background(), gpuMig(), gpuGuestOnSrc("miles", "0000:aa:00.0")); res != nil {
+		t.Errorf("pre-flight on a vfio-ready target with free GPUs should pass; got %+v", res)
+	}
+
+	r2, _ := gpuReconciler(tgtNode("boba", "0000:bb:00.0", false), gpuProfileObj())
+	if res := r2.gpuPreflight(context.Background(), gpuMig(), gpuGuestOnSrc("miles", "0000:aa:00.0")); res == nil {
+		t.Errorf("pre-flight on a non-vfio-ready target should fail")
+	}
+}

--- a/internal/controller/swiftmigration/preparing.go
+++ b/internal/controller/swiftmigration/preparing.go
@@ -97,6 +97,16 @@ func (r *SwiftMigrationReconciler) handlePreparing(
 		return phaseFailure(fmt.Sprintf("another SwiftMigration %q is already in progress for SwiftGuest %q", current, guest.Name), "")
 	}
 
+	// GPU release-and-reallocate: reserve the target GPUs BEFORE stopping the
+	// source (the reserve-before-stop atomicity — a failed reserve never
+	// strands a stopped, GPU-less guest). Idempotent across re-entries; runs
+	// before the claim+stop below. Non-GPU guests skip this entirely.
+	if guest.HasVFIODevices() {
+		if res := r.reserveTargetGPUs(ctx, mig, &guest, status); res != nil {
+			return res
+		}
+	}
+
 	if current == "" {
 		// First entry: claim the guest. Single combined MergeFrom
 		// patch sets both the annotation and runPolicy=Stopped so the

--- a/internal/controller/swiftmigration/stopandcopy.go
+++ b/internal/controller/swiftmigration/stopandcopy.go
@@ -74,6 +74,18 @@ func (r *SwiftMigrationReconciler) handleStopAndCopy(
 
 	target := mig.Spec.Target.NodeName
 
+	// GPU release-and-reallocate cutover: free the source GPUs and stamp
+	// status.GPU=target BEFORE the runPolicy+nodeName spec patch below — so the
+	// pod builder's precedence rule (spec.NodeName must agree with
+	// status.GPU.NodeName) holds when the destination pod is created on the
+	// target. Idempotent: a no-op once status.GPU already points at the target.
+	// Non-GPU guests skip this entirely.
+	if guest.HasVFIODevices() {
+		if res := r.cutoverGPUs(ctx, mig, &guest, status); res != nil {
+			return res
+		}
+	}
+
 	// Combined patch: runPolicy=Running AND nodeName=target. Single
 	// MergeFrom produces one PATCH request → atomic at the API server.
 	// If the spec already matches (re-entry after the patch landed),

--- a/internal/controller/swiftmigration/validating.go
+++ b/internal/controller/swiftmigration/validating.go
@@ -129,6 +129,17 @@ func (r *SwiftMigrationReconciler) handleValidating(
 		return phaseFailure(err.Error(), "")
 	}
 
+	// GPU target pre-flight (VFIO release-and-reallocate): the target node must
+	// be vfio-ready and have free GPUs matching the guest's profile. Early,
+	// clear rejection before the migration stops anything. Offline-only — VFIO
+	// guests never reach the live branch (resolveAutoMode sends them offline;
+	// the webhook rejects explicit mode=live for them).
+	if guest.HasVFIODevices() {
+		if res := r.gpuPreflight(ctx, mig, &guest); res != nil {
+			return res
+		}
+	}
+
 	// All checks passed. Mark Compatible=True, transition to Preparing.
 	setCondition(status, migrationv1alpha1.SwiftMigrationConditionCompatible,
 		metav1.ConditionTrue, ReasonValidating, "validation passed; target node has capacity")

--- a/internal/webhook/swiftmigration/validator.go
+++ b/internal/webhook/swiftmigration/validator.go
@@ -400,24 +400,17 @@ func (v *Validator) validateClusterState(ctx context.Context, mig *migrationv1al
 		}
 	}
 
-	// GPU cross-node refusal: Phase 1 has no release-and-reallocate
-	// primitive for the SwiftGPU controller. Migrating a GPU guest at
-	// all (regardless of whether it's already scheduled) is rejected
-	// because:
-	//   - If sourceNode != "" and != target: classic cross-node
-	//     migration — would orphan the source-node GPU reservation.
-	//   - If sourceNode == "": guest is unscheduled, but the SwiftGPU
-	//     controller's allocation is independent of spec.NodeName.
-	//     Migrating an unscheduled GPU guest creates a race between
-	//     SwiftGPU picking the allocation node and SwiftMigration
-	//     pinning spec.NodeName, ending in the precedence rule from
-	//     commit 3 rejecting the pod build.
-	//   - If sourceNode == target: the same-node check above already
-	//     rejected; this branch wouldn't be reached.
-	// So: reject any GPU SwiftMigration in Phase 1, period.
-	hasGPUWorkload := guest.HasVFIODevices()
-	if hasGPUWorkload {
-		return nil, fmt.Errorf("SwiftGuest %q has VFIO devices (gpuProfileRef or sriov interface); cross-node migration is not supported in Phase 1 — Phase 4+ work pending a release-and-reallocate primitive",
+	// GPU/VFIO migration mode gate. VFIO devices (gpuProfileRef or sriov)
+	// CANNOT live-migrate — Cloud Hypervisor cannot transfer the device's
+	// state to the destination. They CAN migrate OFFLINE via the release-and-
+	// reallocate path (the migration controller reserves target GPUs before
+	// stopping the source, frees the source at cutover, and stamps
+	// status.GPU=target). So:
+	//   - mode=live + VFIO  -> reject (no live VFIO migration, ever).
+	//   - mode=auto/offline + VFIO -> allow; resolveAutoMode sends VFIO guests
+	//     to offline, and the offline GPU sequence handles the handoff.
+	if guest.HasVFIODevices() && mig.Spec.Mode == migrationv1alpha1.SwiftMigrationModeLive {
+		return nil, fmt.Errorf("SwiftGuest %q has VFIO devices (gpuProfileRef or sriov interface); they cannot live-migrate — use mode=offline (or auto, which resolves to offline for VFIO)",
 			guest.Name)
 	}
 

--- a/internal/webhook/swiftmigration/validator_test.go
+++ b/internal/webhook/swiftmigration/validator_test.go
@@ -448,7 +448,11 @@ func TestValidateClusterState_KernelBootMissingLabel(t *testing.T) {
 	}
 }
 
-func TestValidateClusterState_GPUCrossNodeRejected(t *testing.T) {
+func TestValidateClusterState_GPULiveRejected(t *testing.T) {
+	// GPU/VFIO guests cannot live-migrate; mode=live is rejected. (The Phase 4
+	// release-and-reallocate sub-phase lifted the old unconditional rejection:
+	// offline VFIO migration is now allowed — see
+	// TestValidateClusterState_VFIOOfflineNotRejected.)
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default")
 	guest.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu-pcie"}
@@ -456,27 +460,22 @@ func TestValidateClusterState_GPUCrossNodeRejected(t *testing.T) {
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	_, err := v.validate(context.Background(), mig)
 	if err == nil {
-		t.Fatal("validate GPU guest cross-node should reject")
+		t.Fatal("validate GPU guest with mode=live should reject")
 	}
 	if !strings.Contains(err.Error(), "VFIO devices") {
 		t.Errorf("error should mention VFIO devices; got %q", err.Error())
 	}
-	// The Phase-1-not-supported gate text — lock in so a future relax
-	// of the rule (Phase 4 work) requires updating this assertion.
-	if !strings.Contains(err.Error(), "cross-node migration is not supported in Phase 1") {
-		t.Errorf("error should mention the Phase 1 gate; got %q", err.Error())
+	if !strings.Contains(err.Error(), "cannot live-migrate") {
+		t.Errorf("error should mention the live-migration gate; got %q", err.Error())
 	}
 }
 
-func TestValidateClusterState_GPUUnscheduledRejected(t *testing.T) {
-	// GPU guest that hasn't been scheduled yet (status.NodeName empty).
-	// Phase 1 rejects unconditionally — the architect's GPU rejection
-	// rule is unconditional (security tightening), not gated on
-	// sourceNode being known. Without this rule, an operator could
-	// submit a SwiftMigration on an unscheduled GPU guest and create a
-	// race with the SwiftGPU controller's allocation logic.
+func TestValidateClusterState_GPUUnscheduledLiveRejected(t *testing.T) {
+	// An unscheduled GPU guest (status.NodeName empty) with mode=live is
+	// rejected — VFIO cannot live-migrate regardless of scheduling state.
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default")
 	guest.Status.NodeName = "" // unscheduled
@@ -485,13 +484,17 @@ func TestValidateClusterState_GPUUnscheduledRejected(t *testing.T) {
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	_, err := v.validate(context.Background(), mig)
 	if err == nil || !strings.Contains(err.Error(), "VFIO devices") {
-		t.Errorf("validate unscheduled GPU guest should reject; got %v", err)
+		t.Errorf("validate unscheduled GPU guest with mode=live should reject; got %v", err)
 	}
 }
 
-func TestValidateClusterState_SRIOVCrossNodeRejected(t *testing.T) {
+func TestValidateClusterState_SRIOVLiveRejected(t *testing.T) {
+	// VFIO devices (here SR-IOV) cannot LIVE-migrate; mode=live is rejected.
+	// Offline VFIO migration is allowed (the release-and-reallocate path) — see
+	// TestValidateClusterState_VFIOOfflineNotRejected.
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default")
 	guest.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
@@ -501,9 +504,29 @@ func TestValidateClusterState_SRIOVCrossNodeRejected(t *testing.T) {
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	_, err := v.validate(context.Background(), mig)
 	if err == nil || !strings.Contains(err.Error(), "VFIO devices") {
-		t.Errorf("validate SR-IOV guest cross-node should reject; got %v", err)
+		t.Errorf("validate SR-IOV guest with mode=live should reject; got %v", err)
+	}
+}
+
+func TestValidateClusterState_VFIOOfflineNotRejected(t *testing.T) {
+	// A VFIO (GPU) guest migrating OFFLINE must NOT be rejected by the
+	// VFIO-live rule. (It may still fail other cluster-state checks in a real
+	// run; what we assert here is that the "cannot live-migrate" rejection does
+	// not fire for offline.)
+	scheme := migrationScheme(t)
+	guest := newSwiftGuest("guest", "default")
+	guest.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu-pcie"}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	v := &Validator{Client: c}
+
+	mig := newSwiftMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeOffline
+	_, err := v.validate(context.Background(), mig)
+	if err != nil && strings.Contains(err.Error(), "cannot live-migrate") {
+		t.Errorf("offline VFIO migration must not hit the VFIO-live rejection; got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Release-and-reallocate sub-phase (TFU #27) — PR 3 of 5 (the substantive one)

Wires the SwiftGPU Reserve/Release primitives (PR 2) into the SwiftMigration offline state machine so **VFIO/GPU guests can be evacuated off a node**. The migration controller orchestrates (design §5). **Safety invariant:** all GPU logic lives in `gpu_offline.go` and is gated on `guest.HasVFIODevices()` at every call site — **non-GPU offline migration is byte-for-byte unchanged**.

### Sequence (reserve-before-stop atomicity)
| Phase | GPU step |
|---|---|
| **Validating** | `gpuPreflight`: target vfio-ready + free matching GPUs — early, clear rejection before anything stops |
| **Preparing** | `reserveTargetGPUs(T)` **before** the source is stopped — a failed reserve fails the migration with the source still running (never stranded) |
| **StopAndCopy** | `cutoverGPUs`: `ReleaseFromNode(source)` + stamp `status.GPU=target` **before** the runPolicy+nodeName spec patch — so the pod builder's precedence rule holds when the dst pod builds on the target. Idempotent. |
| **Failed (pre-cutover)** | `releaseTargetReservation(T)` — a failed migration doesn't strand the target reservation; the source resumes on its own node |

### Precedence rule (`swiftguest/gpu.go`)
Reworded from "Phase 1 not supported" to a **consistency assertion** the cutover satisfies (commits `status.GPU` + `spec.NodeName` together). Marked **LOAD-BEARING (W26-class)**: `status.GPU.NodeName` stays the binding source for which GPUs gpu-init binds.

### Webhook (`validator.go`)
The unconditional VFIO rejection is **lifted for offline**:
- `mode=live` + VFIO → **reject** (CH cannot live-migrate a VFIO device)
- `mode=auto`/`offline` + VFIO → **allow** (`resolveAutoMode` already sends VFIO to offline)

Existing VFIO-rejection tests updated to the new contract; added a VFIO-offline-not-rejected test.

### Tests
reserve marks-target-keeps-source / not-vfio-ready-fails; cutover releases-source + stamps-status.GPU=target (preserves hypervisor) + idempotent; release drops-target-leaves-source; pre-flight pass/fail. Full `go test ./...` green — non-GPU migration paths unaffected.

### Sub-phase progress
- ✅ Spike (#94), gpu-init fix (#93), design (#95), PR 1 vfioReady (#96), PR 2 primitives (#97)
- ▶️ **PR 3 (this)** — VFIO offline migration sequence + precedence + webhook lift
- ⬜ PR 4 — drain controller GPU wiring (VFIO `Migrate` → offline migration; target via `GPUNodeHasCapacity`)
- ⬜ PR 5 — cluster walkthrough (same-node `boba→boba`) + runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)