### PR TITLE
feat(snapshots): SwiftGuest-native cloneFromSnapshot boot (Tier B) — Phase 4 (3a/5)

### DIFF
--- a/internal/controller/swiftguest/clone.go
+++ b/internal/controller/swiftguest/clone.go
@@ -1,0 +1,152 @@
+package swiftguest
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/snapshot/clonecommon"
+)
+
+// prepareCloneFromSnapshot prepares a SwiftGuest that boots via
+// spec.cloneFromSnapshot (Snapshot Phase 4). It resolves the referenced
+// SwiftSnapshot and the LIVE source guest, self-stamps the restore-receive
+// annotations (so the existing annotation-driven restore path in
+// buildBasePod/RestoreParamsFromAnnotations + the runtime intent fire
+// unchanged), and returns an "effective" guest carrying the SOURCE guest's spec
+// for the resolver — the clone guest itself has no imageRef. Only the spec is
+// overlaid (for resolution); the real guest keeps its identity
+// (name/namespace/annotations) and is used everywhere else.
+//
+// Returns (effective, failReason, requeue, err):
+//   - effective != nil  → resolve THIS instead of the real guest.
+//   - failReason != ""  → set Resolved=False / phase=Failed (terminal).
+//   - requeue           → snapshot not Ready yet; re-reconcile.
+//
+// PR 3a handles Tier B (local, same-node) snapshots. Tier C (s3) needs the
+// download path (PR 3b); the source guest must be live (the snapshot's
+// CapturedGuestSpec is validation-only — cross-cluster/source-gone clones are a
+// future enhancement).
+func (r *SwiftGuestReconciler) prepareCloneFromSnapshot(
+	ctx context.Context, guest *swiftv1alpha1.SwiftGuest,
+) (*swiftv1alpha1.SwiftGuest, string, bool, error) {
+	src := guest.Spec.CloneFromSnapshot
+
+	var snap snapshotv1alpha1.SwiftSnapshot
+	if err := r.Get(ctx, client.ObjectKey{Name: src.SnapshotRef.Name, Namespace: guest.Namespace}, &snap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, "SwiftSnapshot " + src.SnapshotRef.Name + " not found", false, nil
+		}
+		return nil, "", false, err
+	}
+	if snap.Status.Phase != snapshotv1alpha1.SwiftSnapshotPhaseReady {
+		// Transient — the snapshot may still be Capturing/Uploading.
+		return nil, "", true, nil
+	}
+
+	switch snap.Spec.Backend.Type {
+	case snapshotv1alpha1.SnapshotBackendLocal:
+		if snap.Status.NodeName == "" || snap.Spec.Backend.Local == nil || snap.Spec.Backend.Local.HostPath == "" {
+			return nil, "SwiftSnapshot " + snap.Name + " is missing status.nodeName or backend.local.hostPath", false, nil
+		}
+	case snapshotv1alpha1.SnapshotBackendS3:
+		return nil, "cloneFromSnapshot from an s3 (Tier C) snapshot is not yet implemented (Snapshot Phase 4 PR 3b)", false, nil
+	default:
+		return nil, "cloneFromSnapshot requires a memory snapshot (backend.type: local); got " + string(snap.Spec.Backend.Type), false, nil
+	}
+
+	// The clone needs the source guest's full spec (image/seed/class) to build
+	// the launcher pod — a fresh disk from the source image plus the restored
+	// memory. The snapshot's CapturedGuestSpec is insufficient (CPU/mem/image
+	// name only), so the source guest must still exist.
+	var source swiftv1alpha1.SwiftGuest
+	if err := r.Get(ctx, client.ObjectKey{Name: snap.Spec.GuestRef.Name, Namespace: guest.Namespace}, &source); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, "source SwiftGuest " + snap.Spec.GuestRef.Name + " no longer exists; cloneFromSnapshot needs the source spec", false, nil
+		}
+		return nil, "", false, err
+	}
+
+	// Self-stamp the clone-mode restore annotations (mirrors what the
+	// SwiftRestore controller stamps on its clone targets) if not already set.
+	annos := cloneRestoreAnnotations(guest, &snap, &source)
+	if !cloneAnnotationsMatch(guest.Annotations, annos) {
+		patched := guest.DeepCopy()
+		if patched.Annotations == nil {
+			patched.Annotations = map[string]string{}
+		}
+		for k, v := range annos {
+			patched.Annotations[k] = v
+		}
+		if err := r.Patch(ctx, patched, client.MergeFrom(guest)); err != nil {
+			return nil, "", false, err
+		}
+		// Reflect the stamp in-memory so the rest of this reconcile sees it.
+		guest.Annotations = patched.Annotations
+	}
+
+	// Effective guest: the real guest's identity (name/namespace/annotations/
+	// status) with the SOURCE guest's spec, for the resolver only. runPolicy is
+	// clone-owned (it governs the clone's lifecycle via rg.Lifecycle), so keep
+	// the clone's rather than inheriting the source's.
+	effective := guest.DeepCopy()
+	clonePolicy := guest.Spec.RunPolicy
+	effective.Spec = source.Spec
+	effective.Spec.RunPolicy = clonePolicy
+	return effective, "", false, nil
+}
+
+// cloneRestoreAnnotations builds the clone-mode restore-receive annotations for
+// a cloneFromSnapshot guest (Tier B local). MAC rewrites + runtime-dir prefixes
+// use the clonecommon primitives shared with the SwiftRestore clone path.
+func cloneRestoreAnnotations(
+	guest *swiftv1alpha1.SwiftGuest,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+	source *swiftv1alpha1.SwiftGuest,
+) map[string]string {
+	annos := map[string]string{
+		AnnotationActiveRestore:               snap.Name,
+		AnnotationRestoreSnapshotPath:         snap.Spec.Backend.Local.HostPath,
+		AnnotationRestoreNodeName:             snap.Status.NodeName,
+		AnnotationRestoreMode:                 RestoreModeClone,
+		AnnotationRestoreMACRewrites:          clonecommon.ComputeMACRewrites(guest.Namespace, guest.Name, source),
+		AnnotationRestoreRuntimeDirFromPrefix: clonecommon.RuntimeDirPrefix(source.Namespace, source.Name),
+		AnnotationRestoreRuntimeDirToPrefix:   clonecommon.RuntimeDirPrefix(guest.Namespace, guest.Name),
+		AnnotationRestoreNullifyHostMAC:       "true",
+	}
+	if cloneRegenIncludesNonMAC(guest.Spec.CloneFromSnapshot) {
+		annos[AnnotationRestoreAppendCmdlineMarker] = "true"
+	}
+	return annos
+}
+
+// cloneRegenIncludesNonMAC reports whether the clone requests regeneration of a
+// non-MAC identity item (hostname/machineId/sshHostKeys) — these fire on the
+// clone's first reboot via the seed bootcmd. An empty Regenerate defaults to
+// all four. macAddresses is handled separately (always forced via MAC rewrites).
+func cloneRegenIncludesNonMAC(src *swiftv1alpha1.CloneFromSnapshotSource) bool {
+	if src == nil || len(src.Regenerate) == 0 {
+		return true
+	}
+	for _, item := range src.Regenerate {
+		switch item {
+		case swiftv1alpha1.CloneRegenHostname, swiftv1alpha1.CloneRegenMachineID, swiftv1alpha1.CloneRegenSSHHostKeys:
+			return true
+		}
+	}
+	return false
+}
+
+// cloneAnnotationsMatch reports whether every want key is already present in
+// have with the same value (so the stamp is idempotent — no re-patch).
+func cloneAnnotationsMatch(have, want map[string]string) bool {
+	for k, v := range want {
+		if have[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/swiftguest/clone_test.go
+++ b/internal/controller/swiftguest/clone_test.go
@@ -1,0 +1,160 @@
+package swiftguest
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+func cloneScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("clientgoscheme: %v", err)
+	}
+	gvSwift := schema.GroupVersion{Group: "swift.kubeswift.io", Version: "v1alpha1"}
+	s.AddKnownTypes(gvSwift, &swiftv1alpha1.SwiftGuest{}, &swiftv1alpha1.SwiftGuestList{})
+	metav1.AddToGroupVersion(s, gvSwift)
+	gvSnap := schema.GroupVersion{Group: "snapshot.kubeswift.io", Version: "v1alpha1"}
+	s.AddKnownTypes(gvSnap, &snapshotv1alpha1.SwiftSnapshot{}, &snapshotv1alpha1.SwiftSnapshotList{})
+	metav1.AddToGroupVersion(s, gvSnap)
+	return s
+}
+
+func cloneGuest() *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-a", Namespace: "ns"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			RunPolicy: swiftv1alpha1.RunPolicyRunning,
+			CloneFromSnapshot: &swiftv1alpha1.CloneFromSnapshotSource{
+				SnapshotRef: corev1.LocalObjectReference{Name: "snap"},
+			},
+		},
+	}
+}
+
+func sourceGuest() *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: "ns"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef:      &corev1.LocalObjectReference{Name: "rocky9"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "cls"},
+			RunPolicy:     swiftv1alpha1.RunPolicyStopped, // must NOT leak onto the clone
+		},
+	}
+}
+
+func localSnap(phase snapshotv1alpha1.SwiftSnapshotPhase) *snapshotv1alpha1.SwiftSnapshot {
+	return &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "snap", Namespace: "ns"},
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			GuestRef: snapshotv1alpha1.SwiftSnapshotGuestRef{Name: "src"},
+			Backend: snapshotv1alpha1.SwiftSnapshotBackend{
+				Type:  snapshotv1alpha1.SnapshotBackendLocal,
+				Local: &snapshotv1alpha1.LocalBackend{HostPath: "/var/lib/kubeswift/snapshots/ns-snap"},
+			},
+		},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{Phase: phase, NodeName: "boba"},
+	}
+}
+
+func newCloneReconciler(t *testing.T, objs ...client.Object) (*SwiftGuestReconciler, client.Client) {
+	s := cloneScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	return &SwiftGuestReconciler{Client: c, Scheme: s}, c
+}
+
+func TestPrepareCloneFromSnapshot_TierB(t *testing.T) {
+	g := cloneGuest()
+	r, c := newCloneReconciler(t, g, sourceGuest(), localSnap(snapshotv1alpha1.SwiftSnapshotPhaseReady))
+	eff, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || fail != "" || requeue {
+		t.Fatalf("expected success; fail=%q requeue=%v err=%v", fail, requeue, err)
+	}
+	// effective guest carries the SOURCE spec (imageRef) but the CLONE runPolicy.
+	if eff.Spec.ImageRef == nil || eff.Spec.ImageRef.Name != "rocky9" {
+		t.Errorf("effective spec must carry source imageRef; got %+v", eff.Spec.ImageRef)
+	}
+	if eff.Spec.RunPolicy != swiftv1alpha1.RunPolicyRunning {
+		t.Errorf("effective runPolicy = %q, want the clone's Running (not the source's Stopped)", eff.Spec.RunPolicy)
+	}
+	// restore annotations stamped on the real guest, in-cluster + in-memory.
+	var got swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "clone-a", Namespace: "ns"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Annotations[AnnotationActiveRestore] != "snap" ||
+		got.Annotations[AnnotationRestoreMode] != RestoreModeClone ||
+		got.Annotations[AnnotationRestoreNodeName] != "boba" ||
+		got.Annotations[AnnotationRestoreSnapshotPath] != "/var/lib/kubeswift/snapshots/ns-snap" ||
+		got.Annotations[AnnotationRestoreMACRewrites] == "" ||
+		got.Annotations[AnnotationRestoreNullifyHostMAC] != "true" {
+		t.Errorf("clone restore annotations not stamped: %+v", got.Annotations)
+	}
+	if g.Annotations[AnnotationActiveRestore] != "snap" {
+		t.Errorf("in-memory guest annotations not updated: %+v", g.Annotations)
+	}
+}
+
+func TestPrepareCloneFromSnapshot_NotReady(t *testing.T) {
+	g := cloneGuest()
+	r, _ := newCloneReconciler(t, g, sourceGuest(), localSnap(snapshotv1alpha1.SwiftSnapshotPhaseCapturing))
+	_, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || fail != "" || !requeue {
+		t.Fatalf("not-Ready snapshot should requeue; fail=%q requeue=%v err=%v", fail, requeue, err)
+	}
+}
+
+func TestPrepareCloneFromSnapshot_TierCRejected(t *testing.T) {
+	g := cloneGuest()
+	snap := localSnap(snapshotv1alpha1.SwiftSnapshotPhaseReady)
+	snap.Spec.Backend = snapshotv1alpha1.SwiftSnapshotBackend{
+		Type: snapshotv1alpha1.SnapshotBackendS3,
+		S3:   &snapshotv1alpha1.S3Backend{Bucket: "b"},
+	}
+	r, _ := newCloneReconciler(t, g, sourceGuest(), snap)
+	_, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || !strings.Contains(fail, "Phase 4 PR 3b") {
+		t.Fatalf("s3 snapshot should fail with PR-3b message; fail=%q err=%v", fail, err)
+	}
+}
+
+func TestPrepareCloneFromSnapshot_SourceGone(t *testing.T) {
+	g := cloneGuest()
+	r, _ := newCloneReconciler(t, g, localSnap(snapshotv1alpha1.SwiftSnapshotPhaseReady)) // no source guest
+	_, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || !strings.Contains(fail, "no longer exists") {
+		t.Fatalf("missing source should fail; fail=%q err=%v", fail, err)
+	}
+}
+
+func TestCloneRegenIncludesNonMAC(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []swiftv1alpha1.CloneIdentityItem
+		want bool
+	}{
+		{"empty defaults to all", nil, true},
+		{"only macAddresses", []swiftv1alpha1.CloneIdentityItem{swiftv1alpha1.CloneRegenMACAddresses}, false},
+		{"includes hostname", []swiftv1alpha1.CloneIdentityItem{swiftv1alpha1.CloneRegenMACAddresses, swiftv1alpha1.CloneRegenHostname}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cloneRegenIncludesNonMAC(&swiftv1alpha1.CloneFromSnapshotSource{Regenerate: tc.in})
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -100,8 +100,43 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	// cloneFromSnapshot (Snapshot Phase 4): a guest that boots as a clone of a
+	// SwiftSnapshot has no imageRef/kernelRef. Resolve the snapshot + the live
+	// source guest, self-stamp the clone-mode restore annotations, and resolve
+	// using the SOURCE guest's spec (the "effective" guest). Everything after
+	// resolution (seed/intent/rootdisk/pod) runs unchanged off the now-stamped
+	// restore annotations + the source-resolved rg.
+	guestForResolve := &guest
+	if guest.UsesCloneFromSnapshot() {
+		effective, failReason, requeue, perr := r.prepareCloneFromSnapshot(ctx, &guest)
+		if perr != nil {
+			return ctrl.Result{}, perr
+		}
+		if failReason != "" {
+			status := guest.Status.DeepCopy()
+			SetResolvedCondition(status, false, failReason)
+			status.Phase = swiftv1alpha1.SwiftGuestPhaseFailed
+			recordGuestMetrics(&guest, &guest.Status, status, nil)
+			if err := r.patchStatus(ctx, &guest, status); err != nil {
+				return ctrl.Result{}, err
+			}
+			logger.Info("cloneFromSnapshot preparation failed", "reason", failReason)
+			return ctrl.Result{}, nil
+		}
+		if requeue {
+			status := guest.Status.DeepCopy()
+			status.Phase = swiftv1alpha1.SwiftGuestPhasePending
+			SetResolvedCondition(status, false, "waiting for SwiftSnapshot "+guest.Spec.CloneFromSnapshot.SnapshotRef.Name+" to be Ready")
+			if err := r.patchStatus(ctx, &guest, status); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+		guestForResolve = effective
+	}
+
 	res := resolved.NewResolver(r.Client)
-	rg, err := res.Resolve(ctx, &guest)
+	rg, err := res.Resolve(ctx, guestForResolve)
 	if err != nil {
 		var re *resolved.ResolutionError
 		if errors.As(err, &re) {


### PR DESCRIPTION
## Summary

**PR 3a of Snapshot Phase 4.** The SwiftGuest controller now boots a guest as a
**clone of a Tier B (local) SwiftSnapshot**, reusing the existing restore-receive
machinery — **zero new launch mechanism**.

## Mechanism (`internal/controller/swiftguest/clone.go`)

`prepareCloneFromSnapshot` runs **before `Resolve`** for a `UsesCloneFromSnapshot()`
guest:
1. Resolves the referenced `SwiftSnapshot` (must be Ready) + the **live source
   guest**.
2. **Self-stamps** the clone-mode restore-receive annotations
   (`AnnotationActiveRestore` etc.), mirroring what the SwiftRestore controller
   stamps on its clone targets. MAC rewrites + runtime-dir prefixes come from the
   shared `clonecommon` primitives (#121).
3. Returns an **"effective" guest** carrying the **source guest's spec** for the
   resolver (the clone itself has no `imageRef`).

The effective guest is used **only at the `Resolve` call** (minimal blast
radius). `EnsureRootDiskClone` + `buildBasePod`'s restore branch + the runtime
intent read `rg` + `guest.Name`/`Annotations` (verified: **no `guest.Spec`
reads**), so they fire **unchanged** off the now-stamped annotations and the
source-resolved `rg`. The clone gets a **fresh disk from the source image + the
restored memory** (the existing memory-snapshot-clone behavior) and a per-clone
hypervisor MAC. `runPolicy` is clone-owned (governs lifecycle), so it's preserved
on the effective guest rather than inherited from the source.

## Scope / constraints (documented)

- **Tier B (local, same-node) only.** Tier C (s3, cross-node — the pool fit)
  needs the download path and fails with a clear *"Phase 4 PR 3b"* message.
- **The source guest must be live**: the snapshot's `CapturedGuestSpec` is
  validation-only (CPU/mem/image-name), insufficient to rebuild the pod.
  Cross-cluster / source-gone clones are a future enhancement.
- PR 2's resolver guard is now superseded by the real path for Tier B.

## Tests

`prepareCloneFromSnapshot` (Tier B success incl. source-spec overlay +
clone-runPolicy preservation + stamped annotations; not-Ready → requeue; Tier C
→ rejected; source-gone → failed) + `cloneRegenIncludesNonMAC`. **Non-clone
guests are untouched** (the branch only activates on `UsesCloneFromSnapshot()`).
Full suite + vet green.

## Not yet cluster-validated

The clone-boot path runs unit-tested here; the mechanism it reuses is
cluster-proven (Phase 4 spike). End-to-end cluster validation lands in PR 5 (the
N-replica pool walkthrough) — and Tier C, the cross-node pool fit, in PR 3b.

## Next
PR 3b — Tier C download (init container) for cross-node clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)