### PR TITLE
feat(migration): Prometheus metrics — Live Migration Phase 5 (1/3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/projectbeskar/kubeswift
 go 1.25.0
 
 require (
+	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0
 	golang.org/x/term v0.37.0
 	k8s.io/api v0.35.0
@@ -33,7 +35,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -41,7 +43,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,9 +13,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8P3k=
-github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/internal/controller/swiftmigration/controller.go
+++ b/internal/controller/swiftmigration/controller.go
@@ -57,6 +57,7 @@ import (
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
 )
 
 // Standard reasons used for Conditions and Events. Centralised so
@@ -440,6 +441,11 @@ func (r *SwiftMigrationReconciler) persist(
 	if equality.Semantic.DeepEqual(&mig.Status, status) {
 		return nil
 	}
+	// Detect the non-terminal -> terminal transition BEFORE overwriting
+	// mig.Status, so the Phase 5 metric is recorded exactly once per migration
+	// (the Reconcile terminal-phase short-circuit prevents re-entry, and we
+	// only emit after the status patch actually lands).
+	freshTerminal := isTerminalPhase(status.Phase) && !isTerminalPhase(mig.Status.Phase)
 	patch := client.MergeFrom(mig.DeepCopy())
 	mig.Status = *status
 	if err := r.Status().Patch(ctx, mig, patch); err != nil {
@@ -450,7 +456,35 @@ func (r *SwiftMigrationReconciler) persist(
 		}
 		return fmt.Errorf("patch SwiftMigration status: %w", err)
 	}
+	if freshTerminal {
+		recordMigrationTerminal(status)
+	}
 	return nil
+}
+
+// recordMigrationTerminal emits the Phase 5 migration metrics on the
+// non-terminal -> terminal transition: a per-mode/result counter, plus the
+// observed-downtime histogram for completed migrations.
+func recordMigrationTerminal(status *migrationv1alpha1.SwiftMigrationStatus) {
+	mode := string(status.Mode)
+	if mode == "" {
+		mode = "unknown"
+	}
+	var result string
+	switch status.Phase {
+	case migrationv1alpha1.SwiftMigrationPhaseCompleted:
+		result = "completed"
+	case migrationv1alpha1.SwiftMigrationPhaseFailed:
+		result = "failed"
+	case migrationv1alpha1.SwiftMigrationPhaseCancelled:
+		result = "cancelled"
+	default:
+		return
+	}
+	metrics.MigrationTotal.WithLabelValues(mode, result).Inc()
+	if status.Phase == migrationv1alpha1.SwiftMigrationPhaseCompleted && status.ObservedDowntime != nil {
+		metrics.MigrationDowntimeSeconds.WithLabelValues(mode).Observe(status.ObservedDowntime.Duration.Seconds())
+	}
 }
 
 // SetupWithManager registers the reconciler. The watch on Pod is

--- a/internal/controller/swiftmigration/controller_metrics_test.go
+++ b/internal/controller/swiftmigration/controller_metrics_test.go
@@ -1,0 +1,84 @@
+package swiftmigration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
+)
+
+func TestRecordMigrationTerminal_CounterByModeAndResult(t *testing.T) {
+	cases := []struct {
+		mode   migrationv1alpha1.SwiftMigrationMode
+		phase  migrationv1alpha1.SwiftMigrationPhase
+		result string
+	}{
+		{migrationv1alpha1.SwiftMigrationModeLive, migrationv1alpha1.SwiftMigrationPhaseCompleted, "completed"},
+		{migrationv1alpha1.SwiftMigrationModeOffline, migrationv1alpha1.SwiftMigrationPhaseFailed, "failed"},
+		{migrationv1alpha1.SwiftMigrationModeOffline, migrationv1alpha1.SwiftMigrationPhaseCancelled, "cancelled"},
+	}
+	for _, tc := range cases {
+		before := testutil.ToFloat64(metrics.MigrationTotal.WithLabelValues(string(tc.mode), tc.result))
+		recordMigrationTerminal(&migrationv1alpha1.SwiftMigrationStatus{Mode: tc.mode, Phase: tc.phase})
+		if got := testutil.ToFloat64(metrics.MigrationTotal.WithLabelValues(string(tc.mode), tc.result)); got != before+1 {
+			t.Errorf("MigrationTotal{%s,%s} = %v, want %v", tc.mode, tc.result, got, before+1)
+		}
+	}
+}
+
+func TestRecordMigrationTerminal_DowntimeOnlyOnCompleted(t *testing.T) {
+	before := testutil.CollectAndCount(metrics.MigrationDowntimeSeconds)
+	// A failed migration must NOT observe downtime.
+	recordMigrationTerminal(&migrationv1alpha1.SwiftMigrationStatus{
+		Mode:  migrationv1alpha1.SwiftMigrationModeLive,
+		Phase: migrationv1alpha1.SwiftMigrationPhaseFailed,
+	})
+	// A completed migration with downtime observes it.
+	d := metav1.Duration{Duration: 2500 * time.Millisecond}
+	recordMigrationTerminal(&migrationv1alpha1.SwiftMigrationStatus{
+		Mode:             migrationv1alpha1.SwiftMigrationModeLive,
+		Phase:            migrationv1alpha1.SwiftMigrationPhaseCompleted,
+		ObservedDowntime: &d,
+	})
+	if after := testutil.CollectAndCount(metrics.MigrationDowntimeSeconds); after < 1 {
+		t.Errorf("downtime histogram should carry an observation after a completed migration; series=%d (before=%d)", after, before)
+	}
+}
+
+// TestPersist_RecordsTerminalMetricOnce verifies the wiring: persist records the
+// terminal metric exactly once on the non-terminal -> terminal transition, and
+// a subsequent no-op persist (status unchanged) does not double-count.
+func TestPersist_RecordsTerminalMetricOnce(t *testing.T) {
+	scheme := preparingScheme(t)
+	mig := newMigration("m", "default")
+	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseResuming // non-terminal
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mig).WithStatusSubresource(mig).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	before := testutil.ToFloat64(metrics.MigrationTotal.WithLabelValues("offline", "completed"))
+
+	status := mig.Status.DeepCopy()
+	status.Mode = migrationv1alpha1.SwiftMigrationModeOffline
+	status.Phase = migrationv1alpha1.SwiftMigrationPhaseCompleted
+	if err := r.persist(context.Background(), mig, status); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	if got := testutil.ToFloat64(metrics.MigrationTotal.WithLabelValues("offline", "completed")); got != before+1 {
+		t.Fatalf("after terminal persist, counter = %v, want %v", got, before+1)
+	}
+
+	// Re-persist the same terminal status: DeepEqual -> no-op -> no double count.
+	if err := r.persist(context.Background(), mig, mig.Status.DeepCopy()); err != nil {
+		t.Fatalf("second persist: %v", err)
+	}
+	if got := testutil.ToFloat64(metrics.MigrationTotal.WithLabelValues("offline", "completed")); got != before+1 {
+		t.Errorf("no-op persist must not double-count; counter = %v, want %v", got, before+1)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -55,6 +55,31 @@ var (
 		},
 		[]string{"namespace"},
 	)
+
+	// MigrationTotal counts SwiftMigrations that reached a terminal phase,
+	// labelled by resolved mode (live/offline) and result
+	// (completed/failed/cancelled). Recorded once per migration on the
+	// non-terminal -> terminal transition.
+	MigrationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubeswift_migration_total",
+			Help: "Total SwiftMigrations that reached a terminal phase, by mode and result",
+		},
+		[]string{"mode", "result"},
+	)
+
+	// MigrationDowntimeSeconds observes status.observedDowntime for completed
+	// migrations (the operator-visible guest-unavailable window), by mode.
+	// Live migrations sit near the low buckets (~1-3s); offline span the
+	// tens-of-seconds range.
+	MigrationDowntimeSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kubeswift_migration_downtime_seconds",
+			Help:    "Observed guest downtime for completed SwiftMigrations, by mode",
+			Buckets: []float64{0.5, 1, 2, 3, 5, 10, 20, 30, 45, 60, 90, 120},
+		},
+		[]string{"mode"},
+	)
 )
 
 func init() {
@@ -63,5 +88,7 @@ func init() {
 		VMBootSeconds,
 		VMFailuresTotal,
 		ImageImportSeconds,
+		MigrationTotal,
+		MigrationDowntimeSeconds,
 	)
 }


### PR DESCRIPTION
## Live Migration Phase 5 — operational polish (1 of 3)

The migration-capability work is complete; Phase 5 rounds it out with observability. This first slice adds **migration outcome metrics** — the foundation dashboards + alerting build on.

### Metrics (registered with the controller-runtime Prometheus registry)
- **`kubeswift_migration_total{mode, result}`** — counter of SwiftMigrations that reached a terminal phase, by resolved mode (`live`/`offline`) and result (`completed`/`failed`/`cancelled`).
- **`kubeswift_migration_downtime_seconds{mode}`** — histogram of `status.observedDowntime` for completed migrations (sub-second live, tens-of-seconds offline; buckets 0.5s–120s).

### Wiring (record-once)
Recorded in `persist()` — the single status-write choke point — on the **non-terminal → terminal transition**, after the patch lands. The Reconcile terminal-phase short-circuit prevents re-entry, so each migration is counted exactly once. `recordMigrationTerminal` maps phase→result and observes downtime only on `Completed`.

### Tests
Counter increments by mode/result (live-completed, offline-failed, offline-cancelled); downtime observed only on Completed; `persist` records once on the transition and a no-op repeat persist does **not** double-count. Full `go test ./...` green; `go mod tidy` promoted `prometheus/client_golang` to a direct dep (now used via `testutil`).

### Phase 5 plan
- ▶️ **1/3 (this)** — migration metrics
- ⬜ 2/3 — surface the swiftletd `migration-progress-estimate` (already emitted) in SwiftMigration status + a printcolumn (operator progress visibility in `kubectl get swiftmigration`)
- ⬜ 3/3 — Grafana dashboard JSON + completed-migration retention + docs

A post-merge `/metrics` scrape after one migration will confirm the series appear (folds into the 3/3 dashboard validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)