### PR TITLE
feat(snapshots): s3 deploy wiring + samples + operator runbook — Phase 3 (5/5)

### DIFF
--- a/charts/kubeswift/templates/controller-manager/deployment.yaml
+++ b/charts/kubeswift/templates/controller-manager/deployment.yaml
@@ -25,6 +25,8 @@ spec:
           env:
             - name: KUBESWIFT_LAUNCHER_IMAGE
               value: {{ .Values.swiftletd.image.registry }}/swiftletd:{{ include "kubeswift.imageTag" (dict "tag" .Values.swiftletd.image.tag "appVersion" .Chart.AppVersion) }}
+            - name: KUBESWIFT_SNAPSHOT_S3_IMAGE
+              value: {{ .Values.snapshotS3.image.registry }}/snapshot-s3:{{ include "kubeswift.imageTag" (dict "tag" .Values.snapshotS3.image.tag "appVersion" .Chart.AppVersion) }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -39,6 +39,16 @@ swiftletd:
       cpu: 2
       memory: 2Gi
 
+# snapshot-s3: the uploader/downloader image for the Tier C (s3 / object-storage)
+# snapshot backend. The controller passes this to the per-snapshot upload Job and
+# the per-restore download Job via the KUBESWIFT_SNAPSHOT_S3_IMAGE env var. No
+# separate workload is deployed for it; this only sets the image reference.
+snapshotS3:
+  image:
+    registry: ghcr.io/projectbeskar/kubeswift
+    # Same as controllerManager; use tag: latest for local build+load.
+    tag: latest
+
 # GPU discovery DaemonSet: auto-discovers GPU hardware on nodes labeled kubeswift.io/gpu-node=true.
 # Populates SwiftGPUNode status with GPU inventory, NUMA topology, and Fabric Manager state.
 gpuDiscovery:

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -178,7 +178,7 @@ func main() {
 	if err = (&swiftsnapshot.SwiftSnapshotReconciler{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
-		SnapshotS3Image: os.Getenv("KUBESWIFT_SNAPSHOT_S3_IMAGE"),
+		SnapshotS3Image: swiftsnapshot.SnapshotS3Image(),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftSnapshot controller")
 		os.Exit(1)
@@ -187,7 +187,7 @@ func main() {
 	if err = (&swiftrestore.SwiftRestoreReconciler{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
-		SnapshotS3Image: os.Getenv("KUBESWIFT_SNAPSHOT_S3_IMAGE"),
+		SnapshotS3Image: swiftsnapshot.SnapshotS3Image(),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftRestore controller")
 		os.Exit(1)

--- a/config/samples/s3-snapshots/00-minio.yaml
+++ b/config/samples/s3-snapshots/00-minio.yaml
@@ -1,0 +1,64 @@
+# In-cluster MinIO for exercising the Tier C (s3) snapshot backend without an
+# external object store. NOT for production — single replica, emptyDir storage,
+# demo credentials. For production point spec.backend.s3.endpoint at your real
+# S3-compatible store (AWS S3, MinIO, Ceph RGW) and supply real credentials.
+#
+# After this is Running, create the bucket once (e.g. via the MinIO console at
+# the service's :9001 port, or `mc mb local/kubeswift-snapshots`). The snapshot
+# controller does NOT create the bucket.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: quay.io/minio/minio:latest
+          args: ["server", "/data", "--console-address", ":9001"]
+          env:
+            - name: MINIO_ROOT_USER
+              value: minioadmin
+            - name: MINIO_ROOT_PASSWORD
+              value: minioadmin
+          ports:
+            - containerPort: 9000
+              name: s3
+            - containerPort: 9001
+              name: console
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: minio
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: s3
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001

--- a/config/samples/s3-snapshots/01-s3-creds.yaml
+++ b/config/samples/s3-snapshots/01-s3-creds.yaml
@@ -1,0 +1,22 @@
+# S3 credentials Secret, referenced by spec.backend.s3.credentialsSecretRef on
+# the SwiftSnapshot. Must live in the SAME namespace as the SwiftSnapshot /
+# SwiftRestore. Keys:
+#   accessKeyId      (required)
+#   secretAccessKey  (required)
+#   sessionToken     (optional — for temporary STS credentials)
+#
+# These demo values match the MinIO root user in 00-minio.yaml. Replace with
+# real, least-privilege credentials for production (the IAM principal needs
+# s3:PutObject / s3:GetObject / s3:ListBucket on the bucket+prefix only).
+#
+# The credentials are surfaced to the upload/download Jobs as the standard
+# AWS_* environment variables — never written to annotations, logs, or status.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-creds
+  namespace: default
+type: Opaque
+stringData:
+  accessKeyId: minioadmin
+  secretAccessKey: minioadmin

--- a/config/samples/s3-snapshots/02-source-guest.yaml
+++ b/config/samples/s3-snapshots/02-source-guest.yaml
@@ -1,0 +1,32 @@
+# Source SwiftGuest for the Tier C (s3) snapshot round-trip.
+#
+# Reuses the snapshot-local-test-seed SwiftSeedProfile (config/samples/
+# local-snapshots/01-seed-profile.yaml) so a clone restored from this
+# snapshot regenerates machine-id / SSH host keys / hostname on its first
+# reboot — apply that seed profile first.
+#
+# SwiftGuestClass first so the guest's resolver finds it on the first
+# reconcile.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestClass
+metadata:
+  name: snapshot-s3-class
+spec:
+  cpu: 2
+  memory: "2Gi"
+  rootDisk:
+    size: "10Gi"
+    format: raw
+---
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: snapshot-s3-source
+spec:
+  imageRef:
+    name: ubuntu-noble
+  guestClassRef:
+    name: snapshot-s3-class
+  seedProfileRef:
+    name: snapshot-local-test-seed
+  runPolicy: Running

--- a/config/samples/s3-snapshots/03-snapshot.yaml
+++ b/config/samples/s3-snapshots/03-snapshot.yaml
@@ -1,0 +1,34 @@
+# Tier C (s3) SwiftSnapshot of snapshot-s3-source.
+#
+# Capture-then-upload: the launcher captures the VM state node-locally
+# (exactly like Tier B, into a controller-derived dir under
+# /var/lib/kubeswift/snapshots/) and then a node-pinned upload Job pushes the
+# artifacts to object storage. Phases: Pending -> Capturing -> Uploading ->
+# Ready. status.s3.location records the s3:// URI on Ready.
+#
+# includeMemory: true captures RAM (the upload then includes memory-ranges).
+# Set false for a disk-only export.
+#
+# The bucket must already exist; prefix is optional (objects land at
+# <prefix>/<namespace>/<snapshot>/). endpoint + forcePathStyle target MinIO;
+# drop both and set a real region for AWS S3.
+apiVersion: snapshot.kubeswift.io/v1alpha1
+kind: SwiftSnapshot
+metadata:
+  name: snapshot-s3-mem
+  namespace: default
+spec:
+  guestRef:
+    name: snapshot-s3-source
+  backend:
+    type: s3
+    s3:
+      bucket: kubeswift-snapshots
+      prefix: demo
+      endpoint: minio.minio.svc:9000
+      forcePathStyle: true
+      region: us-east-1
+      credentialsSecretRef:
+        name: s3-creds
+  includeMemory: true
+  resumeAfterSnapshot: true

--- a/config/samples/s3-snapshots/04-restore-clone.yaml
+++ b/config/samples/s3-snapshots/04-restore-clone.yaml
@@ -1,0 +1,35 @@
+# Cross-node clone restore from the Tier C (s3) snapshot.
+#
+# Because the artifacts live in object storage, this restore can land on ANY
+# node — set spec.targetNode to the node you want the clone to run on (here
+# "boba"; change to a node in your cluster). A node-pinned download Job pulls
+# the artifacts from S3 into that node's local cache, then the standard restore
+# path boots the clone. Phases: Pending -> Downloading -> Restoring ->
+# Resuming -> Ready.
+#
+# Different target name => clone path => macAddresses regeneration is REQUIRED
+# (two clones sharing a MAC collide on L2). The other identity items fire on
+# the clone's first reboot (CH --restore resumes byte-for-byte; cloud-init does
+# not re-run on resume — see docs/snapshots/identity-regeneration.md).
+#
+# For an IN-PLACE restore instead (same target name as the source), omit
+# spec.targetNode — it defaults to the source guest's current node — and set
+# targetGuest.overwriteExisting: true.
+apiVersion: snapshot.kubeswift.io/v1alpha1
+kind: SwiftRestore
+metadata:
+  name: snapshot-s3-clone
+  namespace: default
+spec:
+  snapshotRef:
+    name: snapshot-s3-mem
+  targetGuest:
+    name: snapshot-s3-clone            # different from source => clone
+  targetNode: boba                     # pin the restore to this node (s3 only)
+  resumeAfterRestore: true
+  identity:
+    regenerate:
+      - macAddresses                   # required for clones (L2 collision)
+      - hostname
+      - machineId
+      - sshHostKeys

--- a/docs/snapshots/s3-snapshots.md
+++ b/docs/snapshots/s3-snapshots.md
@@ -1,0 +1,161 @@
+# S3 Snapshots (Tier C)
+
+Tier C exports a full VM snapshot (disk + optionally memory) to an
+**S3-compatible object store** and restores it back **on any node, any
+cluster**. This is the cluster-portable, off-cluster-durable backup tier.
+
+Use Tier C when:
+
+- You want backups that survive the loss of the capture node (Tier B
+  snapshots live on one node's hostPath; if that node dies, the snapshot
+  is gone).
+- You want to restore onto a *different* node than the one that captured —
+  e.g. clone a golden VM across the cluster, or recover after a node
+  failure.
+- You want off-cluster durability (object storage outlives the cluster).
+
+For same-node memory snapshots with the lowest capture overhead, use
+`backend: local` (Tier B — [local-snapshots.md](local-snapshots.md)). For
+disk-only CSI snapshots, use `backend: csi-volume-snapshot` (Tier A —
+[csi-snapshots.md](csi-snapshots.md)).
+
+## How it works
+
+Tier C is **capture-then-upload, download-then-restore**. It reuses the Tier
+B node-local capture machinery and adds an object-storage hop on each side:
+
+```
+CAPTURE (SwiftSnapshot, backend.type: s3)
+  Pending ──▶ Capturing ──▶ Uploading ──▶ Ready
+              (launcher      (node-pinned    (status.s3.location
+               captures to    upload Job      = s3://bucket/key/)
+               node cache)    → S3)
+
+RESTORE (SwiftRestore from an s3-backed SwiftSnapshot)
+  Pending ──▶ Downloading ──▶ Restoring ──▶ Resuming ──▶ Ready
+              (node-pinned     (existing Tier B path: stamp/clone the
+               download Job     target SwiftGuest, CH --restore from the
+               → node cache)    node cache, resume)
+```
+
+S3 is the only cross-node layer. The capture's node-local cache and the
+restore's node-local cache are staging dirs under
+`/var/lib/kubeswift/snapshots/<namespace>-<name>/` — the durable copy is in
+the bucket. The upload Job pins to the capture node (where the artifacts were
+written); the download Job pins to the **restore-target node** (where CH will
+`--restore`).
+
+### Object layout
+
+Artifacts land under `<prefix>/<namespace>/<snapshot>/` in the bucket:
+
+```
+demo/default/snapshot-s3-mem/
+  config.json          # CH's view of the VM
+  state.json           # CPU/device/regs
+  memory-ranges        # serialized RAM (only when includeMemory: true)
+  manifest.json        # sha256 + size of every artifact — written LAST
+```
+
+`manifest.json` is the upload-complete sentinel and the restore's source of
+truth: it is uploaded last (so a partial upload is detectable) and the
+download Job verifies every artifact's sha256 + size against it before the
+restore proceeds. A checksum or size mismatch fails the download loudly.
+
+## Prerequisites
+
+1. **An S3-compatible object store** reachable from the cluster — AWS S3,
+   MinIO, or Ceph RGW. For a quick in-cluster test store, apply
+   [`config/samples/s3-snapshots/00-minio.yaml`](../../config/samples/s3-snapshots/00-minio.yaml)
+   (demo-grade: single replica, emptyDir, `minioadmin`/`minioadmin`).
+2. **The bucket must already exist** — the controller does not create it.
+3. **A credentials Secret** in the SwiftSnapshot's namespace with keys
+   `accessKeyId`, `secretAccessKey`, and optional `sessionToken`
+   ([`01-s3-creds.yaml`](../../config/samples/s3-snapshots/01-s3-creds.yaml)).
+4. **The `snapshot-s3` image** must be configured on the controller via the
+   `KUBESWIFT_SNAPSHOT_S3_IMAGE` env var (the Helm chart / `make deploy` set
+   this). If unset, s3 snapshots fail with *"snapshot-s3 image not
+   configured"*.
+
+## Quick start
+
+```bash
+# In-cluster test store (skip if you have a real S3 endpoint).
+kubectl apply -f config/samples/s3-snapshots/00-minio.yaml
+# create the bucket once, e.g. via the MinIO console (:9001) or mc:
+#   mc alias set local http://minio.minio.svc:9000 minioadmin minioadmin
+#   mc mb local/kubeswift-snapshots
+
+kubectl apply -f config/samples/local-snapshots/01-seed-profile.yaml   # shared seed
+kubectl apply -f config/samples/s3-snapshots/01-s3-creds.yaml
+kubectl apply -f config/samples/s3-snapshots/02-source-guest.yaml
+# wait for snapshot-s3-source to reach Running, then:
+kubectl apply -f config/samples/s3-snapshots/03-snapshot.yaml
+# watch: Pending -> Capturing -> Uploading -> Ready
+kubectl get swiftsnapshot snapshot-s3-mem -w
+
+# cross-node clone restore (edit spec.targetNode to a node in your cluster):
+kubectl apply -f config/samples/s3-snapshots/04-restore-clone.yaml
+# watch: Pending -> Downloading -> Restoring -> Resuming -> Ready
+kubectl get swiftrestore snapshot-s3-clone -w
+```
+
+## Cross-node restore and `spec.targetNode`
+
+`SwiftRestore.spec.targetNode` pins the node the restore lands on. It is only
+consulted for the s3 backend (Tier A/B ignore it):
+
+- **Clone / cross-node restore** (target name ≠ source): `targetNode` is
+  **required** — the target guest doesn't exist yet, so there's no node to
+  infer. The download Job and the restore-receive launcher both run there.
+- **In-place restore** (target name = source): `targetNode` is optional; when
+  omitted it defaults to the source guest's current node.
+
+Without a resolvable node the restore fails fast with *"s3 restore requires
+spec.targetNode"*.
+
+## Identity on clones
+
+Same as Tier B: CH `--restore` resumes the captured guest **byte-for-byte** —
+cloud-init does not re-run, so a clone inherits the source's machine-id, SSH
+host keys, hostname, and guest-visible MAC. `spec.identity.regenerate`
+**must** include `macAddresses` for clones (the hypervisor rewrites the clone
+MAC to avoid an L2 collision); the other items regenerate on the clone's first
+reboot via the seed profile's bootcmd. See
+[identity-regeneration.md](identity-regeneration.md).
+
+## Security
+
+- **Credentials live in a Secret**, surfaced to the upload/download Jobs as the
+  standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`
+  env vars. They are never written to annotations, logs, or status. Grant the
+  IAM principal least privilege: `s3:PutObject` / `s3:GetObject` /
+  `s3:ListBucket` scoped to the bucket + prefix.
+- **The upload Job** mounts the snapshot dir **read-only** and runs as the
+  image's non-root uid.
+- **The download Job** runs **as root** — it must write the kubelet-created,
+  root-owned node-local cache hostPath (`DirectoryOrCreate`, mode 0755). It is
+  otherwise maximally constrained: drop `ALL` capabilities, no privilege
+  escalation, read-only root filesystem, and the hostPath mount exposes only
+  the single snapshot directory.
+- **Encryption** is the object store's responsibility (SSE on the bucket).
+  KubeSwift does not encrypt artifacts client-side in Phase 3.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| SwiftSnapshot stuck `Pending`, event *"snapshot-s3 image not configured"* | `KUBESWIFT_SNAPSHOT_S3_IMAGE` unset on the controller. Redeploy via Helm / `make deploy`. |
+| Upload/download Job pod `ImagePullBackOff` / `401` | The `snapshot-s3` ghcr package is private, or your registry needs an imagePullSecret. Publicize the package (one-time) or add a pull secret. |
+| Upload Job `Error`, logs show `NoSuchBucket` | The bucket doesn't exist — create it first (the controller doesn't). |
+| Restore `Failed`, *"s3 restore requires spec.targetNode"* | Clone restore without `spec.targetNode`. Set it to the target node. |
+| Download Job `Error`, *"checksum mismatch"* / *"size mismatch"* | Corrupted or partial object. The manifest verification is doing its job — re-run the snapshot. |
+| Restore `Failed`, *"has no status.s3"* | The source SwiftSnapshot never finished uploading (not `Ready`). |
+| MinIO: upload fails with a host/addressing error | Set `forcePathStyle: true` (MinIO / Ceph RGW require path-style addressing). |
+
+## Cluster walkthrough
+
+<!-- Populated after the cluster MinIO round-trip validation (PR 5). -->
+_Empirical round-trip validation (source on one node → s3 snapshot → clone
+restore on another node, sentinel survives) is recorded here after the
+cluster run._

--- a/internal/controller/swiftsnapshot/s3.go
+++ b/internal/controller/swiftsnapshot/s3.go
@@ -10,6 +10,7 @@ package swiftsnapshot
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -23,6 +24,26 @@ import (
 
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
 )
+
+// SnapshotS3ImageEnv overrides the snapshot-s3 uploader/downloader image used
+// by the Tier C (s3) upload + download Jobs.
+const SnapshotS3ImageEnv = "KUBESWIFT_SNAPSHOT_S3_IMAGE"
+
+// SnapshotS3ImageDefault is the fallback when SnapshotS3ImageEnv is unset (the
+// Helm chart overrides it with a version-pinned tag). Mirrors swiftguest's
+// LauncherImage pattern so a chart-less deploy (make deploy / kustomize) still
+// resolves a usable image rather than failing "image not configured".
+const SnapshotS3ImageDefault = "ghcr.io/projectbeskar/kubeswift/snapshot-s3:latest"
+
+// SnapshotS3Image returns the snapshot-s3 image, from SnapshotS3ImageEnv or
+// SnapshotS3ImageDefault. Used to populate the SwiftSnapshot and SwiftRestore
+// reconcilers' SnapshotS3Image field.
+func SnapshotS3Image() string {
+	if img := os.Getenv(SnapshotS3ImageEnv); img != "" {
+		return img
+	}
+	return SnapshotS3ImageDefault
+}
 
 // ensureUploadJob creates the node-pinned upload Job (idempotent) owned by the
 // SwiftSnapshot. Fails if the snapshot-s3 image is not configured.

--- a/internal/controller/swiftsnapshot/s3_test.go
+++ b/internal/controller/swiftsnapshot/s3_test.go
@@ -173,3 +173,14 @@ func TestHandleUploading(t *testing.T) {
 		}
 	})
 }
+
+func TestSnapshotS3Image_Resolver(t *testing.T) {
+	t.Setenv(SnapshotS3ImageEnv, "")
+	if got := SnapshotS3Image(); got != SnapshotS3ImageDefault {
+		t.Errorf("unset env: got %q, want default %q", got, SnapshotS3ImageDefault)
+	}
+	t.Setenv(SnapshotS3ImageEnv, "ghcr.io/x/snapshot-s3:pinned")
+	if got := SnapshotS3Image(); got != "ghcr.io/x/snapshot-s3:pinned" {
+		t.Errorf("set env: got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 closeout for the Tier C (s3 / object-storage) snapshot backend. Ships
the operator-facing surface **and** fixes a deployment-wiring gap that would
have made the feature fail on any real cluster.

### Shipping fix — the W5 catch 🐛

`KUBESWIFT_SNAPSHOT_S3_IMAGE` was read by `main.go` (PRs #114/#115) but **set by
no deployment manifest and had no default** — so s3 snapshots/restores would
fail *"snapshot-s3 image not configured"* on every deployed cluster. The
prep-for-walkthrough recon caught it before the cluster did (unit tests pass an
explicit image; only the deploy path exercises the env). Fixed by mirroring the
launcher-image pattern:

- `swiftsnapshot.SnapshotS3Image()` resolver = env override + a
  `SnapshotS3ImageDefault` fallback (so a chart-less `make deploy` / kustomize
  still resolves a usable image).
- `main.go` uses the resolver for **both** the SwiftSnapshot and SwiftRestore
  reconcilers.
- Helm chart sets `KUBESWIFT_SNAPSHOT_S3_IMAGE` (version-pinned via the
  `imageTag` helper) + a new `values.snapshotS3.image` section.

### Samples — `config/samples/s3-snapshots/`

| File | What |
|---|---|
| `00-minio.yaml` | in-cluster MinIO test store (demo-grade) |
| `01-s3-creds.yaml` | Secret with `accessKeyId` / `secretAccessKey` |
| `02-source-guest.yaml` | source SwiftGuest + class |
| `03-snapshot.yaml` | `backend.type: s3` → capture-then-upload |
| `04-restore-clone.yaml` | cross-node clone via `spec.targetNode` → download-then-restore |

### Runbook — `docs/snapshots/s3-snapshots.md`

When to use Tier C, the capture-then-upload / download-then-restore flow, object
layout + `manifest.json` verification, prerequisites, quick-start,
`spec.targetNode` semantics, identity-on-clones, the security model
(creds-in-Secret; upload read-only/non-root vs download root-rationale), and a
troubleshooting table. A **Cluster walkthrough** section is reserved for the
live round-trip findings.

## Tests

- `SnapshotS3Image()` resolver (env-set vs default).
- Full suite + vet green; `helm template` renders the new env
  (`snapshot-s3:v0.1.0`).

## ⚠️ Live round-trip pending two prerequisites

The cluster MinIO round-trip (source on node A → s3 snapshot → clone restore on
node B → sentinel survives) is **not yet run** — it needs:

1. The post-#115 **controller image** to finish its CI build (the deployed
   controller is still pre-#114).
2. The **`snapshot-s3` ghcr package made public** — it was created private
   (GitHub's default), the same one-time web-UI step every new kubeswift image
   needs (**TFU #26**). Until then the upload/download Jobs `ImagePullBackOff`.

I'll run the round-trip and append findings to the runbook's walkthrough section
once both clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)