### PR TITLE
feat(snapshots): s3 restore (download) path — Phase 3 (4/5)

### DIFF
--- a/api/snapshot/v1alpha1/swiftrestore_types.go
+++ b/api/snapshot/v1alpha1/swiftrestore_types.go
@@ -77,6 +77,16 @@ type SwiftRestoreSpec struct {
 	// (memory snapshots only); accepted in Phase 1 for forward compatibility.
 	// +optional
 	Identity *IdentityRegeneration `json:"identity,omitempty"`
+	// TargetNode pins the node the restore lands on. It is only consulted for
+	// the s3 (Tier C) backend, where the artifacts live in object storage and
+	// the download Job + restore-receive launcher must be co-located on the
+	// chosen node. When empty for an s3 restore, the controller falls back to
+	// the in-place target guest's current node; a clone/cross-node s3 restore
+	// (target guest does not yet exist) requires this field. Ignored for the
+	// csi-volume-snapshot and local backends (local is pinned to the capture
+	// node).
+	// +optional
+	TargetNode string `json:"targetNode,omitempty"`
 }
 
 // SwiftRestoreGuestRef is the SwiftGuest the SwiftRestore produced (or

--- a/charts/kubeswift/crds/snapshot.kubeswift.io_swiftrestores.yaml
+++ b/charts/kubeswift/crds/snapshot.kubeswift.io_swiftrestores.yaml
@@ -110,6 +110,17 @@ spec:
                 required:
                 - name
                 type: object
+              targetNode:
+                description: |-
+                  TargetNode pins the node the restore lands on. It is only consulted for
+                  the s3 (Tier C) backend, where the artifacts live in object storage and
+                  the download Job + restore-receive launcher must be co-located on the
+                  chosen node. When empty for an s3 restore, the controller falls back to
+                  the in-place target guest's current node; a clone/cross-node s3 restore
+                  (target guest does not yet exist) requires this field. Ignored for the
+                  csi-volume-snapshot and local backends (local is pinned to the capture
+                  node).
+                type: string
             required:
             - snapshotRef
             - targetGuest

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -185,8 +185,9 @@ func main() {
 	}
 
 	if err = (&swiftrestore.SwiftRestoreReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		SnapshotS3Image: os.Getenv("KUBESWIFT_SNAPSHOT_S3_IMAGE"),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftRestore controller")
 		os.Exit(1)

--- a/config/crd/bases/snapshot.kubeswift.io_swiftrestores.yaml
+++ b/config/crd/bases/snapshot.kubeswift.io_swiftrestores.yaml
@@ -110,6 +110,17 @@ spec:
                 required:
                 - name
                 type: object
+              targetNode:
+                description: |-
+                  TargetNode pins the node the restore lands on. It is only consulted for
+                  the s3 (Tier C) backend, where the artifacts live in object storage and
+                  the download Job + restore-receive launcher must be co-located on the
+                  chosen node. When empty for an s3 restore, the controller falls back to
+                  the in-place target guest's current node; a clone/cross-node s3 restore
+                  (target guest does not yet exist) requires this field. Ignored for the
+                  csi-volume-snapshot and local backends (local is pinned to the capture
+                  node).
+                type: string
             required:
             - snapshotRef
             - targetGuest

--- a/docs/design/snapshot-phase-3-s3.md
+++ b/docs/design/snapshot-phase-3-s3.md
@@ -77,7 +77,19 @@ type S3Backend struct {
 
 Status additions (SwiftSnapshotStatus): `s3.location` (`s3://bucket/key/`),
 `s3.manifestDigest` (sha256 of the manifest), `observedUploadBytes`,
-`uploadCompletedAt`. SwiftRestore gains a `Downloading` phase + `downloadedBytes`.
+`uploadCompletedAt`. SwiftRestore gains a `Downloading` phase + a `spec.targetNode`
+field (pins where the s3 restore lands — the download Job + restore-receive
+launcher co-locate there; empty falls back to an in-place target guest's current
+node).
+
+> **Byte-count metrics deferred (downloadedBytes / observedUploadBytes).** The
+> original sketch listed `downloadedBytes` (and `observedUploadBytes`) status
+> fields. Surfacing transferred-byte counts requires the snapshot-s3 binary to
+> report them back through a pod annotation that the controller then reads —
+> the same half-wired hazard W27b flagged (a status field with zero writers
+> reads as "implemented" when it isn't). Deferred to Phase 5 (snapshot
+> observability) where the annotation-read plumbing is the explicit deliverable;
+> PR 4 ships the functional `Downloading` phase without the byte gauges.
 
 `includeMemory` is honoured for s3 exactly as for Tier B (memory captured at
 Capturing time); a disk-only s3 snapshot (`includeMemory: false`) exports just

--- a/internal/controller/swiftrestore/controller.go
+++ b/internal/controller/swiftrestore/controller.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +41,10 @@ type SwiftRestoreReconciler struct {
 	// Empty string disables the check — controller surfaces a Warning
 	// rather than blocking.
 	CurrentHypervisorVersion string
+
+	// SnapshotS3Image is the snapshot-s3 image used by the s3 (Tier C)
+	// backend's download Job. Wired from KUBESWIFT_SNAPSHOT_S3_IMAGE.
+	SnapshotS3Image string
 }
 
 // Reconcile drives the SwiftRestore state machine.
@@ -74,6 +79,24 @@ func (r *SwiftRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, err
 		}
 		if !advanced {
+			if updateErr := r.persist(ctx, &restore, status); updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
+			return ctrl.Result{RequeueAfter: requeue}, nil
+		}
+
+	case snapshotv1alpha1.SwiftRestorePhaseDownloading:
+		// s3 backend only: watch the download Job pull artifacts into the
+		// node-local cache, then hand off to the shared Tier B restore tail
+		// (materializeRestoreTarget) and advance to Restoring.
+		advanced, requeue, errMsg, err := r.handleDownloading(ctx, &restore, status)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if errMsg != "" {
+			setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
+			setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed, errMsg)
+		} else if !advanced {
 			if updateErr := r.persist(ctx, &restore, status); updateErr != nil {
 				return ctrl.Result{}, updateErr
 			}
@@ -185,12 +208,16 @@ func (r *SwiftRestoreReconciler) handlePending(
 	//     actual restore-launcher-pod creation is wired in commit 12 along
 	//     with config.json patching for identity regen — splitting them
 	//     would require two passes over the snapshot's config.json.
-	//   s3                 (Phase 3, reserved): rejected by webhook.
+	//   s3                 (Phase 3): download from object storage to a
+	//     node-local cache (handlePendingS3 -> Downloading), then hand off to
+	//     the same Tier B restore path once the cache is populated.
 	switch snap.Spec.Backend.Type {
 	case snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot:
 		// Continue to existing CSI flow below.
 	case snapshotv1alpha1.SnapshotBackendLocal:
 		return r.handlePendingLocal(ctx, restore, &snap, status)
+	case snapshotv1alpha1.SnapshotBackendS3:
+		return r.handlePendingS3(ctx, restore, &snap, status)
 	default:
 		setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
 		setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed,
@@ -384,5 +411,6 @@ func (r *SwiftRestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&snapshotv1alpha1.SwiftRestore{}).
 		Owns(&swiftv1alpha1.SwiftGuest{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
+		Owns(&batchv1.Job{}).
 		Complete(r)
 }

--- a/internal/controller/swiftrestore/local.go
+++ b/internal/controller/swiftrestore/local.go
@@ -173,10 +173,15 @@ func parseVersion(s string) (int, int, int, bool) {
 	return major, minor, patch, true
 }
 
-// IsTierBRestore returns true when the snapshot's backend is local —
-// i.e. this restore should follow the Tier B path rather than CSI.
+// IsTierBRestore returns true when the snapshot's backend drives the
+// node-local-cache restore path (CH --restore from a hostPath) rather than
+// CSI. That covers both local (Tier B) and s3 (Tier C): once the s3 download
+// Job has populated the node-local cache, the Restoring/Resuming phases are
+// identical to local. The Pending phase still forks (local vs s3-download)
+// before reaching that shared path.
 func IsTierBRestore(snap *snapshotv1alpha1.SwiftSnapshot) bool {
-	return snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendLocal
+	return snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendLocal ||
+		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3
 }
 
 // IsInPlaceRestore returns true when this is the fast-path: target name
@@ -222,33 +227,9 @@ func (r *SwiftRestoreReconciler) handlePendingLocal(
 	snap *snapshotv1alpha1.SwiftSnapshot,
 	status *snapshotv1alpha1.SwiftRestoreStatus,
 ) (bool, time.Duration, error) {
-	// Hypervisor version check (architect risk #3). Operator can
-	// override via SkipHypervisorVersionCheckAnnotation for disaster-
-	// recovery scenarios where the cluster's CH was upgraded past the
-	// snapshot's. Default policy: block on minor or major mismatch,
-	// allow patch drift with a Warning, allow exact match.
-	skip := restore.Annotations[SkipHypervisorVersionCheckAnnotation] == "true"
-	if !skip && r.CurrentHypervisorVersion != "" {
-		switch CompareHypervisorVersions(snap.Status.HypervisorVersion, r.CurrentHypervisorVersion) {
-		case VersionMajorMismatch:
-			setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
-			setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed,
-				"hypervisor major-version mismatch: snapshot "+snap.Status.HypervisorVersion+
-					" vs cluster "+r.CurrentHypervisorVersion+
-					" (override with annotation "+SkipHypervisorVersionCheckAnnotation+"=true)")
-			return true, 0, nil
-		case VersionMinorMismatch:
-			setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
-			setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed,
-				"hypervisor minor-version mismatch: snapshot "+snap.Status.HypervisorVersion+
-					" vs cluster "+r.CurrentHypervisorVersion+
-					" (override with annotation "+SkipHypervisorVersionCheckAnnotation+"=true)")
-			return true, 0, nil
-		case VersionPatchDrift, VersionExactMatch, VersionUnknown:
-			// Proceed. Patch drift could be surfaced as a Warning
-			// condition in a future iteration — for now the version
-			// fields on status are enough for an operator to see.
-		}
+	// Hypervisor version check (architect risk #3). Shared with the s3 path.
+	if r.hypervisorVersionBlocked(restore, snap, status) {
+		return true, 0, nil
 	}
 
 	// Sanity-check the snapshot fields we depend on. The webhook
@@ -268,6 +249,27 @@ func (r *SwiftRestoreReconciler) handlePendingLocal(
 		return true, 0, nil
 	}
 
+	// Local backend: the snapshot dir is the operator-supplied hostPath, pinned
+	// to the capture node. The s3 backend reaches materializeRestoreTarget from
+	// handleDownloading with a download-cache dir + a chosen node instead.
+	return r.materializeRestoreTarget(ctx, restore, snap, status,
+		snap.Spec.Backend.Local.HostPath, snap.Status.NodeName)
+}
+
+// materializeRestoreTarget is the backend-agnostic tail of the restore: given
+// the node-local snapshot directory and the node it lives on, it stamps the
+// target SwiftGuest (in-place) or creates it from the source spec (clone) with
+// the restore annotations, then advances to Restoring. The local backend calls
+// this with the operator hostPath + capture node; the s3 backend calls it after
+// the download Job has populated the node-local cache on the chosen node.
+func (r *SwiftRestoreReconciler) materializeRestoreTarget(
+	ctx context.Context,
+	restore *snapshotv1alpha1.SwiftRestore,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+	status *snapshotv1alpha1.SwiftRestoreStatus,
+	snapshotDir string,
+	nodeName string,
+) (bool, time.Duration, error) {
 	// Identity-regen contract: a clone (target.Name != source) MUST
 	// regenerate macAddresses. Without this two clones share a MAC
 	// and L2 collides. The validation webhook enforces the same rule
@@ -302,7 +304,7 @@ func (r *SwiftRestoreReconciler) handlePendingLocal(
 	// Annotation set both branches write onto the target SwiftGuest.
 	// The SwiftGuest controller picks these up in buildPod() and routes
 	// to BuildRestorePod() instead of the normal disk-boot path.
-	annos := r.restoreAnnotations(restore, snap, &source, inPlace)
+	annos := r.restoreAnnotations(restore, snap, &source, inPlace, snapshotDir, nodeName)
 
 	if inPlace {
 		// In-place: target name == source name. The source SwiftGuest
@@ -358,7 +360,7 @@ func (r *SwiftRestoreReconciler) handlePendingLocal(
 	setPhase(status, snapshotv1alpha1.SwiftRestorePhaseRestoring)
 	setReadyCondition(status, metav1.ConditionFalse, ReasonRestoring,
 		"restore-receive launcher requested for SwiftGuest "+restore.Spec.TargetGuest.Name+
-			" on node "+snap.Status.NodeName)
+			" on node "+nodeName)
 	return true, 0, nil
 }
 
@@ -503,6 +505,8 @@ func (r *SwiftRestoreReconciler) restoreAnnotations(
 	snap *snapshotv1alpha1.SwiftSnapshot,
 	source *swiftv1alpha1.SwiftGuest,
 	inPlace bool,
+	snapshotDir string,
+	nodeName string,
 ) map[string]string {
 	mode := swiftguestctrl.RestoreModeClone
 	if inPlace {
@@ -510,8 +514,8 @@ func (r *SwiftRestoreReconciler) restoreAnnotations(
 	}
 	annos := map[string]string{
 		swiftguestctrl.AnnotationActiveRestore:       restore.Name,
-		swiftguestctrl.AnnotationRestoreSnapshotPath: snap.Spec.Backend.Local.HostPath,
-		swiftguestctrl.AnnotationRestoreNodeName:     snap.Status.NodeName,
+		swiftguestctrl.AnnotationRestoreSnapshotPath: snapshotDir,
+		swiftguestctrl.AnnotationRestoreNodeName:     nodeName,
 		swiftguestctrl.AnnotationRestoreMode:         mode,
 	}
 	if !inPlace {

--- a/internal/controller/swiftrestore/local_test.go
+++ b/internal/controller/swiftrestore/local_test.go
@@ -336,7 +336,7 @@ func TestRestoreAnnotations_Clone_SetsRuntimeDirPrefixAndNullifyHostMAC(t *testi
 	}
 	source := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: "default"}}
 
-	annos := r.restoreAnnotations(restore, snap, source, false /* inPlace */)
+	annos := r.restoreAnnotations(restore, snap, source, false /* inPlace */, snap.Spec.Backend.Local.HostPath, snap.Status.NodeName)
 
 	wantFrom := "/var/lib/kubeswift/run/default-src/"
 	wantTo := "/var/lib/kubeswift/run/default-clone-a/"
@@ -378,7 +378,7 @@ func TestRestoreAnnotations_InPlace_DoesNotSetCloneOnlyAnnotations(t *testing.T)
 	}
 	source := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: "default"}}
 
-	annos := r.restoreAnnotations(restore, snap, source, true /* inPlace */)
+	annos := r.restoreAnnotations(restore, snap, source, true /* inPlace */, snap.Spec.Backend.Local.HostPath, snap.Status.NodeName)
 
 	for _, key := range []string{
 		swiftguestctrl.AnnotationRestoreRuntimeDirFromPrefix,

--- a/internal/controller/swiftrestore/s3.go
+++ b/internal/controller/swiftrestore/s3.go
@@ -1,0 +1,355 @@
+// Tier C (s3 / object-storage) restore path for SwiftRestore — Phase 3.
+//
+// An s3-backed SwiftSnapshot stores its artifacts in object storage, so the
+// restore is cross-node/cross-cluster portable: a node-pinned download Job
+// pulls the artifacts from S3 into a node-local cache on the chosen target
+// node, then the EXISTING Tier B restore tail (materializeRestoreTarget) takes
+// over unchanged — CH --restore from the node-local cache.
+//
+//	Pending -> Downloading -> Restoring -> Resuming -> Ready
+//	           (download Job   (shared Tier B path: stamp/clone the target
+//	            -> node cache)   SwiftGuest, restore-receive launcher, resume)
+package swiftrestore
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+const (
+	// s3DownloadMount is where the node-local restore cache is mounted (RW)
+	// inside the download Job — the snapshot-s3 binary writes the artifacts here.
+	s3DownloadMount = "/snap"
+	// s3RestoreCacheBase mirrors swiftsnapshot.HostPathBaseDir — the kubeswift-
+	// managed subtree the restore cache lives under. Kept as a local constant to
+	// avoid importing the swiftsnapshot controller package into swiftrestore.
+	s3RestoreCacheBase = "/var/lib/kubeswift/snapshots/"
+	// s3DownloadBackoffLimit bounds Job retries; the snapshot-s3 binary is
+	// idempotent (skips already-downloaded objects, verifies checksums), so a
+	// retry resumes.
+	s3DownloadBackoffLimit int32 = 4
+)
+
+// hypervisorVersionBlocked runs the architect-risk-#3 CH version compatibility
+// gate shared by the local and s3 restore paths. Returns true (and stamps
+// Failed on status) when the restore must be blocked; false to proceed.
+func (r *SwiftRestoreReconciler) hypervisorVersionBlocked(
+	restore *snapshotv1alpha1.SwiftRestore,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+	status *snapshotv1alpha1.SwiftRestoreStatus,
+) bool {
+	// Operator can override via SkipHypervisorVersionCheckAnnotation for
+	// disaster-recovery scenarios where the cluster's CH was upgraded past the
+	// snapshot's. Default policy: block on minor or major mismatch, allow patch
+	// drift with a Warning, allow exact match.
+	if restore.Annotations[SkipHypervisorVersionCheckAnnotation] == "true" || r.CurrentHypervisorVersion == "" {
+		return false
+	}
+	switch CompareHypervisorVersions(snap.Status.HypervisorVersion, r.CurrentHypervisorVersion) {
+	case VersionMajorMismatch:
+		setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
+		setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed,
+			"hypervisor major-version mismatch: snapshot "+snap.Status.HypervisorVersion+
+				" vs cluster "+r.CurrentHypervisorVersion+
+				" (override with annotation "+SkipHypervisorVersionCheckAnnotation+"=true)")
+		return true
+	case VersionMinorMismatch:
+		setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
+		setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed,
+			"hypervisor minor-version mismatch: snapshot "+snap.Status.HypervisorVersion+
+				" vs cluster "+r.CurrentHypervisorVersion+
+				" (override with annotation "+SkipHypervisorVersionCheckAnnotation+"=true)")
+		return true
+	case VersionPatchDrift, VersionExactMatch, VersionUnknown:
+		// Proceed. Patch drift could be surfaced as a Warning condition in a
+		// future iteration — the version fields on status are enough for now.
+	}
+	return false
+}
+
+// s3RestoreLocalDir is the node-local cache directory the download Job writes
+// to (and CH --restore then reads). Derived deterministically from the
+// snapshot's identity so it is stable across reconciles and matches the
+// capture-side layout when the target happens to be the capture node.
+func s3RestoreLocalDir(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	return filepath.Join(s3RestoreCacheBase, snap.Namespace+"-"+snap.Name)
+}
+
+// s3RestoreKeyPrefix is the object-key prefix the artifacts live under, derived
+// the same way the upload side derives it: <prefix>/<namespace>/<name>.
+func s3RestoreKeyPrefix(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	return path.Join(snap.Spec.Backend.S3.Prefix, snap.Namespace, snap.Name)
+}
+
+// s3DownloadJobName is the deterministic name of the download Job.
+func s3DownloadJobName(restore *snapshotv1alpha1.SwiftRestore) string {
+	return restore.Name + "-s3-download"
+}
+
+// resolveS3RestoreNode picks the node the download Job + restore-receive
+// launcher run on. spec.targetNode wins; otherwise (in-place restore) the
+// target SwiftGuest's currently-assigned node is used. Returns (node, failMsg,
+// err): a non-empty failMsg means the caller should mark the restore Failed; a
+// non-nil err is transient.
+func (r *SwiftRestoreReconciler) resolveS3RestoreNode(
+	ctx context.Context,
+	restore *snapshotv1alpha1.SwiftRestore,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+) (string, string, error) {
+	if restore.Spec.TargetNode != "" {
+		return restore.Spec.TargetNode, "", nil
+	}
+	var guest swiftv1alpha1.SwiftGuest
+	err := r.Get(ctx, client.ObjectKey{Name: restore.Spec.TargetGuest.Name, Namespace: restore.Namespace}, &guest)
+	if apierrors.IsNotFound(err) {
+		return "", "s3 restore requires spec.targetNode: target SwiftGuest " + restore.Spec.TargetGuest.Name +
+			" does not exist (clone/cross-node restore) and no spec.targetNode was set", nil
+	}
+	if err != nil {
+		return "", "", err
+	}
+	if guest.Status.NodeName == "" {
+		return "", "s3 restore: target SwiftGuest " + guest.Name +
+			" has no assigned node yet; set spec.targetNode to pin the restore", nil
+	}
+	return guest.Status.NodeName, "", nil
+}
+
+// ensureDownloadJob creates the node-pinned download Job (idempotent) owned by
+// the SwiftRestore. Fails if the snapshot-s3 image is not configured.
+func (r *SwiftRestoreReconciler) ensureDownloadJob(
+	ctx context.Context,
+	restore *snapshotv1alpha1.SwiftRestore,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+	node string,
+) error {
+	if r.SnapshotS3Image == "" {
+		return fmt.Errorf("snapshot-s3 image not configured (set KUBESWIFT_SNAPSHOT_S3_IMAGE)")
+	}
+	job := buildDownloadJob(restore, snap, r.SnapshotS3Image, node)
+	if err := ctrl.SetControllerReference(restore, job, r.Scheme); err != nil {
+		return err
+	}
+	if err := r.Create(ctx, job); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// handlePendingS3 validates the uploaded snapshot, resolves the target node,
+// and starts the download Job. Advances to Downloading.
+func (r *SwiftRestoreReconciler) handlePendingS3(
+	ctx context.Context,
+	restore *snapshotv1alpha1.SwiftRestore,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+	status *snapshotv1alpha1.SwiftRestoreStatus,
+) (bool, time.Duration, error) {
+	if r.hypervisorVersionBlocked(restore, snap, status) {
+		return true, 0, nil
+	}
+	if snap.Spec.Backend.S3 == nil {
+		setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
+		setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed,
+			"SwiftSnapshot "+snap.Name+" has no backend.s3 — s3 restore requires the object-store config")
+		return true, 0, nil
+	}
+	if snap.Status.S3 == nil || snap.Status.S3.Location == "" {
+		setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
+		setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed,
+			"SwiftSnapshot "+snap.Name+" has no status.s3 — s3 restore requires a completed upload")
+		return true, 0, nil
+	}
+	node, failMsg, err := r.resolveS3RestoreNode(ctx, restore, snap)
+	if err != nil {
+		return false, 0, err
+	}
+	if failMsg != "" {
+		setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
+		setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed, failMsg)
+		return true, 0, nil
+	}
+	if err := r.ensureDownloadJob(ctx, restore, snap, node); err != nil {
+		return false, 0, err
+	}
+	setPhase(status, snapshotv1alpha1.SwiftRestorePhaseDownloading)
+	setReadyCondition(status, metav1.ConditionFalse, ReasonDownloading,
+		"downloading snapshot from "+snap.Status.S3.Location+" to node "+node)
+	return true, 0, nil
+}
+
+// handleDownloading watches the download Job. On Complete it hands off to the
+// shared Tier B restore tail (materializeRestoreTarget) with the node-local
+// cache dir + resolved node; on Failed it returns an errMsg (caller -> Failed).
+// Returns (advanced, requeue, errMsg, err) mirroring handleRestoringLocal.
+func (r *SwiftRestoreReconciler) handleDownloading(
+	ctx context.Context,
+	restore *snapshotv1alpha1.SwiftRestore,
+	status *snapshotv1alpha1.SwiftRestoreStatus,
+) (bool, time.Duration, string, error) {
+	var snap snapshotv1alpha1.SwiftSnapshot
+	if err := r.Get(ctx, client.ObjectKey{Name: restore.Spec.SnapshotRef.Name, Namespace: restore.Namespace}, &snap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, 0, "source SwiftSnapshot " + restore.Spec.SnapshotRef.Name + " disappeared during download", nil
+		}
+		return false, 0, "", err
+	}
+
+	var job batchv1.Job
+	err := r.Get(ctx, client.ObjectKey{Name: s3DownloadJobName(restore), Namespace: restore.Namespace}, &job)
+	if apierrors.IsNotFound(err) {
+		// Job missing (controller restarted before observing creation, or it
+		// was deleted). Recreate — idempotent, and the binary resumes.
+		node, failMsg, rerr := r.resolveS3RestoreNode(ctx, restore, &snap)
+		if rerr != nil {
+			return false, 0, "", rerr
+		}
+		if failMsg != "" {
+			return false, 0, failMsg, nil
+		}
+		if cerr := r.ensureDownloadJob(ctx, restore, &snap, node); cerr != nil {
+			return false, 0, "", cerr
+		}
+		return false, 5 * time.Second, "", nil
+	}
+	if err != nil {
+		return false, 0, "", err
+	}
+
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			node, failMsg, rerr := r.resolveS3RestoreNode(ctx, restore, &snap)
+			if rerr != nil {
+				return false, 0, "", rerr
+			}
+			if failMsg != "" {
+				return false, 0, failMsg, nil
+			}
+			// Hand off to the shared Tier B tail with the node-local cache.
+			advanced, requeue, merr := r.materializeRestoreTarget(ctx, restore, &snap, status, s3RestoreLocalDir(&snap), node)
+			return advanced, requeue, "", merr
+		}
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return false, 0, "S3 download Job failed: " + c.Message, nil
+		}
+	}
+	return false, 5 * time.Second, "", nil // still downloading
+}
+
+// buildDownloadJob constructs the node-pinned download Job. It mounts the
+// node-local restore cache read-write (DirectoryOrCreate — the dir may not
+// exist on a fresh target node), takes S3 credentials from the snapshot's
+// referenced Secret as the standard AWS env vars, and runs snapshot-s3
+// --mode=download. Pinned to the resolved restore node. The caller sets the
+// SwiftRestore ownerRef for GC.
+func buildDownloadJob(restore *snapshotv1alpha1.SwiftRestore, snap *snapshotv1alpha1.SwiftSnapshot, image, node string) *batchv1.Job {
+	s3 := snap.Spec.Backend.S3
+	args := []string{
+		"--mode=download",
+		"--dir=" + s3DownloadMount,
+		"--bucket=" + s3.Bucket,
+		"--key-prefix=" + s3RestoreKeyPrefix(snap),
+		"--snapshot=" + snap.Namespace + "/" + snap.Name,
+	}
+	if s3.Region != "" {
+		args = append(args, "--region="+s3.Region)
+	}
+	if s3.Endpoint != "" {
+		args = append(args, "--endpoint="+s3.Endpoint)
+	}
+	if s3.ForcePathStyle {
+		args = append(args, "--path-style")
+	}
+	if snap.Spec.IncludeMemory {
+		args = append(args, "--include-memory")
+	}
+
+	credName := ""
+	if s3.CredentialsSecretRef != nil {
+		credName = s3.CredentialsSecretRef.Name
+	}
+	secretEnv := func(envName, key string, optional bool) corev1.EnvVar {
+		return corev1.EnvVar{
+			Name: envName,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: credName},
+					Key:                  key,
+					Optional:             ptr.To(optional),
+				},
+			},
+		}
+	}
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s3DownloadJobName(restore),
+			Namespace: restore.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "kubeswift",
+				"app.kubernetes.io/component": "snapshot-s3-download",
+				"kubeswift.io/swiftrestore":   restore.Name,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: ptr.To(s3DownloadBackoffLimit),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					NodeName:      node,
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+					Containers: []corev1.Container{{
+						Name:  "download",
+						Image: image,
+						Args:  args,
+						Env: []corev1.EnvVar{
+							secretEnv("AWS_ACCESS_KEY_ID", "accessKeyId", false),
+							secretEnv("AWS_SECRET_ACCESS_KEY", "secretAccessKey", false),
+							secretEnv("AWS_SESSION_TOKEN", "sessionToken", true),
+						},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "cache",
+							MountPath: s3DownloadMount,
+						}},
+						// Unlike the upload Job (read-only mount, runs as the
+						// image's non-root uid), the download Job WRITES into the
+						// node-local cache hostPath. kubelet creates that
+						// DirectoryOrCreate path root-owned (0755), so the
+						// container must run as root to write it. Still maximally
+						// constrained otherwise: drop ALL capabilities, no
+						// privilege escalation, read-only root filesystem. The
+						// hostPath mount exposes only the single snapshot dir.
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+							RunAsUser:                ptr.To(int64(0)),
+							RunAsNonRoot:             ptr.To(false),
+							ReadOnlyRootFilesystem:   ptr.To(true),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "cache",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: s3RestoreLocalDir(snap),
+								Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/swiftrestore/s3_test.go
+++ b/internal/controller/swiftrestore/s3_test.go
@@ -1,0 +1,249 @@
+package swiftrestore
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+func s3ReadySnap(name, ns, sourceGuest string) *snapshotv1alpha1.SwiftSnapshot {
+	return &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			GuestRef: snapshotv1alpha1.SwiftSnapshotGuestRef{Name: sourceGuest},
+			Backend: snapshotv1alpha1.SwiftSnapshotBackend{
+				Type: snapshotv1alpha1.SnapshotBackendS3,
+				S3: &snapshotv1alpha1.S3Backend{
+					Bucket:               "backups",
+					Prefix:               "kubeswift",
+					Region:               "us-east-1",
+					CredentialsSecretRef: &snapshotv1alpha1.SecretObjectReference{Name: "s3-creds"},
+				},
+			},
+		},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{
+			Phase:    snapshotv1alpha1.SwiftSnapshotPhaseReady,
+			NodeName: "miles",
+			S3:       &snapshotv1alpha1.S3SnapshotStatus{Location: "s3://backups/kubeswift/team-a/snap1/"},
+		},
+	}
+}
+
+func s3Restore(name, ns, snapName, target, targetNode string) *snapshotv1alpha1.SwiftRestore {
+	return &snapshotv1alpha1.SwiftRestore{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: snapshotv1alpha1.SwiftRestoreSpec{
+			SnapshotRef: snapshotv1alpha1.SwiftRestoreSnapshotRef{Name: snapName},
+			TargetGuest: snapshotv1alpha1.SwiftRestoreTarget{Name: target, OverwriteExisting: true},
+			TargetNode:  targetNode,
+		},
+	}
+}
+
+func TestS3Restore_Helpers(t *testing.T) {
+	snap := s3ReadySnap("snap1", "team-a", "g1")
+	restore := s3Restore("r1", "team-a", "snap1", "g1", "boba")
+	if got := s3RestoreLocalDir(snap); got != "/var/lib/kubeswift/snapshots/team-a-snap1" {
+		t.Errorf("localDir = %q", got)
+	}
+	if got := s3RestoreKeyPrefix(snap); got != "kubeswift/team-a/snap1" {
+		t.Errorf("keyPrefix = %q", got)
+	}
+	if got := s3DownloadJobName(restore); got != "r1-s3-download" {
+		t.Errorf("jobName = %q", got)
+	}
+}
+
+func TestResolveS3RestoreNode(t *testing.T) {
+	snap := s3ReadySnap("snap1", "ns", "g1")
+
+	t.Run("targetNode wins", func(t *testing.T) {
+		r, _ := newReconciler(t)
+		node, failMsg, err := r.resolveS3RestoreNode(context.Background(), s3Restore("r", "ns", "snap1", "g1", "boba"), snap)
+		if err != nil || failMsg != "" || node != "boba" {
+			t.Fatalf("node=%q failMsg=%q err=%v", node, failMsg, err)
+		}
+	})
+
+	t.Run("in-place falls back to guest node", func(t *testing.T) {
+		guest := &swiftv1alpha1.SwiftGuest{
+			ObjectMeta: metav1.ObjectMeta{Name: "g1", Namespace: "ns"},
+			Status:     swiftv1alpha1.SwiftGuestStatus{NodeName: "miles"},
+		}
+		r, _ := newReconciler(t, guest)
+		node, failMsg, err := r.resolveS3RestoreNode(context.Background(), s3Restore("r", "ns", "snap1", "g1", ""), snap)
+		if err != nil || failMsg != "" || node != "miles" {
+			t.Fatalf("node=%q failMsg=%q err=%v", node, failMsg, err)
+		}
+	})
+
+	t.Run("clone without targetNode -> failMsg", func(t *testing.T) {
+		r, _ := newReconciler(t)
+		node, failMsg, err := r.resolveS3RestoreNode(context.Background(), s3Restore("r", "ns", "snap1", "clone-a", ""), snap)
+		if err != nil || node != "" || !strings.Contains(failMsg, "requires spec.targetNode") {
+			t.Fatalf("node=%q failMsg=%q err=%v", node, failMsg, err)
+		}
+	})
+
+	t.Run("guest with no node yet -> failMsg", func(t *testing.T) {
+		guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "g1", Namespace: "ns"}}
+		r, _ := newReconciler(t, guest)
+		_, failMsg, err := r.resolveS3RestoreNode(context.Background(), s3Restore("r", "ns", "snap1", "g1", ""), snap)
+		if err != nil || !strings.Contains(failMsg, "no assigned node yet") {
+			t.Fatalf("failMsg=%q err=%v", failMsg, err)
+		}
+	})
+}
+
+func TestBuildDownloadJob(t *testing.T) {
+	snap := s3ReadySnap("snap1", "team-a", "g1")
+	snap.Spec.Backend.S3.Endpoint = "minio.svc:9000"
+	snap.Spec.Backend.S3.ForcePathStyle = true
+	snap.Spec.IncludeMemory = true
+	job := buildDownloadJob(s3Restore("r1", "team-a", "snap1", "g1", "boba"), snap, "ghcr.io/x/snapshot-s3:t", "boba")
+	pod := job.Spec.Template.Spec
+
+	if pod.NodeName != "boba" {
+		t.Errorf("download Job must pin to the resolved node; got %q", pod.NodeName)
+	}
+	if pod.RestartPolicy != corev1.RestartPolicyOnFailure {
+		t.Errorf("restartPolicy = %q, want OnFailure", pod.RestartPolicy)
+	}
+	c := pod.Containers[0]
+
+	// Cache mounted READ-WRITE (download writes artifacts), DirectoryOrCreate.
+	vm := c.VolumeMounts[0]
+	if vm.MountPath != s3DownloadMount || vm.ReadOnly {
+		t.Errorf("cache must mount %s read-write; got %+v", s3DownloadMount, vm)
+	}
+	hp := pod.Volumes[0].VolumeSource.HostPath
+	if hp == nil || hp.Path != "/var/lib/kubeswift/snapshots/team-a-snap1" || *hp.Type != corev1.HostPathDirectoryOrCreate {
+		t.Errorf("hostPath = %+v (want DirectoryOrCreate at the cache dir)", hp)
+	}
+
+	// args carry download mode + derived prefix + flags.
+	a := strings.Join(c.Args, " ")
+	for _, want := range []string{"--mode=download", "--bucket=backups", "--key-prefix=kubeswift/team-a/snap1",
+		"--region=us-east-1", "--endpoint=minio.svc:9000", "--path-style", "--include-memory"} {
+		if !strings.Contains(a, want) {
+			t.Errorf("args missing %q; got %q", want, a)
+		}
+	}
+
+	// creds from the snapshot's Secret as AWS env.
+	gotKeys := map[string]string{}
+	for _, e := range c.Env {
+		if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+			if e.ValueFrom.SecretKeyRef.Name != "s3-creds" {
+				t.Errorf("env %s must source from the creds Secret; got %q", e.Name, e.ValueFrom.SecretKeyRef.Name)
+			}
+			gotKeys[e.Name] = e.ValueFrom.SecretKeyRef.Key
+		}
+	}
+	if gotKeys["AWS_ACCESS_KEY_ID"] != "accessKeyId" || gotKeys["AWS_SECRET_ACCESS_KEY"] != "secretAccessKey" {
+		t.Errorf("creds env mapping wrong: %+v", gotKeys)
+	}
+
+	// Runs as root (writes the root-owned hostPath) but otherwise hardened.
+	sc := c.SecurityContext
+	if sc == nil || sc.RunAsUser == nil || *sc.RunAsUser != 0 ||
+		sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem ||
+		sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation ||
+		len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != "ALL" {
+		t.Errorf("download container must run as root with drop ALL / no-priv-esc / ro-rootfs; got %+v", sc)
+	}
+}
+
+func TestHandlePendingS3(t *testing.T) {
+	t.Run("uploaded + targetNode -> Downloading + Job", func(t *testing.T) {
+		snap := s3ReadySnap("snap1", "ns", "g1")
+		r, c := newReconciler(t, snap)
+		r.SnapshotS3Image = "img"
+		restore := s3Restore("r1", "ns", "snap1", "clone-a", "boba")
+		status := restore.Status.DeepCopy()
+		advanced, _, err := r.handlePendingS3(context.Background(), restore, snap, status)
+		if err != nil || !advanced {
+			t.Fatalf("advanced=%v err=%v", advanced, err)
+		}
+		if status.Phase != snapshotv1alpha1.SwiftRestorePhaseDownloading {
+			t.Errorf("phase = %s, want Downloading", status.Phase)
+		}
+		var job batchv1.Job
+		if err := c.Get(context.Background(), client.ObjectKey{Name: "r1-s3-download", Namespace: "ns"}, &job); err != nil {
+			t.Fatalf("download Job not created: %v", err)
+		}
+	})
+
+	t.Run("not uploaded -> Failed", func(t *testing.T) {
+		snap := s3ReadySnap("snap1", "ns", "g1")
+		snap.Status.S3 = nil
+		r, _ := newReconciler(t, snap)
+		r.SnapshotS3Image = "img"
+		status := &snapshotv1alpha1.SwiftRestoreStatus{}
+		advanced, _, err := r.handlePendingS3(context.Background(), s3Restore("r1", "ns", "snap1", "g1", "boba"), snap, status)
+		if err != nil || !advanced || status.Phase != snapshotv1alpha1.SwiftRestorePhaseFailed {
+			t.Fatalf("advanced=%v phase=%s err=%v", advanced, status.Phase, err)
+		}
+	})
+
+	t.Run("clone without targetNode -> Failed", func(t *testing.T) {
+		snap := s3ReadySnap("snap1", "ns", "g1")
+		r, _ := newReconciler(t, snap)
+		r.SnapshotS3Image = "img"
+		status := &snapshotv1alpha1.SwiftRestoreStatus{}
+		advanced, _, err := r.handlePendingS3(context.Background(), s3Restore("r1", "ns", "snap1", "clone-a", ""), snap, status)
+		if err != nil || !advanced || status.Phase != snapshotv1alpha1.SwiftRestorePhaseFailed {
+			t.Fatalf("advanced=%v phase=%s err=%v", advanced, status.Phase, err)
+		}
+	})
+}
+
+func downloadJobWith(restore *snapshotv1alpha1.SwiftRestore, cond batchv1.JobConditionType) *batchv1.Job {
+	j := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: s3DownloadJobName(restore), Namespace: restore.Namespace}}
+	if cond != "" {
+		j.Status.Conditions = []batchv1.JobCondition{{Type: cond, Status: corev1.ConditionTrue, Message: "boom"}}
+	}
+	return j
+}
+
+func TestHandleDownloading(t *testing.T) {
+	snap := s3ReadySnap("snap1", "ns", "g1")
+	restore := s3Restore("r1", "ns", "snap1", "clone-a", "boba")
+
+	t.Run("failed -> errMsg", func(t *testing.T) {
+		r, _ := newReconciler(t, snap, downloadJobWith(restore, batchv1.JobFailed))
+		_, _, errMsg, err := r.handleDownloading(context.Background(), restore, &snapshotv1alpha1.SwiftRestoreStatus{})
+		if err != nil || !strings.Contains(errMsg, "download Job failed") {
+			t.Fatalf("errMsg=%q err=%v", errMsg, err)
+		}
+	})
+
+	t.Run("running -> requeue", func(t *testing.T) {
+		r, _ := newReconciler(t, snap, downloadJobWith(restore, ""))
+		advanced, requeue, errMsg, err := r.handleDownloading(context.Background(), restore, &snapshotv1alpha1.SwiftRestoreStatus{})
+		if err != nil || advanced || errMsg != "" || requeue == 0 {
+			t.Fatalf("advanced=%v requeue=%v errMsg=%q err=%v", advanced, requeue, errMsg, err)
+		}
+	})
+
+	t.Run("job missing -> recreate", func(t *testing.T) {
+		r, c := newReconciler(t, snap)
+		r.SnapshotS3Image = "img"
+		advanced, _, errMsg, err := r.handleDownloading(context.Background(), restore, &snapshotv1alpha1.SwiftRestoreStatus{})
+		if err != nil || advanced || errMsg != "" {
+			t.Fatalf("advanced=%v errMsg=%q err=%v", advanced, errMsg, err)
+		}
+		var job batchv1.Job
+		if err := c.Get(context.Background(), client.ObjectKey{Name: s3DownloadJobName(restore), Namespace: "ns"}, &job); err != nil {
+			t.Fatalf("download Job not recreated: %v", err)
+		}
+	})
+}

--- a/internal/controller/swiftrestore/status.go
+++ b/internal/controller/swiftrestore/status.go
@@ -9,6 +9,7 @@ import (
 // Condition reasons for SwiftRestore.
 const (
 	ReasonPending          = "Pending"
+	ReasonDownloading      = "Downloading"
 	ReasonRestoring        = "Restoring"
 	ReasonResuming         = "Resuming"
 	ReasonRestoreReady     = "RestoreReady"

--- a/internal/webhook/swiftrestore/validator.go
+++ b/internal/webhook/swiftrestore/validator.go
@@ -130,9 +130,13 @@ func (v *Validator) validateMacAddressesOnClone(ctx context.Context, r *snapshot
 	if err != nil {
 		return fmt.Errorf("look up SwiftSnapshot: %w", err)
 	}
-	// Rule applies only to memory snapshots being cloned (not in-place).
+	// Rule applies only to memory snapshots being cloned (not in-place). Both
+	// the local (Tier B) and s3 (Tier C) backends capture via the same
+	// CH-pause path, so a clone of either resumes byte-for-byte and collides
+	// on MAC/identity without regeneration.
 	hasMemory := snap.Status.MemorySnapshot != nil ||
-		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendLocal
+		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendLocal ||
+		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3
 	if !hasMemory {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Restore an `s3`-backed SwiftSnapshot **on any node** (the capture node may be
gone). A node-pinned download Job pulls the artifacts from object storage into a
node-local cache on the chosen target node, then the **existing Tier B restore
tail** takes over unchanged — `CH --restore` from the cache. This is the
cross-node / cross-cluster portable restore the Tier C backend exists for.

```
Pending ──▶ Downloading ──▶ Restoring ──▶ Resuming ──▶ Ready
            (download Job     (shared Tier B path: stamp/clone the
             → node cache)     target SwiftGuest, restore-receive launcher, resume)
```

#112 shipped the `snapshot-s3` image (with `--mode=download`); #113/#114 shipped
the capture/upload side. This PR is the consume side.

## What changed

- **`swiftrestore/s3.go`** (new) —
  - `buildDownloadJob`: node-pinned, RW `DirectoryOrCreate` cache mount,
    `--mode=download`, S3 creds from the snapshot's Secret as AWS env vars.
  - `resolveS3RestoreNode`: `spec.targetNode` wins; else the in-place target
    guest's current node; else fail with a clear *"set spec.targetNode"* message.
  - `handlePendingS3`: validate the uploaded snapshot (`status.s3`) + resolve the
    node → create the Job → `Downloading`.
  - `handleDownloading`: `JobComplete` → hand off to `materializeRestoreTarget`;
    `JobFailed` → errMsg; running → requeue; `NotFound` → recreate.
  - shared `hypervisorVersionBlocked` gate (runs for s3 too).
- **`local.go`** — extract the backend-agnostic restore tail into
  `materializeRestoreTarget(snapshotDir, nodeName)`. The local path calls it with
  the operator hostPath + capture node; the s3 path calls it post-download with
  the cache dir + resolved node. `restoreAnnotations` now takes
  `(snapshotDir, nodeName)`. `IsTierBRestore` returns true for s3 too, so
  Restoring/Resuming reuse the local handlers (identical once the cache exists).
- **`controller.go`** — s3 dispatch in `handlePending`; `Downloading` case in the
  Reconcile switch (mirrors Restoring); `Owns(&batchv1.Job{})`; `SnapshotS3Image`.
- **CRD** — `SwiftRestore.spec.targetNode` (optional; only consulted for s3).
  `make generate` + chart sync. No deepcopy impact (plain string).
- **webhook** — the `macAddresses`-on-clone rule fires for s3 too (s3 captures via
  the same CH-pause path; a clone resumes byte-for-byte and collides on identity).
- **main.go** — `SnapshotS3Image` → `SwiftRestoreReconciler`.

## Security note

The download Job runs **as root** because it writes the kubelet-created
root-owned cache hostPath (`DirectoryOrCreate`, 0755). It is otherwise maximally
hardened: drop `ALL`, no privilege escalation, read-only rootfs, and the mount
exposes only the single snapshot dir. The upload Job (read-only mount) stays
non-root.

## Tests

- `resolveS3RestoreNode` (targetNode / in-place-guest-node / clone-without-node /
  guest-no-node).
- `buildDownloadJob` (node pin, RW + `DirectoryOrCreate`, root-but-hardened SC,
  creds env, args).
- `handlePendingS3` (uploaded+targetNode → Downloading+Job / not-uploaded → Failed
  / clone-without-targetNode → Failed).
- `handleDownloading` (failed / running / recreate).
- Existing `restoreAnnotations` call sites updated to the new signature.
- Jobs RBAC (config/manager + chart) already grants `create/get/list/watch`.

## Deferred

`downloadedBytes` / `observedUploadBytes` byte gauges → **Phase 5 (snapshot
observability)**. Surfacing them needs the `snapshot-s3` binary to report counts
through a pod annotation the controller reads; shipping the field now without that
plumbing is the W27b half-wired-status-field anti-pattern.

## Not in this PR

PR 5: cluster **MinIO round-trip** (guest on node A → s3 snapshot → SwiftRestore
clone on node B → boots, sentinel survives) + operator runbook + publicize the
`snapshot-s3` ghcr package (TFU #26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)