### PR TITLE
docs(migration): Grafana dashboard + observability guide — Phase 5 (3/3)

### DIFF
--- a/config/grafana/kubeswift-migrations.json
+++ b/config/grafana/kubeswift-migrations.json
@@ -1,0 +1,120 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source scraping the KubeSwift controller-manager /metrics endpoint",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": ["kubeswift", "migration"],
+  "title": "KubeSwift — Live Migration",
+  "uid": "kubeswift-migrations",
+  "time": { "from": "now-24h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Migrations by result (range)",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (result) (increase(kubeswift_migration_total[$__range]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Migration success ratio (range)",
+      "type": "gauge",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
+      "fieldConfig": { "defaults": { "min": 0, "max": 1, "unit": "percentunit" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(kubeswift_migration_total{result=\"completed\"}[$__range])) / clamp_min(sum(increase(kubeswift_migration_total[$__range])), 1)",
+          "legendFormat": "success"
+        }
+      ]
+    },
+    {
+      "title": "Migrations by mode + result (total)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (mode, result) (kubeswift_migration_total)",
+          "legendFormat": "{{mode}}/{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Observed downtime quantiles by mode",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum by (le, mode) (rate(kubeswift_migration_downtime_seconds_bucket[1h])))",
+          "legendFormat": "p50 {{mode}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (le, mode) (rate(kubeswift_migration_downtime_seconds_bucket[1h])))",
+          "legendFormat": "p95 {{mode}}"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum by (le, mode) (rate(kubeswift_migration_downtime_seconds_bucket[1h])))",
+          "legendFormat": "p99 {{mode}}"
+        }
+      ]
+    },
+    {
+      "title": "Downtime distribution (heatmap)",
+      "type": "heatmap",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "options": { "calculate": false, "yAxis": { "unit": "s" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (le) (increase(kubeswift_migration_downtime_seconds_bucket[$__interval]))",
+          "legendFormat": "{{le}}",
+          "format": "heatmap"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/migration/observability.md
+++ b/docs/migration/observability.md
@@ -1,0 +1,99 @@
+# Live Migration — Observability (Operator Guide)
+
+> Live Migration Phase 5. Metrics, live progress, a Grafana dashboard, and
+> retention guidance for SwiftMigration.
+
+## Live progress in `kubectl`
+
+A live migration's pre-copy progress is surfaced on the SwiftMigration:
+
+```bash
+kubectl get swiftmigration
+# NAME        GUEST  FROM   TO    MODE  PHASE        PROGRESS  DOWNTIME  TRANSFER  AGE
+# web-1-mig   web-1  miles  boba  live  StopAndCopy  52        <none>    <none>    14s
+```
+
+`status.transferProgress` (the **Progress** column) is an integer percentage,
+read from the swiftletd-emitted `kubeswift.io/migration-progress-estimate`
+annotation during the transferring substate and pinned to `100` once the source
+reports transfer complete.
+
+**It is a bandwidth heuristic** (Phase 3b design §5.4, calibrated on
+Calico-VXLAN at ~107 MB/s), **not a byte-exact counter** — treat it as
+approximate, and expect it to drift on CNIs far from that baseline. It is
+populated for **live** migrations only; offline migration has no memory-transfer
+RPC, so `transferProgress` stays unset there.
+
+## Metrics
+
+The controller-manager exposes Prometheus metrics on its metrics endpoint
+(`/metrics`, default `:8443`/`:8080` per your deploy). Migration metrics:
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `kubeswift_migration_total` | counter | `mode` (live/offline), `result` (completed/failed/cancelled) | SwiftMigrations that reached a terminal phase. Recorded once per migration. |
+| `kubeswift_migration_downtime_seconds` | histogram | `mode` | `status.observedDowntime` for **completed** migrations (sub-second live; tens of seconds offline). |
+
+(These join the existing `kubeswift_guest_running_total`,
+`kubeswift_vm_boot_seconds`, `kubeswift_vm_failures_total`, and
+`kubeswift_image_import_seconds`.)
+
+Useful queries:
+
+```promql
+# Migration success ratio over the last day
+sum(increase(kubeswift_migration_total{result="completed"}[1d]))
+  / clamp_min(sum(increase(kubeswift_migration_total[1d])), 1)
+
+# p95 live-migration downtime
+histogram_quantile(0.95,
+  sum by (le) (rate(kubeswift_migration_downtime_seconds_bucket{mode="live"}[1h])))
+
+# Failures by mode
+sum by (mode) (increase(kubeswift_migration_total{result="failed"}[1h]))
+```
+
+### Scraping (Prometheus Operator)
+
+If you run the Prometheus Operator, point a `ServiceMonitor`/`PodMonitor` at the
+controller-manager metrics service. The controller-runtime metrics registry
+(which these metrics register with) is served on the manager's metrics bind
+address — match it to your deploy's `--metrics-bind-address`.
+
+## Grafana dashboard
+
+Import [`config/grafana/kubeswift-migrations.json`](../../config/grafana/kubeswift-migrations.json)
+(Dashboards → Import → upload JSON) and select your Prometheus data source. It
+shows: migrations by result, success ratio, mode/result breakdown, downtime
+quantiles (p50/p95/p99) by mode, and a downtime heatmap — all from the two
+metrics above.
+
+## Retention
+
+SwiftMigrations are not auto-deleted when they reach a terminal phase — the
+object is kept so operators (and `kubectl get swiftmigration`) can see the
+outcome.
+
+- **Drain-created migrations** (`reason: node-drain`, named `<guest>-drain-<hash>`)
+  are **owned by the SwiftGuest** (ownerReference) and are garbage-collected
+  automatically when the guest is deleted — no operator action needed.
+- **Operator-created migrations** (via `swiftctl migrate` or a hand-applied
+  SwiftMigration) persist until deleted. Clean them up by age/label, e.g.:
+
+  ```bash
+  # delete all terminal migrations older than a day in a namespace
+  kubectl get swiftmigration -n <ns> -o json \
+    | jq -r '.items[] | select(.status.phase=="Completed" or .status.phase=="Failed" or .status.phase=="Cancelled")
+             | .metadata.name' \
+    | xargs -r kubectl delete swiftmigration -n <ns>
+  ```
+
+> A controller-side TTL auto-GC for terminal migrations is a possible future
+> opt-in (a `--migration-ttl` flag, default disabled). It is intentionally not
+> enabled by default — auto-deleting resources is a behavioral choice operators
+> should opt into.
+
+## See also
+
+- [Phase 4 drain runbook](phase-4.md) — `kubectl drain` auto-evacuation.
+- [Phase 3a reference](phase-3a.md) — live migration internals.


### PR DESCRIPTION
## Live Migration Phase 5 — operational polish (3 of 3) — closes the migration roadmap

The operator-facing observability surface, on top of the metrics (#105) and progress field (#106).

### What
- **`config/grafana/kubeswift-migrations.json`** — importable Grafana dashboard: migrations by result, success ratio, mode/result breakdown, downtime quantiles (p50/p95/p99) by mode, and a downtime heatmap. All panels query the two Phase 5 metrics.
- **`docs/migration/observability.md`** — operator guide: the `Progress` column + `transferProgress` (with the honest *"bandwidth heuristic, not byte-exact"* framing), the metrics reference + example PromQL, scraping notes, dashboard import, and **retention** guidance (drain migrations GC via the SwiftGuest ownerRef; operator-created migrations are manual cleanup; controller-side TTL auto-GC noted as a future opt-in, intentionally not default-on).

### Cluster-validated (sha-6f72c69, live kernel-boot migration miles→boba)
- **Progress column** climbed `13→26→39→52→65→79→92→100` over the send, pinned to 100 at src-completed, then `Completed` (downtime 1.98s):
  ```
  NAME          GUEST     FROM    TO     MODE   PHASE       PROGRESS   DOWNTIME       TRANSFER
  p5-live-mig   p5-live   miles   boba   live   Completed   100        1.982351244s   38.393s
  ```
- **`/metrics` scrape** (PR 1 validated live):
  ```
  kubeswift_migration_total{mode="live",result="completed"} 1
  kubeswift_migration_downtime_seconds_sum{mode="live"} 1.982351244   # == observedDowntime
  kubeswift_migration_downtime_seconds_count{mode="live"} 1
  ```

### Phase 5 complete
- ✅ 1/3 metrics (#105)
- ✅ 2/3 progress (#106)
- ✅ **3/3 dashboard + docs (this)**

The live-migration capability is now functionally complete **and** observable — closing out the migration roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)