### PR TITLE
docs(gpu): VFIO drain walkthrough results + runbook — release-and-reallocate PR 5

### DIFF
--- a/docs/design/vfio-release-reallocate.md
+++ b/docs/design/vfio-release-reallocate.md
@@ -183,16 +183,47 @@ status, shipped explicitly labeled. Tier 1 (the validatable case) has no FM.
 
 ## 9. Validation strategy (one GPU node)
 
-- **Same-node `boba->boba` (real GTX 1080):** a degenerate offline migration
-  that release->reacquires the real GPU exercises ReserveOnNode / ReleaseFromNode
-  / the cutover status stamp / gpu-init rebind end-to-end. The spike already
-  proved the raw choreography; the PR-level test confirms the *orchestrated*
-  sequence.
-- **Cross-node (mocked):** unit/envtest with a second mocked `SwiftGPUNode`
-  for target-selection, pre-flight, reservation-holds-against-other-guests,
-  and the failure/restore path.
-- Ship explicitly labeled **"cross-node GPU migration not hardware-validated
-  (needs a 2nd GPU node)."**
+**Actual approach used (PR 5 walkthrough, 2026-06-03).** Same-node `boba->boba`
+was NOT viable — the SwiftMigration webhook rejects same-node migration
+(`validator.go`: "same-node migration is meaningless", open question §10.4). So
+the orchestration was validated against a **mock second SwiftGPUNode**: a real
+GTX-1080 guest runs on boba, a fake `SwiftGPUNode/miles` (vfioReady, one free
+GPU at a **non-existent PCI `0000:ff:00.0`** so the dst gpu-init fails
+harmlessly without touching any real miles device) is the migration target, and
+`kubectl drain boba` (scoped to the guest pod) drives the whole chain on the
+real apiserver. The dst cannot *boot* (no real GPU on miles) — that is the
+**validation ceiling on a single GPU node** — but every control-plane step is
+exercised end-to-end, and the migration must reach an HONEST terminal state
+(Failed: "destination guest failed to boot"), never a false success.
+
+**Validated end-to-end on the cluster** (image sha-fafc2c9): eviction webhook
+marks the GPU guest -> drain controller selects the GPU target via
+`GPUNodeHasCapacity` -> migration resolves `auto->offline` -> Preparing reserves
+the target (benign double-hold: both nodes `allocatedTo` the guest) -> cutover
+releases the source + stamps `status.GPU=target` -> Resuming detects the dst
+init failure -> **Failed** with `destination guest failed to boot on "miles":
+init container "gpu-init" exited 1`. Final state consistent: `status.GPU=miles`,
+boba freed, no `status.GPU` flip-back. `node/boba drained` (exit 0).
+
+**Cross-node (mocked):** unit/envtest with a second mocked `SwiftGPUNode` for
+target-selection, pre-flight, reservation-holds-against-other-guests, the
+reserve/cutover/release primitives, and the dst-pod-state Resuming gate.
+
+Ship explicitly labeled **"cross-node GPU migration not hardware-validated
+(needs a 2nd real GPU node)"** — the dst *boot* + a `Completed` migration
+require two real GPU nodes.
+
+### 9.1 Bugs the walkthrough surfaced (all fixed; the W5 pattern)
+
+Three real multi-controller / lifecycle bugs that all unit tests missed (fake
+clients, no concurrent controllers, dst always "boots") — each fix revealed the
+next (finding-behind-a-finding):
+
+| # | Bug | Fix (PR) |
+|---|---|---|
+| **W-GPU-1** | The live SwiftGPU controller re-stamps `status.GPU` on every reconcile via `findAndAllocate`, whose first-pass returned the FIRST allocated node. During the reserve double-hold it re-stamped the source, racing the migration. (The §5.1 "SwiftGPU is idle while status.GPU is non-nil" assumption was FALSE.) | `findAndAllocate` prefers the node `status.GPU` already references (#100) |
+| **W-GPU-2** | Offline StopAndCopy checked `pod.Spec.NodeName != target` — but GPU pods pin via a `kubernetes.io/hostname` nodeSelector, so the scheduler fills `spec.NodeName` a moment later. The eager check false-failed "atomicity invariant violated". | Empty `spec.NodeName` = "not yet scheduled" (requeue), unless a nodeSelector pins it away from the target (#101) |
+| **W-GPU-3** | Offline Resuming concluded `Completed` off `GuestRunning=True` + IP, which SURVIVE the cutover pod swap (stale source values). A dst that never boots produced a **false success**. Latent in Phase-1 offline migration generally. | Gate completion on the dst pod's real state: fail on a terminal init failure, require the launcher Ready before trusting GuestRunning/IP (#102) |
 
 ## 10. Open questions (resolve during implementation)
 
@@ -217,22 +248,23 @@ status, shipped explicitly labeled. Tier 1 (the validatable case) has no FM.
    target GPUs for other guests. Bound by `spec.timeout` (the migration's
    runaway gate) + the abort-release in (1).
 
-## 11. Implementation plan (PRs)
+## 11. Implementation plan (PRs) — SHIPPED
 
-1. **PR 1** — this design doc + the `SwiftGPUNode.status` vfioReady surface +
-   gpu-discovery `vfio-pci` check/modprobe + a `GPUNodeHasCapacity` pre-flight
-   helper (no migration wiring yet). Cluster-validate vfioReady on boba.
-2. **PR 2** — `ReserveOnNode` / `ReleaseFromNode` primitives + `deallocateGPUs`
-   refactor to `ReleaseFromNode`. Unit-tested (mock SwiftGPUNodes), including
-   reservation-holds-against-other-guests.
-3. **PR 3** — migration controller offline-GPU sequence (Validating pre-flight,
-   Preparing reserve-before-stop, cutover release+status-stamp, failure
-   release) + the precedence-rule change + lift the webhook VFIO-offline
-   rejection. Unit-tested.
-4. **PR 4** — drain controller: VFIO guests under `drainPolicy: Migrate` now
-   get a marker + an offline migration (remove the PR-4a "VFIO denied" path
-   for Migrate; keep LiveMigrate+VFIO blocked). GPU target selection uses
-   `GPUNodeHasCapacity`.
-5. **PR 5** — cluster walkthrough (same-node `boba->boba` release->reacquire
-   via the orchestrated path; mocked cross-node in tests) + operator runbook
-   (GPU drain + the vfio-pci prerequisite) + design-doc updates.
+1. **PR 1 (#96) — DONE.** `SwiftGPUNode.status.vfioReady` surface + gpu-discovery
+   read-only vfio-pci detection (modprobe descoped — minimal-cap DaemonSet,
+   §4.2) + `GPUNodeHasCapacity` pre-flight. Cluster-validated `boba vfioReady=true`.
+2. **PR 2 (#97) — DONE.** `ReserveOnNode` / `ReleaseFromNode` primitives +
+   `deallocateGPUs` refactor. Unit-tested incl. reservation-holds-against-others.
+3. **PR 3 (#98) — DONE.** Migration offline-GPU sequence (pre-flight,
+   reserve-before-stop, cutover release+stamp, failure release) + precedence-rule
+   reframe + webhook VFIO-offline lift (SR-IOV stays rejected).
+4. **PR 4 (#99) — DONE.** Drain controller GPU wiring (VFIO `Migrate` -> offline
+   migration; SR-IOV stays manual; GPU target selection via `GPUNodeHasCapacity`).
+5. **PR 5 (this doc + #100/#101/#102) — DONE.** Cluster walkthrough
+   (mock-2nd-GPU-node + drain boba; §9) + the three bug fixes it surfaced
+   (W-GPU-1/2/3) + operator runbook (`docs/migration/phase-4.md` GPU drain + the
+   vfio-pci prerequisite) + this design-doc validation update.
+
+**Remaining (tracked, not blocking):** open questions §10.1 (reservation leak on
+guest-delete-mid-migration) and §10.5 (reservation timeout) are not yet
+exercised; cross-node dst *boot* (`Completed`) needs a second real GPU node.

--- a/docs/migration/phase-4.md
+++ b/docs/migration/phase-4.md
@@ -1,9 +1,9 @@
 # Live Migration Phase 4 — Drain Integration (Operator Guide)
 
-> Status: SHIPPED (non-VFIO). `kubectl drain` automatically evacuates
-> SwiftGuest VMs off a node instead of killing them. VFIO/GPU guests block
-> the drain (manual handling) pending the release-and-reallocate sub-phase
-> (TFU #27).
+> Status: SHIPPED. `kubectl drain` automatically evacuates SwiftGuest VMs off
+> a node instead of killing them — including **GPU guests** (offline, via the
+> release-and-reallocate path). SR-IOV NIC passthrough guests still need manual
+> handling (NIC reattach on the target is out of scope).
 
 ## What it does
 
@@ -33,8 +33,8 @@ Set `spec.migration.drainPolicy` on a SwiftGuest (default `Migrate`):
 
 | Value | On drain |
 |---|---|
-| `Migrate` (default) | `mode=auto` — live-migrate where possible, offline otherwise. Drain succeeds (non-VFIO). |
-| `LiveMigrate` | live only; if the guest can't live-migrate, **deny the drain** rather than incur downtime. |
+| `Migrate` (default) | `mode=auto` — live where possible; **offline** for GPU guests (release-and-reallocate) and other non-live-capable guests. Drain succeeds. |
+| `LiveMigrate` | live only; if the guest can't live-migrate (GPU, or non-live-capable storage), **deny the drain** rather than incur downtime. |
 | `Block` | always **deny the drain**; handle the guest manually. |
 
 `spec.migration.enabled: false` is stronger — it disables migration entirely;
@@ -52,14 +52,36 @@ spec:
     drainPolicy: Migrate   # Migrate | LiveMigrate | Block
 ```
 
-## VFIO/GPU guests — NOT auto-evacuated (yet)
+## GPU guests — auto-evacuated OFFLINE
 
-Guests with VFIO devices (`gpuProfileRef`, or any `sriov` interface) **cannot
-be auto-migrated** in this release: cross-node VFIO migration needs a
-release-and-reallocate primitive that does not exist yet (TFU #27). Under any
-`drainPolicy`, the eviction webhook denies their eviction with a
-manual-handling message and does **not** stamp the marker. To drain a node
-with a VFIO/GPU guest, move or stop the guest manually first, or
+GPU guests (`gpuProfileRef`) **are** auto-evacuated on drain, via the SwiftGPU
+**release-and-reallocate** path: the migration controller reserves matching
+GPUs on the target node *before* stopping the source, frees the source GPUs at
+cutover, and the guest reboots on the target with its GPUs. GPU migration is
+**offline only** (Cloud Hypervisor cannot live-migrate a VFIO device), so:
+
+- `drainPolicy: Migrate` (default) → GPU guest is offline-migrated.
+- `drainPolicy: LiveMigrate` → drain is **denied** (GPU can't live-migrate;
+  set `Migrate` to allow the offline move).
+
+**GPU-node prerequisites** for a drain *target*:
+- The node must be a GPU node (`kubeswift.io/gpu-node=true`) with free GPUs
+  matching the guest's `SwiftGPUProfile` (the drain controller's target
+  selection enforces this — `SwiftGPUNode.status.vfioReady` + free matching
+  GPUs).
+- **`vfio-pci` must be loaded** on the target node, persistently —
+  `/etc/modules-load.d/vfio.conf` (one line: `vfio-pci`). The GPU-discovery
+  DaemonSet reports `vfioReady` from `/sys/bus/pci/drivers/vfio-pci`; a node
+  that is not `vfioReady` is never chosen as a target. (gpu-init binds the
+  GPU to vfio-pci at guest start; it needs the module loaded.)
+
+## SR-IOV NIC guests — NOT auto-evacuated
+
+Guests with an `sriov` interface **cannot** be auto-migrated: the
+release-and-reallocate path handles GPUs only; reattaching an SR-IOV NIC on the
+target is out of scope. Under any `drainPolicy`, the eviction webhook denies
+their eviction with a manual-handling message and does **not** mark them. To
+drain a node with an SR-IOV guest, move or stop it manually first, or
 `kubectl drain --force` (which deletes the pod — **the VM is lost**; only do
 this if the guest is disposable).
 
@@ -141,16 +163,19 @@ networking, live-migration mTLS enabled:
 | No schedulable target | webhook keeps denying with a clear message; drain stalls; free capacity or `--force` |
 | Migration fails mid-drain | marker stays; `SwiftMigration` shows the failure; webhook keeps denying (VM unharmed — live pre-copy never pauses the source). `kubectl delete swiftmigration <name>` to retry, or handle manually |
 | `drainPolicy: Block` / `migration.enabled=false` | deny with a manual-handling message; move the guest manually or `--force` |
-| VFIO/GPU guest | deny with a manual-handling message (no marker); not auto-evacuated yet (TFU #27) |
+| GPU guest, no vfio-ready GPU target | webhook marks it, but the drain controller finds no GPU target with capacity → no migration, drain stalls; free a GPU node or load `vfio-pci` on one |
+| SR-IOV NIC guest | deny with a manual-handling message (no marker); not auto-evacuated (NIC reattach out of scope) |
 | `drain --dry-run` | webhook denies (shows it would block) but skips the marker patch (`sideEffects: NoneOnDryRun`) |
 
 ## Troubleshooting
 
 - **Drain hangs forever, no migration created.** Check the SwiftGuest for a
   `DrainNoTarget` event (`kubectl describe swiftguest <g>`): no peer node has
-  capacity. Free capacity on another worker, or `--force`.
-- **Drain hangs, `DrainUnsupported` event.** The guest is VFIO/GPU — not
-  auto-evacuated yet. Handle manually.
+  capacity. For a GPU guest, "capacity" includes a vfio-ready GPU node with
+  free matching GPUs — confirm another GPU node exists, is `vfioReady`
+  (`kubectl get swiftgpunode`), and has free GPUs. Free capacity, or `--force`.
+- **GPU guest won't drain (SR-IOV).** A guest with an `sriov` interface is not
+  auto-evacuated (NIC reattach is out of scope) — handle it manually.
 - **Drain hangs, controller is down.** Expected (PDB hard floor). Bring the
   controller back; the drain then auto-migrates. Or `--force` to delete the
   VM (data loss).

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -1,7 +1,7 @@
 # KubeSwift Project Context
 > This document is the canonical context anchor for AI-assisted KubeSwift development.
 > It should be read at the start of every new session before any work begins.
-> Last updated: May 30, 2026 — Live Migration Phase 3a/3b shipped (mode: live, cluster-validated); Phase 3c mTLS transport spike COMPLETE (PR #75); Phase 3c design doc in progress
+> Last updated: June 3, 2026 — VFIO/GPU release-and-reallocate SHIPPED (TFU #27, PRs #96–#102): GPU guests auto-evacuate OFFLINE on drain; cluster walkthrough surfaced + fixed 3 multi-controller bugs (W-GPU-1/2/3). Prior: Live Migration Phase 3a/3b/3c + Phase 4 drain shipped
 
 ---
 
@@ -1375,6 +1375,57 @@ Document in the release runbook; cross-referenced from
 fail-loud — ImagePullBackOff is obvious). Surfaced 2026-06-01.
 
 ### 27. VFIO/GPU release-and-reallocate primitive (Phase 4 drain follow-on sub-phase)
+
+**SHIPPED 2026-06-03** across PRs #96–#102 (5 feature PRs + 3 walkthrough
+bug-fixes). GPU guests are now auto-evacuated **offline** on `kubectl drain` via
+the migration-controller-orchestrated release-and-reallocate path; SR-IOV NIC
+guests stay manual (NIC reattach out of scope). Design + validation:
+[`docs/design/vfio-release-reallocate.md`](docs/design/vfio-release-reallocate.md);
+operator runbook: [`docs/migration/phase-4.md`](docs/migration/phase-4.md).
+
+- **PR 1 (#96)** — `SwiftGPUNode.status.vfioReady` + gpu-discovery read-only
+  vfio-pci detection (modprobe descoped — minimal-cap DaemonSet) +
+  `GPUNodeHasCapacity` pre-flight. Cluster-validated `boba vfioReady=true`.
+- **PR 2 (#97)** — `ReserveOnNode` / `ReleaseFromNode` primitives (reservation
+  reuses `GPUDevice.AllocatedTo`, no CRD change) + `deallocateGPUs` refactor.
+- **PR 3 (#98)** — migration offline-GPU sequence (Validating pre-flight,
+  Preparing reserve-before-stop, cutover release+`status.GPU=target` stamp,
+  failure release) + precedence-rule reframe + webhook VFIO-offline lift.
+- **PR 4 (#99)** — drain wiring: VFIO `Migrate` → offline migration; SR-IOV
+  denied (manual); GPU target selection via `GPUNodeHasCapacity`. New
+  `SwiftGuest.OfflineGPUMigratable()` / `HasSRIOVInterface()` predicates.
+- **PR 5 (#100/#101/#102 + docs)** — cluster walkthrough (mock 2nd `SwiftGPUNode`
+  + `drain boba`, single-GPU-node ceiling) which surfaced **three** real
+  multi-controller/lifecycle bugs unit tests missed (the W5 pattern, each behind
+  the previous):
+  - **W-GPU-1 (#100)** — SwiftGPU controller re-stamps `status.GPU` to the first
+    allocated node during the reserve double-hold, racing the migration. Fix:
+    `findAndAllocate` prefers the node `status.GPU` already references. (The
+    design's "SwiftGPU idle while status.GPU non-nil" assumption was false.)
+  - **W-GPU-2 (#101)** — offline StopAndCopy read `pod.Spec.NodeName` before the
+    scheduler bound the nodeSelector-pinned GPU pod → false "atomicity violated".
+    Fix: empty nodeName = not-yet-scheduled (requeue) unless a hostname
+    nodeSelector pins it away from the target.
+  - **W-GPU-3 (#102, most serious)** — offline Resuming concluded `Completed`
+    off the stale `GuestRunning`+IP (they survive the cutover pod swap), a
+    **false success** when the dst never boots. Latent in Phase-1 offline
+    migration generally. Fix: gate completion on the dst pod's real state (fail
+    on terminal init failure; require launcher Ready before trusting
+    GuestRunning/IP).
+
+  Final cluster re-run (image sha-fafc2c9): the full chain drives correctly to an
+  HONEST terminal state — migration `Failed: destination guest failed to boot on
+  "miles": init container "gpu-init" exited 1`, `status.GPU=miles` stable (no
+  flip-back), boba freed, `node/boba drained`. **Cross-node dst *boot*
+  (`Completed`) is NOT hardware-validated — needs a second real GPU node.**
+
+- **Tracked-not-blocking:** reservation leak on guest-delete-mid-migration
+  (design §10.1), reservation timeout (§10.5), Tier 2/3 FM-partition handoff
+  (no HGX hardware). The "drain completes when the guest leaves the source even
+  if the migration later fails on the target" is a pre-existing Phase 4 property
+  (not GPU-specific).
+
+Original scoping detail (preserved for context):
 
 Surfaced 2026-06-02 during Phase 4 PR 4a recon. The Phase 4 design doc
 §4.3 promised `drainPolicy: Migrate` does "offline (bounded downtime) for


### PR DESCRIPTION
## Release-and-reallocate sub-phase (TFU #27) — PR 5 of 5 (closes the sub-phase)

The cluster walkthrough + operator docs. **Docs only.**

### The walkthrough (single-GPU-node ceiling)
Same-node `boba→boba` is webhook-rejected ("same-node migration is meaningless"), so the orchestration was validated against a **mock 2nd `SwiftGPUNode`**: real GTX-1080 guest on boba, fake `miles` GPU node (non-existent PCI `0000:ff:00.0` so the dst gpu-init fails *harmlessly*), `kubectl drain boba`. The dst can't *boot* (no real GPU) — the ceiling on one GPU node — but the full control-plane chain runs on the real apiserver and must reach an **honest terminal state**.

**Final re-run (sha-fafc2c9):** eviction marks the GPU guest → drain controller picks the GPU target via `GPUNodeHasCapacity` → `auto→offline` → reserve-before-stop (double-hold) → cutover (release source, stamp `status.GPU=miles`) → Resuming detects the dst init failure → **`Failed: destination guest failed to boot on "miles": init container "gpu-init" exited 1`**. `status.GPU=miles` stable (no flip-back), boba freed, `node/boba drained`. No false success.

### The three bugs it surfaced (the W5 pattern, each behind the previous)
| Bug | Fix |
|---|---|
| **W-GPU-1** SwiftGPU re-stamps `status.GPU` to first node during reserve double-hold → races migration | #100 (merged) |
| **W-GPU-2** StopAndCopy reads `spec.NodeName` before scheduler binds nodeSelector-pinned GPU pod → false "atomicity violated" | #101 (merged) |
| **W-GPU-3** (critical) Resuming completes off stale `GuestRunning`+IP → **false success** when dst never boots (latent in *all* Phase-1 offline migration) | #102 (merged) |

### Docs in this PR
- **`docs/migration/phase-4.md`** — runbook flipped from "VFIO blocks drain" to "GPU guests auto-evacuate OFFLINE"; new GPU + SR-IOV sections; vfio-pci/vfioReady target prerequisites; failure-mode/troubleshooting rows updated.
- **`docs/design/vfio-release-reallocate.md`** — §9 validation rewritten to the real approach + result; new §9.1 cataloguing W-GPU-1/2/3; §11 PR plan marked SHIPPED.
- **`kubeswift_context.md`** — TFU #27 marked SHIPPED (PR map, 3 bugs, ceiling, tracked-not-blocking).

### Sub-phase complete
✅ Spike (#94) · gpu-init fix (#93) · design (#95) · PR1 vfioReady (#96) · PR2 primitives (#97) · PR3 offline sequence (#98) · PR4 drain wiring (#99) · **PR5 walkthrough+fixes (#100/#101/#102 + this)**

**GPU guests now auto-evacuate offline on `kubectl drain`.** Cross-node dst *boot* remains not-hardware-validated (needs a 2nd real GPU node); reservation-leak-on-delete (§10.1) and reservation-timeout (§10.5) are tracked-not-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)