### PR TITLE
fix(migration): offline Resuming gates on dst pod state, not stale condition — W-GPU-3

### DIFF
--- a/internal/controller/swiftmigration/resuming.go
+++ b/internal/controller/swiftmigration/resuming.go
@@ -61,6 +61,46 @@ func (r *SwiftMigrationReconciler) handleResuming(
 		return phaseTransient(fmt.Errorf("get source guest: %w", getErr))
 	}
 
+	// W-GPU-3: gate completion on the DESTINATION pod's actual state, not on
+	// the GuestRunning condition / primaryIP alone. Those are written by
+	// swiftletd and SURVIVE the cutover pod swap — they stay at the source
+	// pod's last values until the destination's swiftletd boots the VM and
+	// overwrites them. If the destination never boots (e.g., gpu-init fails on
+	// the target), the stale GuestRunning=True + stale IP would otherwise drive
+	// a FALSE "Completed". Surfaced by the release-and-reallocate walkthrough.
+	var dstPod corev1.Pod
+	if err := r.Get(ctx, client.ObjectKey{Name: guest.Name, Namespace: guest.Namespace}, &dstPod); err != nil {
+		if apierrors.IsNotFound(err) {
+			setPhaseDetail(status, "awaiting destination pod (re)creation")
+			setReadyCondition(status, metav1.ConditionFalse, ReasonResuming, "awaiting destination pod creation")
+			return phaseRequeue(resumingPollInterval)
+		}
+		return phaseTransient(fmt.Errorf("get destination pod: %w", err))
+	}
+	// A terminal init-container failure (launcher pods are RestartPolicy: Never)
+	// means the destination guest cannot boot — fail rather than hang.
+	for _, ic := range dstPod.Status.InitContainerStatuses {
+		if t := ic.State.Terminated; t != nil && t.ExitCode != 0 {
+			return phaseFailure(fmt.Sprintf("destination guest failed to boot on %q: init container %q exited %d (%s)",
+				status.DestinationNode, ic.Name, t.ExitCode, t.Reason), "")
+		}
+	}
+	// The launcher container must be running (past init) before its
+	// GuestRunning/IP reports can be trusted as the destination's, not the
+	// source's stale values.
+	launcherUp := false
+	for _, cs := range dstPod.Status.ContainerStatuses {
+		if cs.Name == "launcher" && cs.Ready {
+			launcherUp = true
+			break
+		}
+	}
+	if !launcherUp {
+		setPhaseDetail(status, "awaiting destination launcher start")
+		setReadyCondition(status, metav1.ConditionFalse, ReasonResuming, "awaiting destination guest boot")
+		return phaseRequeue(resumingPollInterval)
+	}
+
 	// Poll for GuestRunning=True. Observe + primaryIP also populated
 	// — operators expect the IP to show up at completion in
 	// `kubectl get swiftmigration -o wide`.

--- a/internal/controller/swiftmigration/resuming_test.go
+++ b/internal/controller/swiftmigration/resuming_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -14,6 +15,20 @@ import (
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
 )
+
+// readyDstPod builds a destination launcher pod whose init containers have
+// completed and whose launcher container is Ready (the W-GPU-3 gate's
+// happy-path precondition).
+func readyDstPod(name, ns, node string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec:       corev1.PodSpec{NodeName: node, Containers: []corev1.Container{{Name: "launcher"}}},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "launcher", Ready: true}},
+		},
+	}
+}
 
 // guestRunning constructs a SwiftGuest with the GuestRunning=True
 // condition set and an IP populated. Helper for the happy-path
@@ -46,7 +61,7 @@ func TestResuming_GuestRunningPlusIP_TransitionsToCompleted(t *testing.T) {
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(mig, guest).
+		WithObjects(mig, guest, readyDstPod("guest", "default", "miles")).
 		WithStatusSubresource(mig).
 		Build()
 	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
@@ -103,7 +118,7 @@ func TestResuming_GuestRunningButNoIP_StaysInResuming(t *testing.T) {
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(mig, guest).
+		WithObjects(mig, guest, readyDstPod("guest", "default", "miles")).
 		WithStatusSubresource(mig).
 		Build()
 	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
@@ -142,7 +157,7 @@ func TestResuming_GuestNotRunning_StaysInResuming(t *testing.T) {
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(mig, guest).
+		WithObjects(mig, guest, readyDstPod("guest", "default", "miles")).
 		WithStatusSubresource(mig).
 		Build()
 	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
@@ -179,5 +194,75 @@ func TestResuming_GuestDeletedMidFlight(t *testing.T) {
 	errMsg := result.FailureMsg
 	if !strings.Contains(errMsg, "deleted during Resuming") {
 		t.Errorf("guest deleted should fail clearly; got %q", errMsg)
+	}
+}
+
+// TestResuming_DstInitFailed_Fails is the W-GPU-3 regression: the destination
+// pod's init container terminated with an error (e.g., gpu-init could not bind
+// the GPU on the target), so the guest cannot boot there. Even with a STALE
+// GuestRunning=True + IP carried over from the source pod, the migration must
+// FAIL — not falsely report Completed.
+func TestResuming_DstInitFailed_Fails(t *testing.T) {
+	scheme := preparingScheme(t)
+	guest := guestRunning("guest", "default", "10.244.125.17") // stale True + IP from source
+	mig := newMigration("m", "default")
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseResuming
+	mig.Status.DestinationNode = "miles"
+
+	dstPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "miles"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "gpu-init", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}}},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mig, guest, dstPod).WithStatusSubresource(mig).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	status := mig.Status.DeepCopy()
+	result := r.handleResuming(context.Background(), mig, status)
+	if !strings.Contains(result.FailureMsg, "failed to boot") {
+		t.Errorf("dst init failure must fail the migration (no false Completed); got advanced=%v msg=%q",
+			result.Advanced, result.FailureMsg)
+	}
+	if result.Advanced {
+		t.Error("must NOT advance to Completed when the destination guest failed to boot")
+	}
+}
+
+// TestResuming_DstLauncherNotReady_StaysInResuming: the destination launcher
+// container is not yet Ready (still booting), so even a stale GuestRunning=True
+// must not complete — requeue and wait for the real destination boot.
+func TestResuming_DstLauncherNotReady_StaysInResuming(t *testing.T) {
+	scheme := preparingScheme(t)
+	guest := guestRunning("guest", "default", "10.244.125.17") // stale True + IP
+	mig := newMigration("m", "default")
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseResuming
+	mig.Status.DestinationNode = "miles"
+
+	dstPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "miles", Containers: []corev1.Container{{Name: "launcher"}}},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "launcher", Ready: false}}, // not ready yet
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mig, guest, dstPod).WithStatusSubresource(mig).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	status := mig.Status.DeepCopy()
+	result := r.handleResuming(context.Background(), mig, status)
+	if result.Advanced || result.FailureMsg != "" {
+		t.Errorf("launcher-not-ready must requeue, not complete/fail; got advanced=%v msg=%q", result.Advanced, result.FailureMsg)
+	}
+	if result.Requeue == 0 {
+		t.Error("must requeue while the destination launcher is not ready")
+	}
+	if status.Phase == migrationv1alpha1.SwiftMigrationPhaseCompleted {
+		t.Error("must not be Completed on a stale GuestRunning when the dst launcher isn't ready")
 	}
 }


### PR DESCRIPTION
## W-GPU-3 — third walkthrough bug, and the most serious: a FALSE "Completed"

With W-GPU-1 (#100) and W-GPU-2 (#101) fixed, the GPU offline migration drove cleanly through cutover to Resuming — and then **falsely reported `Completed`**: *"guest running on miles with IP 192.168.125.x"* — while the dst pod sat in **Init:Error** (gpu-init can't bind the fake GPU; the launcher never started).

### Root cause
Offline Resuming concluded success from the SwiftGuest's `GuestRunning=True` condition + `primaryIP`. Both are written by swiftletd and **survive the cutover pod swap** — they hold the **source** pod's last values until the **destination's** swiftletd boots the VM and overwrites them. When the dst never boots, the **stale** `GuestRunning=True` + stale IP drove a false `Completed`.

Violates **Design Principle #6 (no silent failures)** and is exactly the *"Resuming MUST gate on actual destination state"* pattern flagged in the Phase 2 spike (W1). Latent in Phase-1 offline migration generally; masked for non-GPU because the dst usually boots fast and refreshes the signals — the GPU fake-node case reliably fails the dst boot and exposed it.

### Fix — gate on the DESTINATION pod's real state
- **Terminal init-container failure** (launcher pods are `RestartPolicy: Never`) → **fail** the migration with a clear *"destination guest failed to boot"* message (no hang, no false-complete).
- **Launcher container must be Ready** (past init) before its GuestRunning/IP reports are trusted as the dst's, not the source's stale values → else requeue.
- Only then apply the existing `GuestRunning=True` + `primaryIP` checks.

Non-VFIO offline migration is hardened identically (it gates on actual dst state now, not a possibly-stale condition).

### Tests
dst init-failure → migration **Fails** despite a stale `GuestRunning=True`+IP; dst launcher-not-ready → requeue; existing happy-path/no-IP/not-running tests updated to seed a ready dst pod. Full `go test ./...` green.

### Walkthrough tally
The fake-2nd-GPU-node walkthrough has now surfaced **three** real bugs that all unit tests missed — W-GPU-1 (SwiftGPU re-stamp race), W-GPU-2 (eager nodeSelector check), W-GPU-3 (stale-condition false-complete). Each fix peeled back to the next. After this merges I'll redeploy + re-run; the fake-node migration should now correctly **Fail** at Resuming with *"destination guest failed to boot"* (the honest outcome — miles has no real GPU), with consistent control-plane state. Then PR 5 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)