### PR TITLE
fix(snapshots): s3 Tier C — upload-as-root + insecure endpoint (cluster-walkthrough fixes)

### DIFF
--- a/api/snapshot/v1alpha1/swiftsnapshot_types.go
+++ b/api/snapshot/v1alpha1/swiftsnapshot_types.go
@@ -75,6 +75,12 @@ type S3Backend struct {
 	// host) — typically required by MinIO / Ceph RGW.
 	// +optional
 	ForcePathStyle bool `json:"forcePathStyle,omitempty"`
+	// Insecure allows a plaintext (http) endpoint instead of TLS. UNSAFE —
+	// credentials and snapshot bytes traverse the network unencrypted. Use only
+	// for an in-cluster MinIO / test store on a trusted network. Production S3
+	// (AWS, TLS-fronted MinIO/RGW) must leave this false.
+	// +optional
+	Insecure bool `json:"insecure,omitempty"`
 	// CredentialsSecretRef references a Secret (same namespace) with keys
 	// accessKeyId, secretAccessKey, and optional sessionToken.
 	CredentialsSecretRef *SecretObjectReference `json:"credentialsSecretRef,omitempty"`

--- a/charts/kubeswift/crds/snapshot.kubeswift.io_swiftsnapshots.yaml
+++ b/charts/kubeswift/crds/snapshot.kubeswift.io_swiftsnapshots.yaml
@@ -106,6 +106,13 @@ spec:
                           ForcePathStyle uses path-style addressing (bucket in the path, not the
                           host) — typically required by MinIO / Ceph RGW.
                         type: boolean
+                      insecure:
+                        description: |-
+                          Insecure allows a plaintext (http) endpoint instead of TLS. UNSAFE —
+                          credentials and snapshot bytes traverse the network unencrypted. Use only
+                          for an in-cluster MinIO / test store on a trusted network. Production S3
+                          (AWS, TLS-fronted MinIO/RGW) must leave this false.
+                        type: boolean
                       prefix:
                         description: |-
                           Prefix is an optional key prefix; objects land at

--- a/config/crd/bases/snapshot.kubeswift.io_swiftsnapshots.yaml
+++ b/config/crd/bases/snapshot.kubeswift.io_swiftsnapshots.yaml
@@ -106,6 +106,13 @@ spec:
                           ForcePathStyle uses path-style addressing (bucket in the path, not the
                           host) — typically required by MinIO / Ceph RGW.
                         type: boolean
+                      insecure:
+                        description: |-
+                          Insecure allows a plaintext (http) endpoint instead of TLS. UNSAFE —
+                          credentials and snapshot bytes traverse the network unencrypted. Use only
+                          for an in-cluster MinIO / test store on a trusted network. Production S3
+                          (AWS, TLS-fronted MinIO/RGW) must leave this false.
+                        type: boolean
                       prefix:
                         description: |-
                           Prefix is an optional key prefix; objects land at

--- a/config/samples/s3-snapshots/03-snapshot.yaml
+++ b/config/samples/s3-snapshots/03-snapshot.yaml
@@ -27,6 +27,7 @@ spec:
       prefix: demo
       endpoint: minio.minio.svc:9000
       forcePathStyle: true
+      insecure: true            # demo MinIO serves plain HTTP; UNSAFE — drop for TLS endpoints
       region: us-east-1
       credentialsSecretRef:
         name: s3-creds

--- a/docs/snapshots/s3-snapshots.md
+++ b/docs/snapshots/s3-snapshots.md
@@ -131,13 +131,15 @@ reboot via the seed profile's bootcmd. See
   env vars. They are never written to annotations, logs, or status. Grant the
   IAM principal least privilege: `s3:PutObject` / `s3:GetObject` /
   `s3:ListBucket` scoped to the bucket + prefix.
-- **The upload Job** mounts the snapshot dir **read-only** and runs as the
-  image's non-root uid.
-- **The download Job** runs **as root** — it must write the kubelet-created,
-  root-owned node-local cache hostPath (`DirectoryOrCreate`, mode 0755). It is
-  otherwise maximally constrained: drop `ALL` capabilities, no privilege
-  escalation, read-only root filesystem, and the hostPath mount exposes only
-  the single snapshot directory.
+- **Both Jobs run as root**, because both operate on the **root-owned `0600`**
+  snapshot artifacts (the capture writes `config.json` / `state.json` /
+  `memory-ranges` as root with restrictive perms — they contain serialized
+  guest RAM). The upload Job must *read* them (a read-only mount doesn't help —
+  read-only constrains writes, not the files' own mode bits); the download Job
+  must *write* the kubelet-created, root-owned node-local cache hostPath. Both
+  are otherwise maximally constrained: drop `ALL` capabilities, no privilege
+  escalation, read-only root filesystem, and the hostPath mount exposes only the
+  single snapshot directory.
 - **Encryption** is the object store's responsibility (SSE on the bucket).
   KubeSwift does not encrypt artifacts client-side in Phase 3.
 
@@ -152,10 +154,44 @@ reboot via the seed profile's bootcmd. See
 | Download Job `Error`, *"checksum mismatch"* / *"size mismatch"* | Corrupted or partial object. The manifest verification is doing its job — re-run the snapshot. |
 | Restore `Failed`, *"has no status.s3"* | The source SwiftSnapshot never finished uploading (not `Ready`). |
 | MinIO: upload fails with a host/addressing error | Set `forcePathStyle: true` (MinIO / Ceph RGW require path-style addressing). |
+| Upload/download fails *"server gave HTTP response to HTTPS client"* | The endpoint speaks plain HTTP but the client defaulted to TLS. Set `spec.backend.s3.insecure: true` (UNSAFE — trusted-network in-cluster MinIO only) or front the store with TLS. |
 
 ## Cluster walkthrough
 
-<!-- Populated after the cluster MinIO round-trip validation (PR 5). -->
-_Empirical round-trip validation (source on one node → s3 snapshot → clone
-restore on another node, sentinel survives) is recorded here after the
-cluster run._
+Validated on the dev cluster (k0s 1.34, CH v51.1, in-cluster MinIO) with a 2Gi
+rocky9 memory snapshot. Source guest on **boba**, restore target **miles**
+(cross-node). The walkthrough caught **two real bugs** that unit tests
+structurally cannot (the recurring "W5 pattern" — fake-client tests verify
+control flow, not on-cluster kubelet/filesystem/network behavior); both are
+fixed in this PR:
+
+1. **Upload Job permission-denied.** The capture writes the snapshot artifacts
+   as **root, mode `0600`** (they contain serialized guest RAM). The upload Job
+   was running as the image's non-root uid and got `open /snap/config.json:
+   permission denied` — a read-only mount does not grant read access to a file
+   whose own mode bits exclude `other`. **Fix:** the upload Job runs as root
+   (mirroring the download Job), still drop-`ALL` / no-priv-esc / ro-rootfs.
+
+2. **HTTPS-vs-HTTP against plaintext MinIO.** The `snapshot-s3` client defaulted
+   to TLS; the demo MinIO serves plain HTTP → `server gave HTTP response to
+   HTTPS client`. **Fix:** `spec.backend.s3.insecure: true` plumbs `--insecure`
+   through to both Jobs (UNSAFE — trusted-network in-cluster store only).
+
+Empirical results after the fixes (run as standalone Jobs to validate the
+data path independently of the controller image):
+
+| Step | Result |
+|---|---|
+| Capture (boba) | `Capturing → Uploading`, artifacts written to the node-local cache |
+| Upload → MinIO | **SUCCEEDED** — `config.json` + `state.json` + 2GiB `memory-ranges` + `manifest.json` (uploaded last) landed under `demo/default/snapshot-s3-mem/` |
+| manifest.json | well-formed: per-artifact sha256 + size, `totalBytes: 2147549372` |
+| Download → miles (cross-node) | **SUCCEEDED** — all 3 artifacts pulled and **sha256-verified** against the manifest (`got memory-ranges … verified`) |
+
+The s3-specific data movement (capture → upload → cross-node download +
+checksum verification) is validated end-to-end. The restore *orchestration*
+that follows the download (materialize the target SwiftGuest → restore-receive
+launcher → `CH --restore` → resume) is the **shared Tier B path** already
+validated in the local-snapshot walkthroughs; a state sentinel
+(`S3-ROUNDTRIP-…`, md5 `a6deb3ca…`) was written into the source guest before
+capture for that final boot-and-verify step, which completes once a controller
+image carrying these two fixes is deployed.

--- a/internal/controller/swiftrestore/s3.go
+++ b/internal/controller/swiftrestore/s3.go
@@ -273,6 +273,9 @@ func buildDownloadJob(restore *snapshotv1alpha1.SwiftRestore, snap *snapshotv1al
 	if s3.ForcePathStyle {
 		args = append(args, "--path-style")
 	}
+	if s3.Insecure {
+		args = append(args, "--insecure")
+	}
 	if snap.Spec.IncludeMemory {
 		args = append(args, "--include-memory")
 	}

--- a/internal/controller/swiftrestore/s3_test.go
+++ b/internal/controller/swiftrestore/s3_test.go
@@ -107,6 +107,7 @@ func TestBuildDownloadJob(t *testing.T) {
 	snap := s3ReadySnap("snap1", "team-a", "g1")
 	snap.Spec.Backend.S3.Endpoint = "minio.svc:9000"
 	snap.Spec.Backend.S3.ForcePathStyle = true
+	snap.Spec.Backend.S3.Insecure = true
 	snap.Spec.IncludeMemory = true
 	job := buildDownloadJob(s3Restore("r1", "team-a", "snap1", "g1", "boba"), snap, "ghcr.io/x/snapshot-s3:t", "boba")
 	pod := job.Spec.Template.Spec
@@ -132,7 +133,7 @@ func TestBuildDownloadJob(t *testing.T) {
 	// args carry download mode + derived prefix + flags.
 	a := strings.Join(c.Args, " ")
 	for _, want := range []string{"--mode=download", "--bucket=backups", "--key-prefix=kubeswift/team-a/snap1",
-		"--region=us-east-1", "--endpoint=minio.svc:9000", "--path-style", "--include-memory"} {
+		"--region=us-east-1", "--endpoint=minio.svc:9000", "--path-style", "--insecure", "--include-memory"} {
 		if !strings.Contains(a, want) {
 			t.Errorf("args missing %q; got %q", want, a)
 		}

--- a/internal/controller/swiftsnapshot/s3.go
+++ b/internal/controller/swiftsnapshot/s3.go
@@ -165,6 +165,9 @@ func buildUploadJob(snap *snapshotv1alpha1.SwiftSnapshot, image, captureNode str
 	if s3.ForcePathStyle {
 		args = append(args, "--path-style")
 	}
+	if s3.Insecure {
+		args = append(args, "--insecure")
+	}
 	if snap.Spec.IncludeMemory {
 		args = append(args, "--include-memory")
 	}
@@ -216,9 +219,19 @@ func buildUploadJob(snap *snapshotv1alpha1.SwiftSnapshot, image, captureNode str
 							MountPath: s3UploadMount,
 							ReadOnly:  true,
 						}},
+						// Runs as root: the capture writes the snapshot artifacts
+						// (config.json, state.json, memory-ranges) as root with
+						// mode 0600 — they contain serialized guest RAM, so the
+						// restrictive perms are deliberate — and a non-root upload
+						// container cannot read them even via a read-only mount
+						// (read-only constrains writes, not the file's own mode
+						// bits). Mirrors the download Job. Otherwise maximally
+						// constrained: drop ALL, no privilege escalation, read-only
+						// rootfs; the mount exposes only the single snapshot dir.
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.To(false),
-							RunAsNonRoot:             ptr.To(true),
+							RunAsUser:                ptr.To(int64(0)),
+							RunAsNonRoot:             ptr.To(false),
 							ReadOnlyRootFilesystem:   ptr.To(true),
 							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 						},

--- a/internal/controller/swiftsnapshot/s3_test.go
+++ b/internal/controller/swiftsnapshot/s3_test.go
@@ -59,6 +59,7 @@ func TestBuildUploadJob_Pinning_Mount_Creds(t *testing.T) {
 		s.Spec.Backend.S3.Region = "us-east-1"
 		s.Spec.Backend.S3.Endpoint = "minio.svc:9000"
 		s.Spec.Backend.S3.ForcePathStyle = true
+		s.Spec.Backend.S3.Insecure = true
 	})
 	job := buildUploadJob(s, "ghcr.io/x/snapshot-s3:t", "boba")
 	pod := job.Spec.Template.Spec
@@ -84,7 +85,7 @@ func TestBuildUploadJob_Pinning_Mount_Creds(t *testing.T) {
 	// args carry the derived prefix + flags.
 	a := strings.Join(c.Args, " ")
 	for _, want := range []string{"--mode=upload", "--bucket=backups", "--key-prefix=kubeswift/team-a/snap1",
-		"--region=us-east-1", "--endpoint=minio.svc:9000", "--path-style", "--include-memory", "--snapshot=team-a/snap1"} {
+		"--region=us-east-1", "--endpoint=minio.svc:9000", "--path-style", "--insecure", "--include-memory", "--snapshot=team-a/snap1"} {
 		if !strings.Contains(a, want) {
 			t.Errorf("args missing %q; got %q", want, a)
 		}
@@ -107,11 +108,14 @@ func TestBuildUploadJob_Pinning_Mount_Creds(t *testing.T) {
 		}
 	}
 
-	// hardened container.
+	// Runs as root (must read the root-owned 0600 snapshot artifacts) but
+	// otherwise hardened: drop ALL, no priv-esc, ro-rootfs.
 	sc := c.SecurityContext
-	if sc == nil || sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot || sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem ||
+	if sc == nil || sc.RunAsUser == nil || *sc.RunAsUser != 0 ||
+		sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem ||
+		sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation ||
 		len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != "ALL" {
-		t.Errorf("upload container must be hardened (non-root, ro-rootfs, drop ALL); got %+v", sc)
+		t.Errorf("upload container must run as root with drop ALL / no-priv-esc / ro-rootfs; got %+v", sc)
 	}
 }
 
@@ -120,7 +124,7 @@ func TestBuildUploadJob_OptionalFlagsOmitted(t *testing.T) {
 	s := s3Snap("snap1", "ns", nil)
 	job := buildUploadJob(s, "img", "miles")
 	a := strings.Join(job.Spec.Template.Spec.Containers[0].Args, " ")
-	for _, absent := range []string{"--region", "--endpoint", "--path-style", "--include-memory"} {
+	for _, absent := range []string{"--region", "--endpoint", "--path-style", "--insecure", "--include-memory"} {
 		if strings.Contains(a, absent) {
 			t.Errorf("flag %q should be omitted when unset; got %q", absent, a)
 		}


### PR DESCRIPTION
## Summary

The Phase 3 PR 5 cluster MinIO round-trip surfaced **two real bugs** that unit
tests structurally cannot catch (the recurring **W5 pattern** — fake-client
tests verify control flow, not on-cluster kubelet/filesystem/network behavior).
Both validated and fixed against a 2Gi rocky9 memory snapshot, **boba → miles**
cross-node.

### Bug 1 — upload Job permission-denied 🐛

The capture writes `config.json` / `state.json` / `memory-ranges` as **root,
mode `0600`** (they hold serialized guest RAM — restrictive perms are
deliberate). The upload Job ran as the image's non-root uid →
`open /snap/config.json: permission denied`. A read-only mount does **not**
grant read access to a file whose own mode bits exclude `other` — my earlier
*"upload mounts read-only so it can stay non-root"* reasoning (PR #114) was
wrong.

**Fix:** the upload Job runs as **root** (mirroring the download Job), still
drop-`ALL` / no-priv-esc / ro-rootfs / single-snapshot-dir mount.

### Bug 2 — HTTPS-vs-HTTP against plaintext MinIO 🐛

The `snapshot-s3` client defaulted to TLS; an HTTP-only endpoint (in-cluster
MinIO) failed with `server gave HTTP response to HTTPS client`. The binary
already had an `--insecure` flag but the **controller never passed it**.

**Fix:** new `spec.backend.s3.insecure` bool plumbs `--insecure` through both
the upload and download Job builders (UNSAFE — trusted-network in-cluster store
only; documented as such).

## Empirical cluster validation

Standalone Jobs (to exercise the data path independent of the controller image):

| Step | Result |
|---|---|
| upload boba → MinIO | ✅ `config.json` + `state.json` + 2GiB `memory-ranges` + `manifest.json` (last) under `demo/default/snapshot-s3-mem/` |
| manifest.json | per-artifact sha256 + size, `totalBytes: 2147549372` |
| download MinIO → **miles** (cross-node) | ✅ all 3 artifacts **sha256-verified** (`got memory-ranges … verified`) |

The s3-specific data movement (capture → upload → cross-node download + checksum
verify) is validated **end-to-end**. The restore orchestration *after* the
download is the **shared Tier B path** (already validated in the local-snapshot
walkthroughs); a sentinel was written pre-capture for the final boot-verify,
which completes once a controller image carrying these fixes is deployed.

## Changes

- `api/.../swiftsnapshot_types.go`: `S3Backend.Insecure` (CRD `generate` + chart sync).
- `swiftsnapshot/s3.go`: upload Job → root SC; `--insecure` when set.
- `swiftrestore/s3.go`: `--insecure` when set (download already runs as root since #115).
- Tests: upload runs-as-root; `--insecure` present-when-set / absent-when-unset (both Jobs).
- `docs/snapshots/s3-snapshots.md`: security note corrected, troubleshooting row, **Cluster walkthrough** findings; MinIO sample sets `insecure: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)