### PR TITLE
fix(gpu): findAndAllocate prefers status.GPU node — W-GPU-1 migration race

### DIFF
--- a/internal/controller/swiftgpu/allocate.go
+++ b/internal/controller/swiftgpu/allocate.go
@@ -32,8 +32,29 @@ func (r *SwiftGPUReconciler) findAndAllocate(
 
 	allocatedTo := guest.Namespace + "/" + guest.Name
 
-	// First pass: check whether a previous allocation already exists for this
-	// guest (idempotency guard — handles partial status patch failure).
+	// The node status.GPU already references, if any. The first pass prefers it.
+	preferredNode := ""
+	if guest.Status.GPU != nil {
+		preferredNode = guest.Status.GPU.NodeName
+	}
+
+	// First pass: return an existing allocation for this guest (idempotency
+	// guard — handles partial status patch failure). PREFER the node
+	// status.GPU already points at over the first node found.
+	//
+	// W-GPU-1: during a VFIO offline migration's reserve-before-stop window the
+	// guest is briefly allocated on BOTH the source and the target node (the
+	// reservation reuses AllocatedTo). Returning the FIRST allocated node would
+	// make this controller re-stamp status.GPU to that node — racing the
+	// migration controller, which owns status.GPU during the migration (it sets
+	// status.GPU=target at cutover). Preferring the node status.GPU already
+	// references makes the re-stamp a no-op that never fights the migration:
+	// status.GPU=source during reserve → returns source; status.GPU=target
+	// after cutover → returns target.
+	var fbNode *gpuv1alpha1.SwiftGPUNode
+	var fbGPUs []gpuv1alpha1.GPUDevice
+	var fbNUMA []int
+	fbPart := -1
 	for i := range nodeList.Items {
 		n := &nodeList.Items[i]
 		var existing []gpuv1alpha1.GPUDevice
@@ -53,10 +74,18 @@ func (r *SwiftGPUReconciler) findAndAllocate(
 				}
 			}
 		}
-		if len(existing) > 0 {
-			nodes := numaSetToSlice(numaSet)
-			return n, existing, nodes, existingPartID, nil
+		if len(existing) == 0 {
+			continue
 		}
+		if preferredNode != "" && n.Name == preferredNode {
+			return n, existing, numaSetToSlice(numaSet), existingPartID, nil
+		}
+		if fbNode == nil {
+			fbNode, fbGPUs, fbNUMA, fbPart = n, existing, numaSetToSlice(numaSet), existingPartID
+		}
+	}
+	if fbNode != nil {
+		return fbNode, fbGPUs, fbNUMA, fbPart, nil
 	}
 
 	// Second pass: find a node with capacity and allocate.

--- a/internal/controller/swiftgpu/allocate_wgpu1_test.go
+++ b/internal/controller/swiftgpu/allocate_wgpu1_test.go
@@ -1,0 +1,86 @@
+package swiftgpu
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// nodeAllocatedTo builds a SwiftGPUNode whose single GPU is allocated to the
+// given guest key.
+func nodeAllocatedTo(name, pci, guestKey string) *gpuv1alpha1.SwiftGPUNode {
+	return &gpuv1alpha1.SwiftGPUNode{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: gpuv1alpha1.SwiftGPUNodeStatus{
+			VfioReady: true,
+			GPUModel:  "GeForce GTX 1080",
+			GPUs: []gpuv1alpha1.GPUDevice{
+				{Index: 0, PCIAddress: pci, Vendor: "NVIDIA", Model: "GeForce GTX 1080", Allocated: true, AllocatedTo: guestKey},
+			},
+		},
+	}
+}
+
+func wgpu1Profile() *gpuv1alpha1.SwiftGPUProfile {
+	return &gpuv1alpha1.SwiftGPUProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+		Spec:       gpuv1alpha1.SwiftGPUProfileSpec{Count: 1, PartitionMode: "isolated"},
+	}
+}
+
+func wgpu1Guest(statusNode string) *swiftv1alpha1.SwiftGuest {
+	g := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "default"}}
+	if statusNode != "" {
+		g.Status.GPU = &swiftv1alpha1.GPUStatus{NodeName: statusNode}
+	}
+	return g
+}
+
+// TestFindAndAllocate_PrefersStatusGPUNode is the W-GPU-1 regression: during a
+// VFIO migration's reserve-before-stop double-hold the guest is allocated on
+// BOTH "boba" (first in the list) and "miles". findAndAllocate must return the
+// node status.GPU references, NOT the first-found node — otherwise the SwiftGPU
+// controller re-stamps status.GPU and races the migration controller.
+func TestFindAndAllocate_PrefersStatusGPUNode(t *testing.T) {
+	boba := nodeAllocatedTo("boba", "0000:01:00.0", "default/g")
+	miles := nodeAllocatedTo("miles", "0000:ff:00.0", "default/g")
+	profile := wgpu1Profile()
+
+	t.Run("status.GPU=miles returns miles (not first-found boba)", func(t *testing.T) {
+		r := newReconciler(boba, miles, wgpu1Guest("miles"))
+		node, _, _, _, err := r.findAndAllocate(context.Background(), wgpu1Guest("miles"), profile)
+		if err != nil {
+			t.Fatalf("findAndAllocate: %v", err)
+		}
+		if node == nil || node.Name != "miles" {
+			t.Fatalf("must prefer the status.GPU node (miles); got %v", node)
+		}
+	})
+
+	t.Run("status.GPU=boba returns boba", func(t *testing.T) {
+		r := newReconciler(boba, miles, wgpu1Guest("boba"))
+		node, _, _, _, err := r.findAndAllocate(context.Background(), wgpu1Guest("boba"), profile)
+		if err != nil {
+			t.Fatalf("findAndAllocate: %v", err)
+		}
+		if node == nil || node.Name != "boba" {
+			t.Fatalf("must prefer the status.GPU node (boba); got %v", node)
+		}
+	})
+
+	t.Run("no status.GPU falls back to first-found", func(t *testing.T) {
+		// Single allocation (no double-hold), no status.GPU → returns it.
+		r := newReconciler(boba, wgpu1Guest(""))
+		node, _, _, _, err := r.findAndAllocate(context.Background(), wgpu1Guest(""), profile)
+		if err != nil {
+			t.Fatalf("findAndAllocate: %v", err)
+		}
+		if node == nil || node.Name != "boba" {
+			t.Fatalf("with no status.GPU and one allocation, returns that node; got %v", node)
+		}
+	})
+}


### PR DESCRIPTION
## W-GPU-1 — blocking multi-controller race, surfaced by the PR 5 cluster walkthrough

The release-and-reallocate walkthrough validated the orchestration primitives (reserve-before-stop, cutover release+stamp, drain target selection) **on the real apiserver**, but the migration **failed end-to-end** because of a race the unit tests couldn't see (fake clients, no concurrent controllers — the **W5 pattern**).

### Root cause
The SwiftGPU controller re-derives + re-stamps `status.GPU` on **every** reconcile via `findAndAllocate`, whose idempotency first-pass returned the **first** `SwiftGPUNode` with a GPU `AllocatedTo` the guest. During a VFIO migration's **reserve-before-stop double-hold** the guest is briefly allocated on **both** the source and target node (the reservation reuses `AllocatedTo`), so the first-pass returned the wrong node and re-stamped `status.GPU` — racing the migration controller, which owns `status.GPU` during the migration and sets it to the target at cutover.

The design's "SwiftGPU is idle while `status.GPU` is non-nil" (§5.1) assumption was **false**.

### Fix (no CRD change)
`findAndAllocate`'s first-pass now **prefers the node `status.GPU` already references**; it falls back to the first-found node only when `status.GPU` is unset or the guest isn't allocated there. The controller then re-stamps `status.GPU` to the node it *already points at* — a no-op that never fights the migration (source during reserve, target after cutover). Normal allocation (single node, or `status.GPU=nil` initial) is unchanged.

### Test
Double-hold on `boba` (first-listed) + `miles` with `status.GPU=miles` must return **miles** — load-bearing (returns `boba` without the fix). Inverse + no-status fallback covered. Full `go test ./...` green.

### Next
Once merged: redeploy + **re-run the walkthrough** to confirm the migration now succeeds end-to-end on the cluster (control-plane), then PR 5 (the walkthrough doc + operator docs) lands with the W-GPU-1 finding documented as found-and-fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)