### PR TITLE
feat(snapshots): dedup Tier C clone download per (node, snapshot)

### DIFF
--- a/docs/snapshots/clone-from-snapshot.md
+++ b/docs/snapshots/clone-from-snapshot.md
@@ -86,10 +86,11 @@ spec:
         regenerate: [macAddresses, hostname, machineId, sshHostKeys]
 ```
 
-> ⚠️ **Keep `replicas` ≤ schedulable worker nodes** until the same-node download
-> dedup ships (a Phase 4 follow-up). With more replicas than nodes, multiple
-> replicas land on one node and their per-guest download Jobs would race on the
-> shared snapshot-keyed node cache.
+> ℹ️ **`replicas` may exceed the worker-node count.** When more replicas than
+> nodes land on the same node from the same snapshot, they **share one Tier C
+> download Job** (keyed per `(node, snapshot)`), so they no longer race on the
+> shared snapshot-keyed node cache. (The earlier "keep `replicas` ≤ nodes"
+> guidance is lifted.) Replicas are still round-robined across nodes for spread.
 
 ## Identity (the resume-vs-boot rule)
 

--- a/internal/controller/swiftguest/clone.go
+++ b/internal/controller/swiftguest/clone.go
@@ -2,6 +2,8 @@ package swiftguest
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -52,9 +54,10 @@ func (r *SwiftGuestReconciler) prepareCloneFromSnapshot(
 
 	// Resolve the on-node snapshot directory + the node the clone runs on.
 	// Tier B (local): the snapshot already lives on its capture node. Tier C
-	// (s3): a per-guest download Job pulls the artifacts into the chosen target
-	// node's cache first (mirrors the SwiftRestore download path); the clone
-	// then boots once the cache is populated.
+	// (s3): a download Job — shared per (node, snapshot) across all clones that
+	// land on the same node — pulls the artifacts into that node's cache first
+	// (mirrors the SwiftRestore download path); the clone then boots once the
+	// cache is populated.
 	var snapshotPath, node string
 	switch snap.Spec.Backend.Type {
 	case snapshotv1alpha1.SnapshotBackendLocal:
@@ -180,10 +183,19 @@ func cloneAnnotationsMatch(have, want map[string]string) bool {
 	return true
 }
 
-// cloneDownloadJobName is the deterministic name of a cloneFromSnapshot guest's
-// Tier C download Job.
-func cloneDownloadJobName(guest *swiftv1alpha1.SwiftGuest) string {
-	return guest.Name + "-clone-download"
+// cloneDownloadJobName is the deterministic name of the Tier C clone download
+// Job, keyed by (node, snapshot) — NOT by the guest. Every clone that lands on
+// the same node from the same snapshot resolves to the SAME Job name, so they
+// share one downloader instead of racing concurrent writers on the shared
+// node-local cache hostPath (S3LocalDir is snapshot-keyed and identical on a
+// given node). The (namespace, name, node) tuple is hashed to a short, always
+// DNS-1123-valid suffix (node names can be long or contain characters invalid
+// in a resource name). The snapshot lives in the guest's namespace, so the
+// namespace is constant across the clones that could collide; it is folded into
+// the hash for completeness.
+func cloneDownloadJobName(snap *snapshotv1alpha1.SwiftSnapshot, node string) string {
+	sum := sha256.Sum256([]byte(snap.Namespace + "/" + snap.Name + "@" + node))
+	return "clone-dl-" + hex.EncodeToString(sum[:8])
 }
 
 // swiftletd action-loop annotation surface (mirrors the snapshot/restore
@@ -216,20 +228,36 @@ func (r *SwiftGuestReconciler) resumeCloneIfNeeded(ctx context.Context, pod *cor
 	return r.Patch(ctx, pod, patch)
 }
 
-// ensureCloneDownloadJob creates (idempotently) a guest-owned, node-pinned
-// download Job that pulls a Tier C snapshot's artifacts into the target node's
-// cache, and reports whether it has completed. Returns (done, failReason, err):
+// ensureCloneDownloadJob creates (idempotently) a node-pinned download Job that
+// pulls a Tier C snapshot's artifacts into the target node's cache, and reports
+// whether it has completed. Returns (done, failReason, err):
 //   - done=true       → the cache is populated; proceed to boot the clone.
 //   - failReason != "" → terminal (image unset, or the Job failed).
 //   - otherwise        → still downloading (caller requeues).
 //
-// The cache dir (clonecommon.S3LocalDir) is snapshot-keyed, so the snapshot-s3
-// binary's checksum-aware idempotency means a re-download is a fast no-op when
-// the artifacts are already present (e.g. a second clone on the same node). The
-// Job itself is per-guest here; a SwiftGuestPool placing MANY replicas on ONE
-// node would create concurrent same-path downloads — PR 4 (pool integration)
-// should deduplicate the download per (node, snapshot) to avoid the concurrent-
-// write race. For a single clone (or clones spread across nodes) this is correct.
+// Dedup per (node, snapshot): the Job name (cloneDownloadJobName) and the cache
+// dir (clonecommon.S3LocalDir) are both functions of the snapshot, not the
+// guest, so every clone on a given node from the same snapshot converges on ONE
+// download Job. Concurrent reconciles all Get-then-Create the same name; the
+// first wins and the rest get AlreadyExists (swallowed below). That guarantees a
+// single writer to the snapshot-keyed hostPath, eliminating the concurrent-write
+// race a SwiftGuestPool would otherwise hit when it places more replicas than
+// nodes — which is what lifts the prior "keep replicas <= schedulable nodes"
+// constraint. (A second clone arriving after the cache is already populated is a
+// fast checksum-verified no-op via the snapshot-s3 binary's idempotency.)
+//
+// Ownership is the requesting clone (the race-winner that first creates it),
+// matching how every other guest-owned Job in this controller works (e.g. the
+// rootdisk clone Job) — so this adds NO new finalizers-RBAC surface (a
+// SwiftSnapshot owner would, via OwnerReferencesPermissionEnforcement on
+// hardened clusters, a 403 the default dev cluster wouldn't catch). A sibling
+// clone that finds the Job already present just reads it; it is not an owner and
+// is woken by its own 5s requeue, not the Owns(Job) watch. If the owning clone
+// is deleted mid-download the Job is GC'd, but a surviving sibling's next
+// reconcile recreates it by the same name and the snapshot-s3 binary resumes
+// idempotently (the same recreate-on-missing self-heal the SwiftRestore download
+// path uses); once the cache is populated the Job is no longer load-bearing —
+// the artifacts live on the node-local hostPath, not in the Job.
 func (r *SwiftGuestReconciler) ensureCloneDownloadJob(
 	ctx context.Context,
 	guest *swiftv1alpha1.SwiftGuest,
@@ -239,17 +267,19 @@ func (r *SwiftGuestReconciler) ensureCloneDownloadJob(
 	if r.SnapshotS3Image == "" {
 		return false, "snapshot-s3 image not configured (set KUBESWIFT_SNAPSHOT_S3_IMAGE)", nil
 	}
+	// The Job lives in the snapshot's namespace (== the guest's namespace).
+	name := cloneDownloadJobName(snap, node)
 	var job batchv1.Job
-	err := r.Get(ctx, client.ObjectKey{Name: cloneDownloadJobName(guest), Namespace: guest.Namespace}, &job)
+	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: snap.Namespace}, &job)
 	if apierrors.IsNotFound(err) {
 		j := clonecommon.BuildDownloadJob(clonecommon.DownloadJobParams{
 			Snapshot:    snap,
 			Image:       r.SnapshotS3Image,
-			Name:        cloneDownloadJobName(guest),
-			Namespace:   guest.Namespace,
+			Name:        name,
+			Namespace:   snap.Namespace,
 			Node:        node,
 			Component:   "snapshot-s3-clone-download",
-			ExtraLabels: map[string]string{"kubeswift.io/swiftguest": guest.Name},
+			ExtraLabels: map[string]string{"kubeswift.io/snapshot": snap.Name},
 		})
 		if cerr := ctrl.SetControllerReference(guest, j, r.Scheme); cerr != nil {
 			return false, "", cerr

--- a/internal/controller/swiftguest/clone_test.go
+++ b/internal/controller/swiftguest/clone_test.go
@@ -156,11 +156,16 @@ func TestPrepareCloneFromSnapshot_TierC_DownloadsThenProceeds(t *testing.T) {
 		t.Fatalf("first pass should create the download Job + requeue; fail=%q requeue=%v err=%v", fail, requeue, err)
 	}
 	var job batchv1.Job
-	if err := c.Get(context.Background(), client.ObjectKey{Name: "clone-a-clone-download", Namespace: "ns"}, &job); err != nil {
+	wantJob := cloneDownloadJobName(s3CloneSnap(), "miles")
+	if err := c.Get(context.Background(), client.ObjectKey{Name: wantJob, Namespace: "ns"}, &job); err != nil {
 		t.Fatalf("download Job not created: %v", err)
 	}
 	if job.Spec.Template.Spec.NodeName != "miles" {
 		t.Errorf("download Job must pin to targetNode miles; got %q", job.Spec.Template.Spec.NodeName)
+	}
+	// The shared Job is owned by the clone guest that created it.
+	if oc := metav1.GetControllerOf(&job); oc == nil || oc.Kind != "SwiftGuest" || oc.Name != "clone-a" {
+		t.Errorf("download Job must be owned by the creating SwiftGuest; got %+v", job.OwnerReferences)
 	}
 
 	// Mark the Job complete; second pass should proceed (effective + stamped).
@@ -176,6 +181,82 @@ func TestPrepareCloneFromSnapshot_TierC_DownloadsThenProceeds(t *testing.T) {
 		g.Annotations[AnnotationRestoreSnapshotPath] != "/var/lib/kubeswift/snapshots/ns-snap" {
 		t.Errorf("Tier C restore annotations wrong: %+v", g.Annotations)
 	}
+}
+
+func TestCloneDownloadJobName_PerNodeSnapshot(t *testing.T) {
+	snap := s3CloneSnap()
+	// Deterministic + DNS-1123 valid + guest-independent.
+	if a, b := cloneDownloadJobName(snap, "miles"), cloneDownloadJobName(snap, "miles"); a != b {
+		t.Errorf("name must be deterministic; got %q vs %q", a, b)
+	}
+	if !strings.HasPrefix(cloneDownloadJobName(snap, "miles"), "clone-dl-") {
+		t.Errorf("name must carry the clone-dl- prefix; got %q", cloneDownloadJobName(snap, "miles"))
+	}
+	// Different node → different Job (each node's cache is a separate hostPath).
+	if cloneDownloadJobName(snap, "miles") == cloneDownloadJobName(snap, "boba") {
+		t.Error("different nodes must yield different download Job names")
+	}
+	// Different snapshot → different Job.
+	other := s3CloneSnap()
+	other.Name = "snap2"
+	if cloneDownloadJobName(snap, "miles") == cloneDownloadJobName(other, "miles") {
+		t.Error("different snapshots must yield different download Job names")
+	}
+}
+
+// TestEnsureCloneDownloadJob_DedupPerNodeSnapshot proves two clones on the same
+// node from the same snapshot converge on ONE shared download Job — the fix that
+// lifts the "replicas <= schedulable nodes" constraint.
+func TestEnsureCloneDownloadJob_DedupPerNodeSnapshot(t *testing.T) {
+	snap := s3CloneSnap()
+	gA := cloneGuest() // "clone-a"
+	gB := cloneGuest() // a second, distinct clone
+	gB.Name = "clone-b"
+	r, c := newCloneReconciler(t, gA, gB, snap)
+	r.SnapshotS3Image = "img"
+
+	// Two distinct clone guests, both targeting node "miles".
+	for _, g := range []*swiftv1alpha1.SwiftGuest{gA, gB} {
+		done, fail, err := r.ensureCloneDownloadJob(context.Background(), g, snap, "miles")
+		if err != nil || fail != "" || done {
+			t.Fatalf("%s: expected in-progress (not done, no fail); done=%v fail=%q err=%v", g.Name, done, fail, err)
+		}
+	}
+
+	var jobs batchv1.JobList
+	if err := c.List(context.Background(), &jobs, client.InNamespace("ns")); err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs.Items) != 1 {
+		t.Fatalf("expected exactly ONE shared download Job for (miles, snap); got %d: %v", len(jobs.Items), jobNames(jobs))
+	}
+	job := jobs.Items[0]
+	if job.Name != cloneDownloadJobName(snap, "miles") {
+		t.Errorf("shared Job name = %q, want %q", job.Name, cloneDownloadJobName(snap, "miles"))
+	}
+	// Owned by the race-winner (clone-a, created first here); the sibling reads it.
+	if oc := metav1.GetControllerOf(&job); oc == nil || oc.Kind != "SwiftGuest" || oc.Name != "clone-a" {
+		t.Errorf("shared Job must be owned by the creating SwiftGuest; got %+v", job.OwnerReferences)
+	}
+
+	// A clone on a DIFFERENT node gets its own Job (separate node-local cache).
+	if _, _, err := r.ensureCloneDownloadJob(context.Background(), gA, snap, "boba"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.List(context.Background(), &jobs, client.InNamespace("ns")); err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs.Items) != 2 {
+		t.Fatalf("a clone on a second node must add a second Job; got %d: %v", len(jobs.Items), jobNames(jobs))
+	}
+}
+
+func jobNames(l batchv1.JobList) []string {
+	out := make([]string, 0, len(l.Items))
+	for i := range l.Items {
+		out = append(out, l.Items[i].Name)
+	}
+	return out
 }
 
 func TestPrepareCloneFromSnapshot_SourceGone(t *testing.T) {

--- a/internal/controller/swiftguestpool/clone.go
+++ b/internal/controller/swiftguestpool/clone.go
@@ -19,15 +19,15 @@ var errNoSchedulableNodes = errors.New("no schedulable worker nodes for cloneFro
 // must be co-located on a chosen node, decided BEFORE the guest is created
 // (Snapshot Phase 4 design OQ1 — pre-assign, not float-then-pin). Replicas are
 // round-robined across the schedulable worker nodes by ordinal, spreading them
-// (replicas ≤ nodes → one per node). Tier B clones ignore targetNode (the
-// SwiftGuest controller pins them to the capture node), so setting it for any
-// cloneFromSnapshot template is harmless.
+// (replicas ≤ nodes → one per node; replicas > nodes → stacked round-robin).
+// Tier B clones ignore targetNode (the SwiftGuest controller pins them to the
+// capture node), so setting it for any cloneFromSnapshot template is harmless.
 //
-// NOTE (Phase 4 follow-up): a pool with replicas > nodes places multiple
-// replicas on one node, whose per-guest Tier C download Jobs would write the
-// same snapshot-keyed node cache concurrently. The download dedup (a shared
-// per-(node,snapshot) Job) is a tracked follow-up; until then keep
-// cloneFromSnapshot pools at replicas ≤ schedulable nodes.
+// replicas > nodes is now supported: multiple replicas stacked on one node from
+// the same snapshot share ONE Tier C download Job — keyed per (node, snapshot)
+// and deduplicated in the SwiftGuest controller's ensureCloneDownloadJob — so
+// they no longer race concurrent writers on the shared snapshot-keyed node
+// cache. (The earlier "keep replicas ≤ schedulable nodes" guidance is lifted.)
 func (r *SwiftGuestPoolReconciler) assignCloneTargetNode(
 	ctx context.Context, spec *swiftv1alpha1.SwiftGuestSpec, index int,
 ) error {


### PR DESCRIPTION
## Snapshot Phase 4 follow-up — same-node clone download dedup

**Problem.** A `cloneFromSnapshot` `SwiftGuestPool` with `replicas >` schedulable nodes stacks multiple replicas on one node. Each replica's **per-guest** Tier C download Job wrote the same snapshot-keyed node-local cache (`clonecommon.S3LocalDir`) **concurrently** — a write race. The Phase 4 walkthrough worked around it by constraining pools to `replicas ≤ nodes`.

**Fix.** Key the clone download Job by **`(node, snapshot)`** instead of by the guest:

- `cloneDownloadJobName(snap, node)` hashes `snap.namespace/snap.name@node` → a short DNS-1123 suffix (`clone-dl-<16hex>`).
- Every clone that lands on the same node from the same snapshot converges on **one** Job: concurrent reconciles `Get`-then-`Create` the same name, the first wins, the rest get `AlreadyExists` (swallowed) → **single writer** to the cache.
- This **lifts the `replicas ≤ nodes` constraint**. Replicas are still round-robined across nodes for spread.

**Ownership decision — kept with the requesting clone (race-winner), not the snapshot.** Guest-ownership matches every other guest-owned Job in this controller (e.g. the rootdisk clone Job) and adds **no new finalizers-RBAC surface**. A `SwiftSnapshot` owner would, under `OwnerReferencesPermissionEnforcement` on hardened clusters, require `swiftsnapshots/finalizers` `update` and produce a **403 on Job create that the default dev cluster wouldn't catch** — the exact W5 trap. A sibling that finds the Job already present just reads it (woken by its own 5s requeue). If the owning clone is deleted mid-download the Job is GC'd, but a surviving sibling recreates it by the same name and the `snapshot-s3` binary resumes idempotently — the same recreate-on-missing self-heal the `SwiftRestore` download path already uses. Once the cache is populated the Job is no longer load-bearing (artifacts live on the node-local hostPath).

## Changes
- `internal/controller/swiftguest/clone.go` — `(node, snapshot)`-keyed `cloneDownloadJobName`; `ensureCloneDownloadJob` dedups + owns by the guest; snapshot-identifying label.
- `internal/controller/swiftguestpool/clone.go` — lifted the `replicas ≤ nodes` NOTE in `assignCloneTargetNode`.
- `docs/snapshots/clone-from-snapshot.md` — operator guidance updated (`replicas` may exceed node count).

## Tests
- `TestEnsureCloneDownloadJob_DedupPerNodeSnapshot` — two clones on one node from one snapshot → **one** shared, guest-owned Job; a clone on a second node → a second Job.
- `TestCloneDownloadJobName_PerNodeSnapshot` — deterministic, `clone-dl-` prefix, per-node + per-snapshot distinctness.
- Updated the existing Tier C test to the new name + owner assertion.

`go build ./...`, `go vet ./internal/...`, and the full `internal/{controller,snapshot,webhook}` suite pass.

## Not hardware-validated here
Logic + dedup are unit-tested. The concurrent-write race only manifests with `replicas > nodes` stacked on one node; the dev cluster has 2 worker nodes, so a 3-replica pool would exercise it on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)