### PR TITLE
feat(gpu): drain auto-evacuates GPU guests (offline); SR-IOV stays manual

### DIFF
--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -183,12 +183,28 @@ func (g *SwiftGuest) HasVFIODevices() bool {
 	if g.Spec.GPUProfileRef != nil {
 		return true
 	}
+	return g.HasSRIOVInterface()
+}
+
+// HasSRIOVInterface reports whether the guest has any SR-IOV (VFIO NIC)
+// interface. SR-IOV NIC passthrough cannot be migrated off a node by the GPU
+// release-and-reallocate path (that handles GPUs only; NIC reattach on the
+// target is out of scope) — so an sriov guest is not auto-evacuated on drain,
+// regardless of GPU presence.
+func (g *SwiftGuest) HasSRIOVInterface() bool {
 	for _, iface := range g.Spec.Interfaces {
 		if iface.Type == InterfaceTypeSRIOV {
 			return true
 		}
 	}
 	return false
+}
+
+// OfflineGPUMigratable reports whether the guest can be evacuated off a node by
+// the offline GPU release-and-reallocate path: it has a GPU profile and no
+// SR-IOV NIC (which the path cannot reattach on the target).
+func (g *SwiftGuest) OfflineGPUMigratable() bool {
+	return g.Spec.GPUProfileRef != nil && !g.HasSRIOVInterface()
 }
 
 // DataDiskRef references either a SwiftImage or a PVC for a data disk.

--- a/internal/controller/swiftdrain/controller.go
+++ b/internal/controller/swiftdrain/controller.go
@@ -11,11 +11,11 @@
 // guest is off the draining node, it clears the marker; the next eviction
 // retry then finds the pod gone (or moved) and is allowed, so drain proceeds.
 //
-// VFIO/GPU guests are NOT handled here: cross-node migration of VFIO devices
-// needs a release-and-reallocate primitive that does not exist yet (tracked
-// follow-up). The eviction webhook denies those without marking; this
-// controller guards defensively and surfaces a manual-handling event if a
-// VFIO guest is somehow marked.
+// VFIO/GPU guests ARE handled (offline): the eviction webhook marks them under
+// drainPolicy=Migrate (not LiveMigrate — VFIO can't live-migrate), the created
+// migration resolves to offline, and the migration controller's release-and-
+// reallocate sequence moves the GPUs. selectTarget requires a vfio-ready
+// target with free matching GPUs for these guests.
 package swiftdrain
 
 import (
@@ -70,15 +70,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	// VFIO/GPU guests cannot be auto-migrated yet (release-and-reallocate
-	// pending). The eviction webhook should not have marked them; guard
-	// defensively and surface a manual-handling event rather than create a
-	// migration the SwiftMigration webhook would reject.
-	if guest.HasVFIODevices() {
-		r.event(&guest, corev1.EventTypeWarning, "DrainUnsupported",
-			fmt.Sprintf("guest on node %q uses VFIO/GPU devices; automatic evacuation is not supported yet (release-and-reallocate pending) — handle manually", drainingNode))
-		return ctrl.Result{}, nil
-	}
+	// VFIO/GPU guests ARE now auto-migratable (offline, via the SwiftGPU
+	// release-and-reallocate path). The eviction webhook only marks them under
+	// drainPolicy=Migrate (LiveMigrate+VFIO is denied — VFIO can't live-
+	// migrate), so a marked VFIO guest here is a Migrate guest: drainMode
+	// resolves to auto, and the migration controller's auto-mode sends VFIO to
+	// offline. selectTarget additionally requires a vfio-ready target with free
+	// matching GPUs for these guests (GPUNodeHasCapacity).
 
 	migName := drainMigrationName(guest.Name, drainingNode)
 	var mig migrationv1alpha1.SwiftMigration

--- a/internal/controller/swiftdrain/controller_test.go
+++ b/internal/controller/swiftdrain/controller_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
 	"github.com/projectbeskar/kubeswift/internal/scheme"
@@ -150,17 +151,65 @@ func TestReconcile_GuestMovedOff_ClearsMarker(t *testing.T) {
 	}
 }
 
-func TestReconcile_VFIOGuest_NoMigration(t *testing.T) {
-	r, c := newR(guest("g", drain("miles"), statusNode("miles"), vfio()), node("miles"), node("boba"), smallClass())
+func gpuProfileFixture() *gpuv1alpha1.SwiftGPUProfile {
+	return &gpuv1alpha1.SwiftGPUProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu", Namespace: ns},
+		Spec:       gpuv1alpha1.SwiftGPUProfileSpec{Count: 1, PartitionMode: "isolated"},
+	}
+}
+
+func swiftGPUNode(name string, vfioReady bool, free int) *gpuv1alpha1.SwiftGPUNode {
+	return &gpuv1alpha1.SwiftGPUNode{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     gpuv1alpha1.SwiftGPUNodeStatus{VfioReady: vfioReady, FreeGPUs: free, GPUModel: "GeForce GTX 1080"},
+	}
+}
+
+func TestReconcile_GPUGuest_NoGPUTarget_NoMigration(t *testing.T) {
+	// GPU guest, profile exists, but boba is not a GPU node (no SwiftGPUNode)
+	// → no schedulable GPU target → no migration; marker stays.
+	r, c := newR(guest("g", drain("miles"), statusNode("miles"), vfio()),
+		node("miles"), node("boba"), smallClass(), gpuProfileFixture())
+	res := reconcileGuest(t, r, "g")
+	if migs := listMigs(t, c); len(migs) != 0 {
+		t.Errorf("no GPU target → no migration; got %d", len(migs))
+	}
+	if res.RequeueAfter == 0 {
+		t.Errorf("no GPU target should requeue")
+	}
+	if getGuest(t, c, "g").Annotations[swiftv1alpha1.AnnotationDrainRequested] != "miles" {
+		t.Errorf("marker must stay when there is no GPU target")
+	}
+}
+
+func TestReconcile_GPUGuest_CreatesOfflineMigration(t *testing.T) {
+	// GPU guest with a vfio-ready GPU target (boba) → creates an offline
+	// (auto→offline) migration via release-and-reallocate.
+	r, c := newR(guest("g", drain("miles"), statusNode("miles"), vfio()),
+		node("miles"), node("boba"), smallClass(), gpuProfileFixture(),
+		swiftGPUNode("boba", true, 1))
+	reconcileGuest(t, r, "g")
+	migs := listMigs(t, c)
+	if len(migs) != 1 {
+		t.Fatalf("GPU guest with a vfio-ready GPU target should create 1 migration; got %d", len(migs))
+	}
+	if migs[0].Spec.Target.NodeName != "boba" {
+		t.Errorf("target = %q, want boba (the vfio-ready GPU node)", migs[0].Spec.Target.NodeName)
+	}
+	if migs[0].Spec.Mode != migrationv1alpha1.SwiftMigrationModeAuto {
+		t.Errorf("mode = %q, want auto (resolves to offline for VFIO)", migs[0].Spec.Mode)
+	}
+}
+
+func TestReconcile_GPUGuest_NonVfioReadyTarget_NoMigration(t *testing.T) {
+	// boba is a GPU node but NOT vfio-ready → GPUNodeHasCapacity rejects it →
+	// no GPU target → no migration.
+	r, c := newR(guest("g", drain("miles"), statusNode("miles"), vfio()),
+		node("miles"), node("boba"), smallClass(), gpuProfileFixture(),
+		swiftGPUNode("boba", false, 1))
 	reconcileGuest(t, r, "g")
 	if migs := listMigs(t, c); len(migs) != 0 {
-		t.Errorf("VFIO guest cannot auto-migrate yet; must create no migration, got %d", len(migs))
-	}
-	// Marker is left as-is (the controller doesn't clear it; the operator
-	// handles the guest manually).
-	g := getGuest(t, c, "g")
-	if g.Annotations[swiftv1alpha1.AnnotationDrainRequested] != "miles" {
-		t.Errorf("VFIO marker should be left for manual handling")
+		t.Errorf("a non-vfio-ready GPU node is not a valid target; got %d migrations", len(migs))
 	}
 }
 

--- a/internal/controller/swiftdrain/target.go
+++ b/internal/controller/swiftdrain/target.go
@@ -9,7 +9,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftgpu"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftmigration"
 )
 
@@ -32,6 +34,17 @@ func (r *Reconciler) selectTarget(ctx context.Context, guest *swiftv1alpha1.Swif
 			return "", fmt.Errorf("SwiftGuestClass %q not found", guest.Spec.GuestClassRef.Name)
 		}
 		return "", fmt.Errorf("get SwiftGuestClass %q: %w", guest.Spec.GuestClassRef.Name, err)
+	}
+
+	// For an offline-GPU-migratable guest, resolve its GPU profile so each
+	// candidate node is also checked for vfio-readiness + free matching GPUs.
+	var gpuProfile *gpuv1alpha1.SwiftGPUProfile
+	if guest.OfflineGPUMigratable() {
+		var p gpuv1alpha1.SwiftGPUProfile
+		if err := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: guest.Spec.GPUProfileRef.Name}, &p); err != nil {
+			return "", fmt.Errorf("get SwiftGPUProfile %q: %w", guest.Spec.GPUProfileRef.Name, err)
+		}
+		gpuProfile = &p
 	}
 
 	var nodes corev1.NodeList
@@ -68,6 +81,13 @@ func (r *Reconciler) selectTarget(ctx context.Context, guest *swiftv1alpha1.Swif
 		if err := swiftmigration.NodeHasCapacity(ctx, r.Client, n, &class); err != nil {
 			skipped++
 			continue
+		}
+		// GPU guests: the target must also be vfio-ready with free matching GPUs.
+		if gpuProfile != nil {
+			if err := swiftgpu.GPUNodeHasCapacity(ctx, r.Client, n.Name, gpuProfile); err != nil {
+				skipped++
+				continue
+			}
 		}
 		fitting = append(fitting, cand{name: n.Name, allocCPU: n.Status.Allocatable.Cpu().MilliValue()})
 	}

--- a/internal/webhook/eviction/handler.go
+++ b/internal/webhook/eviction/handler.go
@@ -111,29 +111,40 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 			guestName, node))
 	}
 
-	// VFIO/GPU guests cannot be auto-migrated yet — neither live nor offline
-	// cross-node migration of VFIO devices is supported (the SwiftGPU
-	// release-and-reallocate primitive is a tracked follow-up). Deny with a
-	// manual-handling message under ANY drainPolicy and do NOT mark: a marker
-	// would drive the drain controller to create a SwiftMigration the
-	// migration webhook rejects, looping a doomed object every 5s.
-	if guest.HasVFIODevices() {
-		return denyRetry(fmt.Sprintf(
-			"SwiftGuest %q uses VFIO/GPU devices that cannot be auto-migrated yet; it will not be evacuated off node %q — handle it manually (cross-node VFIO migration is pending the release-and-reallocate primitive)",
-			guestName, node))
-	}
-
 	switch policy {
 	case swiftv1alpha1.DrainPolicyBlock:
 		return denyRetry(fmt.Sprintf(
 			"SwiftGuest %q has drainPolicy=Block; it will not be auto-migrated off node %q — handle this guest manually",
 			guestName, node))
-	case swiftv1alpha1.DrainPolicyLiveMigrate, swiftv1alpha1.DrainPolicyMigrate:
-		// Non-VFIO + Migrate (auto: live where possible, offline otherwise)
-		// or LiveMigrate (live only) — migratable; fall through to mark.
+	case swiftv1alpha1.DrainPolicyLiveMigrate:
+		// LiveMigrate forbids incurring downtime. A VFIO/GPU guest can only
+		// move OFFLINE (CH cannot live-migrate a VFIO device), so block the
+		// drain rather than evacuate it with downtime — the operator opted out
+		// of offline by choosing LiveMigrate. Non-VFIO LiveMigrate falls
+		// through to mark (live).
+		if guest.HasVFIODevices() {
+			return denyRetry(fmt.Sprintf(
+				"SwiftGuest %q has drainPolicy=LiveMigrate but uses VFIO/GPU devices that cannot live-migrate; it will not be evacuated off node %q — set drainPolicy=Migrate to allow offline (release-and-reallocate) migration, or handle it manually",
+				guestName, node))
+		}
+	case swiftv1alpha1.DrainPolicyMigrate:
+		// Migratable: non-VFIO resolves to live where possible; VFIO/GPU
+		// resolves to OFFLINE via the release-and-reallocate path. Fall
+		// through to mark.
 	default:
 		// Unknown/unvalidated policy: treat as Migrate (the CRD enum should
 		// have rejected anything else at admission of the SwiftGuest).
+	}
+
+	// SR-IOV NIC passthrough cannot be auto-migrated: the GPU release-and-
+	// reallocate path handles GPUs only; reattaching an SR-IOV NIC on the
+	// target is out of scope. Deny without marking (a marker would drive a
+	// migration that fails for lack of a GPU profile). Reaches here only for
+	// Migrate/unknown policy (LiveMigrate already denied any VFIO above).
+	if guest.HasSRIOVInterface() {
+		return denyRetry(fmt.Sprintf(
+			"SwiftGuest %q uses SR-IOV NIC passthrough that cannot be auto-migrated off node %q — handle it manually",
+			guestName, node))
 	}
 
 	// Migratable. Stamp the drain-requested marker (skip on dry-run) and

--- a/internal/webhook/eviction/handler_test.go
+++ b/internal/webhook/eviction/handler_test.go
@@ -73,6 +73,11 @@ func TestHandle(t *testing.T) {
 		g.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu"}
 		return g
 	}
+	sriovGuest := func(name, policy string) *swiftv1alpha1.SwiftGuest {
+		g := swiftGuest(name, ns, &swiftv1alpha1.MigrationSpec{DrainPolicy: policy})
+		g.Spec.Interfaces = []swiftv1alpha1.GuestInterface{{Name: "data", Type: swiftv1alpha1.InterfaceTypeSRIOV}}
+		return g
+	}
 
 	tests := []struct {
 		name        string
@@ -150,10 +155,20 @@ func TestHandle(t *testing.T) {
 			wantMarked:  "",
 		},
 		{
-			name: "VFIO guest with Migrate denies without marking (cannot auto-migrate yet)",
+			name: "GPU guest with Migrate marks (offline release-and-reallocate)",
 			objects: []client.Object{
 				guestPod("g-pod", ns, "g", "miles"),
 				vfioGuestSpec("g", swiftv1alpha1.DrainPolicyMigrate),
+			},
+			req:         evictReq(ns, "g-pod", false),
+			wantAllowed: false,
+			wantMarked:  "miles",
+		},
+		{
+			name: "SR-IOV guest with Migrate denies without marking (NIC reattach unsupported)",
+			objects: []client.Object{
+				guestPod("g-pod", ns, "g", "miles"),
+				sriovGuest("g", swiftv1alpha1.DrainPolicyMigrate),
 			},
 			req:         evictReq(ns, "g-pod", false),
 			wantAllowed: false,

--- a/internal/webhook/swiftmigration/validator.go
+++ b/internal/webhook/swiftmigration/validator.go
@@ -400,17 +400,21 @@ func (v *Validator) validateClusterState(ctx context.Context, mig *migrationv1al
 		}
 	}
 
-	// GPU/VFIO migration mode gate. VFIO devices (gpuProfileRef or sriov)
-	// CANNOT live-migrate — Cloud Hypervisor cannot transfer the device's
-	// state to the destination. They CAN migrate OFFLINE via the release-and-
-	// reallocate path (the migration controller reserves target GPUs before
-	// stopping the source, frees the source at cutover, and stamps
-	// status.GPU=target). So:
-	//   - mode=live + VFIO  -> reject (no live VFIO migration, ever).
-	//   - mode=auto/offline + VFIO -> allow; resolveAutoMode sends VFIO guests
-	//     to offline, and the offline GPU sequence handles the handoff.
+	// VFIO migration gate. VFIO devices CANNOT live-migrate — Cloud Hypervisor
+	// cannot transfer device state to the destination — so mode=live + VFIO is
+	// rejected. GPU guests CAN migrate OFFLINE via the release-and-reallocate
+	// path (the migration controller reserves target GPUs before stopping the
+	// source, frees the source at cutover, stamps status.GPU=target).
 	if guest.HasVFIODevices() && mig.Spec.Mode == migrationv1alpha1.SwiftMigrationModeLive {
-		return nil, fmt.Errorf("SwiftGuest %q has VFIO devices (gpuProfileRef or sriov interface); they cannot live-migrate — use mode=offline (or auto, which resolves to offline for VFIO)",
+		return nil, fmt.Errorf("SwiftGuest %q has VFIO devices (gpuProfileRef or sriov interface); they cannot live-migrate — use mode=offline (or auto, which resolves to offline for VFIO GPU guests)",
+			guest.Name)
+	}
+	// SR-IOV NIC passthrough cannot migrate cross-node at all: the offline GPU
+	// release-and-reallocate path handles GPUs only; reattaching an SR-IOV NIC
+	// on the target is out of scope. (A GPU-only guest, no sriov, IS offline-
+	// migratable.)
+	if guest.HasSRIOVInterface() {
+		return nil, fmt.Errorf("SwiftGuest %q has an SR-IOV interface; cross-node migration of SR-IOV NIC passthrough is not supported",
 			guest.Name)
 	}
 

--- a/internal/webhook/swiftmigration/validator_test.go
+++ b/internal/webhook/swiftmigration/validator_test.go
@@ -530,6 +530,26 @@ func TestValidateClusterState_VFIOOfflineNotRejected(t *testing.T) {
 	}
 }
 
+func TestValidateClusterState_SRIOVOfflineRejected(t *testing.T) {
+	// SR-IOV NIC passthrough cannot migrate cross-node at all (the offline GPU
+	// release-and-reallocate path handles GPUs only; NIC reattach is out of
+	// scope) — rejected even for mode=offline.
+	scheme := migrationScheme(t)
+	guest := newSwiftGuest("guest", "default")
+	guest.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
+		{Name: "data", Type: swiftv1alpha1.InterfaceTypeSRIOV, ResourceName: "intel.com/sriov_netdevice"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	v := &Validator{Client: c}
+
+	mig := newSwiftMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeOffline
+	_, err := v.validate(context.Background(), mig)
+	if err == nil || !strings.Contains(err.Error(), "SR-IOV") {
+		t.Errorf("offline SR-IOV migration should reject; got %v", err)
+	}
+}
+
 func TestValidateClusterState_DefaultNetworkingNeedsAllowIPChange(t *testing.T) {
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default") // no spec.interfaces, default networking


### PR DESCRIPTION
## Release-and-reallocate sub-phase (TFU #27) — PR 4 of 5 (last code PR)

Lifts the Phase 4 "VFIO can't be evacuated" guards now that **offline GPU migration works** (PR 3), and routes drain GPU target selection through `GPUNodeHasCapacity`. Scopes the offline path to **GPUs** — SR-IOV NIC passthrough stays manual (NIC reattach on the target is a design non-goal).

### New predicates (`api/swift`)
- `SwiftGuest.HasSRIOVInterface()`
- `OfflineGPUMigratable()` = `gpuProfileRef != nil && no SR-IOV`
- `HasVFIODevices` refactored to reuse `HasSRIOVInterface`.

### Eviction webhook
The blanket "VFIO denied" gate (Phase 4 PR 4a) is removed. Per policy now:
| Guest | Behaviour |
|---|---|
| `LiveMigrate` + VFIO | **deny** (CH can't live-migrate a VFIO device) |
| `Migrate` + GPU | **mark** (offline release-and-reallocate) |
| any + SR-IOV | **deny** without marking (NIC reattach unsupported) |
| non-VFIO | unchanged |

### Drain controller
The `DrainUnsupported` VFIO guard is removed — GPU guests get an offline (auto→offline) migration. `selectTarget` resolves the GPU profile and additionally requires each candidate to pass `GPUNodeHasCapacity` (vfio-ready + free matching GPUs), so a GPU guest only targets a node that can host it.

### SwiftMigration webhook
The VFIO rejection is now precise: `mode=live` + VFIO rejected; any SR-IOV rejected; **GPU + offline allowed**.

### Tests
Eviction (GPU+Migrate marks; SR-IOV+Migrate denies; GPU+LiveMigrate denies); drain (GPU guest + vfio-ready target → auto migration; no-GPU-target / non-vfio-ready → no migration); webhook (SR-IOV offline rejected). Full `go test ./...` green — non-VFIO drain paths unaffected.

Operator docs (removing the "VFIO not auto-evacuated" caveat in `docs/migration/phase-4.md` + design §4.3) land with **PR 5**.

### Sub-phase progress
- ✅ Spike (#94), gpu-init fix (#93), design (#95), PR 1 vfioReady (#96), PR 2 primitives (#97), PR 3 offline sequence (#98)
- ▶️ **PR 4 (this)** — drain GPU wiring
- ⬜ **PR 5** — cluster walkthrough (same-node `boba→boba` orchestrated release→reacquire on the real GTX 1080) + operator runbook + doc updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)