### PR TITLE
fix(snapshots): s3 upload idempotency must be checksum-aware, not size-only

### DIFF
--- a/cmd/snapshot-s3/manifest.go
+++ b/cmd/snapshot-s3/manifest.go
@@ -89,6 +89,13 @@ func fileSHA256(path string) (string, int64, error) {
 	return hex.EncodeToString(h.Sum(nil)), n, nil
 }
 
+// sha256Hex returns the hex sha256 of an in-memory byte slice (used for the
+// manifest object's own content-hash metadata).
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
 // verifyArtifact checks a file under dir against its manifest entry (size +
 // sha256). Returns a descriptive error on any mismatch or read failure.
 func verifyArtifact(dir string, a Artifact) error {

--- a/cmd/snapshot-s3/store.go
+++ b/cmd/snapshot-s3/store.go
@@ -13,12 +13,22 @@ import (
 // objectStore is the minimal S3 surface snapshot-s3 needs. It is an interface so
 // the upload/download orchestration is unit-testable with an in-memory fake.
 type objectStore interface {
-	// stat returns the object's size; ok=false (nil err) when it does not exist.
-	stat(ctx context.Context, key string) (size int64, ok bool, err error)
-	put(ctx context.Context, key string, r io.Reader, size int64) error
+	// stat returns the object's size and the sha256 recorded as user metadata at
+	// upload time (empty if the object predates checksum metadata); ok=false
+	// (nil err) when the object does not exist.
+	stat(ctx context.Context, key string) (size int64, sha256 string, ok bool, err error)
+	// put writes the object and records sha256 as user metadata so a later
+	// upload can detect same-size-but-different-content (a memory-ranges file is
+	// always the same byte size as the guest RAM, so size alone cannot tell a
+	// stale object from a current one).
+	put(ctx context.Context, key string, r io.Reader, size int64, sha256 string) error
 	get(ctx context.Context, key string) (io.ReadCloser, error)
 	remove(ctx context.Context, key string) error
 }
+
+// objectSHA256MetaKey is the user-metadata key (sent as the x-amz-meta-sha256
+// header) that records an uploaded artifact's content hash.
+const objectSHA256MetaKey = "sha256"
 
 type minioStore struct {
 	client *minio.Client
@@ -53,22 +63,27 @@ func newMinioStore(endpoint, region, bucket string, pathStyle, secure bool) (*mi
 	return &minioStore{client: client, bucket: bucket}, nil
 }
 
-func (s *minioStore) stat(ctx context.Context, key string) (int64, bool, error) {
+func (s *minioStore) stat(ctx context.Context, key string) (int64, string, bool, error) {
 	info, err := s.client.StatObject(ctx, s.bucket, key, minio.StatObjectOptions{})
 	if err != nil {
 		if minio.ToErrorResponse(err).Code == "NoSuchKey" || minio.ToErrorResponse(err).StatusCode == 404 {
-			return 0, false, nil
+			return 0, "", false, nil
 		}
-		return 0, false, err
+		return 0, "", false, err
 	}
-	return info.Size, true, nil
+	// info.Metadata is the raw http.Header; Get is case-insensitive and handles
+	// the x-amz-meta- canonicalization regardless of minio-go's UserMetadata
+	// key-casing quirks.
+	sha := info.Metadata.Get("X-Amz-Meta-" + objectSHA256MetaKey)
+	return info.Size, sha, true, nil
 }
 
-func (s *minioStore) put(ctx context.Context, key string, r io.Reader, size int64) error {
+func (s *minioStore) put(ctx context.Context, key string, r io.Reader, size int64, sha256 string) error {
 	// minio-go streams and auto-multiparts large objects; size enables a
 	// single known-length transfer (use -1 for unknown).
 	_, err := s.client.PutObject(ctx, s.bucket, key, r, size, minio.PutObjectOptions{
-		ContentType: "application/octet-stream",
+		ContentType:  "application/octet-stream",
+		UserMetadata: map[string]string{objectSHA256MetaKey: sha256},
 	})
 	return err
 }

--- a/cmd/snapshot-s3/transfer.go
+++ b/cmd/snapshot-s3/transfer.go
@@ -26,8 +26,13 @@ func runUpload(ctx context.Context, store objectStore, srcDir, keyPrefix, snapNa
 
 	for _, a := range m.Artifacts {
 		key := path.Join(keyPrefix, a.Path)
-		if size, ok, serr := store.stat(ctx, key); serr == nil && ok && size == a.Bytes {
-			log.Printf("  skip %s (already uploaded, %d bytes)", a.Path, size)
+		// Resume only when the existing object matches BOTH size and content
+		// hash. Size alone is unsafe: a memory-ranges file is always exactly the
+		// guest's RAM size, so a stale object left at this key by a prior
+		// same-named snapshot would be silently kept while the manifest records
+		// the new hash — a permanent mismatch the restore then fails on.
+		if size, sha, ok, serr := store.stat(ctx, key); serr == nil && ok && size == a.Bytes && sha == a.SHA256 {
+			log.Printf("  skip %s (already uploaded, %d bytes, sha matches)", a.Path, size)
 			continue
 		}
 		f, err := os.Open(filepath.Join(srcDir, filepath.FromSlash(a.Path)))
@@ -35,7 +40,7 @@ func runUpload(ctx context.Context, store objectStore, srcDir, keyPrefix, snapNa
 			return fmt.Errorf("open artifact %q: %w", a.Path, err)
 		}
 		log.Printf("  put %s (%d bytes)", a.Path, a.Bytes)
-		err = store.put(ctx, key, f, a.Bytes)
+		err = store.put(ctx, key, f, a.Bytes, a.SHA256)
 		f.Close()
 		if err != nil {
 			return fmt.Errorf("upload artifact %q: %w", a.Path, err)
@@ -46,7 +51,7 @@ func runUpload(ctx context.Context, store objectStore, srcDir, keyPrefix, snapNa
 	if err != nil {
 		return err
 	}
-	if err := store.put(ctx, path.Join(keyPrefix, manifestObjectName), bytes.NewReader(data), int64(len(data))); err != nil {
+	if err := store.put(ctx, path.Join(keyPrefix, manifestObjectName), bytes.NewReader(data), int64(len(data)), sha256Hex(data)); err != nil {
 		return fmt.Errorf("upload manifest: %w", err)
 	}
 	log.Printf("snapshot-s3 upload complete: %s/%s", keyPrefix, manifestObjectName)

--- a/cmd/snapshot-s3/transfer_test.go
+++ b/cmd/snapshot-s3/transfer_test.go
@@ -13,25 +13,29 @@ import (
 // fakeStore is an in-memory objectStore for round-trip + idempotency tests.
 type fakeStore struct {
 	objs map[string][]byte
+	meta map[string]string // key -> recorded sha256 (mirrors x-amz-meta-sha256)
 	puts int
 	gets int
 }
 
-func newFakeStore() *fakeStore { return &fakeStore{objs: map[string][]byte{}} }
+func newFakeStore() *fakeStore {
+	return &fakeStore{objs: map[string][]byte{}, meta: map[string]string{}}
+}
 
-func (f *fakeStore) stat(_ context.Context, key string) (int64, bool, error) {
+func (f *fakeStore) stat(_ context.Context, key string) (int64, string, bool, error) {
 	b, ok := f.objs[key]
 	if !ok {
-		return 0, false, nil
+		return 0, "", false, nil
 	}
-	return int64(len(b)), true, nil
+	return int64(len(b)), f.meta[key], true, nil
 }
-func (f *fakeStore) put(_ context.Context, key string, r io.Reader, _ int64) error {
+func (f *fakeStore) put(_ context.Context, key string, r io.Reader, _ int64, sha256 string) error {
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}
 	f.objs[key] = data
+	f.meta[key] = sha256
 	f.puts++
 	return nil
 }
@@ -116,6 +120,43 @@ func TestUpload_IdempotentSkipsExisting(t *testing.T) {
 	}
 	if delta := store.puts - first; delta != 1 {
 		t.Errorf("re-upload should only re-put the manifest (1 put); got %d extra puts", delta)
+	}
+}
+
+// TestUpload_ReuploadsStaleSameSizeContent reproduces the cluster-walkthrough
+// bug: a memory-ranges file is always exactly the guest's RAM size, so a second
+// snapshot reusing the same key prefix (a deleted+recreated same-named snapshot)
+// with same-size-but-different-content must RE-UPLOAD it — a size-only resume
+// check would keep the stale object while the manifest records the new hash, and
+// the restore would then fail verification forever.
+func TestUpload_ReuploadsStaleSameSizeContent(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeStore()
+
+	// First snapshot at ns/snap.
+	src1, _ := seedSnapshotDir(t)
+	if err := runUpload(ctx, store, src1, "ns/snap", "ns/snap", false); err != nil {
+		t.Fatalf("first upload: %v", err)
+	}
+
+	// Second snapshot reusing the SAME key prefix: memory.img is the SAME 4096
+	// bytes but DIFFERENT content; config.json + root.raw are unchanged.
+	src2 := t.TempDir()
+	writeFile(t, src2, "config.json", []byte(`{"cpus":2}`))
+	writeFile(t, src2, "memory.img", bytes.Repeat([]byte("X"), 4096))
+	writeFile(t, src2, "disks/root.raw", bytes.Repeat([]byte("D"), 8192))
+	if err := runUpload(ctx, store, src2, "ns/snap", "ns/snap", false); err != nil {
+		t.Fatalf("second upload: %v", err)
+	}
+
+	// memory.img must now hold the NEW content (re-uploaded), not the stale "M".
+	if got := store.objs["ns/snap/memory.img"]; !bytes.Equal(got, bytes.Repeat([]byte("X"), 4096)) {
+		t.Fatalf("memory.img kept stale content; size-only skip not fixed (len=%d, first byte=%q)", len(got), got[0])
+	}
+	// And a fresh download must verify cleanly against the new manifest.
+	dst := t.TempDir()
+	if err := runDownload(ctx, store, dst, "ns/snap"); err != nil {
+		t.Fatalf("download after re-upload must verify clean: %v", err)
 	}
 }
 

--- a/docs/snapshots/s3-snapshots.md
+++ b/docs/snapshots/s3-snapshots.md
@@ -177,21 +177,42 @@ fixed in this PR:
    HTTPS client`. **Fix:** `spec.backend.s3.insecure: true` plumbs `--insecure`
    through to both Jobs (UNSAFE — trusted-network in-cluster store only).
 
-Empirical results after the fixes (run as standalone Jobs to validate the
-data path independently of the controller image):
+A third bug surfaced while re-running the full controller-driven flow (fixed in
+a follow-up PR):
+
+3. **Upload resume used size-only idempotency → stale content on key reuse.** A
+   `memory-ranges` file is always *exactly* the guest's RAM size, so when a
+   same-named snapshot was deleted and recreated (reusing the `<prefix>/<ns>/
+   <name>` key), the re-upload `stat`'d the old object, saw a matching size, and
+   **skipped** it — leaving capture #1's bytes in the bucket while the fresh
+   `manifest.json` recorded capture #2's hash. The cross-node download then
+   failed `verify memory-ranges: sha256 mismatch` forever. **Fix:** the upload
+   records each artifact's sha256 as object metadata and skips only when **size
+   AND sha256** match; same-size-different-content re-uploads.
+
+### Full controller-driven round-trip — VALIDATED ✅
+
+After deploying a controller image carrying all three fixes, the complete flow
+was driven entirely by the controllers (no manual Jobs):
 
 | Step | Result |
 |---|---|
-| Capture (boba) | `Capturing → Uploading`, artifacts written to the node-local cache |
-| Upload → MinIO | **SUCCEEDED** — `config.json` + `state.json` + 2GiB `memory-ranges` + `manifest.json` (uploaded last) landed under `demo/default/snapshot-s3-mem/` |
-| manifest.json | well-formed: per-artifact sha256 + size, `totalBytes: 2147549372` |
-| Download → miles (cross-node) | **SUCCEEDED** — all 3 artifacts pulled and **sha256-verified** against the manifest (`got memory-ranges … verified`) |
+| Sentinel written into source (boba) | `S3-RT-FULL-1780557632`, md5 `2b945b3e57ba25efd687bb370953eff0` |
+| SwiftSnapshot (s3) | `Pending → Capturing → Uploading → Ready` (~20s); `status.s3.location = s3://kubeswift-snapshots/demo/default/s3-clean/` |
+| MinIO objects | `config.json` + `state.json` + 2GiB `memory-ranges` + `manifest.json`, per-artifact sha256 |
+| SwiftRestore (`targetNode: miles`, clone) | `Pending → Downloading → Restoring → Resuming → Ready` |
+| Download → miles (cross-node) | all 3 artifacts **sha256-verified** against the manifest |
+| Clone guest | **Running on miles** (cross-node from boba), `GuestRunning=True` |
+| **Sentinel on the clone** | `S3-RT-FULL-1780557632`, md5 `2b945b3e57ba25efd687bb370953eff0` — **byte-identical** ✅ |
 
-The s3-specific data movement (capture → upload → cross-node download +
-checksum verification) is validated end-to-end. The restore *orchestration*
-that follows the download (materialize the target SwiftGuest → restore-receive
-launcher → `CH --restore` → resume) is the **shared Tier B path** already
-validated in the local-snapshot walkthroughs; a state sentinel
-(`S3-ROUNDTRIP-…`, md5 `a6deb3ca…`) was written into the source guest before
-capture for that final boot-and-verify step, which completes once a controller
-image carrying these two fixes is deployed.
+Guest state survived the full Tier C round-trip **across nodes via object
+storage**: capture on boba → upload to MinIO → cross-node download on miles →
+`CH --restore` → resume, with the in-guest sentinel preserved exactly.
+
+### Tracked follow-up
+
+S3 object lifecycle on snapshot deletion is **not** part of Phase 3: deleting a
+SwiftSnapshot does not purge its bucket objects, so reusing a snapshot *name*
+relies on bug-3's checksum-aware re-upload to overwrite stale artifacts (it
+does). A future phase should add `deletionPolicy: Delete` S3 cleanup so a reused
+name starts from an empty prefix.


### PR DESCRIPTION
## Summary

Third cluster-walkthrough finding for Tier C s3 (after the upload-root +
`--insecure` fixes in #117), surfaced while re-running the **full
controller-driven round-trip**.

The upload resume check skipped an artifact when an object already existed at
its key with a matching **size**. A `memory-ranges` file is always *exactly*
the guest's RAM size, so when a same-named SwiftSnapshot was deleted and
recreated (reusing the `<prefix>/<ns>/<name>` key), the re-upload saw the stale
object's matching size and **skipped** it — leaving capture #1's bytes in the
bucket while the fresh `manifest.json` recorded capture #2's hash. The
cross-node download then failed `verify memory-ranges: sha256 mismatch`
permanently.

## Fix

The upload records each artifact's **sha256 as object user-metadata**
(`x-amz-meta-sha256`) and skips only when **size AND sha256** match; a
same-size-different-content object is re-uploaded. `objectStore.stat` now
returns the recorded sha256; `put` takes + stores it. The download side already
re-fetched and sha256-verified, so no change there.

**Regression test** reproduces the exact bug: two snapshots at the same key
prefix where `memory.img` is the same 4096 bytes but different content → the
second upload must re-put it, and a subsequent download must verify clean.

## Full controller-driven round-trip — VALIDATED ✅

With a controller image carrying **all three** Tier C fixes
(upload-root + `--insecure` + checksum-idempotency), the complete flow ran
entirely through the controllers:

| Step | Result |
|---|---|
| Sentinel into source (boba) | `S3-RT-FULL-1780557632`, md5 `2b945b3e57ba25efd687bb370953eff0` |
| SwiftSnapshot (s3) | `Pending → Capturing → Uploading → Ready`; `status.s3.location` set |
| SwiftRestore (`targetNode: miles`, clone) | `Pending → Downloading → Restoring → Resuming → Ready` |
| Download → miles | all artifacts **sha256-verified** |
| Clone guest | **Running on miles** (cross-node from boba), `GuestRunning=True` |
| **Sentinel on the clone** | `S3-RT-FULL-1780557632` / md5 `2b945b3e…` — **byte-identical** ✅ |

Guest state survived the full Tier C round-trip **across nodes via object
storage**.

## Tracked follow-up

S3 object lifecycle on snapshot deletion is not part of Phase 3 — deleting a
SwiftSnapshot doesn't purge its bucket objects, so reusing a snapshot *name*
relies on this PR's checksum-aware re-upload to overwrite stale artifacts (it
does). A future phase should add `deletionPolicy: Delete` S3 cleanup. Noted in
the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)