### PR TITLE
feat(migration): default spec.timeout to 30m — TFU #22

### DIFF
--- a/api/migration/v1alpha1/swiftmigration_types.go
+++ b/api/migration/v1alpha1/swiftmigration_types.go
@@ -277,9 +277,16 @@ type SwiftMigrationSpec struct {
 	// migration stream in live mode. Ignored in Phase 1.
 	// +optional
 	ParallelConnections int32 `json:"parallelConnections,omitempty"`
-	// Timeout bounds the entire migration operation. On expiry, behavior
-	// is controlled by TimeoutStrategy. Phase 1 default: 30 minutes.
+	// Timeout bounds the entire migration operation (StartedAt -> terminal).
+	// On expiry, behaviour is controlled by TimeoutStrategy (default cancel).
+	// It is a runaway BACKSTOP, not a tight SLA: the default 30m sits well
+	// above swiftletd's own per-action timeout (600s, sized for a ~200 GiB
+	// VM), so it never pre-empts a legitimately slow transfer — it only
+	// rescues a genuinely wedged migration. The webhook enforces a 60s
+	// minimum for mode=live. Operators wanting a tighter bound set it
+	// explicitly (e.g. swiftctl migrate --timeout).
 	// +optional
+	// +kubebuilder:default="30m0s"
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// TimeoutStrategy controls behavior on timeout. Phase 1 supports cancel
 	// only (the default); ignore is reserved for live mode.

--- a/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
+++ b/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
@@ -170,9 +170,16 @@ spec:
                     type: object
                 type: object
               timeout:
+                default: 30m0s
                 description: |-
-                  Timeout bounds the entire migration operation. On expiry, behavior
-                  is controlled by TimeoutStrategy. Phase 1 default: 30 minutes.
+                  Timeout bounds the entire migration operation (StartedAt -> terminal).
+                  On expiry, behaviour is controlled by TimeoutStrategy (default cancel).
+                  It is a runaway BACKSTOP, not a tight SLA: the default 30m sits well
+                  above swiftletd's own per-action timeout (600s, sized for a ~200 GiB
+                  VM), so it never pre-empts a legitimately slow transfer — it only
+                  rescues a genuinely wedged migration. The webhook enforces a 60s
+                  minimum for mode=live. Operators wanting a tighter bound set it
+                  explicitly (e.g. swiftctl migrate --timeout).
                 type: string
               timeoutStrategy:
                 default: cancel

--- a/cmd/swiftctl/migration.go
+++ b/cmd/swiftctl/migration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,7 @@ var (
 	migrateAllowIPChange bool
 	migrateName          string
 	migratePreferredMode string
+	migrateTimeout       time.Duration
 	migrationListAllNS   bool
 )
 
@@ -113,6 +115,8 @@ func init() {
 		"Acknowledge that the guest IP will change cross-node on default node-local networking")
 	migrateCmd.Flags().StringVar(&migrateName, "name", "",
 		"Optional SwiftMigration resource name (default: <guest>-migrate-<rand>)")
+	migrateCmd.Flags().DurationVar(&migrateTimeout, "timeout", 0,
+		"Runaway backstop for the whole migration (e.g. 10m); 0 uses the CRD default of 30m")
 	migrateCmd.Flags().StringVar(&migratePreferredMode, "preferred-mode", "auto",
 		"Migration mode: auto (live when eligible, else offline), live, or offline")
 	_ = migrateCmd.MarkFlagRequired("to")
@@ -176,6 +180,9 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 			AllowIPChange: migrateAllowIPChange,
 		},
 	}
+	// Only set spec.timeout when the operator passed --timeout; leaving it nil
+	// lets the apiserver apply the CRD default (30m).
+	mig.Spec.Timeout = migrationTimeoutPtr(migrateTimeout)
 	if name == "" {
 		mig.GenerateName = guestName + "-migrate-"
 	} else {
@@ -186,6 +193,16 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "swiftmigration.migration.kubeswift.io/%s created\n", mig.Name)
 	return nil
+}
+
+// migrationTimeoutPtr maps the --timeout flag to spec.timeout: a positive
+// duration becomes an explicit override; zero (the flag default) returns nil so
+// the apiserver applies the CRD default (30m).
+func migrationTimeoutPtr(d time.Duration) *metav1.Duration {
+	if d <= 0 {
+		return nil
+	}
+	return &metav1.Duration{Duration: d}
 }
 
 func runMigrationList(cmd *cobra.Command, _ []string) error {

--- a/cmd/swiftctl/migration_test.go
+++ b/cmd/swiftctl/migration_test.go
@@ -131,3 +131,16 @@ func TestRenderMigrationDescribe_LiveProgress(t *testing.T) {
 		t.Errorf("output missing heuristic note\n---\n%s", out)
 	}
 }
+
+func TestMigrationTimeoutPtr(t *testing.T) {
+	if got := migrationTimeoutPtr(0); got != nil {
+		t.Errorf("0 (flag default) must return nil so the CRD default applies; got %v", got)
+	}
+	if got := migrationTimeoutPtr(-5 * time.Second); got != nil {
+		t.Errorf("negative must return nil; got %v", got)
+	}
+	got := migrationTimeoutPtr(10 * time.Minute)
+	if got == nil || got.Duration != 10*time.Minute {
+		t.Errorf("positive must return an explicit override; got %v", got)
+	}
+}

--- a/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
+++ b/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
@@ -170,9 +170,16 @@ spec:
                     type: object
                 type: object
               timeout:
+                default: 30m0s
                 description: |-
-                  Timeout bounds the entire migration operation. On expiry, behavior
-                  is controlled by TimeoutStrategy. Phase 1 default: 30 minutes.
+                  Timeout bounds the entire migration operation (StartedAt -> terminal).
+                  On expiry, behaviour is controlled by TimeoutStrategy (default cancel).
+                  It is a runaway BACKSTOP, not a tight SLA: the default 30m sits well
+                  above swiftletd's own per-action timeout (600s, sized for a ~200 GiB
+                  VM), so it never pre-empts a legitimately slow transfer — it only
+                  rescues a genuinely wedged migration. The webhook enforces a 60s
+                  minimum for mode=live. Operators wanting a tighter bound set it
+                  explicitly (e.g. swiftctl migrate --timeout).
                 type: string
               timeoutStrategy:
                 default: cancel

--- a/internal/controller/swiftmigration/resuming_live.go
+++ b/internal/controller/swiftmigration/resuming_live.go
@@ -69,7 +69,7 @@ const (
 //     and D3's write. spec.timeout is the safety net.
 //  7. spec.timeout enforcement (F4.3 detection mechanism per §4.3):
 //     elapsed > spec.timeout from status.StartedAt → Failed with
-//     FailureReasonTimeout. Default 5min per F3.5; webhook minimum
+//     FailureReasonTimeout. Default 30m; webhook minimum
 //     60s for mode=live (PR B1).
 //  8. Compute and stamp:
 //     - status.ObservedDowntime = now - status.ResumingStartedAt
@@ -134,7 +134,7 @@ func (r *SwiftMigrationReconciler) handleResumingLive(
 	}
 
 	// spec.timeout enforcement. F4.3 per §4.3: total-migration cap
-	// from status.StartedAt. Default 5min per F3.5; webhook minimum
+	// from status.StartedAt. Default 30m; webhook minimum
 	// 60s for mode=live.
 	if mig.Spec.Timeout != nil && mig.Spec.Timeout.Duration > 0 && status.StartedAt != nil {
 		if time.Since(status.StartedAt.Time) > mig.Spec.Timeout.Duration {

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -51,7 +51,7 @@ const migrationLocalPlaintextPort = 6790
 // 600s covers typical workloads (Phase 2 spike Q2: LOW dirty-rate
 // ~19s, HIGH dirty-rate ~37s for 1 GiB guest; large guests scale
 // roughly linearly with memory). The migration's overall timeout
-// is governed by spec.timeout (default 5min per F3.5; webhook
+// is governed by spec.timeout (default 30m; webhook
 // minimum 60s for mode=live).
 const migrationActionTimeoutSeconds = 600
 
@@ -152,7 +152,7 @@ func guestRAMMiB(ctx context.Context, r *SwiftMigrationReconciler, guest *swiftv
 //
 // **spec.timeout enforcement (F4.3)**: every reconcile compares
 // elapsed time since status.StartedAt against spec.timeout. Default
-// 5min per F3.5; webhook minimum 60s for mode=live (B1).
+// 30m; webhook minimum 60s for mode=live (B1).
 //
 // **Defensive guard**: assert isLiveMode at entry per architect Q1.
 func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
@@ -168,7 +168,7 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 	}
 
 	// spec.timeout enforcement (F4.3). Total-migration cap from
-	// status.StartedAt; default 5min per F3.5.
+	// status.StartedAt; default 30m.
 	if mig.Spec.Timeout != nil && mig.Spec.Timeout.Duration > 0 && status.StartedAt != nil {
 		if time.Since(status.StartedAt.Time) > mig.Spec.Timeout.Duration {
 			return phaseFailure(

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -1213,7 +1213,20 @@ PR; future standalone hygiene PR.
 
 Severity: LOW (cosmetic + minor type safety; no functional impact).
 
-### 22. spec.timeout default reconciliation
+### 22. spec.timeout default reconciliation — RESOLVED
+
+**RESOLVED** via Option (a): added `+kubebuilder:default="30m0s"` to
+SwiftMigration.spec.timeout. The apiserver now stamps 30m on every migration
+that doesn't set one, activating the existing runaway-cancel gate (the
+stopandcopy_live/resuming_live checks guard on `Timeout != nil`). 30m chosen
+deliberately as a runaway BACKSTOP above swiftletd's own 600s per-action
+timeout (a 5min cap could pre-empt a legitimately slow ~200 GiB transfer); the
+stale "5min per F3.5" controller comments reconciled to 30m. Added `swiftctl
+migrate --timeout` for a tighter operator-set bound (nil-when-zero so the CRD
+default applies). Cluster-validated: a migration created without spec.timeout
+returns spec.timeout=30m0s. The webhook's 60s live-mode minimum is unaffected.
+
+Original framing (preserved):
 
 The SwiftMigration CRD has no +kubebuilder:default for
 spec.timeout, but code carries two contradictory documentary


### PR DESCRIPTION
## TFU #22 — `spec.timeout` runaway-gate default

`spec.timeout` had **no `+kubebuilder:default`**, so an unset value meant **no runaway gate** (the timeout checks guard on `Timeout != nil`) — a no-progress migration could hang indefinitely. The docstrings also contradicted themselves: the CRD type said "30m", the controller comments said "5min per F3.5", and **neither was enforced**.

### Fix
- **`+kubebuilder:default="30m0s"`** on `SwiftMigration.spec.timeout` — the apiserver now stamps 30m on every migration that doesn't set one, activating the existing runaway-cancel gate.
- Stale "5min per F3.5" comments in `resuming_live.go` / `stopandcopy_live.go` reconciled to 30m.
- **`swiftctl migrate --timeout <dur>`** for a tighter operator-set bound; `0` (flag default) leaves `spec.timeout` nil so the CRD default applies (`migrationTimeoutPtr` helper, unit-tested).

### Why 30m, not the comments' 5min
`spec.timeout` is a runaway **backstop**, not a tight SLA. swiftletd's own per-action timeout is **600s** (sized for a ~200 GiB VM), so a 5min controller cap could **pre-empt a legitimately slow transfer**. 30m sits safely above swiftletd's timeout — it only rescues a genuinely wedged migration. The webhook's 60s live-mode minimum is unaffected.

### Validation
**Cluster-validated:** a SwiftMigration created without `spec.timeout` returns **`spec.timeout=30m0s`** (apiserver default applied at admission). `make generate` + chart CRD sync; `migrationTimeoutPtr` unit test (0/negative → nil, positive → override); full `go test ./...` green.

Context tracker TFU #22 marked RESOLVED.

> **Upgrade note:** this is a new CRD default — re-apply the CRDs (`make deploy` / `helm upgrade`) so the apiserver knows it. Existing migrations created before the upgrade keep their nil timeout (no retroactive default); new ones get 30m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)