### PR TITLE
fix(gpu): tolerate nodeSelector-pinned dst pod in StopAndCopy — W-GPU-2

### DIFF
--- a/internal/controller/swiftmigration/stopandcopy.go
+++ b/internal/controller/swiftmigration/stopandcopy.go
@@ -121,9 +121,26 @@ func (r *SwiftMigrationReconciler) handleStopAndCopy(
 		return phaseTransient(fmt.Errorf("get destination pod: %w", getErr))
 	}
 
-	// Pod exists. Verify it's pinned to the destination node — if it
-	// somehow landed elsewhere (race window we believe is closed but
-	// belt-and-suspenders), surface as Failed.
+	// Pod exists. Verify it's committed to the destination node.
+	//
+	// Two pinning mechanisms (W-GPU-2): non-VFIO guests bind directly
+	// (pod.Spec.NodeName=target at creation, via applyNodeName); GPU guests pin
+	// via a kubernetes.io/hostname nodeSelector and the SCHEDULER fills in
+	// pod.Spec.NodeName a moment later (controller-cache lag can also briefly
+	// show an empty nodeName right after the cutover spec patch). So an empty
+	// pod.Spec.NodeName is "not yet scheduled", NOT a violation — requeue and
+	// wait, as long as nothing pins the pod AWAY from the target. Only a
+	// populated nodeName (or a hostname nodeSelector) that disagrees with the
+	// target is the real atomicity violation.
+	if pod.Spec.NodeName == "" {
+		if sel := pod.Spec.NodeSelector["kubernetes.io/hostname"]; sel != "" && sel != target {
+			return phaseFailure(fmt.Sprintf("destination pod %q pins to %q via nodeSelector, expected %q (atomicity invariant violated)",
+				pod.Name, sel, target), "")
+		}
+		setPhaseDetail(status, fmt.Sprintf("awaiting destination pod scheduling on %q", target))
+		setReadyCondition(status, metav1.ConditionFalse, ReasonStopAndCopy, "awaiting destination pod scheduling")
+		return phaseRequeue(stopAndCopyPollInterval)
+	}
 	if pod.Spec.NodeName != target {
 		return phaseFailure(fmt.Sprintf("destination pod %q scheduled on %q, expected %q (atomicity invariant violated)",
 			pod.Name, pod.Spec.NodeName, target), "")

--- a/internal/controller/swiftmigration/stopandcopy_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_test.go
@@ -181,6 +181,76 @@ func TestStopAndCopy_PodOnWrongNode_Fails(t *testing.T) {
 	}
 }
 
+// TestStopAndCopy_GPUPodUnscheduled_NodeSelectorTarget_Requeues is the W-GPU-2
+// regression: a GPU destination pod pins to the target via a hostname
+// nodeSelector and is not yet scheduled (pod.Spec.NodeName==""). The atomicity
+// check must REQUEUE (await the scheduler), not false-fail.
+func TestStopAndCopy_GPUPodUnscheduled_NodeSelectorTarget_Requeues(t *testing.T) {
+	scheme := preparingScheme(t)
+	guest := newGuestForValidating("guest", "default", "class-default")
+	guest.Status.NodeName = "boba"
+	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyRunning
+	guest.Spec.NodeName = "miles"
+	guest.Annotations = map[string]string{migrationv1alpha1.AnnotationMigrationInProgress: "m"}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			NodeName:     "", // not yet scheduled (GPU pod pins via nodeSelector)
+			NodeSelector: map[string]string{"kubernetes.io/hostname": "miles"},
+			Containers:   []corev1.Container{{Name: "launcher", Image: "x"}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+	mig := newMigration("m", "default")
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseStopAndCopy
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mig, guest, pod).WithStatusSubresource(mig).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	status := mig.Status.DeepCopy()
+	result := r.handleStopAndCopy(context.Background(), mig, status)
+	if result.Err != nil || result.FailureMsg != "" {
+		t.Fatalf("unscheduled GPU pod pinned to target must NOT fail; err=%v msg=%q", result.Err, result.FailureMsg)
+	}
+	if result.Advanced {
+		t.Fatal("must not advance until the dst pod is scheduled")
+	}
+	if result.Requeue == 0 {
+		t.Fatal("must requeue to await the scheduler binding the GPU pod")
+	}
+}
+
+// TestStopAndCopy_GPUPodNodeSelectorWrongNode_Fails verifies the atomicity
+// check still fires when an unscheduled pod's hostname nodeSelector pins it AWAY
+// from the target.
+func TestStopAndCopy_GPUPodNodeSelectorWrongNode_Fails(t *testing.T) {
+	scheme := preparingScheme(t)
+	guest := newGuestForValidating("guest", "default", "class-default")
+	guest.Status.NodeName = "boba"
+	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyRunning
+	guest.Spec.NodeName = "miles"
+	guest.Annotations = map[string]string{migrationv1alpha1.AnnotationMigrationInProgress: "m"}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			NodeName:     "",
+			NodeSelector: map[string]string{"kubernetes.io/hostname": "boba"}, // pinned to the WRONG node
+			Containers:   []corev1.Container{{Name: "launcher", Image: "x"}},
+		},
+	}
+	mig := newMigration("m", "default")
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseStopAndCopy
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mig, guest, pod).WithStatusSubresource(mig).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	status := mig.Status.DeepCopy()
+	result := r.handleStopAndCopy(context.Background(), mig, status)
+	if !strings.Contains(result.FailureMsg, "atomicity invariant violated") {
+		t.Errorf("nodeSelector pinned to wrong node should fail; got %q", result.FailureMsg)
+	}
+}
+
 // TestStopAndCopy_GuestDeleted_Fails verifies graceful handling when
 // the source guest is deleted mid-flight.
 func TestStopAndCopy_GuestDeleted_Fails(t *testing.T) {


### PR DESCRIPTION
## W-GPU-2 — second walkthrough bug (revealed once W-GPU-1 #100 was fixed)

The "finding behind a finding" pattern: with the W-GPU-1 fix deployed, the GPU offline migration drove **past** the SwiftGPU re-stamp race and reached the StopAndCopy dst-pod atomicity check — which then false-failed.

### Root cause
Offline StopAndCopy verified `if pod.Spec.NodeName != target { fail }` — assuming Phase 1's **direct** `spec.NodeName` binding. **GPU guest pods pin via a `kubernetes.io/hostname` nodeSelector**, so the scheduler populates `spec.NodeName` a moment later (cache lag after the cutover patch can also briefly show empty). The check read `spec.NodeName==""` before the scheduler bound the pod → *"destination pod scheduled on '', expected miles (atomicity invariant violated)"* — even though the pod then scheduled correctly onto the target.

### Cluster evidence
After the failure, the dst pod was confirmed on the target: `spec.NodeName=miles`, `nodeSelector={kubernetes.io/hostname: miles}`, guest `spec.NodeName=miles`, `status.GPU.NodeName=miles` — all consistent (W-GPU-1 fix held; no flip-back). The migration had simply checked too eagerly.

### Fix
An empty `pod.Spec.NodeName` means *"not yet scheduled"*, not a violation — **requeue and wait**, unless a hostname nodeSelector pins the pod **away** from the target (real violation). A populated nodeName must still equal the target. **Non-VFIO offline migration is unaffected** (direct binding sets `spec.NodeName=target` at creation).

### Tests
Unscheduled GPU pod with nodeSelector=target → requeues; nodeSelector pinned to wrong node → still fails. Full `go test ./...` green.

### Walkthrough status
The fake-2nd-GPU-node walkthrough has now surfaced **two** real multi-controller bugs (W-GPU-1 #100, W-GPU-2 this) that all unit tests missed — the W5 pattern. After this merges I'll redeploy + re-run; the migration should drive cleanly through cutover to **Resuming** with consistent control-plane state (the dst still won't *boot* on the fake GPU — that's the validation ceiling on a single real GPU node). Then PR 5 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)