### PR TITLE
feat(metrics): snapshot/restore/clone Prometheus metrics — Phase 5 (1/6)

### DIFF
--- a/docs/design/snapshot-phase-5.md
+++ b/docs/design/snapshot-phase-5.md
@@ -237,23 +237,36 @@ multi-controller surface — the W5 pattern lives here: a TTL-GC that deletes a
 pool-referenced snapshot, or an S3 delete Job that 403s on a missing-cred path,
 won't show up in fake-client tests).
 
-## 8. Open questions
+## 8. Open questions — RESOLVED (2026-06-05)
 
-- **OQ1 — delete-Job key set.** `--mode=delete` could (a) read `manifest.json`
-  from S3 and remove exactly its artifacts, or (b) list-and-remove the whole key
-  prefix. (b) is simpler and also catches stale/orphaned objects under the prefix;
-  (a) is precise but misses orphans. **Lean (b)** (prefix-scoped, the prefix is
-  per-`<namespace>/<snapshot>` so blast radius is one snapshot), with a guard
-  refusing an empty prefix.
-- **OQ2 — TTL re-check cap.** A 30-day TTL shouldn't pin a reconcile for 30 days;
-  cap `RequeueAfter` at ~1h so controller restarts/clock are tolerated. Confirm
-  the cap value.
-- **OQ3 — `deletionPolicy` for csi-volume-snapshot.** Proposed: ignored (the
-  VolumeSnapshot's own policy governs). Confirm we don't want to surface a
-  warning when an operator sets `Delete`/`Retain` on a CSI snapshot.
-- **OQ4 — byte report on a *failed* transfer.** If the Job fails mid-transfer the
-  termination message may be partial/absent; we leave the field nil (no metric).
-  Confirm we don't want a `…_failed_bytes` surface (probably not — noise).
+- **OQ1 — delete-Job key set → (b) prefix-scoped list-and-remove**, with an
+  empty/short-prefix guard. The prefix is per-`<namespace>/<snapshot>` (blast
+  radius = one snapshot) and (b) also reaps orphans a manifest-driven delete
+  would miss (a partial upload that never reached `manifest.json`, PR #118's
+  stale same-size objects). Requires `s3:ListBucket` on the prefix alongside
+  delete — standard for creds that already get/put there.
+- **OQ2 — TTL re-check cap → 1h.** Bounds worst-case staleness after a controller
+  restart / clock skew to ≤1h past expiry without pinning a reconcile for a
+  30-day TTL. Matches the project's other backstop intervals (30m migration
+  timeout, SyncPeriod defense-in-depth).
+- **OQ3 — `deletionPolicy` on csi-volume-snapshot → ignored + a webhook
+  Warning.** The VolumeSnapshotClass `deletionPolicy` + ownerRefs govern the
+  VolumeSnapshot; our field is a no-op there. A non-blocking `admission.Warnings`
+  from `vswiftsnapshot` makes that visible in `kubectl` (no silent surprise,
+  Principle #6) without rejecting a valid spec.
+- **OQ4 — bytes on a *failed* transfer → leave nil, no `…_failed_bytes`
+  metric.** A partial count isn't operationally meaningful; the failure is already
+  captured by `kubeswift_snapshot_total{result="failed"}`.
+
+### 8.1 PR 1 implementation note (metrics)
+
+`kubeswift_restore_total` / `kubeswift_restore_seconds` carry **no `backend`
+label** (the §3.1 inventory listed one). A `SwiftRestore` does not store its
+source snapshot's backend, and a status-path `Get` purely to recover it for a
+label isn't worth the cost. Snapshot metrics keep `backend` (the
+`SwiftSnapshot` object has it). If a backend split on restore is wanted later,
+PR 2 (which already touches restore status for `downloadedBytes`) can stamp a
+`status.backend` to label off.
 
 ## 9. Non-goals
 

--- a/internal/controller/swiftguest/clone_metrics_test.go
+++ b/internal/controller/swiftguest/clone_metrics_test.go
@@ -1,0 +1,56 @@
+package swiftguest
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
+)
+
+func TestRecordGuestMetrics_CloneCounter(t *testing.T) {
+	clone := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-a", Namespace: "ns"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			CloneFromSnapshot: &swiftv1alpha1.CloneFromSnapshotSource{SnapshotRef: corev1.LocalObjectReference{Name: "snap"}},
+		},
+	}
+	pending := &swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhasePending}
+	running := &swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning}
+	failed := &swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseFailed}
+
+	// Transition into Running -> clone_total{running} +1.
+	before := testutil.ToFloat64(metrics.CloneTotal.WithLabelValues("running"))
+	recordGuestMetrics(clone, pending, running, nil)
+	if got := testutil.ToFloat64(metrics.CloneTotal.WithLabelValues("running")); got != before+1 {
+		t.Errorf("CloneTotal{running} = %v, want %v", got, before+1)
+	}
+
+	// Transition into Failed -> clone_total{failed} +1.
+	fb := testutil.ToFloat64(metrics.CloneTotal.WithLabelValues("failed"))
+	recordGuestMetrics(clone, pending, failed, nil)
+	if got := testutil.ToFloat64(metrics.CloneTotal.WithLabelValues("failed")); got != fb+1 {
+		t.Errorf("CloneTotal{failed} = %v, want %v", got, fb+1)
+	}
+
+	// Running -> Running (no transition) must not increment.
+	rb := testutil.ToFloat64(metrics.CloneTotal.WithLabelValues("running"))
+	recordGuestMetrics(clone, running, running, nil)
+	if got := testutil.ToFloat64(metrics.CloneTotal.WithLabelValues("running")); got != rb {
+		t.Errorf("no phase transition must not increment clone_total{running}; %v -> %v", rb, got)
+	}
+
+	// A NON-clone guest never touches clone_total.
+	nonClone := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "img", Namespace: "ns"},
+		Spec:       swiftv1alpha1.SwiftGuestSpec{ImageRef: &corev1.LocalObjectReference{Name: "img"}},
+	}
+	nb := testutil.ToFloat64(metrics.CloneTotal.WithLabelValues("running"))
+	recordGuestMetrics(nonClone, pending, running, nil)
+	if got := testutil.ToFloat64(metrics.CloneTotal.WithLabelValues("running")); got != nb {
+		t.Errorf("a non-clone guest must not increment clone_total{running}; %v -> %v", nb, got)
+	}
+}

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -546,6 +546,19 @@ func recordGuestMetrics(guest *swiftv1alpha1.SwiftGuest, oldStatus, newStatus *s
 		}
 		metrics.VMFailuresTotal.WithLabelValues(ns, reason).Inc()
 	}
+
+	// CloneTotal (Phase 5): cloneFromSnapshot guests, by result. Rides the same
+	// phase-transition detection above so it fires once per entry into the
+	// state (Running on a successful clone-resume; Failed on a clone prep/boot
+	// failure).
+	if guest.UsesCloneFromSnapshot() {
+		if newPhase == swiftv1alpha1.SwiftGuestPhaseRunning && oldPhase != swiftv1alpha1.SwiftGuestPhaseRunning {
+			metrics.CloneTotal.WithLabelValues("running").Inc()
+		}
+		if newPhase == swiftv1alpha1.SwiftGuestPhaseFailed && oldPhase != swiftv1alpha1.SwiftGuestPhaseFailed {
+			metrics.CloneTotal.WithLabelValues("failed").Inc()
+		}
+	}
 }
 
 func findCondition(status *swiftv1alpha1.SwiftGuestStatus, condType string) *metav1.Condition {

--- a/internal/controller/swiftrestore/controller.go
+++ b/internal/controller/swiftrestore/controller.go
@@ -28,6 +28,7 @@ import (
 
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
 )
 
 // SwiftRestoreReconciler reconciles SwiftRestore resources.
@@ -373,8 +374,43 @@ func isGuestRunning(guest *swiftv1alpha1.SwiftGuest) bool {
 }
 
 func (r *SwiftRestoreReconciler) persist(ctx context.Context, restore *snapshotv1alpha1.SwiftRestore, status *snapshotv1alpha1.SwiftRestoreStatus) error {
+	// Fire the Phase 5 metric once, on the non-terminal -> terminal transition.
+	freshTerminal := isRestoreTerminal(status.Phase) && !isRestoreTerminal(restore.Status.Phase)
 	restore.Status = *status
-	return r.Status().Update(ctx, restore)
+	if err := r.Status().Update(ctx, restore); err != nil {
+		return err
+	}
+	if freshTerminal {
+		recordRestoreTerminal(restore)
+	}
+	return nil
+}
+
+// isRestoreTerminal reports whether a SwiftRestore phase is terminal.
+func isRestoreTerminal(p snapshotv1alpha1.SwiftRestorePhase) bool {
+	return p == snapshotv1alpha1.SwiftRestorePhaseReady || p == snapshotv1alpha1.SwiftRestorePhaseFailed
+}
+
+// recordRestoreTerminal emits the Phase 5 restore metrics on the
+// non-terminal -> terminal transition: a per-result counter plus the
+// start->complete latency for successful restores.
+func recordRestoreTerminal(restore *snapshotv1alpha1.SwiftRestore) {
+	st := &restore.Status
+	var result string
+	switch st.Phase {
+	case snapshotv1alpha1.SwiftRestorePhaseReady:
+		result = "ready"
+	case snapshotv1alpha1.SwiftRestorePhaseFailed:
+		result = "failed"
+	default:
+		return
+	}
+	metrics.RestoreTotal.WithLabelValues(result).Inc()
+	if result == "ready" && st.StartedAt != nil && st.CompletedAt != nil {
+		if d := st.CompletedAt.Sub(st.StartedAt.Time); d > 0 {
+			metrics.RestoreSeconds.Observe(d.Seconds())
+		}
+	}
 }
 
 func isNotFound(err error) bool {

--- a/internal/controller/swiftrestore/controller_metrics_test.go
+++ b/internal/controller/swiftrestore/controller_metrics_test.go
@@ -1,0 +1,69 @@
+package swiftrestore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
+)
+
+func histCount(t *testing.T, m prometheus.Metric) uint64 {
+	t.Helper()
+	var d dto.Metric
+	if err := m.Write(&d); err != nil {
+		t.Fatalf("write metric: %v", err)
+	}
+	return d.GetHistogram().GetSampleCount()
+}
+
+func restore(phase snapshotv1alpha1.SwiftRestorePhase, started, completed *metav1.Time) *snapshotv1alpha1.SwiftRestore {
+	return &snapshotv1alpha1.SwiftRestore{
+		Status: snapshotv1alpha1.SwiftRestoreStatus{Phase: phase, StartedAt: started, CompletedAt: completed},
+	}
+}
+
+func TestRecordRestoreTerminal_CounterByResult(t *testing.T) {
+	for _, tc := range []struct {
+		phase  snapshotv1alpha1.SwiftRestorePhase
+		result string
+	}{
+		{snapshotv1alpha1.SwiftRestorePhaseReady, "ready"},
+		{snapshotv1alpha1.SwiftRestorePhaseFailed, "failed"},
+	} {
+		before := testutil.ToFloat64(metrics.RestoreTotal.WithLabelValues(tc.result))
+		recordRestoreTerminal(restore(tc.phase, nil, nil))
+		if got := testutil.ToFloat64(metrics.RestoreTotal.WithLabelValues(tc.result)); got != before+1 {
+			t.Errorf("RestoreTotal{%s} = %v, want %v", tc.result, got, before+1)
+		}
+	}
+	// A non-terminal phase records nothing.
+	before := testutil.CollectAndCount(metrics.RestoreTotal)
+	recordRestoreTerminal(restore(snapshotv1alpha1.SwiftRestorePhaseRestoring, nil, nil))
+	if after := testutil.CollectAndCount(metrics.RestoreTotal); after != before {
+		t.Errorf("a non-terminal restore must not record a counter; series %d -> %d", before, after)
+	}
+}
+
+func TestRecordRestoreTerminal_SecondsOnlyOnReady(t *testing.T) {
+	base := time.Date(2026, 6, 5, 0, 0, 0, 0, time.UTC)
+	started := &metav1.Time{Time: base}
+	completed := &metav1.Time{Time: base.Add(30 * time.Second)}
+
+	// A FAILED restore — even with both timestamps — does not observe latency.
+	before := histCount(t, metrics.RestoreSeconds)
+	recordRestoreTerminal(restore(snapshotv1alpha1.SwiftRestorePhaseFailed, started, completed))
+	if got := histCount(t, metrics.RestoreSeconds); got != before {
+		t.Errorf("failed restore must not observe latency; %d -> %d", before, got)
+	}
+	// A READY restore observes start->complete latency.
+	recordRestoreTerminal(restore(snapshotv1alpha1.SwiftRestorePhaseReady, started, completed))
+	if got := histCount(t, metrics.RestoreSeconds); got != before+1 {
+		t.Errorf("ready restore should observe latency; %d -> %d", before, got)
+	}
+}

--- a/internal/controller/swiftsnapshot/controller.go
+++ b/internal/controller/swiftsnapshot/controller.go
@@ -28,6 +28,7 @@ import (
 
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
 )
 
 // SwiftSnapshotReconciler reconciles SwiftSnapshot resources.
@@ -273,8 +274,59 @@ func capturedGuestSpec(guest *swiftv1alpha1.SwiftGuest) *snapshotv1alpha1.Captur
 
 // persist writes status changes back to the API server.
 func (r *SwiftSnapshotReconciler) persist(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot, status *snapshotv1alpha1.SwiftSnapshotStatus) error {
+	// Fire the Phase 5 metric exactly once, on the non-terminal -> terminal
+	// transition (compare the live object's old phase against the new one).
+	freshTerminal := isSnapshotTerminal(status.Phase) && !isSnapshotTerminal(snap.Status.Phase)
 	snap.Status = *status
-	return r.Status().Update(ctx, snap)
+	if err := r.Status().Update(ctx, snap); err != nil {
+		return err
+	}
+	if freshTerminal {
+		recordSnapshotTerminal(snap)
+	}
+	return nil
+}
+
+// isSnapshotTerminal reports whether a SwiftSnapshot phase is terminal.
+func isSnapshotTerminal(p snapshotv1alpha1.SwiftSnapshotPhase) bool {
+	return p == snapshotv1alpha1.SwiftSnapshotPhaseReady || p == snapshotv1alpha1.SwiftSnapshotPhaseFailed
+}
+
+// recordSnapshotTerminal emits the Phase 5 snapshot metrics on the
+// non-terminal -> terminal transition: a per-backend/result counter, plus
+// capture/pause/upload latency and size for successful captures.
+func recordSnapshotTerminal(snap *snapshotv1alpha1.SwiftSnapshot) {
+	backend := string(snap.Spec.Backend.Type)
+	st := &snap.Status
+	var result string
+	switch st.Phase {
+	case snapshotv1alpha1.SwiftSnapshotPhaseReady:
+		result = "ready"
+	case snapshotv1alpha1.SwiftSnapshotPhaseFailed:
+		result = "failed"
+	default:
+		return
+	}
+	metrics.SnapshotTotal.WithLabelValues(backend, result).Inc()
+	if result != "ready" {
+		return
+	}
+	if st.CapturedAt != nil {
+		if d := st.CapturedAt.Sub(snap.CreationTimestamp.Time); d > 0 {
+			metrics.SnapshotCaptureSeconds.WithLabelValues(backend).Observe(d.Seconds())
+		}
+	}
+	if st.ObservedPauseWindowMs > 0 {
+		metrics.SnapshotPauseWindowSeconds.WithLabelValues(backend).Observe(float64(st.ObservedPauseWindowMs) / 1000.0)
+	}
+	if st.TotalSizeBytes > 0 {
+		metrics.SnapshotSizeBytes.WithLabelValues(backend).Observe(float64(st.TotalSizeBytes))
+	}
+	if st.S3 != nil && st.S3.UploadedAt != nil && st.CapturedAt != nil {
+		if d := st.S3.UploadedAt.Sub(st.CapturedAt.Time); d > 0 {
+			metrics.SnapshotUploadSeconds.Observe(d.Seconds())
+		}
+	}
 }
 
 // isNotFound is a small wrapper so this package doesn't grow extra imports

--- a/internal/controller/swiftsnapshot/controller_metrics_test.go
+++ b/internal/controller/swiftsnapshot/controller_metrics_test.go
@@ -1,0 +1,95 @@
+package swiftsnapshot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
+)
+
+// histCount reads a histogram's accumulated sample count via the dto wire form.
+func histCount(t *testing.T, m prometheus.Metric) uint64 {
+	t.Helper()
+	var d dto.Metric
+	if err := m.Write(&d); err != nil {
+		t.Fatalf("write metric: %v", err)
+	}
+	return d.GetHistogram().GetSampleCount()
+}
+
+func snap(backend snapshotv1alpha1.SnapshotBackendType, phase snapshotv1alpha1.SwiftSnapshotPhase) *snapshotv1alpha1.SwiftSnapshot {
+	return &snapshotv1alpha1.SwiftSnapshot{
+		Spec:   snapshotv1alpha1.SwiftSnapshotSpec{Backend: snapshotv1alpha1.SwiftSnapshotBackend{Type: backend}},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{Phase: phase},
+	}
+}
+
+func TestRecordSnapshotTerminal_CounterByBackendResult(t *testing.T) {
+	cases := []struct {
+		backend snapshotv1alpha1.SnapshotBackendType
+		phase   snapshotv1alpha1.SwiftSnapshotPhase
+		result  string
+	}{
+		{snapshotv1alpha1.SnapshotBackendLocal, snapshotv1alpha1.SwiftSnapshotPhaseReady, "ready"},
+		{snapshotv1alpha1.SnapshotBackendS3, snapshotv1alpha1.SwiftSnapshotPhaseFailed, "failed"},
+		{snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot, snapshotv1alpha1.SwiftSnapshotPhaseReady, "ready"},
+	}
+	for _, tc := range cases {
+		before := testutil.ToFloat64(metrics.SnapshotTotal.WithLabelValues(string(tc.backend), tc.result))
+		recordSnapshotTerminal(snap(tc.backend, tc.phase))
+		if got := testutil.ToFloat64(metrics.SnapshotTotal.WithLabelValues(string(tc.backend), tc.result)); got != before+1 {
+			t.Errorf("SnapshotTotal{%s,%s} = %v, want %v", tc.backend, tc.result, got, before+1)
+		}
+	}
+	// A non-terminal phase records nothing.
+	before := testutil.CollectAndCount(metrics.SnapshotTotal)
+	recordSnapshotTerminal(snap(snapshotv1alpha1.SnapshotBackendLocal, snapshotv1alpha1.SwiftSnapshotPhaseCapturing))
+	if after := testutil.CollectAndCount(metrics.SnapshotTotal); after != before {
+		t.Errorf("a non-terminal snapshot must not record a counter; series %d -> %d", before, after)
+	}
+}
+
+func TestRecordSnapshotTerminal_LatenciesOnlyOnReady(t *testing.T) {
+	base := time.Date(2026, 6, 5, 0, 0, 0, 0, time.UTC)
+	capH := metrics.SnapshotCaptureSeconds.WithLabelValues("s3").(prometheus.Metric)
+	sizeH := metrics.SnapshotSizeBytes.WithLabelValues("s3").(prometheus.Metric)
+	pauseH := metrics.SnapshotPauseWindowSeconds.WithLabelValues("s3").(prometheus.Metric)
+
+	// A FAILED snapshot records the counter but observes no latency/size.
+	capBefore, sizeBefore, pauseBefore := histCount(t, capH), histCount(t, sizeH), histCount(t, pauseH)
+	uploadBefore := histCount(t, metrics.SnapshotUploadSeconds)
+	failed := snap(snapshotv1alpha1.SnapshotBackendS3, snapshotv1alpha1.SwiftSnapshotPhaseFailed)
+	failed.Status.CapturedAt = &metav1.Time{Time: base.Add(10 * time.Second)}
+	failed.Status.TotalSizeBytes = 1 << 30
+	recordSnapshotTerminal(failed)
+	if histCount(t, capH) != capBefore || histCount(t, sizeH) != sizeBefore {
+		t.Error("a failed snapshot must not observe capture latency or size")
+	}
+
+	// A READY snapshot observes capture latency, size, pause window, and upload.
+	ready := snap(snapshotv1alpha1.SnapshotBackendS3, snapshotv1alpha1.SwiftSnapshotPhaseReady)
+	ready.CreationTimestamp = metav1.NewTime(base)
+	ready.Status.CapturedAt = &metav1.Time{Time: base.Add(10 * time.Second)}
+	ready.Status.TotalSizeBytes = 2 << 30
+	ready.Status.ObservedPauseWindowMs = 2500
+	ready.Status.S3 = &snapshotv1alpha1.S3SnapshotStatus{UploadedAt: &metav1.Time{Time: base.Add(40 * time.Second)}}
+	recordSnapshotTerminal(ready)
+	if got := histCount(t, capH); got != capBefore+1 {
+		t.Errorf("ready snapshot should observe capture latency; %d -> %d", capBefore, got)
+	}
+	if got := histCount(t, sizeH); got != sizeBefore+1 {
+		t.Errorf("ready snapshot should observe size; %d -> %d", sizeBefore, got)
+	}
+	if got := histCount(t, pauseH); got != pauseBefore+1 {
+		t.Errorf("ready snapshot should observe pause window; %d -> %d", pauseBefore, got)
+	}
+	if got := histCount(t, metrics.SnapshotUploadSeconds); got != uploadBefore+1 {
+		t.Errorf("ready s3 snapshot should observe upload latency; %d -> %d", uploadBefore, got)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -80,6 +80,98 @@ var (
 		},
 		[]string{"mode"},
 	)
+
+	// --- Snapshot / restore / clone metrics (Phase 5) ---
+	// Recorded once per resource on the non-terminal -> terminal transition,
+	// mirroring recordMigrationTerminal. Labels stay low-cardinality
+	// (backend x result); no per-namespace label on the result-bearing series.
+
+	// SnapshotTotal counts SwiftSnapshots that reached a terminal phase, by
+	// backend (csi-volume-snapshot/local/s3) and result (ready/failed).
+	SnapshotTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubeswift_snapshot_total",
+			Help: "Total SwiftSnapshots that reached a terminal phase, by backend and result",
+		},
+		[]string{"backend", "result"},
+	)
+
+	// SnapshotCaptureSeconds observes capture latency (capturedAt -
+	// creationTimestamp) for successful snapshots, by backend.
+	SnapshotCaptureSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kubeswift_snapshot_capture_seconds",
+			Help:    "Time from SwiftSnapshot creation to capturedAt, by backend",
+			Buckets: []float64{1, 2, 5, 10, 20, 30, 60, 120, 300, 600, 900},
+		},
+		[]string{"backend"},
+	)
+
+	// SnapshotPauseWindowSeconds observes the source-VM pause window during
+	// capture (status.observedPauseWindowMs), by backend. Set for local/s3
+	// (memory) captures; absent for csi-volume-snapshot (no pause).
+	SnapshotPauseWindowSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kubeswift_snapshot_pause_window_seconds",
+			Help:    "Source VM pause window during capture, by backend",
+			Buckets: []float64{0.1, 0.5, 1, 2, 3, 5, 10, 20, 30, 45, 60},
+		},
+		[]string{"backend"},
+	)
+
+	// SnapshotUploadSeconds observes Tier C upload latency (s3.uploadedAt -
+	// capturedAt). Unlabelled: s3 is the only backend that uploads.
+	SnapshotUploadSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "kubeswift_snapshot_upload_seconds",
+			Help:    "Time from capturedAt to s3 uploadedAt for Tier C snapshots",
+			Buckets: []float64{1, 5, 10, 20, 30, 60, 120, 300, 600, 900},
+		},
+	)
+
+	// SnapshotSizeBytes observes total snapshot size (status.totalSizeBytes) at
+	// Ready, by backend. Exponential buckets 64MiB .. ~128GiB.
+	SnapshotSizeBytes = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kubeswift_snapshot_size_bytes",
+			Help:    "Total SwiftSnapshot size at Ready, by backend",
+			Buckets: prometheus.ExponentialBuckets(64*1024*1024, 2, 12),
+		},
+		[]string{"backend"},
+	)
+
+	// RestoreTotal counts SwiftRestores that reached a terminal phase, by
+	// result (ready/failed). No backend label: a SwiftRestore does not carry
+	// its source snapshot's backend, and a status-path Get to recover it isn't
+	// worth the cost.
+	RestoreTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubeswift_restore_total",
+			Help: "Total SwiftRestores that reached a terminal phase, by result",
+		},
+		[]string{"result"},
+	)
+
+	// RestoreSeconds observes restore latency (completedAt - startedAt) for
+	// successful restores.
+	RestoreSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "kubeswift_restore_seconds",
+			Help:    "Time from SwiftRestore startedAt to completedAt for successful restores",
+			Buckets: []float64{5, 10, 20, 30, 60, 90, 120, 180, 300},
+		},
+	)
+
+	// CloneTotal counts cloneFromSnapshot SwiftGuests by result, incremented on
+	// the transition into Running ("running") or Failed ("failed") — riding the
+	// SwiftGuest controller's existing phase-transition detection.
+	CloneTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubeswift_clone_total",
+			Help: "cloneFromSnapshot SwiftGuests by result (running/failed)",
+		},
+		[]string{"result"},
+	)
 )
 
 func init() {
@@ -90,5 +182,13 @@ func init() {
 		ImageImportSeconds,
 		MigrationTotal,
 		MigrationDowntimeSeconds,
+		SnapshotTotal,
+		SnapshotCaptureSeconds,
+		SnapshotPauseWindowSeconds,
+		SnapshotUploadSeconds,
+		SnapshotSizeBytes,
+		RestoreTotal,
+		RestoreSeconds,
+		CloneTotal,
 	)
 }


### PR DESCRIPTION
## Snapshot Phase 5 — PR 1/6: metrics

First implementation PR off the merged design doc (#129). Adds observability for the snapshot/restore/clone machinery, **mirroring the existing migration metrics pattern** — recorded once on the non-terminal→terminal transition via a `freshTerminal` guard in `persist`.

### New metrics (`internal/metrics`)
| Metric | Type | Labels |
|---|---|---|
| `kubeswift_snapshot_total` | Counter | `backend`, `result` |
| `kubeswift_snapshot_capture_seconds` | Histogram | `backend` |
| `kubeswift_snapshot_pause_window_seconds` | Histogram | `backend` |
| `kubeswift_snapshot_upload_seconds` | Histogram | — (Tier C only) |
| `kubeswift_snapshot_size_bytes` | Histogram | `backend` |
| `kubeswift_restore_total` | Counter | `result` |
| `kubeswift_restore_seconds` | Histogram | — |
| `kubeswift_clone_total` | Counter | `result` |

### Recording sites
- **swiftsnapshot / swiftrestore** — `recordSnapshotTerminal` / `recordRestoreTerminal` fired from `persist` on the first terminal transition. Idempotent: the Ready/Failed reconcile branches return early without calling `persist` again, so no double-count.
- **swiftguest** — the clone counter rides `recordGuestMetrics`' existing phase-transition detection (old≠new phase), so **no new dedup helper**.

### Decisions baked in
- **Cardinality discipline:** `backend`×`result` only; no per-namespace label on result-bearing series (the unbounded-cardinality trap).
- **Restore metrics carry no `backend` label** — a `SwiftRestore` doesn't store its source snapshot's backend, and a status-path `Get` purely for a label isn't worth it. Documented in design doc §8.1; can be added in PR 2 (which already touches restore status) if wanted.
- Folds the **resolved open questions (OQ1–OQ4)** into `snapshot-phase-5.md` §8.

### Scope
**No CRD change.** Tests mirror `controller_metrics_test.go` (`testutil` + `dto` sample-count assertions): counter-by-label, latency-only-on-`ready`, clone transition + non-clone no-op. `go build ./...`, `go vet ./internal/...`, and the full `internal/...` suite pass.

Next: PR 2 (byte gauges via container termination message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)