### PR TITLE
feat(snapshots): s3 capture-path phase wiring — Phase 3 (3.5/5)

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -176,8 +176,9 @@ func main() {
 	}
 
 	if err = (&swiftsnapshot.SwiftSnapshotReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		SnapshotS3Image: os.Getenv("KUBESWIFT_SNAPSHOT_S3_IMAGE"),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftSnapshot controller")
 		os.Exit(1)

--- a/internal/controller/swiftsnapshot/controller.go
+++ b/internal/controller/swiftsnapshot/controller.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +34,9 @@ import (
 type SwiftSnapshotReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// SnapshotS3Image is the snapshot-s3 uploader image used by the s3
+	// (Tier C) backend's upload Job. Wired from KUBESWIFT_SNAPSHOT_S3_IMAGE.
+	SnapshotS3Image string
 }
 
 // Reconcile drives the SwiftSnapshot state machine.
@@ -107,9 +111,25 @@ func (r *SwiftSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 
+	case snapshotv1alpha1.SwiftSnapshotPhaseUploading:
+		// s3 backend only: the capture is on the node-local hostPath; watch the
+		// upload Job push it to S3, then stamp status.S3 and go Ready.
+		ready, errMsg, err := r.handleUploading(ctx, &snap, status)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if errMsg != "" {
+			setPhase(status, snapshotv1alpha1.SwiftSnapshotPhaseFailed)
+			setReadyCondition(status, metav1.ConditionFalse, ReasonSnapshotFailed, errMsg)
+		} else if !ready {
+			if updateErr := r.persist(ctx, &snap, status); updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
 	default:
-		// Unknown phase — treat as Pending. Future-phase additions
-		// (Uploading) live in their own cases.
+		// Unknown phase — treat as Pending.
 		logger.Info("unknown phase, restarting at Pending", "phase", phase)
 		setPhase(status, snapshotv1alpha1.SwiftSnapshotPhasePending)
 	}
@@ -132,11 +152,12 @@ func (r *SwiftSnapshotReconciler) handlePending(
 	// Backend dispatch:
 	//   csi-volume-snapshot (Phase 1): create snapshot.storage VolumeSnapshot
 	//   local              (Phase 2): drive launcher pod via action annotations
-	//   s3                 (reserved Phase 3): rejected by webhook
+	//   s3                 (Phase 3): reuse the local capture (into a derived
+	//                       node-local dir), then upload to S3 in the Uploading phase
 	switch snap.Spec.Backend.Type {
 	case snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot:
 		// Falls through to the existing csi-volume-snapshot path.
-	case snapshotv1alpha1.SnapshotBackendLocal:
+	case snapshotv1alpha1.SnapshotBackendLocal, snapshotv1alpha1.SnapshotBackendS3:
 		return r.handlePendingLocal(ctx, snap, status)
 	default:
 		setPhase(status, snapshotv1alpha1.SwiftSnapshotPhaseFailed)
@@ -201,9 +222,10 @@ func (r *SwiftSnapshotReconciler) handleCapturing(
 	snap *snapshotv1alpha1.SwiftSnapshot,
 	status *snapshotv1alpha1.SwiftSnapshotStatus,
 ) (bool, string, error) {
-	// Backend dispatch — local takes its own path (poll launcher pod
-	// status annotations); CSI continues to drive VolumeSnapshot below.
-	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendLocal {
+	// Backend dispatch — local and s3 both capture via the launcher pod's
+	// status annotations (s3 just uploads afterward); CSI drives VolumeSnapshot.
+	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendLocal ||
+		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3 {
 		return r.handleCapturingLocal(ctx, snap, status)
 	}
 	pvc, err := r.guestRootPVC(ctx, snap.Namespace, snap.Spec.GuestRef.Name)
@@ -275,6 +297,7 @@ func (r *SwiftSnapshotReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&snapshotv1alpha1.SwiftSnapshot{}).
 		Owns(&volumesnapshotv1.VolumeSnapshot{}).
+		Owns(&batchv1.Job{}).
 		Watches(
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.podToSnapshots),

--- a/internal/controller/swiftsnapshot/controller_test.go
+++ b/internal/controller/swiftsnapshot/controller_test.go
@@ -105,13 +105,12 @@ func get(t *testing.T, c client.Client, name, ns string) *snapshotv1alpha1.Swift
 }
 
 func TestPending_UnsupportedBackend_FlipsToFailed(t *testing.T) {
-	// Phase 2: csi-volume-snapshot and local are wired up. S3 remains
-	// reserved and is the only backend that should hit the controller's
-	// UnsupportedBackend path. (The webhook rejects S3 too, but defense
-	// in depth: existing pre-Phase-2 SwiftSnapshot resources can sneak
-	// through if upgraded in place.)
+	// csi-volume-snapshot, local, and s3 are all wired up now. Only a
+	// genuinely-unrecognized backend type hits the UnsupportedBackend path
+	// (defense in depth: the webhook rejects unknown types, but a pre-existing
+	// resource upgraded in place could sneak one through).
 	snap := makeSwiftSnapshot("snap1", "default", "g1", "")
-	snap.Spec.Backend.Type = snapshotv1alpha1.SnapshotBackendS3
+	snap.Spec.Backend.Type = snapshotv1alpha1.SnapshotBackendType("nonsense")
 
 	r, c := newReconciler(t, snap)
 	reconcile(t, r, "snap1", "default")

--- a/internal/controller/swiftsnapshot/local.go
+++ b/internal/controller/swiftsnapshot/local.go
@@ -143,10 +143,11 @@ func (r *SwiftSnapshotReconciler) handlePendingLocal(
 	status.NodeName = pod.Spec.NodeName
 	status.SnapshotDirVersion = SnapshotDirVersionV1
 
-	// Resolve destination directory. The webhook ensures the operator
-	// supplied a hostPath under HostPathBaseDir; the controller does
-	// not auto-generate paths in this commit.
-	destDir := snap.Spec.Backend.Local.HostPath
+	// Resolve destination directory. For the local backend the webhook
+	// ensures the operator supplied a hostPath under HostPathBaseDir; for the
+	// s3 backend the controller derives the dir (s3LocalDir). swiftletd mkdir's
+	// it before capture.
+	destDir := captureDestDir(snap)
 	srcURL := destDir
 	if !strings.HasSuffix(srcURL, "/") {
 		srcURL = srcURL + "/"
@@ -260,7 +261,21 @@ func (r *SwiftSnapshotReconciler) handleCapturingLocal(
 	now := metav1.Now()
 	status.CapturedAt = &now
 	status.MemorySnapshot = &snapshotv1alpha1.MemorySnapshotRef{
-		Handle: snap.Spec.Backend.Local.HostPath,
+		Handle: captureDestDir(snap),
+	}
+
+	// s3 backend: capture is done locally; now upload to S3. Create the
+	// node-pinned upload Job and advance to Uploading (handleUploading watches
+	// it to completion, then stamps status.S3 + Ready). The local backend is
+	// done — go straight to Ready.
+	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3 {
+		if err := r.ensureUploadJob(ctx, snap, status); err != nil {
+			return false, "", err
+		}
+		setPhase(status, snapshotv1alpha1.SwiftSnapshotPhaseUploading)
+		setReadyCondition(status, metav1.ConditionFalse, ReasonCapturing,
+			"capture complete on node "+status.NodeName+"; uploading to S3")
+		return true, "", nil
 	}
 
 	setPhase(status, snapshotv1alpha1.SwiftSnapshotPhaseReady)

--- a/internal/controller/swiftsnapshot/s3.go
+++ b/internal/controller/swiftsnapshot/s3.go
@@ -2,21 +2,79 @@
 //
 // The s3 backend reuses Tier B's node-local capture, then runs a node-pinned
 // upload Job that pushes the captured artifacts to S3 via the snapshot-s3 image.
-// This file builds that Job; the phase-machine wiring (Capturing -> Uploading ->
-// Ready) lands in a follow-up so this controller change stays small.
+// This file builds that Job and drives the Capturing -> Uploading -> Ready
+// transition (ensureUploadJob + handleUploading); the controller's phase switch
+// routes the Uploading phase here.
 package swiftsnapshot
 
 import (
+	"context"
+	"fmt"
 	"path"
 	"path/filepath"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
 )
+
+// ensureUploadJob creates the node-pinned upload Job (idempotent) owned by the
+// SwiftSnapshot. Fails if the snapshot-s3 image is not configured.
+func (r *SwiftSnapshotReconciler) ensureUploadJob(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot, status *snapshotv1alpha1.SwiftSnapshotStatus) error {
+	if r.SnapshotS3Image == "" {
+		return fmt.Errorf("snapshot-s3 image not configured (set KUBESWIFT_SNAPSHOT_S3_IMAGE)")
+	}
+	job := buildUploadJob(snap, r.SnapshotS3Image, status.NodeName)
+	if err := ctrl.SetControllerReference(snap, job, r.Scheme); err != nil {
+		return err
+	}
+	if err := r.Create(ctx, job); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create s3 upload Job: %w", err)
+	}
+	return nil
+}
+
+// handleUploading watches the upload Job. On Complete it stamps status.S3 and
+// transitions to Ready; on Failed it returns an errMsg (caller -> Failed).
+// Returns (ready, errMsg, err) following handleCapturing's contract.
+func (r *SwiftSnapshotReconciler) handleUploading(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot, status *snapshotv1alpha1.SwiftSnapshotStatus) (bool, string, error) {
+	var job batchv1.Job
+	err := r.Get(ctx, client.ObjectKey{Name: s3UploadJobName(snap), Namespace: snap.Namespace}, &job)
+	if apierrors.IsNotFound(err) {
+		// Job missing (e.g. controller restarted before observing creation, or
+		// it was deleted). Recreate — idempotent, and the binary resumes.
+		if cerr := r.ensureUploadJob(ctx, snap, status); cerr != nil {
+			return false, "", cerr
+		}
+		return false, "", nil
+	}
+	if err != nil {
+		return false, "", err
+	}
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			now := metav1.Now()
+			status.S3 = &snapshotv1alpha1.S3SnapshotStatus{
+				Location:   s3Location(snap),
+				UploadedAt: &now,
+			}
+			setPhase(status, snapshotv1alpha1.SwiftSnapshotPhaseReady)
+			setReadyCondition(status, metav1.ConditionTrue, ReasonSnapshotReady,
+				"snapshot uploaded to "+s3Location(snap))
+			return true, "", nil
+		}
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return false, "S3 upload Job failed: " + c.Message, nil
+		}
+	}
+	return false, "", nil // still uploading
+}
 
 const (
 	// s3UploadMount is where the node-local snapshot dir is mounted (read-only)
@@ -26,6 +84,19 @@ const (
 	// idempotent (skips already-uploaded objects), so a retry resumes.
 	s3UploadBackoffLimit int32 = 4
 )
+
+// captureDestDir is the node-local directory the launcher captures the snapshot
+// into. The local backend uses the operator-supplied hostPath; the s3 backend
+// uses a controller-derived dir the upload Job then reads.
+func captureDestDir(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3 {
+		return s3LocalDir(snap)
+	}
+	if snap.Spec.Backend.Local != nil {
+		return snap.Spec.Backend.Local.HostPath
+	}
+	return ""
+}
 
 // s3LocalDir is the node-local hostPath directory the s3 backend captures into
 // (and the upload Job reads from). Derived deterministically — the s3 backend

--- a/internal/controller/swiftsnapshot/s3_test.go
+++ b/internal/controller/swiftsnapshot/s3_test.go
@@ -1,9 +1,11 @@
 package swiftsnapshot
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -123,4 +125,51 @@ func TestBuildUploadJob_OptionalFlagsOmitted(t *testing.T) {
 			t.Errorf("flag %q should be omitted when unset; got %q", absent, a)
 		}
 	}
+}
+
+func uploadJobWith(snap *snapshotv1alpha1.SwiftSnapshot, cond batchv1.JobConditionType) *batchv1.Job {
+	j := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: s3UploadJobName(snap), Namespace: snap.Namespace}}
+	if cond != "" {
+		j.Status.Conditions = []batchv1.JobCondition{{Type: cond, Status: corev1.ConditionTrue, Message: "boom"}}
+	}
+	return j
+}
+
+func TestHandleUploading(t *testing.T) {
+	base := s3Snap("snap1", "ns", nil)
+	base.Status.NodeName = "boba"
+
+	t.Run("complete -> Ready + status.S3", func(t *testing.T) {
+		snap := base.DeepCopy()
+		r, _ := newReconciler(t, snap, uploadJobWith(snap, batchv1.JobComplete))
+		status := snap.Status.DeepCopy()
+		ready, errMsg, err := r.handleUploading(context.Background(), snap, status)
+		if err != nil || errMsg != "" || !ready {
+			t.Fatalf("complete: ready=%v errMsg=%q err=%v", ready, errMsg, err)
+		}
+		if status.Phase != snapshotv1alpha1.SwiftSnapshotPhaseReady {
+			t.Errorf("phase = %s, want Ready", status.Phase)
+		}
+		if status.S3 == nil || status.S3.Location != s3Location(snap) {
+			t.Errorf("status.S3 = %+v, want Location=%s", status.S3, s3Location(snap))
+		}
+	})
+
+	t.Run("failed -> errMsg", func(t *testing.T) {
+		snap := base.DeepCopy()
+		r, _ := newReconciler(t, snap, uploadJobWith(snap, batchv1.JobFailed))
+		ready, errMsg, err := r.handleUploading(context.Background(), snap, snap.Status.DeepCopy())
+		if err != nil || ready || !strings.Contains(errMsg, "upload Job failed") {
+			t.Fatalf("failed: ready=%v errMsg=%q err=%v", ready, errMsg, err)
+		}
+	})
+
+	t.Run("running -> requeue", func(t *testing.T) {
+		snap := base.DeepCopy()
+		r, _ := newReconciler(t, snap, uploadJobWith(snap, ""))
+		ready, errMsg, err := r.handleUploading(context.Background(), snap, snap.Status.DeepCopy())
+		if err != nil || ready || errMsg != "" {
+			t.Fatalf("running should requeue; ready=%v errMsg=%q err=%v", ready, errMsg, err)
+		}
+	})
 }

--- a/internal/webhook/swiftsnapshot/validator.go
+++ b/internal/webhook/swiftsnapshot/validator.go
@@ -149,21 +149,41 @@ func validateShape(snap *snapshotv1alpha1.SwiftSnapshot) error {
 			return err
 		}
 	case snapshotv1alpha1.SnapshotBackendS3:
-		return fmt.Errorf("spec.backend.type %q is not implemented in Phase 2; use csi-volume-snapshot or local", snap.Spec.Backend.Type)
+		if err := validateS3Backend(snap); err != nil {
+			return err
+		}
 	case "":
 		return fmt.Errorf("spec.backend.type is required")
 	default:
 		return fmt.Errorf("spec.backend.type %q is not a recognised value", snap.Spec.Backend.Type)
 	}
-	// Carrier-only fields for not-yet-implemented backends, and for backends
-	// other than the one selected, must be empty — otherwise the admission
-	// tells the operator immediately rather than the controller silently
-	// ignoring the values at runtime.
+	// Carrier-only fields for backends other than the one selected must be
+	// empty — otherwise admission tells the operator immediately rather than
+	// the controller silently ignoring the values at runtime.
 	if snap.Spec.Backend.Type != snapshotv1alpha1.SnapshotBackendLocal && snap.Spec.Backend.Local != nil {
 		return fmt.Errorf("spec.backend.local is only valid when spec.backend.type=local")
 	}
-	if snap.Spec.Backend.S3 != nil {
-		return fmt.Errorf("spec.backend.s3 is reserved for Phase 3 and must be unset")
+	if snap.Spec.Backend.Type != snapshotv1alpha1.SnapshotBackendS3 && snap.Spec.Backend.S3 != nil {
+		return fmt.Errorf("spec.backend.s3 is only valid when spec.backend.type=s3")
+	}
+	return nil
+}
+
+// validateS3Backend checks the Tier C (Phase 3) object-storage backend config.
+func validateS3Backend(snap *snapshotv1alpha1.SwiftSnapshot) error {
+	s3 := snap.Spec.Backend.S3
+	if s3 == nil {
+		return fmt.Errorf("spec.backend.s3 is required when spec.backend.type=s3")
+	}
+	if s3.Bucket == "" {
+		return fmt.Errorf("spec.backend.s3.bucket is required")
+	}
+	if s3.CredentialsSecretRef == nil || s3.CredentialsSecretRef.Name == "" {
+		return fmt.Errorf("spec.backend.s3.credentialsSecretRef.name is required (Secret with accessKeyId/secretAccessKey)")
+	}
+	// AWS needs a region; an S3-compatible store is identified by its endpoint.
+	if s3.Endpoint == "" && s3.Region == "" {
+		return fmt.Errorf("spec.backend.s3.region is required for AWS S3 (or set spec.backend.s3.endpoint for an S3-compatible store)")
 	}
 	return nil
 }

--- a/internal/webhook/swiftsnapshot/validator_test.go
+++ b/internal/webhook/swiftsnapshot/validator_test.go
@@ -99,11 +99,44 @@ func TestValidate_LocalCarrier_OnNonLocalBackend_Rejected(t *testing.T) {
 	}
 }
 
-func TestValidate_S3Backend_Rejected(t *testing.T) {
+func TestValidate_S3Backend(t *testing.T) {
 	v := &Validator{}
-	_, err := v.ValidateCreate(context.Background(), makeSnap(snapshotv1alpha1.SnapshotBackendS3))
-	if err == nil || !strings.Contains(err.Error(), "Phase 2") {
-		t.Errorf("expected Phase 2 rejection of s3 backend, got: %v", err)
+	valid := func() *snapshotv1alpha1.SwiftSnapshot {
+		s := makeSnap(snapshotv1alpha1.SnapshotBackendS3)
+		s.Spec.Backend.S3 = &snapshotv1alpha1.S3Backend{
+			Bucket:               "b",
+			Region:               "us-east-1",
+			CredentialsSecretRef: &snapshotv1alpha1.SecretObjectReference{Name: "creds"},
+		}
+		return s
+	}
+	if _, err := v.ValidateCreate(context.Background(), valid()); err != nil {
+		t.Errorf("valid s3 backend should be accepted; got %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		mut    func(*snapshotv1alpha1.S3Backend)
+		reject string
+	}{
+		{"missing bucket", func(s *snapshotv1alpha1.S3Backend) { s.Bucket = "" }, "bucket"},
+		{"missing creds", func(s *snapshotv1alpha1.S3Backend) { s.CredentialsSecretRef = nil }, "credentialsSecretRef"},
+		{"missing region and endpoint", func(s *snapshotv1alpha1.S3Backend) { s.Region = "" }, "region"},
+	}
+	for _, tc := range cases {
+		s := valid()
+		tc.mut(s.Spec.Backend.S3)
+		if _, err := v.ValidateCreate(context.Background(), s); err == nil || !strings.Contains(err.Error(), tc.reject) {
+			t.Errorf("%s: want rejection mentioning %q; got %v", tc.name, tc.reject, err)
+		}
+	}
+
+	// Endpoint set (S3-compatible) without region is accepted.
+	s := valid()
+	s.Spec.Backend.S3.Region = ""
+	s.Spec.Backend.S3.Endpoint = "minio.svc:9000"
+	if _, err := v.ValidateCreate(context.Background(), s); err != nil {
+		t.Errorf("endpoint without region should be accepted; got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Wires the Tier C (s3 / object-storage) backend through the SwiftSnapshot phase
machine. An s3-backend snapshot now captures **node-locally** (reusing the Tier B
launcher capture path) and then **uploads** to object storage via the node-pinned
upload Job introduced in #113.

```
Pending ──▶ Capturing ──▶ Uploading ──▶ Ready
            (node-local    (upload Job     (status.S3
             hostPath)      → S3)           stamped)
```

This is the controller-flow half of Phase 3's capture path; #113 shipped the
CRD surface + Job builder, this PR makes the phases reachable.

## What changed

- **controller.go** — route `s3` through `handlePendingLocal` + `handleCapturingLocal`
  (identical node-local capture to the `local` backend); add the `Uploading` case
  to the `Reconcile` switch (mirrors `Capturing`: `errMsg → Failed`, `!ready →
  requeue 5s`, `ready → persist Ready`); `Owns(&batchv1.Job{})` so the upload Job's
  completion re-enqueues the snapshot; `SnapshotS3Image` field on the reconciler.
- **local.go** — capture into `captureDestDir(snap)` (`s3` → derived `s3LocalDir`,
  `local` → operator hostPath). On capture-complete the `s3` branch creates the
  upload Job and advances to `Uploading`; the `local` branch goes straight to `Ready`.
- **s3.go** — `ensureUploadJob` (idempotent, owner-ref'd, errors loudly if the
  image is unset) + `handleUploading` (`JobComplete` → stamp `status.S3` + `Ready`;
  `JobFailed` → errMsg; running → requeue; `NotFound` → recreate).
- **webhook** — lift the `s3` rejection: `validateS3Backend` now runs (bucket,
  `credentialsSecretRef.name`, and region-unless-endpoint required); the
  carrier-exclusivity rule keeps `spec.backend.s3` valid only for `type=s3`.
- **main.go** — `SnapshotS3Image` from `KUBESWIFT_SNAPSHOT_S3_IMAGE`.

## Tests

- `handleUploading`: complete → `Ready` + `status.S3.Location`; failed → errMsg;
  running → requeue.
- `TestPending_UnsupportedBackend_FlipsToFailed` now uses a bogus backend type
  (s3 is a supported value).
- Webhook s3 test: valid accepted; missing bucket / creds / region rejected;
  endpoint-without-region accepted.
- Jobs RBAC (`config/manager` + chart) already grants `create/get/list/watch`.
- No CRD change — the s3 surface shipped in #113.

## Not in this PR

- The restore-side s3 path (download Job) and the cluster MinIO round-trip +
  operator runbook land in PR 4/5.
- Cross-node retrieval relies on S3 being the durable layer; the node-local
  hostPath is a capture staging dir only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)