### PR TITLE
docs: W9.x cluster-validated + marked shipped (cloneStrategy=snapshot + Block)

### DIFF
--- a/docs/migration/phase-3a.md
+++ b/docs/migration/phase-3a.md
@@ -36,9 +36,11 @@ When to use it:
 
 - Kernel-boot SwiftGuests (no disk handoff complexity).
 - Disk-boot SwiftGuests on RWX+Block storage (PR #35 / W9 path).
-  Use `cloneStrategy: copy` until W9.x ships
-  (`cloneStrategy: snapshot` + `volumeMode: Block` is gapped at
-  the CSI provisioner — see `docs/snapshots/walkthrough-findings.md`).
+  Both `cloneStrategy: copy` and `cloneStrategy: snapshot` work with
+  `volumeMode: Block` — W9.x (PR #37) shipped the
+  `snapshot.storage.kubernetes.io/allow-volume-mode-change` annotation on the
+  cloneSeed VolumeSnapshotContent, so the CSI provisioner permits the
+  Filesystem-snapshot → Block-PVC clone (cluster-validated).
 - Workloads where multi-second downtime is unacceptable but
   sub-second is not strictly required.
 

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -536,12 +536,14 @@ Two follow-ups from the walkthrough:
   succeeds. Non-blocking; investigate as a CH v51.1 quirk in the early-
   boot virtio-blk request validation path. Document for operators.
 - **W11 / W9.x — `cloneStrategy=snapshot` + `volumeMode: Block` fails at
-  PVC provisioning.** CSI external-snapshotter requires the
+  PVC provisioning. — RESOLVED (PR #37, cluster-validated 2026-06-03).** CSI
+  external-snapshotter requires the
   `snapshot.storage.kubernetes.io/allow-volume-mode-change: "true"`
   annotation on the source VolumeSnapshotContent when destination
-  volumeMode differs from source. The SwiftImage controller's
-  cloneSeed-creation path needs to set this annotation. Small fix;
-  separate follow-up issue per W9 prompt's binding language.
+  volumeMode differs from source. Fixed: the SwiftImage controller's
+  `ensureAllowVolumeModeChange` patches the bound VolumeSnapshotContent with it.
+  See Next-Priorities item 3 for the cluster-validation evidence. (The
+  operator workaround "use `cloneStrategy: copy`" is no longer needed.)
 
 For historical reference (the original W9 scoping doc still describes
 the gap as it existed before PR #35):
@@ -2310,15 +2312,23 @@ Phase 2 deliverable surface complete: operators can manually demonstrate cross-n
   W11=W9.x (cloneStrategy=snapshot + Block, separate follow-up — see
   Tracked Follow-up #6 for details and Tracked Follow-up #7 below)
 
-**3. W9.x — `cloneStrategy=snapshot` + `volumeMode: Block` (small follow-up to PR #35)**
-- The SwiftImage controller's cloneSeed VolumeSnapshot needs the
-  `snapshot.storage.kubernetes.io/allow-volume-mode-change: "true"`
-  annotation when the SwiftImage may be cloned to Block-mode PVCs
-  (or unconditionally — the annotation is no-op when destination
-  volumeMode matches source)
-- ~30 lines of Go change in the SwiftImage controller's snapshot
-  creation path; one cluster integration test verifying RWX+Block guest
-  boots from a cloneStrategy=snapshot SwiftImage
+**3. W9.x — `cloneStrategy=snapshot` + `volumeMode: Block` — SHIPPED (PR #37) + cluster-validated 2026-06-03**
+- Code shipped in PR #37 (`08bf42b`): `SwiftImageReconciler.ensureAllowVolumeModeChange`
+  patches the cloneSeed's **bound VolumeSnapshotContent** with
+  `snapshot.storage.kubernetes.io/allow-volume-mode-change: "true"` once the
+  snapshotter populates `status.boundVolumeSnapshotContentName` (the annotation
+  must be on the VSC, not the VolumeSnapshot). 5 unit tests
+  (`snapshot_w9x_test.go`).
+- **Cluster validation (the never-run W5 gap, done 2026-06-03):** a
+  `cloneStrategy: snapshot` SwiftImage (Rocky9, `volumeSnapshotClassName:
+  longhorn-snapshot`) reached Ready with the cloneSeed VSC carrying
+  `allow-volume-mode-change=true`; a SwiftGuest on the `live-migratable`
+  (RWX+Block / longhorn-migratable) class cloned from it → the clone PVC bound
+  `volumeMode=Block` `dataSource=<Filesystem cloneSeed>` with **no
+  "modifies the mode of the source volume" provisioning error**, and the guest
+  reached **Running**. The original W9.x failure case now works end-to-end.
+- Stale "use `cloneStrategy: copy` until W9.x ships" guidance corrected in
+  `docs/migration/phase-3a.md`.
 
 **4. Live Migration Phase 3 — live mode + mTLS**
 - **Live mode: SHIPPED.** Phase 3a (controller state machine, `mode:


### PR DESCRIPTION
## W9.x — `cloneStrategy=snapshot` + `volumeMode: Block`

Turns out W9.x's **code already shipped** in PR #37 (`08bf42b`): `ensureAllowVolumeModeChange` patches the cloneSeed's **bound VolumeSnapshotContent** with `snapshot.storage.kubernetes.io/allow-volume-mode-change: "true"` (it must be on the VSC, not the VolumeSnapshot), with 5 passing unit tests. But the **end-to-end cluster validation was never run**, and the docs still said *"use `cloneStrategy: copy` until W9.x ships."* This closes that gap (the recurring W5 pattern: code shipped, never cluster-validated, docs stale).

### Cluster validation (2026-06-03, deployed `sha-6f72c69`)
1. `cloneStrategy: snapshot` SwiftImage (Rocky9, `volumeSnapshotClassName: longhorn-snapshot`) → **Ready**, and the cloneSeed's bound VSC carried **`allow-volume-mode-change=true`** (the W9.x patch fired on the dynamically-created VSC).
2. A SwiftGuest on the `live-migratable` (RWX+Block / longhorn-migratable) class cloned from it:
   ```
   clone PVC: Bound  mode=Block  from-snapshot=w9x-rocky-snap-clone-seed
   guest: phase=Running
   ```
   **No "modifies the mode of the source volume" provisioning error** — the exact failure that originally defined W9.x. Guest booted.

### Docs
- `docs/migration/phase-3a.md`: corrected the stale "use `cloneStrategy: copy` until W9.x ships" guidance (both strategies now work with Block).
- `kubeswift_context.md`: Next-Priorities item 3 + the PR #35 walkthrough W11 note marked **SHIPPED + cluster-validated**, with the evidence.

**No code change** — the code was already correct; this validates it on the cluster and de-stales the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)