### PR TITLE
fix(gpu): deallocateGPUs frees all nodes — reservation leak on delete-mid-migration

### DIFF
--- a/docs/design/vfio-release-reallocate.md
+++ b/docs/design/vfio-release-reallocate.md
@@ -227,11 +227,14 @@ next (finding-behind-a-finding):
 
 ## 10. Open questions (resolve during implementation)
 
-1. **Reservation leak on guest-delete-mid-migration.** If the guest is deleted
-   while a target reservation is held (status.GPU=S), `deallocateGPUs` frees
-   only S; T's reservation leaks. Fix: the SwiftMigration finalizer/cleanup
-   `ReleaseFromNode(T)` on abort; OR a periodic reconcile that GCs reservations
-   whose owning migration is gone. Lean toward the former (explicit).
+1. **Reservation leak on guest-delete-mid-migration — RESOLVED.** If the guest
+   was deleted while a target reservation was held (status.GPU=S),
+   `deallocateGPUs` freed only S and T's reservation leaked (a GPU stranded
+   AllocatedTo a now-deleted guest). Fixed: `deallocateGPUs` now lists **all**
+   SwiftGPUNodes and `ReleaseFromNode`s each (idempotent), so it frees both the
+   source allocation and any held target reservation — robust even if the
+   SwiftMigration object is also gone. Regression test: double-hold
+   (source+target) delete frees both nodes.
 2. **vfioReady representation.** A `SwiftGPUNode.status.conditions[vfioReady]`
    vs a boolean `status.vfioReady`. Conditions are the kube-idiomatic choice;
    confirm with the discovery DaemonSet's existing status shape.

--- a/internal/controller/swiftgpu/allocate.go
+++ b/internal/controller/swiftgpu/allocate.go
@@ -153,13 +153,30 @@ func (r *SwiftGPUReconciler) findAndAllocate(
 // deallocateGPUs releases the GPU allocation recorded in guest.status.gpu from
 // the SwiftGPUNode. No-op if no allocation is recorded or the node is gone.
 func (r *SwiftGPUReconciler) deallocateGPUs(ctx context.Context, guest *swiftv1alpha1.SwiftGuest) error {
-	if guest.Status.GPU == nil || guest.Status.GPU.NodeName == "" {
+	if guest.Status.GPU == nil {
 		return nil
 	}
-	// Delegate to the exported ReleaseFromNode primitive (the same one the
-	// migration release-and-reallocate path uses), keyed on the guest's
-	// currently-allocated node.
-	return ReleaseFromNode(ctx, r.Client, guest, guest.Status.GPU.NodeName)
+	// Free the guest's GPUs (and FM partitions) on EVERY SwiftGPUNode, not just
+	// status.GPU.NodeName. During a VFIO offline migration's reserve-before-stop
+	// window the guest is briefly allocated on BOTH the source
+	// (status.GPU.NodeName) and the target node — the reservation reuses
+	// GPUDevice.AllocatedTo. If the guest is deleted in that window, releasing
+	// only status.GPU.NodeName would strand the target reservation forever
+	// (AllocatedTo a now-deleted guest, never freed). Listing all nodes and
+	// releasing each covers both the source allocation and any held reservation.
+	// ReleaseFromNode is idempotent (a no-op on nodes the guest doesn't hold),
+	// so this is safe and the per-node Get cost is trivial (few GPU nodes).
+	// (Design doc vfio-release-reallocate.md §10.1.)
+	var nodes gpuv1alpha1.SwiftGPUNodeList
+	if err := r.List(ctx, &nodes); err != nil {
+		return fmt.Errorf("list SwiftGPUNodes for deallocation: %w", err)
+	}
+	for i := range nodes.Items {
+		if err := ReleaseFromNode(ctx, r.Client, guest, nodes.Items[i].Name); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // selectGPUs picks count free GPUs from gpus, preferring GPUs on the same NUMA

--- a/internal/controller/swiftgpu/allocate_wgpu1_test.go
+++ b/internal/controller/swiftgpu/allocate_wgpu1_test.go
@@ -84,3 +84,28 @@ func TestFindAndAllocate_PrefersStatusGPUNode(t *testing.T) {
 		}
 	})
 }
+
+// TestDeallocateGPUs_FreesAllNodes is the §10.1 regression: a guest allocated on
+// BOTH the source ("miles", = status.GPU.NodeName) and the target ("boba", a
+// held reservation) — the reserve-before-stop double-hold — must have BOTH
+// freed when the guest is deleted. Releasing only status.GPU.NodeName would
+// strand the target reservation forever (AllocatedTo a now-deleted guest).
+func TestDeallocateGPUs_FreesAllNodes(t *testing.T) {
+	source := nodeAllocatedTo("miles", "0000:01:00.0", "default/g")
+	target := nodeAllocatedTo("boba", "0000:ff:00.0", "default/g")
+	guest := wgpu1Guest("miles") // status.GPU.NodeName = miles (source)
+	r := newReconciler(source, target, guest)
+
+	if err := r.deallocateGPUs(context.Background(), guest); err != nil {
+		t.Fatalf("deallocateGPUs: %v", err)
+	}
+	for _, name := range []string{"miles", "boba"} {
+		n := getNode(t, r.Client, name)
+		if got := n.Status.GPUs[0].AllocatedTo; got != "" {
+			t.Errorf("node %q GPU still AllocatedTo %q after dealloc; reservation/allocation leaked", name, got)
+		}
+		if n.Status.FreeGPUs != 1 {
+			t.Errorf("node %q FreeGPUs=%d, want 1 after dealloc", name, n.Status.FreeGPUs)
+		}
+	}
+}

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -1419,11 +1419,15 @@ operator runbook: [`docs/migration/phase-4.md`](docs/migration/phase-4.md).
   flip-back), boba freed, `node/boba drained`. **Cross-node dst *boot*
   (`Completed`) is NOT hardware-validated — needs a second real GPU node.**
 
-- **Tracked-not-blocking:** reservation leak on guest-delete-mid-migration
-  (design §10.1), reservation timeout (§10.5), Tier 2/3 FM-partition handoff
-  (no HGX hardware). The "drain completes when the guest leaves the source even
-  if the migration later fails on the target" is a pre-existing Phase 4 property
-  (not GPU-specific).
+- **Follow-up fix (post-PR-5):** reservation leak on guest-delete-mid-migration
+  (design §10.1) — **RESOLVED**: `deallocateGPUs` now frees the guest's GPUs on
+  **all** SwiftGPUNodes (not just status.GPU.NodeName), so a guest deleted in the
+  reserve-before-stop window no longer strands the held target reservation.
+  Double-hold regression test added.
+- **Tracked-not-blocking:** reservation timeout (§10.5 / TFU #22), Tier 2/3
+  FM-partition handoff (no HGX hardware). The "drain completes when the guest
+  leaves the source even if the migration later fails on the target" is a
+  pre-existing Phase 4 property (not GPU-specific).
 
 Original scoping detail (preserved for context):
 


### PR DESCRIPTION
## §10.1 — GPU reservation leak on guest-delete-mid-migration

Tracked follow-up from the release-and-reallocate sub-phase (design doc §10.1).

### The bug
During a VFIO offline migration's **reserve-before-stop** window, the guest is briefly allocated on **both** the source (`status.GPU.NodeName`) and the target node — the reservation reuses `GPUDevice.AllocatedTo`. `deallocateGPUs` released only `status.GPU.NodeName`, so a guest **deleted in that window** stranded the target reservation forever: the GPU stayed `AllocatedTo` a now-deleted guest, and `freeGPUs` was permanently short by one.

### The fix
`deallocateGPUs` now lists **all** `SwiftGPUNode`s and `ReleaseFromNode`s each (idempotent — a no-op on nodes the guest doesn't hold). This frees both the source allocation and any held target reservation, and is robust even if the `SwiftMigration` object is also gone (no reliance on the migration finalizer).

```go
// before: ReleaseFromNode(ctx, r.Client, guest, guest.Status.GPU.NodeName)
// after:  list all SwiftGPUNodes; ReleaseFromNode each (idempotent)
```

### Test
Load-bearing regression: a guest allocated on **both** source and target (the double-hold) is deallocated → **both** nodes freed (`AllocatedTo` cleared, `freeGPUs` restored to 1). Without the fix the target node stays allocated. Full `go test ./...` green.

### Docs
§10.1 marked **RESOLVED**; TFU #27 tracked-not-blocking note updated.

Closes the one concrete correctness gap left open after the sub-phase shipped. Remaining tracked-not-blocking: reservation timeout (§10.5 / TFU #22), Tier 2/3 FM-partition handoff (no HGX hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)