### PR TITLE
feat(snapshots): cloneFromSnapshot pool walkthrough + runbook + samples — Phase 4 (5/5)

### DIFF
--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -58,8 +58,9 @@ type SwiftGuestSpec struct {
 	// captured state byte-for-byte (CH --restore) with per-clone identity
 	// regeneration. Mutually exclusive with imageRef, kernelRef, and
 	// gpuProfileRef (VFIO state cannot be CH-restored). The resumed VM's CPU/
-	// memory come from the snapshot, so guestClassRef is optional in this mode.
-	// (Snapshot Phase 4.)
+	// memory come from the snapshot, so guestClassRef is not used for resources
+	// in this mode — but it is still required by the CRD schema (set it to any
+	// class). (Snapshot Phase 4.)
 	// +optional
 	CloneFromSnapshot *CloneFromSnapshotSource `json:"cloneFromSnapshot,omitempty"`
 	// DataDiskRef references a SwiftImage to attach as a secondary data disk.

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
@@ -116,8 +116,9 @@ spec:
                           captured state byte-for-byte (CH --restore) with per-clone identity
                           regeneration. Mutually exclusive with imageRef, kernelRef, and
                           gpuProfileRef (VFIO state cannot be CH-restored). The resumed VM's CPU/
-                          memory come from the snapshot, so guestClassRef is optional in this mode.
-                          (Snapshot Phase 4.)
+                          memory come from the snapshot, so guestClassRef is not used for resources
+                          in this mode — but it is still required by the CRD schema (set it to any
+                          class). (Snapshot Phase 4.)
                         properties:
                           regenerate:
                             description: |-

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -48,8 +48,9 @@ spec:
                   captured state byte-for-byte (CH --restore) with per-clone identity
                   regeneration. Mutually exclusive with imageRef, kernelRef, and
                   gpuProfileRef (VFIO state cannot be CH-restored). The resumed VM's CPU/
-                  memory come from the snapshot, so guestClassRef is optional in this mode.
-                  (Snapshot Phase 4.)
+                  memory come from the snapshot, so guestClassRef is not used for resources
+                  in this mode — but it is still required by the CRD schema (set it to any
+                  class). (Snapshot Phase 4.)
                 properties:
                   regenerate:
                     description: |-

--- a/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
@@ -116,8 +116,9 @@ spec:
                           captured state byte-for-byte (CH --restore) with per-clone identity
                           regeneration. Mutually exclusive with imageRef, kernelRef, and
                           gpuProfileRef (VFIO state cannot be CH-restored). The resumed VM's CPU/
-                          memory come from the snapshot, so guestClassRef is optional in this mode.
-                          (Snapshot Phase 4.)
+                          memory come from the snapshot, so guestClassRef is not used for resources
+                          in this mode — but it is still required by the CRD schema (set it to any
+                          class). (Snapshot Phase 4.)
                         properties:
                           regenerate:
                             description: |-

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -48,8 +48,9 @@ spec:
                   captured state byte-for-byte (CH --restore) with per-clone identity
                   regeneration. Mutually exclusive with imageRef, kernelRef, and
                   gpuProfileRef (VFIO state cannot be CH-restored). The resumed VM's CPU/
-                  memory come from the snapshot, so guestClassRef is optional in this mode.
-                  (Snapshot Phase 4.)
+                  memory come from the snapshot, so guestClassRef is not used for resources
+                  in this mode — but it is still required by the CRD schema (set it to any
+                  class). (Snapshot Phase 4.)
                 properties:
                   regenerate:
                     description: |-

--- a/config/samples/clone-from-snapshot/02-source-guest.yaml
+++ b/config/samples/clone-from-snapshot/02-source-guest.yaml
@@ -1,0 +1,32 @@
+# Source SwiftGuest for the cloneFromSnapshot pool walkthrough (Snapshot Phase 4).
+#
+# Prerequisites (apply first):
+#   config/samples/s3-snapshots/00-minio.yaml          # in-cluster MinIO + bucket
+#   config/samples/local-snapshots/01-seed-profile.yaml # identity-regen seed
+#   config/samples/s3-snapshots/01-s3-creds.yaml         # s3 credentials Secret
+#
+# The seed profile's kubeswift.clone=true bootcmd regenerates machine-id /
+# hostname / SSH host keys on each clone's first reboot.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestClass
+metadata:
+  name: clone-src-class
+spec:
+  cpu: 2
+  memory: "2Gi"
+  rootDisk:
+    size: "10Gi"
+    format: raw
+---
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: clone-source
+spec:
+  imageRef:
+    name: rocky9-cloud
+  guestClassRef:
+    name: clone-src-class
+  seedProfileRef:
+    name: snapshot-local-test-seed
+  runPolicy: Running

--- a/config/samples/clone-from-snapshot/03-snapshot.yaml
+++ b/config/samples/clone-from-snapshot/03-snapshot.yaml
@@ -1,0 +1,29 @@
+# Tier C (s3) memory snapshot of clone-source — the source the pool clones from.
+#
+# Apply once clone-source is Running (and after writing whatever in-VM state you
+# want every clone to start from). The snapshot must reach Ready (its artifacts
+# uploaded to object storage) before the clone pool can boot.
+#
+# endpoint + forcePathStyle + insecure target the in-cluster demo MinIO; drop
+# them and set a real region for AWS S3.
+apiVersion: snapshot.kubeswift.io/v1alpha1
+kind: SwiftSnapshot
+metadata:
+  name: clone-snap
+  namespace: default
+spec:
+  guestRef:
+    name: clone-source
+  backend:
+    type: s3
+    s3:
+      bucket: kubeswift-snapshots
+      prefix: clones
+      endpoint: minio.minio.svc:9000
+      forcePathStyle: true
+      insecure: true            # demo MinIO serves plain HTTP; UNSAFE — drop for TLS
+      region: us-east-1
+      credentialsSecretRef:
+        name: s3-creds
+  includeMemory: true
+  resumeAfterSnapshot: true

--- a/config/samples/clone-from-snapshot/04-clone-pool.yaml
+++ b/config/samples/clone-from-snapshot/04-clone-pool.yaml
@@ -1,0 +1,36 @@
+# A SwiftGuestPool whose replicas are each a clone of clone-snap (Snapshot Phase 4).
+#
+# The pool pre-assigns each replica a targetNode (round-robin across schedulable
+# worker nodes), so the Tier C clones spread across the cluster. Each replica:
+#   - runs a node-pinned download Job that pulls clone-snap's artifacts into that
+#     node's cache,
+#   - boots via CH --restore from the cache (resumes the captured memory state),
+#   - gets a deterministic per-replica hypervisor MAC (no L2 collision).
+#
+# IMPORTANT: keep replicas <= number of schedulable worker nodes until the
+# same-node download dedup ships (a Phase 4 follow-up) — multiple replicas on one
+# node would otherwise race on the shared snapshot-keyed node cache. This demo
+# uses 2 replicas for a 2-worker cluster (one per node).
+#
+# Identity: macAddresses is always regenerated (forced). hostname/machineId/
+# sshHostKeys regenerate on each clone's FIRST REBOOT (CH --restore resumes
+# byte-for-byte; cloud-init does not re-run on resume). Reboot each replica once
+# for unique guest-visible identity — see docs/snapshots/clone-from-snapshot.md.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestPool
+metadata:
+  name: clone-pool
+  namespace: default
+spec:
+  replicas: 2
+  template:
+    spec:
+      runPolicy: Running
+      cloneFromSnapshot:
+        snapshotRef:
+          name: clone-snap
+        regenerate:
+          - macAddresses
+          - hostname
+          - machineId
+          - sshHostKeys

--- a/config/samples/clone-from-snapshot/04-clone-pool.yaml
+++ b/config/samples/clone-from-snapshot/04-clone-pool.yaml
@@ -26,6 +26,11 @@ spec:
   template:
     spec:
       runPolicy: Running
+      # guestClassRef is required by the CRD schema. A clone resumes the
+      # snapshot's CPU/memory, so this class is not used for resources — it just
+      # satisfies the schema (reuse the source's class).
+      guestClassRef:
+        name: clone-src-class
       cloneFromSnapshot:
         snapshotRef:
           name: clone-snap

--- a/docs/snapshots/clone-from-snapshot.md
+++ b/docs/snapshots/clone-from-snapshot.md
@@ -1,0 +1,143 @@
+# Clone from snapshot (Snapshot Phase 4)
+
+`SwiftGuest.spec.cloneFromSnapshot` boots a guest as a **clone of a
+SwiftSnapshot** — the guest resumes the captured memory state byte-for-byte
+(Cloud Hypervisor `--restore`) with a per-clone hypervisor identity. Templated
+on a `SwiftGuestPool`, it spins up **N VMs all cloned from one snapshot** —
+seconds per clone instead of minutes-per-cloud-image-boot.
+
+This is the ergonomic layer over the Phase 1/2/3 snapshot primitives; it adds no
+new runtime mechanism (it reuses the restore-receive launcher + the s3 download).
+
+## When to use it
+
+- Fast horizontal scale-out from a *warmed* VM (a memory snapshot captures a
+  running, post-boot, post-init state).
+- A pool of identical workers cloned from one golden snapshot.
+
+For a single disk-only clone or pool scaling from a *disk* image, use
+`SwiftImage.cloneStrategy: snapshot` (Tier A) instead — that clones an image's
+PVC, not a running VM's full state.
+
+## The boot source
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+spec:
+  cloneFromSnapshot:
+    snapshotRef:
+      name: my-snapshot        # a Ready SwiftSnapshot in the same namespace
+    targetNode: boba           # REQUIRED for a Tier C (s3) snapshot; ignored for Tier B
+    regenerate:                # identity reset on the clone (default: all four)
+      - macAddresses
+      - hostname
+      - machineId
+      - sshHostKeys
+```
+
+`cloneFromSnapshot` is **mutually exclusive** with `imageRef`, `kernelRef`, and
+`gpuProfileRef` (VFIO state cannot be CH-restored). `guestClassRef` is optional —
+the resumed VM's CPU/memory come from the snapshot.
+
+## How it works
+
+```
+SwiftGuest (cloneFromSnapshot)
+  → controller resolves the snapshot (Ready) + the LIVE source guest
+  → Tier C: a node-pinned download Job pulls the artifacts into the target node's cache
+  → self-stamps the clone-mode restore annotations (per-clone MAC, runtime-dir rewrites)
+  → restore-receive launcher boots: snapshot-stager stages+patches config.json,
+    swiftletd runs CH --restore from the node-local cache
+  → the clone resumes the captured memory; a fresh root disk is provisioned from
+    the source's image
+```
+
+**The source guest must be live.** The snapshot records only a small
+`CapturedGuestSpec` (CPU/mem/image-name) for validation; the clone needs the full
+source spec (image / seed / class) to build its pod. A clone of a snapshot whose
+source guest was deleted fails with a clear message. (Cross-cluster / source-gone
+clones are a future enhancement.)
+
+**Tier B vs Tier C:**
+
+| Backend | Clone runs on | Notes |
+|---|---|---|
+| `local` (Tier B) | the **capture node** (`targetNode` ignored) | same-node only; no download |
+| `s3` (Tier C) | the node named by `targetNode` | a download Job populates that node's cache first — the cross-node / pool fit |
+
+## Pools — N clones from one snapshot
+
+`SwiftGuestPool.spec.template.spec.cloneFromSnapshot` clones every replica from
+the snapshot. The pool **pre-assigns each replica a `targetNode`** (round-robin
+across schedulable worker nodes), so Tier C clones spread across the cluster.
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestPool
+spec:
+  replicas: 2
+  template:
+    spec:
+      runPolicy: Running
+      cloneFromSnapshot:
+        snapshotRef: {name: my-snapshot}
+        regenerate: [macAddresses, hostname, machineId, sshHostKeys]
+```
+
+> ⚠️ **Keep `replicas` ≤ schedulable worker nodes** until the same-node download
+> dedup ships (a Phase 4 follow-up). With more replicas than nodes, multiple
+> replicas land on one node and their per-guest download Jobs would race on the
+> shared snapshot-keyed node cache.
+
+## Identity (the resume-vs-boot rule)
+
+CH `--restore` resumes byte-for-byte — **cloud-init does not re-run** — so without
+intervention every clone inherits the source's identity. Two layers handle it:
+
+- **MAC**: the controller rewrites each clone's *hypervisor* `config.net[].mac` to
+  a value deterministic in `(namespace, name, iface)` — **always**, regardless of
+  the `regenerate` list. Combined with each clone's own pod network namespace,
+  this makes N coexisting clones collision-safe **by construction** (the
+  guest-visible MAC stays the source's until reboot, but the clones are never on
+  the same L2 segment).
+- **hostname / machine-id / SSH host keys**: regenerated on each clone's **first
+  reboot** via the seed profile's `kubeswift.clone=true` bootcmd (listed in
+  `regenerate`). Until a reboot they are inherited.
+
+**To diverge guest-visible identity, reboot each replica once after it resumes.**
+(An in-guest vsock agent to do this without a reboot is a future enhancement.)
+
+## Quick start (walkthrough)
+
+```bash
+# Prereqs: in-cluster MinIO + bucket, the identity-regen seed, and s3 creds.
+kubectl apply -f config/samples/s3-snapshots/00-minio.yaml      # + create the bucket
+kubectl apply -f config/samples/local-snapshots/01-seed-profile.yaml
+kubectl apply -f config/samples/s3-snapshots/01-s3-creds.yaml
+
+kubectl apply -f config/samples/clone-from-snapshot/02-source-guest.yaml
+# (optional) write some in-VM state you want every clone to start from, then:
+kubectl apply -f config/samples/clone-from-snapshot/03-snapshot.yaml
+kubectl get swiftsnapshot clone-snap -w        # wait for Ready
+
+kubectl apply -f config/samples/clone-from-snapshot/04-clone-pool.yaml
+kubectl get swiftguest -l swift.kubeswift.io/pool-name=clone-pool -o wide -w
+# each replica: Downloading (Tier C) → Restoring → Running, spread across nodes
+```
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| Guest `Failed`, *"source SwiftGuest … no longer exists"* | The snapshot's source guest was deleted. cloneFromSnapshot needs the live source spec. |
+| Guest `Failed`, *"requires spec.cloneFromSnapshot.targetNode"* | Tier C clone without a target node. In a pool the controller assigns it; a standalone clone must set it. |
+| Guest stuck `Pending`, *"waiting for SwiftSnapshot … to be Ready"* | The snapshot is still Capturing/Uploading. |
+| Guest stuck `Pending`, download Job present | The Tier C download is in progress (or `ImagePullBackOff` / `snapshot-s3 image not configured`). |
+| All clones share hostname/machine-id | Expected on resume — reboot each clone once to fire the regen bootcmd. |
+
+## Cluster walkthrough
+
+<!-- Populated after the cluster pool-of-clones validation (PR 5). -->
+_Empirical validation (an N-replica pool cloned from one Tier C snapshot, spread
+across nodes, sentinel per replica) is recorded here after the cluster run._

--- a/docs/snapshots/clone-from-snapshot.md
+++ b/docs/snapshots/clone-from-snapshot.md
@@ -37,8 +37,9 @@ spec:
 ```
 
 `cloneFromSnapshot` is **mutually exclusive** with `imageRef`, `kernelRef`, and
-`gpuProfileRef` (VFIO state cannot be CH-restored). `guestClassRef` is optional —
-the resumed VM's CPU/memory come from the snapshot.
+`gpuProfileRef` (VFIO state cannot be CH-restored). `guestClassRef` is **still
+required** by the CRD schema (set it to any class) but is not used for
+resources — the resumed VM's CPU/memory come from the snapshot.
 
 ## How it works
 

--- a/docs/snapshots/clone-from-snapshot.md
+++ b/docs/snapshots/clone-from-snapshot.md
@@ -139,6 +139,40 @@ kubectl get swiftguest -l swift.kubeswift.io/pool-name=clone-pool -o wide -w
 
 ## Cluster walkthrough
 
-<!-- Populated after the cluster pool-of-clones validation (PR 5). -->
-_Empirical validation (an N-replica pool cloned from one Tier C snapshot, spread
-across nodes, sentinel per replica) is recorded here after the cluster run._
+Validated on the dev cluster (k0s 1.34, CH v51.1, in-cluster MinIO, miles+boba).
+A `clone-source` (rocky9) on boba got a sentinel + a Tier C `clone-snap`
+(Ready); a 2-replica `clone-pool` then cloned it. The walkthrough caught **two
+real bugs** unit tests structurally cannot (the recurring **W5 pattern** —
+fake-client tests verify control flow, not on-cluster runtime behavior); both
+are fixed.
+
+1. **The clone loaded `--restore` but stayed PAUSED.** The restore-receive
+   launcher runs `CH --restore` (which loads the guest with vCPUs *stopped*) and
+   reports `GuestRunning=True`, but nothing unpaused it — a cloneFromSnapshot
+   guest has no SwiftRestore controller to drive a Resuming phase. On-cluster:
+   `vm.info` `state=Paused`, console dead. **Fix:** the SwiftGuest controller
+   sends the one-shot `kubeswift.io/snapshot-action: resume` to the clone's
+   launcher pod once it is Running (idempotent), mirroring SwiftRestore.
+2. **`guestClassRef` CRD-vs-webhook mismatch.** PR 2's webhook made
+   `guestClassRef` optional for clones, but the CRD schema **requires** it — so
+   the apiserver rejected the pool template before the webhook ran. **Fix:**
+   require `guestClassRef` for every boot source (clones ignore it for resources
+   but must set it).
+
+Results after the fixes:
+
+| | clone-pool-0 | clone-pool-1 |
+|---|---|---|
+| Assigned node | **boba** | **miles** (cross-node) |
+| Tier C download Job | on boba ✓ | on miles ✓ |
+| Phase | Running | Running |
+| Hypervisor MAC | `52:54:00:7e:0c:47` | `52:54:00:fd:c6:1a` (distinct) |
+| Sentinel `CLONE-POOL-…` | survived ✓ | survived ✓ |
+| machine-id | inherited (resume-vs-boot) | inherited (resume-vs-boot) |
+
+The 2-replica pool pre-assigned one replica per worker node, each ran its own
+node-pinned download from object storage, booted as a clone via `CH --restore`,
+resumed (one-shot resume action), and came up with the source's in-VM state
+preserved and a distinct per-clone hypervisor MAC. Guest-visible identity
+(machine-id / hostname / MAC) is inherited until each clone's first reboot — the
+documented resume-vs-boot rule.

--- a/internal/controller/swiftguest/clone.go
+++ b/internal/controller/swiftguest/clone.go
@@ -186,6 +186,36 @@ func cloneDownloadJobName(guest *swiftv1alpha1.SwiftGuest) string {
 	return guest.Name + "-clone-download"
 }
 
+// swiftletd action-loop annotation surface (mirrors the snapshot/restore
+// controllers): the controller writes these onto the launcher pod and swiftletd
+// dedupes by action-id.
+const (
+	cloneActionKey     = "kubeswift.io/snapshot-action"
+	cloneActionIDKey   = "kubeswift.io/snapshot-action-id"
+	cloneActionArgsKey = "kubeswift.io/snapshot-action-args"
+	cloneVerbResume    = "resume"
+)
+
+// resumeCloneIfNeeded sends the one-shot resume action to a cloneFromSnapshot
+// clone's launcher pod. CH --restore loads the guest PAUSED; swiftletd's action
+// loop unpauses it when this annotation appears. Idempotent: a stable action-id
+// means swiftletd resumes exactly once (and we skip re-patching once it's set).
+// Without this the clone reports GuestRunning but its vCPUs never start.
+func (r *SwiftGuestReconciler) resumeCloneIfNeeded(ctx context.Context, pod *corev1.Pod, guest *swiftv1alpha1.SwiftGuest) error {
+	id := guest.Name + "-clone-resume"
+	if pod.Annotations[cloneActionIDKey] == id {
+		return nil // already sent
+	}
+	patch := client.MergeFrom(pod.DeepCopy())
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	pod.Annotations[cloneActionKey] = cloneVerbResume
+	pod.Annotations[cloneActionIDKey] = id
+	pod.Annotations[cloneActionArgsKey] = "{}"
+	return r.Patch(ctx, pod, patch)
+}
+
 // ensureCloneDownloadJob creates (idempotently) a guest-owned, node-pinned
 // download Job that pulls a Tier C snapshot's artifacts into the target node's
 // cache, and reports whether it has completed. Returns (done, failReason, err):

--- a/internal/controller/swiftguest/clone_test.go
+++ b/internal/controller/swiftguest/clone_test.go
@@ -206,3 +206,32 @@ func TestCloneRegenIncludesNonMAC(t *testing.T) {
 		})
 	}
 }
+
+func TestResumeCloneIfNeeded(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "clone-a", Namespace: "ns"}}
+	r := poolCloneReconciler(t, pod)
+	g := cloneGuest()
+
+	// First call: stamps the resume action onto the pod.
+	if err := r.resumeCloneIfNeeded(context.Background(), pod, g); err != nil {
+		t.Fatal(err)
+	}
+	if pod.Annotations[cloneActionKey] != cloneVerbResume || pod.Annotations[cloneActionIDKey] != "clone-a-clone-resume" {
+		t.Fatalf("resume action not stamped: %+v", pod.Annotations)
+	}
+	// Second call (action-id already set): no-op (idempotent).
+	before := pod.Annotations[cloneActionIDKey]
+	if err := r.resumeCloneIfNeeded(context.Background(), pod, g); err != nil {
+		t.Fatal(err)
+	}
+	if pod.Annotations[cloneActionIDKey] != before {
+		t.Errorf("resume should be idempotent once the action-id is set")
+	}
+}
+
+func poolCloneReconciler(t *testing.T, objs ...client.Object) *SwiftGuestReconciler {
+	t.Helper()
+	s := cloneScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	return &SwiftGuestReconciler{Client: c, Scheme: s}
+}

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -462,6 +462,17 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Pod exists; update status from pod
 		podForMetrics = &existingPod
 		MapPodToStatus(&existingPod, status)
+		// cloneFromSnapshot (Snapshot Phase 4): CH loaded the snapshot PAUSED
+		// (GuestRunning is reported once the API socket is up, but the vCPUs are
+		// stopped). Send the one-shot resume action so swiftletd unpauses the VM
+		// — a clone has no SwiftRestore controller to drive its Resuming phase.
+		if guest.UsesCloneFromSnapshot() &&
+			status.Phase == swiftv1alpha1.SwiftGuestPhaseRunning &&
+			rg.GetLifecycle() != "stop" {
+			if err := r.resumeCloneIfNeeded(ctx, &existingPod, &guest); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 		// If guest is running but IP not yet discovered, requeue to catch annotation update
 		if status.Phase == swiftv1alpha1.SwiftGuestPhaseRunning &&
 			(status.Network == nil || status.Network.PrimaryIP == "") {

--- a/internal/webhook/swiftguest/validator.go
+++ b/internal/webhook/swiftguest/validator.go
@@ -61,9 +61,12 @@ func validateSwiftGuest(g *swiftv1alpha1.SwiftGuest) error {
 		}
 	}
 
-	// guestClassRef is required for image/kernel boot but optional for a clone
-	// (the resumed VM's CPU/memory come from the snapshot).
-	if !hasClone && spec.GuestClassRef.Name == "" {
+	// guestClassRef is required by the CRD schema (a non-pointer struct field),
+	// so it is required for every boot source — including clones, which ignore
+	// it for resources (the resumed VM's CPU/memory come from the snapshot) but
+	// must still set it to satisfy admission. Keeping the webhook aligned with
+	// the CRD avoids a confusing "webhook says optional, apiserver rejects" gap.
+	if spec.GuestClassRef.Name == "" {
 		return fmt.Errorf("spec.guestClassRef.name is required")
 	}
 	validPolicies := map[swiftv1alpha1.RunPolicy]bool{

--- a/internal/webhook/swiftguest/validator_test.go
+++ b/internal/webhook/swiftguest/validator_test.go
@@ -43,16 +43,21 @@ func TestValidate_BootSourceExclusivity(t *testing.T) {
 	})); err != nil {
 		t.Errorf("kernelRef-only should be valid: %v", err)
 	}
-	// cloneFromSnapshot alone (no guestClassRef): OK.
+	// cloneFromSnapshot (with guestClassRef, which the CRD requires): OK.
 	if err := validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.ImageRef = nil
-		g.Spec.GuestClassRef = corev1.LocalObjectReference{}
 		g.Spec.CloneFromSnapshot = &swiftv1alpha1.CloneFromSnapshotSource{
 			SnapshotRef: corev1.LocalObjectReference{Name: "snap"},
 		}
 	})); err != nil {
-		t.Errorf("cloneFromSnapshot-only should be valid (guestClassRef optional): %v", err)
+		t.Errorf("cloneFromSnapshot should be valid: %v", err)
 	}
+	// cloneFromSnapshot without guestClassRef: rejected (CRD requires it; webhook aligned).
+	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.ImageRef = nil
+		g.Spec.GuestClassRef = corev1.LocalObjectReference{}
+		g.Spec.CloneFromSnapshot = &swiftv1alpha1.CloneFromSnapshotSource{SnapshotRef: corev1.LocalObjectReference{Name: "snap"}}
+	})), "spec.guestClassRef.name is required")
 	// none set.
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) { g.Spec.ImageRef = nil })),
 		"exactly one of spec.imageRef")


### PR DESCRIPTION
## Summary

**PR 5 of Snapshot Phase 4** — the operator surface + the cluster walkthrough
that validates the whole stack end-to-end.

### Samples (`config/samples/clone-from-snapshot/`)
- `02-source-guest.yaml` — source guest + identity-regen seed.
- `03-snapshot.yaml` — Tier C (s3) memory snapshot of the source.
- `04-clone-pool.yaml` — a 2-replica `cloneFromSnapshot` `SwiftGuestPool` (one per
  worker node — the documented `replicas ≤ nodes` constraint).

Reuses the `s3-snapshots` MinIO + creds as prereqs.

### Runbook (`docs/snapshots/clone-from-snapshot.md`)
When to use it, the boot source + exclusivity, Tier B vs Tier C, pools (node
pre-assignment + the `replicas ≤ nodes` constraint pending the download dedup),
the resume-vs-boot identity rule (forced per-clone MAC + reboot-to-diverge),
quick-start, troubleshooting.

## ⏳ Cluster walkthrough — pending the post-#125 image

The live pool-of-clones validation (an N-replica pool cloned from one Tier C
snapshot, spread across miles+boba, sentinel byte-identical per replica) runs
once the post-#125 controller image finishes building + deploys. Findings get
folded into the runbook's walkthrough section as a follow-up commit to this PR —
this is the W5-pattern step that historically catches what unit tests miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)