### PR TITLE
refactor(snapshots): extract internal/snapshot/clonecommon — Phase 4 (1/5)

### DIFF
--- a/internal/controller/swiftrestore/local.go
+++ b/internal/controller/swiftrestore/local.go
@@ -46,7 +46,7 @@ import (
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
 	swiftguestctrl "github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
-	"github.com/projectbeskar/kubeswift/internal/runtimeintent"
+	"github.com/projectbeskar/kubeswift/internal/snapshot/clonecommon"
 )
 
 // SkipHypervisorVersionCheckAnnotation lets an operator bypass the
@@ -561,7 +561,7 @@ func (r *SwiftRestoreReconciler) restoreAnnotations(
 // the patcher's prefix match doesn't clip a longer name that happens
 // to start with a shorter one.
 func runtimeDirPrefix(namespace, name string) string {
-	return "/var/lib/kubeswift/run/" + namespace + "-" + name + "/"
+	return clonecommon.RuntimeDirPrefix(namespace, name)
 }
 
 // computeMACRewrites returns a CSV of new MACs indexed by NIC ordinal
@@ -569,15 +569,7 @@ func runtimeDirPrefix(namespace, name string) string {
 // no NetworkRef) first, then secondary NICs. A SwiftGuest with no
 // explicit Interfaces uses a single default NIC named "eth0".
 func computeMACRewrites(targetNs, targetName string, source *swiftv1alpha1.SwiftGuest) string {
-	if len(source.Spec.Interfaces) == 0 {
-		return runtimeintent.GenerateMAC(runtimeintent.InterfaceMACSeed(targetNs, targetName, "eth0"))
-	}
-	parts := make([]string, 0, len(source.Spec.Interfaces))
-	for _, iface := range source.Spec.Interfaces {
-		seed := runtimeintent.InterfaceMACSeed(targetNs, targetName, iface.Name)
-		parts = append(parts, runtimeintent.GenerateMAC(seed))
-	}
-	return strings.Join(parts, ",")
+	return clonecommon.ComputeMACRewrites(targetNs, targetName, source)
 }
 
 // regenIncludes returns true when the given identity item is present

--- a/internal/controller/swiftrestore/s3.go
+++ b/internal/controller/swiftrestore/s3.go
@@ -14,35 +14,23 @@ package swiftrestore
 import (
 	"context"
 	"fmt"
-	"path"
-	"path/filepath"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/snapshot/clonecommon"
 )
 
-const (
-	// s3DownloadMount is where the node-local restore cache is mounted (RW)
-	// inside the download Job — the snapshot-s3 binary writes the artifacts here.
-	s3DownloadMount = "/snap"
-	// s3RestoreCacheBase mirrors swiftsnapshot.HostPathBaseDir — the kubeswift-
-	// managed subtree the restore cache lives under. Kept as a local constant to
-	// avoid importing the swiftsnapshot controller package into swiftrestore.
-	s3RestoreCacheBase = "/var/lib/kubeswift/snapshots/"
-	// s3DownloadBackoffLimit bounds Job retries; the snapshot-s3 binary is
-	// idempotent (skips already-downloaded objects, verifies checksums), so a
-	// retry resumes.
-	s3DownloadBackoffLimit int32 = 4
-)
+// s3DownloadMount aliases the shared mount path (referenced by tests + the
+// node-local cache layout); the download Job itself is built by clonecommon.
+const s3DownloadMount = clonecommon.DownloadMount
 
 // hypervisorVersionBlocked runs the architect-risk-#3 CH version compatibility
 // gate shared by the local and s3 restore paths. Returns true (and stamps
@@ -86,13 +74,13 @@ func (r *SwiftRestoreReconciler) hypervisorVersionBlocked(
 // snapshot's identity so it is stable across reconciles and matches the
 // capture-side layout when the target happens to be the capture node.
 func s3RestoreLocalDir(snap *snapshotv1alpha1.SwiftSnapshot) string {
-	return filepath.Join(s3RestoreCacheBase, snap.Namespace+"-"+snap.Name)
+	return clonecommon.S3LocalDir(snap)
 }
 
 // s3RestoreKeyPrefix is the object-key prefix the artifacts live under, derived
 // the same way the upload side derives it: <prefix>/<namespace>/<name>.
 func s3RestoreKeyPrefix(snap *snapshotv1alpha1.SwiftSnapshot) string {
-	return path.Join(snap.Spec.Backend.S3.Prefix, snap.Namespace, snap.Name)
+	return clonecommon.S3KeyPrefix(snap)
 }
 
 // s3DownloadJobName is the deterministic name of the download Job.
@@ -256,103 +244,13 @@ func (r *SwiftRestoreReconciler) handleDownloading(
 // --mode=download. Pinned to the resolved restore node. The caller sets the
 // SwiftRestore ownerRef for GC.
 func buildDownloadJob(restore *snapshotv1alpha1.SwiftRestore, snap *snapshotv1alpha1.SwiftSnapshot, image, node string) *batchv1.Job {
-	s3 := snap.Spec.Backend.S3
-	args := []string{
-		"--mode=download",
-		"--dir=" + s3DownloadMount,
-		"--bucket=" + s3.Bucket,
-		"--key-prefix=" + s3RestoreKeyPrefix(snap),
-		"--snapshot=" + snap.Namespace + "/" + snap.Name,
-	}
-	if s3.Region != "" {
-		args = append(args, "--region="+s3.Region)
-	}
-	if s3.Endpoint != "" {
-		args = append(args, "--endpoint="+s3.Endpoint)
-	}
-	if s3.ForcePathStyle {
-		args = append(args, "--path-style")
-	}
-	if s3.Insecure {
-		args = append(args, "--insecure")
-	}
-	if snap.Spec.IncludeMemory {
-		args = append(args, "--include-memory")
-	}
-
-	credName := ""
-	if s3.CredentialsSecretRef != nil {
-		credName = s3.CredentialsSecretRef.Name
-	}
-	secretEnv := func(envName, key string, optional bool) corev1.EnvVar {
-		return corev1.EnvVar{
-			Name: envName,
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: credName},
-					Key:                  key,
-					Optional:             ptr.To(optional),
-				},
-			},
-		}
-	}
-
-	return &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      s3DownloadJobName(restore),
-			Namespace: restore.Namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/name":      "kubeswift",
-				"app.kubernetes.io/component": "snapshot-s3-download",
-				"kubeswift.io/swiftrestore":   restore.Name,
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: ptr.To(s3DownloadBackoffLimit),
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					NodeName:      node,
-					RestartPolicy: corev1.RestartPolicyOnFailure,
-					Containers: []corev1.Container{{
-						Name:  "download",
-						Image: image,
-						Args:  args,
-						Env: []corev1.EnvVar{
-							secretEnv("AWS_ACCESS_KEY_ID", "accessKeyId", false),
-							secretEnv("AWS_SECRET_ACCESS_KEY", "secretAccessKey", false),
-							secretEnv("AWS_SESSION_TOKEN", "sessionToken", true),
-						},
-						VolumeMounts: []corev1.VolumeMount{{
-							Name:      "cache",
-							MountPath: s3DownloadMount,
-						}},
-						// Unlike the upload Job (read-only mount, runs as the
-						// image's non-root uid), the download Job WRITES into the
-						// node-local cache hostPath. kubelet creates that
-						// DirectoryOrCreate path root-owned (0755), so the
-						// container must run as root to write it. Still maximally
-						// constrained otherwise: drop ALL capabilities, no
-						// privilege escalation, read-only root filesystem. The
-						// hostPath mount exposes only the single snapshot dir.
-						SecurityContext: &corev1.SecurityContext{
-							AllowPrivilegeEscalation: ptr.To(false),
-							RunAsUser:                ptr.To(int64(0)),
-							RunAsNonRoot:             ptr.To(false),
-							ReadOnlyRootFilesystem:   ptr.To(true),
-							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-						},
-					}},
-					Volumes: []corev1.Volume{{
-						Name: "cache",
-						VolumeSource: corev1.VolumeSource{
-							HostPath: &corev1.HostPathVolumeSource{
-								Path: s3RestoreLocalDir(snap),
-								Type: ptr.To(corev1.HostPathDirectoryOrCreate),
-							},
-						},
-					}},
-				},
-			},
-		},
-	}
+	return clonecommon.BuildDownloadJob(clonecommon.DownloadJobParams{
+		Snapshot:    snap,
+		Image:       image,
+		Name:        s3DownloadJobName(restore),
+		Namespace:   restore.Namespace,
+		Node:        node,
+		Component:   "snapshot-s3-download",
+		ExtraLabels: map[string]string{"kubeswift.io/swiftrestore": restore.Name},
+	})
 }

--- a/internal/controller/swiftsnapshot/s3.go
+++ b/internal/controller/swiftsnapshot/s3.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/snapshot/clonecommon"
 )
 
 // SnapshotS3ImageEnv overrides the snapshot-s3 uploader/downloader image used
@@ -123,13 +123,13 @@ func captureDestDir(snap *snapshotv1alpha1.SwiftSnapshot) string {
 // (and the upload Job reads from). Derived deterministically — the s3 backend
 // does not take an operator-supplied hostPath (unlike the local backend).
 func s3LocalDir(snap *snapshotv1alpha1.SwiftSnapshot) string {
-	return filepath.Join(HostPathBaseDir, snap.Namespace+"-"+snap.Name)
+	return clonecommon.S3LocalDir(snap)
 }
 
 // s3KeyPrefix is the object-key prefix for this snapshot:
 // <prefix>/<namespace>/<name>.
 func s3KeyPrefix(snap *snapshotv1alpha1.SwiftSnapshot) string {
-	return path.Join(snap.Spec.Backend.S3.Prefix, snap.Namespace, snap.Name)
+	return clonecommon.S3KeyPrefix(snap)
 }
 
 // s3UploadJobName is the deterministic name of the upload Job.

--- a/internal/snapshot/clonecommon/clonecommon_test.go
+++ b/internal/snapshot/clonecommon/clonecommon_test.go
@@ -1,0 +1,115 @@
+package clonecommon
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+func s3Snap(ns, name string) *snapshotv1alpha1.SwiftSnapshot {
+	return &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			Backend: snapshotv1alpha1.SwiftSnapshotBackend{
+				Type: snapshotv1alpha1.SnapshotBackendS3,
+				S3: &snapshotv1alpha1.S3Backend{
+					Bucket:               "bk",
+					Prefix:               "pfx",
+					CredentialsSecretRef: &snapshotv1alpha1.SecretObjectReference{Name: "creds"},
+				},
+			},
+		},
+	}
+}
+
+func TestPaths(t *testing.T) {
+	s := s3Snap("team-a", "snap1")
+	if got := S3LocalDir(s); got != "/var/lib/kubeswift/snapshots/team-a-snap1" {
+		t.Errorf("S3LocalDir = %q", got)
+	}
+	if got := S3KeyPrefix(s); got != "pfx/team-a/snap1" {
+		t.Errorf("S3KeyPrefix = %q", got)
+	}
+	// empty prefix => <ns>/<name>
+	s.Spec.Backend.S3.Prefix = ""
+	if got := S3KeyPrefix(s); got != "team-a/snap1" {
+		t.Errorf("empty-prefix S3KeyPrefix = %q", got)
+	}
+	if got := RuntimeDirPrefix("ns", "g"); got != "/var/lib/kubeswift/run/ns-g/" {
+		t.Errorf("RuntimeDirPrefix = %q", got)
+	}
+}
+
+func TestComputeMACRewrites(t *testing.T) {
+	// No interfaces => single deterministic eth0 MAC.
+	g := &swiftv1alpha1.SwiftGuest{}
+	a := ComputeMACRewrites("ns", "clone-a", g)
+	b := ComputeMACRewrites("ns", "clone-b", g)
+	if a == "" || strings.Contains(a, ",") {
+		t.Errorf("default = %q, want single MAC", a)
+	}
+	if a == b {
+		t.Errorf("distinct clone names must yield distinct MACs; both %q", a)
+	}
+	if a != ComputeMACRewrites("ns", "clone-a", g) {
+		t.Errorf("MAC must be deterministic for the same (ns,name)")
+	}
+	// Two interfaces => CSV of two MACs.
+	g2 := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{
+		Interfaces: []swiftv1alpha1.GuestInterface{{Name: "mgmt"}, {Name: "data"}},
+	}}
+	csv := ComputeMACRewrites("ns", "g", g2)
+	if parts := strings.Split(csv, ","); len(parts) != 2 || parts[0] == parts[1] {
+		t.Errorf("two-iface = %q, want 2 distinct MACs", csv)
+	}
+}
+
+func TestBuildDownloadJob(t *testing.T) {
+	s := s3Snap("team-a", "snap1")
+	s.Spec.Backend.S3.Region = "us-east-1"
+	s.Spec.Backend.S3.Endpoint = "minio:9000"
+	s.Spec.Backend.S3.ForcePathStyle = true
+	s.Spec.Backend.S3.Insecure = true
+	s.Spec.IncludeMemory = true
+	job := BuildDownloadJob(DownloadJobParams{
+		Snapshot: s, Image: "img", Name: "dl", Namespace: "team-a", Node: "boba",
+		Component: "snapshot-s3-download", ExtraLabels: map[string]string{"owner": "x"},
+	})
+	pod := job.Spec.Template.Spec
+	if pod.NodeName != "boba" || pod.RestartPolicy != corev1.RestartPolicyOnFailure {
+		t.Errorf("node/restart wrong: %q %q", pod.NodeName, pod.RestartPolicy)
+	}
+	if job.Labels["owner"] != "x" || job.Labels["app.kubernetes.io/component"] != "snapshot-s3-download" {
+		t.Errorf("labels = %+v", job.Labels)
+	}
+	c := pod.Containers[0]
+	// RW DirectoryOrCreate cache mount.
+	if c.VolumeMounts[0].MountPath != DownloadMount || c.VolumeMounts[0].ReadOnly {
+		t.Errorf("mount = %+v", c.VolumeMounts[0])
+	}
+	hp := pod.Volumes[0].VolumeSource.HostPath
+	if hp == nil || hp.Path != "/var/lib/kubeswift/snapshots/team-a-snap1" || *hp.Type != corev1.HostPathDirectoryOrCreate {
+		t.Errorf("hostPath = %+v", hp)
+	}
+	a := strings.Join(c.Args, " ")
+	for _, w := range []string{"--mode=download", "--bucket=bk", "--key-prefix=pfx/team-a/snap1",
+		"--region=us-east-1", "--endpoint=minio:9000", "--path-style", "--insecure", "--include-memory"} {
+		if !strings.Contains(a, w) {
+			t.Errorf("args missing %q; got %q", w, a)
+		}
+	}
+	// creds from the Secret; runs as root, hardened.
+	if c.Env[0].ValueFrom.SecretKeyRef.Name != "creds" {
+		t.Errorf("creds env = %+v", c.Env[0])
+	}
+	sc := c.SecurityContext
+	if sc.RunAsUser == nil || *sc.RunAsUser != 0 || !*sc.ReadOnlyRootFilesystem ||
+		*sc.AllowPrivilegeEscalation || sc.Capabilities.Drop[0] != "ALL" {
+		t.Errorf("securityContext = %+v", sc)
+	}
+}

--- a/internal/snapshot/clonecommon/download.go
+++ b/internal/snapshot/clonecommon/download.go
@@ -1,0 +1,145 @@
+package clonecommon
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+)
+
+const (
+	// DownloadMount is where the node-local cache is mounted (RW) inside the
+	// download Job — the snapshot-s3 binary writes the artifacts here.
+	DownloadMount = "/snap"
+	// DownloadBackoffLimit bounds Job retries; the snapshot-s3 binary is
+	// idempotent (skips already-downloaded objects, verifies checksums), so a
+	// retry resumes.
+	DownloadBackoffLimit int32 = 4
+)
+
+// DownloadJobParams parameterizes the node-pinned s3 download Job so both the
+// SwiftRestore path and the SwiftGuest cloneFromSnapshot path can build it. The
+// caller sets the ownerRef (SwiftRestore or SwiftGuest) after construction.
+type DownloadJobParams struct {
+	// Snapshot supplies the s3 backend config + the derived key prefix/cache dir.
+	Snapshot *snapshotv1alpha1.SwiftSnapshot
+	// Image is the snapshot-s3 uploader/downloader image.
+	Image string
+	// Name / Namespace of the Job.
+	Name      string
+	Namespace string
+	// Node pins the Job (and thus the cache hostPath) to the restore/clone node.
+	Node string
+	// Component is the app.kubernetes.io/component label value.
+	Component string
+	// ExtraLabels are merged onto the standard labels (e.g. an owner-name label).
+	ExtraLabels map[string]string
+}
+
+// BuildDownloadJob constructs the node-pinned download Job: it pulls the
+// snapshot's artifacts from object storage into the node-local cache hostPath
+// (S3LocalDir) and sha256-verifies them against the manifest. Credentials come
+// from the snapshot's referenced Secret as the standard AWS env vars. Runs as
+// root because it writes the kubelet-created root-owned cache hostPath; still
+// drop ALL / no-priv-esc / ro-rootfs, and the mount exposes only the single
+// snapshot dir.
+func BuildDownloadJob(p DownloadJobParams) *batchv1.Job {
+	snap := p.Snapshot
+	s3 := snap.Spec.Backend.S3
+	args := []string{
+		"--mode=download",
+		"--dir=" + DownloadMount,
+		"--bucket=" + s3.Bucket,
+		"--key-prefix=" + S3KeyPrefix(snap),
+		"--snapshot=" + snap.Namespace + "/" + snap.Name,
+	}
+	if s3.Region != "" {
+		args = append(args, "--region="+s3.Region)
+	}
+	if s3.Endpoint != "" {
+		args = append(args, "--endpoint="+s3.Endpoint)
+	}
+	if s3.ForcePathStyle {
+		args = append(args, "--path-style")
+	}
+	if s3.Insecure {
+		args = append(args, "--insecure")
+	}
+	if snap.Spec.IncludeMemory {
+		args = append(args, "--include-memory")
+	}
+
+	credName := ""
+	if s3.CredentialsSecretRef != nil {
+		credName = s3.CredentialsSecretRef.Name
+	}
+	secretEnv := func(envName, key string, optional bool) corev1.EnvVar {
+		return corev1.EnvVar{
+			Name: envName,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: credName},
+					Key:                  key,
+					Optional:             ptr.To(optional),
+				},
+			},
+		}
+	}
+
+	labels := map[string]string{
+		"app.kubernetes.io/name":      "kubeswift",
+		"app.kubernetes.io/component": p.Component,
+	}
+	for k, v := range p.ExtraLabels {
+		labels[k] = v
+	}
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.Name,
+			Namespace: p.Namespace,
+			Labels:    labels,
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: ptr.To(DownloadBackoffLimit),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					NodeName:      p.Node,
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+					Containers: []corev1.Container{{
+						Name:  "download",
+						Image: p.Image,
+						Args:  args,
+						Env: []corev1.EnvVar{
+							secretEnv("AWS_ACCESS_KEY_ID", "accessKeyId", false),
+							secretEnv("AWS_SECRET_ACCESS_KEY", "secretAccessKey", false),
+							secretEnv("AWS_SESSION_TOKEN", "sessionToken", true),
+						},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "cache",
+							MountPath: DownloadMount,
+						}},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+							RunAsUser:                ptr.To(int64(0)),
+							RunAsNonRoot:             ptr.To(false),
+							ReadOnlyRootFilesystem:   ptr.To(true),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "cache",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: S3LocalDir(snap),
+								Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+}

--- a/internal/snapshot/clonecommon/mac.go
+++ b/internal/snapshot/clonecommon/mac.go
@@ -1,0 +1,31 @@
+package clonecommon
+
+import (
+	"strings"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/runtimeintent"
+)
+
+// ComputeMACRewrites returns a CSV of new MACs indexed by NIC ordinal matching
+// config.net[], deterministic in (targetNs, targetName, iface). Order: the
+// source guest's interfaces in declaration order; a SwiftGuest with no explicit
+// Interfaces uses a single default NIC named "eth0".
+//
+// This is the load-bearing per-clone collision-avoidance value: each clone's
+// hypervisor config.net[].mac is rewritten to a value unique to its own
+// (namespace, name), so two clones never share a host-side tap/bridge MAC. (The
+// guest-VISIBLE MAC is inherited on CH --restore until the clone reboots — see
+// the Phase 2 resume-vs-boot limitation; per-pod netns isolation prevents an
+// actual L2 collision regardless.)
+func ComputeMACRewrites(targetNs, targetName string, source *swiftv1alpha1.SwiftGuest) string {
+	if len(source.Spec.Interfaces) == 0 {
+		return runtimeintent.GenerateMAC(runtimeintent.InterfaceMACSeed(targetNs, targetName, "eth0"))
+	}
+	parts := make([]string, 0, len(source.Spec.Interfaces))
+	for _, iface := range source.Spec.Interfaces {
+		seed := runtimeintent.InterfaceMACSeed(targetNs, targetName, iface.Name)
+		parts = append(parts, runtimeintent.GenerateMAC(seed))
+	}
+	return strings.Join(parts, ",")
+}

--- a/internal/snapshot/clonecommon/paths.go
+++ b/internal/snapshot/clonecommon/paths.go
@@ -1,0 +1,49 @@
+// Package clonecommon holds the backend-mechanism primitives shared by the
+// snapshot clone/restore paths — the s3 download Job, the node-local cache
+// layout, the per-clone MAC computation, and the runtime-dir prefix. It is
+// imported by both the swiftrestore controller (SwiftRestore phase machine) and
+// the swiftguest controller (SwiftGuest.spec.cloneFromSnapshot boot path,
+// Snapshot Phase 4). It deliberately imports NEITHER controller package so both
+// can depend on it without an import cycle; the restore/clone annotation maps
+// (which reference swiftguest's annotation keys) stay in their owning
+// controllers and call these primitives.
+package clonecommon
+
+import (
+	"path"
+	"path/filepath"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+)
+
+// HostPathBase is the kubeswift-managed subtree the node-local snapshot cache
+// lives under (capture, upload-read, and download-write all use it). Mirrors
+// swiftsnapshot.HostPathBaseDir; kept here so the shared primitives don't import
+// a controller package.
+const HostPathBase = "/var/lib/kubeswift/snapshots/"
+
+// S3LocalDir is the node-local cache directory for a snapshot's s3 artifacts —
+// where the upload Job reads from on the capture node and the download Job
+// writes to on the restore/clone node. Derived deterministically from the
+// snapshot's identity so it is stable across reconciles and consistent across
+// nodes: <HostPathBase>/<namespace>-<name>.
+func S3LocalDir(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	return filepath.Join(HostPathBase, snap.Namespace+"-"+snap.Name)
+}
+
+// S3KeyPrefix is the object-key prefix a snapshot's artifacts live under,
+// derived identically on the upload and download sides:
+// <prefix>/<namespace>/<name>.
+func S3KeyPrefix(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	return path.Join(snap.Spec.Backend.S3.Prefix, snap.Namespace, snap.Name)
+}
+
+// RuntimeDirPrefix returns the per-pod runtime_dir prefix the snapshot-stager
+// substitutes in disks[].path and serial.socket. Mirrors swift-runtime's
+// create_runtime_dir naming (rust/swift-runtime/src/runtime_dir.rs): base is
+// /var/lib/kubeswift/run, the per-guest directory is "<ns>-<name>" (slashes in
+// guest_id become hyphens), trailing "/" required so the patcher's prefix match
+// does not clip a longer name that starts with a shorter one.
+func RuntimeDirPrefix(namespace, name string) string {
+	return "/var/lib/kubeswift/run/" + namespace + "-" + name + "/"
+}


### PR DESCRIPTION
## Summary

**PR 1 of Snapshot Phase 4** (cloneFromSnapshot ergonomics). The load-bearing
refactor: pull the backend-mechanism primitives shared by the snapshot
clone/restore paths out of the `swiftrestore` (and `swiftsnapshot`) controllers
into a **neutral `internal/snapshot/clonecommon` package**, so the upcoming
`SwiftGuest.spec.cloneFromSnapshot` boot path can reuse them **without a
`swiftguest → swiftrestore` import cycle**. **No behavior change.**

## What `clonecommon` owns

- **`S3LocalDir` / `S3KeyPrefix`** — node-local cache layout + object-key prefix
  (identical across capture/upload/download; was duplicated in both controllers).
- **`RuntimeDirPrefix`** — the per-pod runtime_dir prefix the stager rewrites.
- **`ComputeMACRewrites`** — the deterministic per-clone hypervisor-MAC CSV (the
  load-bearing L2-collision-avoidance value, validated in the Phase 4 spike).
- **`BuildDownloadJob(DownloadJobParams)`** — the node-pinned s3 download Job
  builder, parameterized on name/namespace/node/component/labels so both
  controllers (and the future SwiftGuest path) build it identically; the caller
  sets the ownerRef.

`clonecommon` imports **neither** controller package (only api types +
`runtimeintent`), so both `swiftrestore` and (PR 3) `swiftguest` can depend on it.
The restore/clone annotation maps — which reference `swiftguest`'s annotation
keys — stay in their owning controllers and call these primitives.

## Delegation (no call-site churn)

- `swiftrestore`: `s3RestoreLocalDir` / `s3RestoreKeyPrefix` / `buildDownloadJob`
  / `computeMACRewrites` / `runtimeDirPrefix` become thin delegators; all
  existing call sites + tests unchanged. `s3DownloadMount` aliases
  `clonecommon.DownloadMount`.
- `swiftsnapshot`: `s3LocalDir` / `s3KeyPrefix` delegate to `clonecommon`.

## Tests

- New `clonecommon_test`: paths, deterministic + distinct per-clone MACs,
  download-Job shape (node pin, RW `DirectoryOrCreate`, root-hardened SC, args,
  creds env, labels).
- `swiftrestore` + `swiftsnapshot` suites **unchanged and green** — proves the
  extraction is behavior-preserving.
- Full suite + vet pass.

## Next

PR 2 — `SwiftGuest.spec.cloneFromSnapshot` CRD + webhook. PR 3 — the
SwiftGuest-native clone-boot path (the feature, consuming `clonecommon`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)