### PR TITLE
feat(snapshots): SwiftGuestPool node pre-assignment for cloneFromSnapshot — Phase 4 (4/5)

### DIFF
--- a/internal/controller/swiftguestpool/clone.go
+++ b/internal/controller/swiftguestpool/clone.go
@@ -1,0 +1,89 @@
+package swiftguestpool
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// errNoSchedulableNodes is returned when a cloneFromSnapshot pool replica needs
+// a target node but no Ready, schedulable worker node exists.
+var errNoSchedulableNodes = errors.New("no schedulable worker nodes for cloneFromSnapshot pool replica")
+
+// assignCloneTargetNode pins a cloneFromSnapshot pool replica's targetNode for
+// the Tier C (s3) path: the replica's download Job + restore-receive launcher
+// must be co-located on a chosen node, decided BEFORE the guest is created
+// (Snapshot Phase 4 design OQ1 — pre-assign, not float-then-pin). Replicas are
+// round-robined across the schedulable worker nodes by ordinal, spreading them
+// (replicas ≤ nodes → one per node). Tier B clones ignore targetNode (the
+// SwiftGuest controller pins them to the capture node), so setting it for any
+// cloneFromSnapshot template is harmless.
+//
+// NOTE (Phase 4 follow-up): a pool with replicas > nodes places multiple
+// replicas on one node, whose per-guest Tier C download Jobs would write the
+// same snapshot-keyed node cache concurrently. The download dedup (a shared
+// per-(node,snapshot) Job) is a tracked follow-up; until then keep
+// cloneFromSnapshot pools at replicas ≤ schedulable nodes.
+func (r *SwiftGuestPoolReconciler) assignCloneTargetNode(
+	ctx context.Context, spec *swiftv1alpha1.SwiftGuestSpec, index int,
+) error {
+	if spec.CloneFromSnapshot == nil {
+		return nil
+	}
+	nodes, err := r.schedulableWorkerNodes(ctx)
+	if err != nil {
+		return err
+	}
+	if len(nodes) == 0 {
+		return errNoSchedulableNodes
+	}
+	spec.CloneFromSnapshot.TargetNode = nodes[index%len(nodes)]
+	return nil
+}
+
+// schedulableWorkerNodes returns the names of Ready, schedulable, non-control-
+// plane nodes, sorted for deterministic round-robin assignment.
+func (r *SwiftGuestPoolReconciler) schedulableWorkerNodes(ctx context.Context) ([]string, error) {
+	var list corev1.NodeList
+	if err := r.List(ctx, &list); err != nil {
+		return nil, err
+	}
+	var names []string
+	for i := range list.Items {
+		n := &list.Items[i]
+		if n.Spec.Unschedulable || isControlPlaneNode(n) || !nodeIsReady(n) {
+			continue
+		}
+		names = append(names, n.Name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func isControlPlaneNode(n *corev1.Node) bool {
+	if _, ok := n.Labels["node-role.kubernetes.io/control-plane"]; ok {
+		return true
+	}
+	if _, ok := n.Labels["node-role.kubernetes.io/master"]; ok {
+		return true
+	}
+	for _, t := range n.Spec.Taints {
+		if t.Key == "node-role.kubernetes.io/control-plane" || t.Key == "node-role.kubernetes.io/master" {
+			return true
+		}
+	}
+	return false
+}
+
+func nodeIsReady(n *corev1.Node) bool {
+	for _, c := range n.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/internal/controller/swiftguestpool/clone_test.go
+++ b/internal/controller/swiftguestpool/clone_test.go
@@ -1,0 +1,82 @@
+package swiftguestpool
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+func node(name string, ready bool, mut func(*corev1.Node)) *corev1.Node {
+	st := corev1.ConditionFalse
+	if ready {
+		st = corev1.ConditionTrue
+	}
+	n := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: st}}},
+	}
+	if mut != nil {
+		mut(n)
+	}
+	return n
+}
+
+func poolReconciler(t *testing.T, objs ...client.Object) *SwiftGuestPoolReconciler {
+	t.Helper()
+	c := fake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).WithObjects(objs...).Build()
+	return &SwiftGuestPoolReconciler{Client: c}
+}
+
+func TestAssignCloneTargetNode_RoundRobin(t *testing.T) {
+	r := poolReconciler(t,
+		node("boba", true, nil),
+		node("miles", true, nil),
+		node("frida", true, func(n *corev1.Node) { // control-plane: excluded
+			n.Labels = map[string]string{"node-role.kubernetes.io/control-plane": ""}
+		}),
+		node("down", false, nil), // not ready: excluded
+		node("cordoned", true, func(n *corev1.Node) { n.Spec.Unschedulable = true }), // excluded
+	)
+	// schedulable workers sorted: [boba, miles]. Round-robin by index.
+	want := []string{"boba", "miles", "boba", "miles"}
+	for i, w := range want {
+		spec := &swiftv1alpha1.SwiftGuestSpec{
+			CloneFromSnapshot: &swiftv1alpha1.CloneFromSnapshotSource{
+				SnapshotRef: corev1.LocalObjectReference{Name: "snap"},
+			},
+		}
+		if err := r.assignCloneTargetNode(context.Background(), spec, i); err != nil {
+			t.Fatalf("index %d: %v", i, err)
+		}
+		if spec.CloneFromSnapshot.TargetNode != w {
+			t.Errorf("index %d: targetNode = %q, want %q", i, spec.CloneFromSnapshot.TargetNode, w)
+		}
+	}
+}
+
+func TestAssignCloneTargetNode_NonCloneNoop(t *testing.T) {
+	r := poolReconciler(t, node("boba", true, nil))
+	spec := &swiftv1alpha1.SwiftGuestSpec{ImageRef: &corev1.LocalObjectReference{Name: "img"}}
+	if err := r.assignCloneTargetNode(context.Background(), spec, 0); err != nil {
+		t.Fatalf("non-clone should be a no-op: %v", err)
+	}
+}
+
+func TestAssignCloneTargetNode_NoSchedulableNodes(t *testing.T) {
+	r := poolReconciler(t, node("frida", true, func(n *corev1.Node) {
+		n.Labels = map[string]string{"node-role.kubernetes.io/control-plane": ""}
+	}))
+	spec := &swiftv1alpha1.SwiftGuestSpec{
+		CloneFromSnapshot: &swiftv1alpha1.CloneFromSnapshotSource{SnapshotRef: corev1.LocalObjectReference{Name: "snap"}},
+	}
+	if err := r.assignCloneTargetNode(context.Background(), spec, 0); err != errNoSchedulableNodes {
+		t.Fatalf("want errNoSchedulableNodes, got %v", err)
+	}
+}

--- a/internal/controller/swiftguestpool/controller.go
+++ b/internal/controller/swiftguestpool/controller.go
@@ -241,6 +241,14 @@ func (r *SwiftGuestPoolReconciler) createSwiftGuest(ctx context.Context, pool *s
 
 	spec := pool.Spec.Template.Spec.DeepCopy()
 
+	// cloneFromSnapshot (Snapshot Phase 4): pre-assign each replica's targetNode
+	// (round-robin across schedulable worker nodes) so a Tier C clone's download
+	// + restore-receive land on a decided node. No-op for non-clone templates;
+	// ignored by the SwiftGuest controller for Tier B clones (capture-node-pinned).
+	if err := r.assignCloneTargetNode(ctx, spec, index); err != nil {
+		return fmt.Errorf("assign clone target node for %s: %w", name, err)
+	}
+
 	// Apply topology spread constraints.
 	spec.TopologySpreadConstraints = r.buildTopologyConstraints(pool)
 


### PR DESCRIPTION
## Summary

**PR 4 of Snapshot Phase 4.** A `SwiftGuestPool` whose template uses
`cloneFromSnapshot` now **pre-assigns each replica's `targetNode`**, so a Tier C
(s3) clone's download Job + restore-receive launcher land on a decided node — the
pool-of-clones enabler. Resolves design **OQ1** (pre-assign, not float-then-pin).

## What changed

- `swiftguestpool/clone.go`: `assignCloneTargetNode` **round-robins** each replica
  across the schedulable worker nodes by ordinal (sorted for determinism;
  excludes control-plane, cordoned, and not-Ready nodes). Called from
  `createSwiftGuest` after the template `DeepCopy`. **No-op for non-clone
  templates**; Tier B clones ignore `targetNode` (the SwiftGuest controller pins
  them to the capture node), so setting it for any cloneFromSnapshot template is
  harmless. Errors when no schedulable worker node exists.
- Reuses the existing `nodes` get/list/watch RBAC.

## Tests

Round-robin across `[boba, miles]` (control-plane / cordoned / not-Ready
excluded), non-clone no-op, no-schedulable-nodes error.

## Deferred (Phase 4 follow-ups, documented inline)

- **Download dedup**: a pool with **replicas > nodes** places >1 replica per
  node, whose per-guest Tier C download Jobs write the same snapshot-keyed node
  cache concurrently. A shared per-`(node, snapshot)` download Job is the fix;
  **until then keep cloneFromSnapshot pools at replicas ≤ schedulable nodes.**
- **Snapshot-lifetime guard (OQ2)**: a finalizer/webhook preventing deletion of a
  SwiftSnapshot a pool still references.

Full suite + vet green.

## Next
PR 5 — cluster walkthrough (an N-replica pool cloned from one Tier C snapshot,
spread across miles+boba, sentinel per replica) + runbook + samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)