### PR TITLE
feat(snapshots): cloneFromSnapshot Tier C (s3) cross-node download — Phase 4 (3b/5)

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -147,6 +147,7 @@ func main() {
 		// ConfigMap + per-node identity Secrets live.
 		MigrationMTLSEnabled: *migrationMTLSEnabled,
 		SystemNamespace:      leaderElectionNS,
+		SnapshotS3Image:      swiftsnapshot.SnapshotS3Image(),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftGuest controller")
 		os.Exit(1)

--- a/internal/controller/swiftguest/clone.go
+++ b/internal/controller/swiftguest/clone.go
@@ -3,7 +3,10 @@ package swiftguest
 import (
 	"context"
 
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
@@ -47,15 +50,40 @@ func (r *SwiftGuestReconciler) prepareCloneFromSnapshot(
 		return nil, "", true, nil
 	}
 
+	// Resolve the on-node snapshot directory + the node the clone runs on.
+	// Tier B (local): the snapshot already lives on its capture node. Tier C
+	// (s3): a per-guest download Job pulls the artifacts into the chosen target
+	// node's cache first (mirrors the SwiftRestore download path); the clone
+	// then boots once the cache is populated.
+	var snapshotPath, node string
 	switch snap.Spec.Backend.Type {
 	case snapshotv1alpha1.SnapshotBackendLocal:
 		if snap.Status.NodeName == "" || snap.Spec.Backend.Local == nil || snap.Spec.Backend.Local.HostPath == "" {
 			return nil, "SwiftSnapshot " + snap.Name + " is missing status.nodeName or backend.local.hostPath", false, nil
 		}
+		snapshotPath, node = snap.Spec.Backend.Local.HostPath, snap.Status.NodeName
 	case snapshotv1alpha1.SnapshotBackendS3:
-		return nil, "cloneFromSnapshot from an s3 (Tier C) snapshot is not yet implemented (Snapshot Phase 4 PR 3b)", false, nil
+		node = src.TargetNode
+		if node == "" {
+			return nil, "cloneFromSnapshot from a Tier C (s3) snapshot requires spec.cloneFromSnapshot.targetNode", false, nil
+		}
+		if snap.Status.S3 == nil || snap.Status.S3.Location == "" {
+			return nil, "SwiftSnapshot " + snap.Name + " has no status.s3 — its upload is not complete", false, nil
+		}
+		done, failReason, derr := r.ensureCloneDownloadJob(ctx, guest, &snap, node)
+		if derr != nil {
+			return nil, "", false, derr
+		}
+		if failReason != "" {
+			return nil, failReason, false, nil
+		}
+		if !done {
+			// Still downloading the snapshot artifacts onto the target node.
+			return nil, "", true, nil
+		}
+		snapshotPath = clonecommon.S3LocalDir(&snap)
 	default:
-		return nil, "cloneFromSnapshot requires a memory snapshot (backend.type: local); got " + string(snap.Spec.Backend.Type), false, nil
+		return nil, "cloneFromSnapshot requires a memory snapshot (backend.type: local or s3); got " + string(snap.Spec.Backend.Type), false, nil
 	}
 
 	// The clone needs the source guest's full spec (image/seed/class) to build
@@ -72,7 +100,7 @@ func (r *SwiftGuestReconciler) prepareCloneFromSnapshot(
 
 	// Self-stamp the clone-mode restore annotations (mirrors what the
 	// SwiftRestore controller stamps on its clone targets) if not already set.
-	annos := cloneRestoreAnnotations(guest, &snap, &source)
+	annos := cloneRestoreAnnotations(guest, &snap, &source, snapshotPath, node)
 	if !cloneAnnotationsMatch(guest.Annotations, annos) {
 		patched := guest.DeepCopy()
 		if patched.Annotations == nil {
@@ -106,11 +134,12 @@ func cloneRestoreAnnotations(
 	guest *swiftv1alpha1.SwiftGuest,
 	snap *snapshotv1alpha1.SwiftSnapshot,
 	source *swiftv1alpha1.SwiftGuest,
+	snapshotPath, node string,
 ) map[string]string {
 	annos := map[string]string{
 		AnnotationActiveRestore:               snap.Name,
-		AnnotationRestoreSnapshotPath:         snap.Spec.Backend.Local.HostPath,
-		AnnotationRestoreNodeName:             snap.Status.NodeName,
+		AnnotationRestoreSnapshotPath:         snapshotPath,
+		AnnotationRestoreNodeName:             node,
 		AnnotationRestoreMode:                 RestoreModeClone,
 		AnnotationRestoreMACRewrites:          clonecommon.ComputeMACRewrites(guest.Namespace, guest.Name, source),
 		AnnotationRestoreRuntimeDirFromPrefix: clonecommon.RuntimeDirPrefix(source.Namespace, source.Name),
@@ -149,4 +178,67 @@ func cloneAnnotationsMatch(have, want map[string]string) bool {
 		}
 	}
 	return true
+}
+
+// cloneDownloadJobName is the deterministic name of a cloneFromSnapshot guest's
+// Tier C download Job.
+func cloneDownloadJobName(guest *swiftv1alpha1.SwiftGuest) string {
+	return guest.Name + "-clone-download"
+}
+
+// ensureCloneDownloadJob creates (idempotently) a guest-owned, node-pinned
+// download Job that pulls a Tier C snapshot's artifacts into the target node's
+// cache, and reports whether it has completed. Returns (done, failReason, err):
+//   - done=true       → the cache is populated; proceed to boot the clone.
+//   - failReason != "" → terminal (image unset, or the Job failed).
+//   - otherwise        → still downloading (caller requeues).
+//
+// The cache dir (clonecommon.S3LocalDir) is snapshot-keyed, so the snapshot-s3
+// binary's checksum-aware idempotency means a re-download is a fast no-op when
+// the artifacts are already present (e.g. a second clone on the same node). The
+// Job itself is per-guest here; a SwiftGuestPool placing MANY replicas on ONE
+// node would create concurrent same-path downloads — PR 4 (pool integration)
+// should deduplicate the download per (node, snapshot) to avoid the concurrent-
+// write race. For a single clone (or clones spread across nodes) this is correct.
+func (r *SwiftGuestReconciler) ensureCloneDownloadJob(
+	ctx context.Context,
+	guest *swiftv1alpha1.SwiftGuest,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+	node string,
+) (bool, string, error) {
+	if r.SnapshotS3Image == "" {
+		return false, "snapshot-s3 image not configured (set KUBESWIFT_SNAPSHOT_S3_IMAGE)", nil
+	}
+	var job batchv1.Job
+	err := r.Get(ctx, client.ObjectKey{Name: cloneDownloadJobName(guest), Namespace: guest.Namespace}, &job)
+	if apierrors.IsNotFound(err) {
+		j := clonecommon.BuildDownloadJob(clonecommon.DownloadJobParams{
+			Snapshot:    snap,
+			Image:       r.SnapshotS3Image,
+			Name:        cloneDownloadJobName(guest),
+			Namespace:   guest.Namespace,
+			Node:        node,
+			Component:   "snapshot-s3-clone-download",
+			ExtraLabels: map[string]string{"kubeswift.io/swiftguest": guest.Name},
+		})
+		if cerr := ctrl.SetControllerReference(guest, j, r.Scheme); cerr != nil {
+			return false, "", cerr
+		}
+		if cerr := r.Create(ctx, j); cerr != nil && !apierrors.IsAlreadyExists(cerr) {
+			return false, "", cerr
+		}
+		return false, "", nil
+	}
+	if err != nil {
+		return false, "", err
+	}
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			return true, "", nil
+		}
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return false, "snapshot download Job failed: " + c.Message, nil
+		}
+	}
+	return false, "", nil
 }

--- a/internal/controller/swiftguest/clone_test.go
+++ b/internal/controller/swiftguest/clone_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -116,17 +117,64 @@ func TestPrepareCloneFromSnapshot_NotReady(t *testing.T) {
 	}
 }
 
-func TestPrepareCloneFromSnapshot_TierCRejected(t *testing.T) {
-	g := cloneGuest()
-	snap := localSnap(snapshotv1alpha1.SwiftSnapshotPhaseReady)
-	snap.Spec.Backend = snapshotv1alpha1.SwiftSnapshotBackend{
-		Type: snapshotv1alpha1.SnapshotBackendS3,
-		S3:   &snapshotv1alpha1.S3Backend{Bucket: "b"},
+func s3CloneSnap() *snapshotv1alpha1.SwiftSnapshot {
+	return &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "snap", Namespace: "ns"},
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			GuestRef: snapshotv1alpha1.SwiftSnapshotGuestRef{Name: "src"},
+			Backend: snapshotv1alpha1.SwiftSnapshotBackend{
+				Type: snapshotv1alpha1.SnapshotBackendS3,
+				S3:   &snapshotv1alpha1.S3Backend{Bucket: "bk", CredentialsSecretRef: &snapshotv1alpha1.SecretObjectReference{Name: "c"}},
+			},
+		},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{
+			Phase: snapshotv1alpha1.SwiftSnapshotPhaseReady,
+			S3:    &snapshotv1alpha1.S3SnapshotStatus{Location: "s3://bk/ns/snap/"},
+		},
 	}
-	r, _ := newCloneReconciler(t, g, sourceGuest(), snap)
+}
+
+func TestPrepareCloneFromSnapshot_TierC_RequiresTargetNode(t *testing.T) {
+	g := cloneGuest() // no targetNode
+	r, _ := newCloneReconciler(t, g, sourceGuest(), s3CloneSnap())
+	r.SnapshotS3Image = "img"
 	_, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
-	if err != nil || !strings.Contains(fail, "Phase 4 PR 3b") {
-		t.Fatalf("s3 snapshot should fail with PR-3b message; fail=%q err=%v", fail, err)
+	if err != nil || !strings.Contains(fail, "requires spec.cloneFromSnapshot.targetNode") {
+		t.Fatalf("Tier C without targetNode should fail; fail=%q err=%v", fail, err)
+	}
+}
+
+func TestPrepareCloneFromSnapshot_TierC_DownloadsThenProceeds(t *testing.T) {
+	g := cloneGuest()
+	g.Spec.CloneFromSnapshot.TargetNode = "miles"
+	r, c := newCloneReconciler(t, g, sourceGuest(), s3CloneSnap())
+	r.SnapshotS3Image = "img"
+
+	// First pass: creates the download Job + requeues (not yet complete).
+	_, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || fail != "" || !requeue {
+		t.Fatalf("first pass should create the download Job + requeue; fail=%q requeue=%v err=%v", fail, requeue, err)
+	}
+	var job batchv1.Job
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "clone-a-clone-download", Namespace: "ns"}, &job); err != nil {
+		t.Fatalf("download Job not created: %v", err)
+	}
+	if job.Spec.Template.Spec.NodeName != "miles" {
+		t.Errorf("download Job must pin to targetNode miles; got %q", job.Spec.Template.Spec.NodeName)
+	}
+
+	// Mark the Job complete; second pass should proceed (effective + stamped).
+	job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+	if err := c.Status().Update(context.Background(), &job); err != nil {
+		t.Fatal(err)
+	}
+	eff, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || fail != "" || requeue || eff == nil {
+		t.Fatalf("after download completes, should proceed; fail=%q requeue=%v err=%v", fail, requeue, err)
+	}
+	if g.Annotations[AnnotationRestoreNodeName] != "miles" ||
+		g.Annotations[AnnotationRestoreSnapshotPath] != "/var/lib/kubeswift/snapshots/ns-snap" {
+		t.Errorf("Tier C restore annotations wrong: %+v", g.Annotations)
 	}
 }
 

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -75,6 +75,13 @@ type SwiftGuestReconciler struct {
 	// ConfigMap into guest namespaces. Only consulted when
 	// MigrationMTLSEnabled.
 	SystemNamespace string
+
+	// SnapshotS3Image is the snapshot-s3 downloader image used by a
+	// cloneFromSnapshot guest cloning from a Tier C (s3) snapshot — the
+	// per-guest download Job pulls the artifacts into the target node's cache
+	// before the restore-receive launcher boots. Wired from
+	// KUBESWIFT_SNAPSHOT_S3_IMAGE.
+	SnapshotS3Image string
 }
 
 // Reconcile implements the reconcile loop.


### PR DESCRIPTION
## Summary

**PR 3b of Snapshot Phase 4.** A `cloneFromSnapshot` guest can now clone from a
**Tier C (s3) snapshot onto any node** — the cross-node fit for pools. Reuses the
proven **download-then-restore** pattern (like SwiftRestore) rather than an init
container, keeping `BuildRestorePod` **untouched**.

## How it works

`prepareCloneFromSnapshot`'s backend switch now handles `s3`:
1. `spec.cloneFromSnapshot.targetNode` is **required**; the snapshot must have
   `status.s3` (upload complete).
2. A **per-guest, node-pinned download Job** (`clonecommon.BuildDownloadJob`,
   owned by the guest → GC'd with it) pulls the artifacts into the target node's
   cache. The reconcile **requeues until the Job completes**.
3. On completion it stamps the restore annotations (`snapshotPath =
   clonecommon.S3LocalDir`, `node = targetNode`) and proceeds — the existing
   restore-receive launcher boots off the now-populated cache (the
   `snapshotSourceVolume` `Type=Directory` is satisfied because the download ran
   first).

Tier B is unchanged (no download, capture-node-pinned). `cloneRestoreAnnotations`
is parameterized on `(snapshotPath, node)` so both tiers share it.

## Pool note (PR 4)

The cache dir is **snapshot-keyed**, and the checksum-aware `snapshot-s3` binary
makes a re-download a no-op when present. Documented inline: a SwiftGuestPool
placing **many replicas on one node** needs per-`(node, snapshot)` download
**dedup** (PR 4) to avoid a concurrent same-path write race. Single-clone /
cross-node spread is correct as-is.

## Wiring

`SwiftGuestReconciler.SnapshotS3Image` (from `KUBESWIFT_SNAPSHOT_S3_IMAGE` via
`main.go`). `Owns(&batchv1.Job{})` + jobs RBAC already present (the rootdisk
clone Job), so the guest re-reconciles on download completion.

## Tests

Tier C requires-`targetNode`; Tier C downloads-then-proceeds (creates the
node-pinned Job → requeues → on `JobComplete` stamps the s3-derived path/node
annotations). Tier B tests unchanged. Full suite + vet green.

## Next
PR 4 — SwiftGuestPool node-assignment (fill each replica's `targetNode`) +
same-node download dedup + snapshot-lifetime guard. PR 5 — cluster walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)