### PR TITLE
feat(snapshots): Tier C S3 object cleanup on snapshot deletion — Phase 5 (3/6)

### DIFF
--- a/cmd/snapshot-s3/main.go
+++ b/cmd/snapshot-s3/main.go
@@ -7,6 +7,7 @@
 //
 //	snapshot-s3 --mode=upload   --dir=/snap --bucket=B --key-prefix=ns/snap [--endpoint=...] [--path-style]
 //	snapshot-s3 --mode=download --dir=/snap --bucket=B --key-prefix=ns/snap [--endpoint=...] [--path-style]
+//	snapshot-s3 --mode=delete   --bucket=B --key-prefix=ns/snap [--endpoint=...] [--path-style]
 //
 // Credentials come from the standard AWS environment variables (mounted from a
 // Secret by the controller) — never from flags, annotations, or logs.
@@ -40,7 +41,7 @@ func reportTransfer(s transferStats) {
 }
 
 func main() {
-	mode := flag.String("mode", "", "upload | download")
+	mode := flag.String("mode", "", "upload | download | delete")
 	dir := flag.String("dir", "", "local snapshot directory (source for upload, destination for download)")
 	bucket := flag.String("bucket", "", "S3 bucket")
 	keyPrefix := flag.String("key-prefix", "", "object key prefix for this snapshot (e.g. backups/ns/snap)")
@@ -68,11 +69,18 @@ type runArgs struct {
 }
 
 func (a runArgs) validate() error {
-	if a.mode != "upload" && a.mode != "download" {
-		return fmt.Errorf("--mode must be \"upload\" or \"download\"")
+	switch a.mode {
+	case "upload", "download":
+		if a.dir == "" {
+			return fmt.Errorf("--dir is required for %s", a.mode)
+		}
+	case "delete":
+		// delete operates purely on S3 (no local dir).
+	default:
+		return fmt.Errorf("--mode must be \"upload\", \"download\", or \"delete\"")
 	}
-	if a.dir == "" || a.bucket == "" || a.keyPrefix == "" {
-		return fmt.Errorf("--dir, --bucket and --key-prefix are required")
+	if a.bucket == "" || a.keyPrefix == "" {
+		return fmt.Errorf("--bucket and --key-prefix are required")
 	}
 	if a.endpoint == "" && a.insecure {
 		return fmt.Errorf("--insecure has no effect with the default AWS endpoint (always TLS)")
@@ -102,6 +110,8 @@ func run(a runArgs) error {
 			return err
 		}
 		reportTransfer(stats)
+	case "delete":
+		return runDelete(ctx, store, a.keyPrefix)
 	}
 	return nil
 }

--- a/cmd/snapshot-s3/store.go
+++ b/cmd/snapshot-s3/store.go
@@ -24,6 +24,8 @@ type objectStore interface {
 	put(ctx context.Context, key string, r io.Reader, size int64, sha256 string) error
 	get(ctx context.Context, key string) (io.ReadCloser, error)
 	remove(ctx context.Context, key string) error
+	// list returns every object key under prefix (recursive).
+	list(ctx context.Context, prefix string) ([]string, error)
 }
 
 // objectSHA256MetaKey is the user-metadata key (sent as the x-amz-meta-sha256
@@ -98,4 +100,15 @@ func (s *minioStore) get(ctx context.Context, key string) (io.ReadCloser, error)
 
 func (s *minioStore) remove(ctx context.Context, key string) error {
 	return s.client.RemoveObject(ctx, s.bucket, key, minio.RemoveObjectOptions{})
+}
+
+func (s *minioStore) list(ctx context.Context, prefix string) ([]string, error) {
+	var keys []string
+	for obj := range s.client.ListObjects(ctx, s.bucket, minio.ListObjectsOptions{Prefix: prefix, Recursive: true}) {
+		if obj.Err != nil {
+			return nil, obj.Err
+		}
+		keys = append(keys, obj.Key)
+	}
+	return keys, nil
 }

--- a/cmd/snapshot-s3/transfer.go
+++ b/cmd/snapshot-s3/transfer.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 )
 
 // transferStats reports how many artifact bytes a transfer moved vs skipped
@@ -114,6 +115,31 @@ func runDownload(ctx context.Context, store objectStore, dstDir, keyPrefix strin
 	}
 	log.Printf("snapshot-s3 download complete into %s (%d transferred, %d skipped)", dstDir, stats.TransferredBytes, stats.SkippedBytes)
 	return stats, nil
+}
+
+// runDelete removes every object under keyPrefix (prefix-scoped list-and-remove,
+// per the Phase 5 design OQ1). The prefix is per-<namespace>/<snapshot>, so the
+// blast radius is a single snapshot — and a prefix-list also reaps orphans a
+// manifest-driven delete would miss (a partial upload that never reached
+// manifest.json, stale same-size objects). Refuses an empty prefix (which would
+// target the whole bucket).
+func runDelete(ctx context.Context, store objectStore, keyPrefix string) error {
+	if strings.Trim(keyPrefix, "/ ") == "" {
+		return fmt.Errorf("refusing to delete: empty key prefix would target the whole bucket")
+	}
+	keys, err := store.list(ctx, keyPrefix)
+	if err != nil {
+		return fmt.Errorf("list %q: %w", keyPrefix, err)
+	}
+	log.Printf("snapshot-s3 delete: %d object(s) under %s", len(keys), keyPrefix)
+	for _, k := range keys {
+		if err := store.remove(ctx, k); err != nil {
+			return fmt.Errorf("remove %q: %w", k, err)
+		}
+		log.Printf("  rm %s", k)
+	}
+	log.Printf("snapshot-s3 delete complete: %s", keyPrefix)
+	return nil
 }
 
 func downloadOne(ctx context.Context, store objectStore, key, dst string) error {

--- a/cmd/snapshot-s3/transfer_test.go
+++ b/cmd/snapshot-s3/transfer_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -48,6 +49,15 @@ func (f *fakeStore) get(_ context.Context, key string) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(b)), nil
 }
 func (f *fakeStore) remove(_ context.Context, key string) error { delete(f.objs, key); return nil }
+func (f *fakeStore) list(_ context.Context, prefix string) ([]string, error) {
+	var keys []string
+	for k := range f.objs {
+		if strings.HasPrefix(k, prefix) {
+			keys = append(keys, k)
+		}
+	}
+	return keys, nil
+}
 
 func writeFile(t *testing.T, dir, rel string, content []byte) {
 	t.Helper()
@@ -242,15 +252,54 @@ func TestDownload_DetectsCorruption(t *testing.T) {
 	}
 }
 
+// TestRunDelete removes every object under the snapshot prefix and refuses an
+// empty prefix (whole-bucket blast-radius guard).
+func TestRunDelete(t *testing.T) {
+	ctx := context.Background()
+	src, _ := seedSnapshotDir(t)
+	store := newFakeStore()
+	if _, err := runUpload(ctx, store, src, "ns/snap", "ns/snap", false); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	// An unrelated object under a different prefix must survive.
+	store.objs["other/keep.bin"] = []byte("keep")
+
+	if err := runDelete(ctx, store, "ns/snap"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	for k := range store.objs {
+		if k != "other/keep.bin" {
+			t.Errorf("object %q under the deleted prefix survived", k)
+		}
+	}
+	if _, ok := store.objs["other/keep.bin"]; !ok {
+		t.Error("delete must not touch objects outside the snapshot prefix")
+	}
+
+	// Empty / whitespace prefix is refused (would target the whole bucket).
+	for _, bad := range []string{"", "  ", "/"} {
+		if err := runDelete(ctx, store, bad); err == nil {
+			t.Errorf("empty-ish prefix %q must be refused", bad)
+		}
+	}
+}
+
 func TestRunArgs_Validate(t *testing.T) {
-	ok := runArgs{mode: "upload", dir: "/d", bucket: "b", keyPrefix: "p"}
-	if err := ok.validate(); err != nil {
-		t.Errorf("valid args rejected: %v", err)
+	for _, ok := range []runArgs{
+		{mode: "upload", dir: "/d", bucket: "b", keyPrefix: "p"},
+		{mode: "download", dir: "/d", bucket: "b", keyPrefix: "p"},
+		{mode: "delete", bucket: "b", keyPrefix: "p"}, // delete needs no dir
+	} {
+		if err := ok.validate(); err != nil {
+			t.Errorf("valid args rejected: %+v: %v", ok, err)
+		}
 	}
 	for _, bad := range []runArgs{
 		{mode: "sideways", dir: "/d", bucket: "b", keyPrefix: "p"},
 		{mode: "upload", bucket: "b", keyPrefix: "p"},              // no dir
 		{mode: "upload", dir: "/d", keyPrefix: "p"},                // no bucket
+		{mode: "delete", bucket: "b"},                              // no key-prefix
+		{mode: "delete", keyPrefix: "p"},                           // no bucket
 		{mode: "download", dir: "/d", bucket: "b", insecure: true}, // insecure + default endpoint
 	} {
 		if err := bad.validate(); err == nil {

--- a/internal/controller/swiftsnapshot/cleanup.go
+++ b/internal/controller/swiftsnapshot/cleanup.go
@@ -20,10 +20,12 @@ import (
 	"fmt"
 	"strings"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
 )
@@ -32,6 +34,25 @@ import (
 // transition to Ready. The deletion handler runs the cleanup pod and
 // removes the finalizer once the pod reports Succeeded.
 const HostPathFinalizer = "kubeswift.io/snapshot-hostpath-cleanup"
+
+// S3ObjectFinalizer is added to s3-backend (Tier C) SwiftSnapshots once
+// they transition to Ready. The deletion handler runs a delete Job that
+// purges the snapshot's object-storage prefix, then removes the finalizer.
+const S3ObjectFinalizer = "kubeswift.io/snapshot-s3-cleanup"
+
+// cleanupFinalizerFor returns the cleanup finalizer a SwiftSnapshot's
+// backend needs, or "" for backends with no controller-managed artifact
+// cleanup (csi-volume-snapshot — the VolumeSnapshot lifecycle handles it).
+func cleanupFinalizerFor(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	switch snap.Spec.Backend.Type {
+	case snapshotv1alpha1.SnapshotBackendLocal:
+		return HostPathFinalizer
+	case snapshotv1alpha1.SnapshotBackendS3:
+		return S3ObjectFinalizer
+	default:
+		return ""
+	}
+}
 
 // CleanupImage is the container image used by the cleanup pod. Kept
 // minimal — just needs `rm -rf` and a writable hostPath mount.
@@ -50,12 +71,13 @@ func cleanupPodName(snap *snapshotv1alpha1.SwiftSnapshot) string {
 	return "swift-snap-cleanup-" + snap.Name
 }
 
-// ensureFinalizer adds HostPathFinalizer to a Tier B SwiftSnapshot
-// once it reaches Ready. No-op for csi-volume-snapshot snapshots —
-// VolumeSnapshot deletion is handled via OwnerReferences, not a
-// finalizer.
+// ensureFinalizer adds the backend's cleanup finalizer once a SwiftSnapshot
+// reaches Ready: HostPathFinalizer for Tier B (local), S3ObjectFinalizer for
+// Tier C (s3). No-op for csi-volume-snapshot — VolumeSnapshot deletion is
+// handled via OwnerReferences, not a finalizer.
 func (r *SwiftSnapshotReconciler) ensureFinalizer(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot) error {
-	if snap.Spec.Backend.Type != snapshotv1alpha1.SnapshotBackendLocal {
+	fin := cleanupFinalizerFor(snap)
+	if fin == "" {
 		return nil
 	}
 	if snap.DeletionTimestamp != nil {
@@ -63,27 +85,40 @@ func (r *SwiftSnapshotReconciler) ensureFinalizer(ctx context.Context, snap *sna
 		// the apiserver's "finalizer added during deletion" warning.
 		return nil
 	}
-	for _, f := range snap.Finalizers {
-		if f == HostPathFinalizer {
-			return nil
-		}
+	if hasFinalizer(snap, fin) {
+		return nil
 	}
 	patched := snap.DeepCopy()
-	patched.Finalizers = append(patched.Finalizers, HostPathFinalizer)
+	patched.Finalizers = append(patched.Finalizers, fin)
 	return r.Patch(ctx, patched, client.MergeFrom(snap))
 }
 
-// handleDeletion runs when DeletionTimestamp is set on a SwiftSnapshot
-// that still carries HostPathFinalizer. Creates (or re-checks) a
-// cleanup pod on the source node; once the pod reports Succeeded,
-// removes the finalizer so the apiserver garbage-collects the
-// SwiftSnapshot.
+// handleDeletion dispatches the backend-specific artifact cleanup when a
+// SwiftSnapshot is being deleted: Tier B (local) runs a node-pinned hostPath
+// cleanup pod; Tier C (s3) runs a delete Job that purges the object-storage
+// prefix. Each removes its finalizer once cleanup succeeds, so the apiserver
+// can GC. A snapshot with neither finalizer (csi-volume-snapshot, or never
+// reached Ready) has nothing to clean — done immediately.
 //
-// Returns (done, requeue, err):
-//   - done=true: finalizer removed. Caller can return without requeue.
-//   - done=false, err==nil: pod still running or just created;
-//     caller requeues.
+// Returns (done, err): done=true means the finalizer is gone (or never
+// existed); done=false (nil err) means cleanup is in flight — requeue.
 func (r *SwiftSnapshotReconciler) handleDeletion(
+	ctx context.Context,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+) (bool, error) {
+	switch {
+	case hasFinalizer(snap, S3ObjectFinalizer):
+		return r.handleS3Deletion(ctx, snap)
+	case hasFinalizer(snap, HostPathFinalizer):
+		return r.handleLocalDeletion(ctx, snap)
+	default:
+		return true, nil
+	}
+}
+
+// handleLocalDeletion runs the Tier B hostPath cleanup pod on the source node;
+// once it reports Succeeded, removes HostPathFinalizer.
+func (r *SwiftSnapshotReconciler) handleLocalDeletion(
 	ctx context.Context,
 	snap *snapshotv1alpha1.SwiftSnapshot,
 ) (bool, error) {
@@ -215,10 +250,16 @@ func (r *SwiftSnapshotReconciler) createCleanupPod(
 }
 
 func (r *SwiftSnapshotReconciler) removeFinalizer(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot) (bool, error) {
+	return r.removeNamedFinalizer(ctx, snap, HostPathFinalizer)
+}
+
+// removeNamedFinalizer strips a specific finalizer and patches. Returns
+// (true, nil) on success so a caller can `return r.removeNamedFinalizer(...)`.
+func (r *SwiftSnapshotReconciler) removeNamedFinalizer(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot, name string) (bool, error) {
 	patched := snap.DeepCopy()
 	out := patched.Finalizers[:0]
 	for _, f := range patched.Finalizers {
-		if f != HostPathFinalizer {
+		if f != name {
 			out = append(out, f)
 		}
 	}
@@ -227,6 +268,60 @@ func (r *SwiftSnapshotReconciler) removeFinalizer(ctx context.Context, snap *sna
 		return false, err
 	}
 	return true, nil
+}
+
+// handleS3Deletion purges a Tier C snapshot's object-storage prefix via a
+// delete Job, then removes S3ObjectFinalizer. Drops the finalizer without a
+// purge in the cases where there is nothing to purge or no way to (never
+// uploaded, no s3 config, or the snapshot-s3 image is unconfigured) — never
+// wedge namespace deletion on a snapshot we cannot clean (the finalizer-trap
+// lesson, Design Principle #10).
+//
+// NOTE: deletionPolicy (Delete|Retain) lands in the next PR; until then a Tier C
+// snapshot deletion always purges (the implicit default).
+func (r *SwiftSnapshotReconciler) handleS3Deletion(
+	ctx context.Context,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+) (bool, error) {
+	if !hasFinalizer(snap, S3ObjectFinalizer) {
+		return true, nil
+	}
+	// Nothing to purge: never uploaded, or no s3 config. Drop the finalizer.
+	if snap.Status.S3 == nil || snap.Spec.Backend.S3 == nil || snap.Spec.Backend.S3.Bucket == "" {
+		return r.removeNamedFinalizer(ctx, snap, S3ObjectFinalizer)
+	}
+	// Can't purge without the snapshot-s3 image — don't wedge deletion forever.
+	if r.SnapshotS3Image == "" {
+		log.FromContext(ctx).Info("snapshot-s3 image not configured; dropping S3 cleanup finalizer without purging objects (orphan objects remain)", "snapshot", snap.Name)
+		return r.removeNamedFinalizer(ctx, snap, S3ObjectFinalizer)
+	}
+
+	podName := s3DeleteJobName(snap)
+	var job batchv1.Job
+	getErr := r.Get(ctx, client.ObjectKey{Name: podName, Namespace: snap.Namespace}, &job)
+	if apierrors.IsNotFound(getErr) {
+		if err := r.ensureDeleteJob(ctx, snap); err != nil {
+			return false, fmt.Errorf("create s3 delete Job: %w", err)
+		}
+		return false, nil // Job just created; requeue.
+	}
+	if getErr != nil {
+		return false, getErr
+	}
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			// Objects purged. Best-effort delete the Job (+ its pod) then drop
+			// the finalizer so the apiserver GCs the SwiftSnapshot.
+			_ = r.Delete(ctx, &job, client.PropagationPolicy(metav1.DeletePropagationBackground))
+			return r.removeNamedFinalizer(ctx, snap, S3ObjectFinalizer)
+		}
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			// Leave the finalizer so the failure is visible; operator can
+			// `kubectl delete job` to retry, or delete the finalizer by hand.
+			return false, nil
+		}
+	}
+	return false, nil // still purging
 }
 
 func hasFinalizer(snap *snapshotv1alpha1.SwiftSnapshot, target string) bool {

--- a/internal/controller/swiftsnapshot/s3.go
+++ b/internal/controller/swiftsnapshot/s3.go
@@ -150,6 +150,113 @@ func s3Location(snap *snapshotv1alpha1.SwiftSnapshot) string {
 	return "s3://" + path.Join(snap.Spec.Backend.S3.Bucket, s3KeyPrefix(snap)) + "/"
 }
 
+// s3DeleteJobName is the deterministic name of the object-cleanup Job.
+func s3DeleteJobName(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	return snap.Name + "-s3-delete"
+}
+
+// s3JobArgs builds the common snapshot-s3 flags for a given mode (the S3
+// connection/auth-independent ones; credentials come from env). mode is
+// "upload"/"download"/"delete".
+func s3JobArgs(snap *snapshotv1alpha1.SwiftSnapshot, mode string) []string {
+	s3 := snap.Spec.Backend.S3
+	args := []string{"--mode=" + mode, "--bucket=" + s3.Bucket, "--key-prefix=" + s3KeyPrefix(snap)}
+	if s3.Region != "" {
+		args = append(args, "--region="+s3.Region)
+	}
+	if s3.Endpoint != "" {
+		args = append(args, "--endpoint="+s3.Endpoint)
+	}
+	if s3.ForcePathStyle {
+		args = append(args, "--path-style")
+	}
+	if s3.Insecure {
+		args = append(args, "--insecure")
+	}
+	return args
+}
+
+// ensureDeleteJob creates (idempotently) the snapshot-owned object-cleanup Job
+// that purges the snapshot's S3 prefix. Unlike the upload Job it is
+// node-agnostic (S3 is reachable from anywhere), mounts nothing, and runs
+// non-root (it touches no local files) — maximally constrained.
+func (r *SwiftSnapshotReconciler) ensureDeleteJob(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot) error {
+	if r.SnapshotS3Image == "" {
+		return fmt.Errorf("snapshot-s3 image not configured (set %s)", SnapshotS3ImageEnv)
+	}
+	job := buildDeleteJob(snap, r.SnapshotS3Image)
+	if err := ctrl.SetControllerReference(snap, job, r.Scheme); err != nil {
+		return err
+	}
+	if err := r.Create(ctx, job); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// buildDeleteJob constructs the object-cleanup Job: snapshot-s3 --mode=delete
+// against the snapshot's S3 prefix, credentials from the referenced Secret. No
+// volumes, node-agnostic, non-root, drop ALL.
+func buildDeleteJob(snap *snapshotv1alpha1.SwiftSnapshot, image string) *batchv1.Job {
+	s3 := snap.Spec.Backend.S3
+	credName := ""
+	if s3.CredentialsSecretRef != nil {
+		credName = s3.CredentialsSecretRef.Name
+	}
+	secretEnv := func(envName, key string, optional bool) corev1.EnvVar {
+		return corev1.EnvVar{
+			Name: envName,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: credName},
+					Key:                  key,
+					Optional:             ptr.To(optional),
+				},
+			},
+		}
+	}
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s3DeleteJobName(snap),
+			Namespace: snap.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "kubeswift",
+				"app.kubernetes.io/component": "snapshot-s3-delete",
+				"kubeswift.io/swiftsnapshot":  snap.Name,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: ptr.To(s3UploadBackoffLimit),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+					Containers: []corev1.Container{{
+						Name:  "delete",
+						Image: image,
+						Args:  s3JobArgs(snap, "delete"),
+						Env: []corev1.EnvVar{
+							secretEnv("AWS_ACCESS_KEY_ID", "accessKeyId", false),
+							secretEnv("AWS_SECRET_ACCESS_KEY", "secretAccessKey", false),
+							secretEnv("AWS_SESSION_TOKEN", "sessionToken", true),
+						},
+						// Non-root: delete touches no local files (pure S3 API). The
+						// image's USER is 65534; set it explicitly so RunAsNonRoot
+						// can't trip an admission check on clusters that demand a
+						// numeric uid. Otherwise maximally constrained.
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+							RunAsNonRoot:             ptr.To(true),
+							RunAsUser:                ptr.To(int64(65534)),
+							ReadOnlyRootFilesystem:   ptr.To(true),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
 // buildUploadJob constructs the node-pinned upload Job. It mounts the captured
 // snapshot dir read-only, takes S3 credentials from the referenced Secret as
 // the standard AWS env vars, and runs snapshot-s3 --mode=upload. Pinned to the

--- a/internal/controller/swiftsnapshot/s3_cleanup_test.go
+++ b/internal/controller/swiftsnapshot/s3_cleanup_test.go
@@ -1,0 +1,173 @@
+package swiftsnapshot
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+)
+
+// s3SnapReady returns an s3 snapshot carrying S3ObjectFinalizer + a populated
+// status.S3 (i.e. it was uploaded), as it would be at deletion time.
+func s3SnapReady(name, ns string) *snapshotv1alpha1.SwiftSnapshot {
+	s := s3Snap(name, ns, nil)
+	s.Finalizers = []string{S3ObjectFinalizer}
+	s.Status.S3 = &snapshotv1alpha1.S3SnapshotStatus{Location: s3Location(s)}
+	return s
+}
+
+func deleteJobWith(snap *snapshotv1alpha1.SwiftSnapshot, cond batchv1.JobConditionType) *batchv1.Job {
+	j := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: s3DeleteJobName(snap), Namespace: snap.Namespace}}
+	if cond != "" {
+		j.Status.Conditions = []batchv1.JobCondition{{Type: cond, Status: corev1.ConditionTrue}}
+	}
+	return j
+}
+
+func hasFin(t *testing.T, c client.Client, snap *snapshotv1alpha1.SwiftSnapshot, fin string) bool {
+	t.Helper()
+	var got snapshotv1alpha1.SwiftSnapshot
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(snap), &got); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range got.Finalizers {
+		if f == fin {
+			return true
+		}
+	}
+	return false
+}
+
+func TestEnsureFinalizer_S3Backend_Adds(t *testing.T) {
+	snap := s3Snap("snap1", "team-a", nil)
+	r, c := newReconciler(t, snap)
+	if err := r.ensureFinalizer(context.Background(), snap); err != nil {
+		t.Fatal(err)
+	}
+	if !hasFin(t, c, snap, S3ObjectFinalizer) {
+		t.Error("s3 snapshot should get S3ObjectFinalizer")
+	}
+}
+
+func TestBuildDeleteJob(t *testing.T) {
+	snap := s3Snap("snap1", "team-a", nil)
+	job := buildDeleteJob(snap, "ghcr.io/x/snapshot-s3:t")
+	if job.Name != "snap1-s3-delete" {
+		t.Errorf("name = %q", job.Name)
+	}
+	ct := job.Spec.Template.Spec.Containers[0]
+	args := strings.Join(ct.Args, " ")
+	for _, want := range []string{"--mode=delete", "--bucket=backups", "--key-prefix=kubeswift/team-a/snap1"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("delete args missing %q: %v", want, ct.Args)
+		}
+	}
+	// No volumes/mounts (pure S3), node-agnostic, non-root.
+	if len(job.Spec.Template.Spec.Volumes) != 0 || len(ct.VolumeMounts) != 0 {
+		t.Error("delete Job must mount nothing")
+	}
+	if job.Spec.Template.Spec.NodeName != "" {
+		t.Error("delete Job must be node-agnostic")
+	}
+	if sc := ct.SecurityContext; sc == nil || sc.RunAsUser == nil || *sc.RunAsUser != 65534 || sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
+		t.Errorf("delete Job must run non-root as 65534; got %+v", ct.SecurityContext)
+	}
+	// Credentials come from the referenced Secret via env.
+	if len(ct.Env) == 0 || ct.Env[0].ValueFrom == nil || ct.Env[0].ValueFrom.SecretKeyRef.Name != "s3-creds" {
+		t.Errorf("delete Job must take creds from the Secret env; got %+v", ct.Env)
+	}
+}
+
+func TestHandleS3Deletion_CreatesDeleteJob(t *testing.T) {
+	snap := s3SnapReady("snap1", "team-a")
+	r, c := newReconciler(t, snap)
+	r.SnapshotS3Image = "img"
+	done, err := r.handleS3Deletion(context.Background(), snap)
+	if err != nil || done {
+		t.Fatalf("first pass should create the delete Job + requeue; done=%v err=%v", done, err)
+	}
+	var job batchv1.Job
+	if err := c.Get(context.Background(), client.ObjectKey{Name: s3DeleteJobName(snap), Namespace: snap.Namespace}, &job); err != nil {
+		t.Fatalf("delete Job not created: %v", err)
+	}
+	if !hasFin(t, c, snap, S3ObjectFinalizer) {
+		t.Error("finalizer must be retained while the delete Job runs")
+	}
+}
+
+func TestHandleS3Deletion_JobComplete_RemovesFinalizer(t *testing.T) {
+	snap := s3SnapReady("snap1", "team-a")
+	r, c := newReconciler(t, snap, deleteJobWith(snap, batchv1.JobComplete))
+	r.SnapshotS3Image = "img"
+	done, err := r.handleS3Deletion(context.Background(), snap)
+	if err != nil || !done {
+		t.Fatalf("complete delete Job should remove the finalizer; done=%v err=%v", done, err)
+	}
+	if hasFin(t, c, snap, S3ObjectFinalizer) {
+		t.Error("finalizer must be removed after the purge completes")
+	}
+}
+
+func TestHandleS3Deletion_JobFailed_RetainsFinalizer(t *testing.T) {
+	snap := s3SnapReady("snap1", "team-a")
+	r, c := newReconciler(t, snap, deleteJobWith(snap, batchv1.JobFailed))
+	r.SnapshotS3Image = "img"
+	done, err := r.handleS3Deletion(context.Background(), snap)
+	if err != nil || done {
+		t.Fatalf("a failed delete Job must leave the finalizer for visibility; done=%v err=%v", done, err)
+	}
+	if !hasFin(t, c, snap, S3ObjectFinalizer) {
+		t.Error("finalizer must be retained on a failed purge")
+	}
+}
+
+func TestHandleS3Deletion_NothingToPurge_DropsFinalizer(t *testing.T) {
+	// status.S3 nil (never uploaded) -> drop finalizer, no Job.
+	snap := s3Snap("snap1", "team-a", nil)
+	snap.Finalizers = []string{S3ObjectFinalizer}
+	r, c := newReconciler(t, snap)
+	r.SnapshotS3Image = "img"
+	done, err := r.handleS3Deletion(context.Background(), snap)
+	if err != nil || !done {
+		t.Fatalf("never-uploaded snapshot should drop the finalizer; done=%v err=%v", done, err)
+	}
+	if hasFin(t, c, snap, S3ObjectFinalizer) {
+		t.Error("finalizer should be dropped when there is nothing to purge")
+	}
+}
+
+func TestHandleS3Deletion_NoImage_DropsFinalizer(t *testing.T) {
+	// Can't purge without the image -> drop the finalizer rather than wedge
+	// namespace deletion forever (the finalizer-trap lesson).
+	snap := s3SnapReady("snap1", "team-a")
+	r, c := newReconciler(t, snap)
+	r.SnapshotS3Image = "" // unconfigured
+	done, err := r.handleS3Deletion(context.Background(), snap)
+	if err != nil || !done {
+		t.Fatalf("missing image should drop the finalizer, not wedge; done=%v err=%v", done, err)
+	}
+	if hasFin(t, c, snap, S3ObjectFinalizer) {
+		t.Error("finalizer should be dropped when the snapshot-s3 image is unconfigured")
+	}
+}
+
+// TestHandleDeletion_DispatchesS3 verifies the top-level dispatcher routes an
+// s3 snapshot to the S3 path (creates the delete Job).
+func TestHandleDeletion_DispatchesS3(t *testing.T) {
+	snap := s3SnapReady("snap1", "team-a")
+	r, c := newReconciler(t, snap)
+	r.SnapshotS3Image = "img"
+	if _, err := r.handleDeletion(context.Background(), snap); err != nil {
+		t.Fatal(err)
+	}
+	var job batchv1.Job
+	if err := c.Get(context.Background(), client.ObjectKey{Name: s3DeleteJobName(snap), Namespace: snap.Namespace}, &job); err != nil {
+		t.Errorf("handleDeletion should route s3 backend to the delete-Job path: %v", err)
+	}
+}


### PR DESCRIPTION
## Snapshot Phase 5 — PR 3/6: Tier C S3 object cleanup

**Closes the long-standing "S3 object lifecycle on snapshot deletion" follow-up.** Deleting an `s3`-backend SwiftSnapshot removed the CR but **left the bucket objects orphaned** — `HostPathFinalizer` was Tier B only, so Tier C had no deletion cleanup at all.

### `snapshot-s3` binary
- **New `--mode=delete`**: prefix-scoped list-and-remove of the snapshot's S3 prefix (design **OQ1(b)** — also reaps orphans a manifest-driven delete would miss: a partial upload that never reached `manifest.json`, PR #118's stale same-size objects). The prefix is per-`<namespace>/<snapshot>`, so blast radius is one snapshot; an empty prefix is **refused** (whole-bucket guard).
- `store` gains `list()`; `validate()` drops the `--dir` requirement for `delete`.

### swiftsnapshot controller
- `S3ObjectFinalizer` added to s3 snapshots at Ready (`ensureFinalizer` generalized via `cleanupFinalizerFor`).
- `handleDeletion` is now a **backend dispatcher**: Tier B → hostPath cleanup pod (existing, renamed `handleLocalDeletion`); Tier C → `handleS3Deletion` — a snapshot-owned, **node-agnostic, non-root (uid 65534)** delete Job running `snapshot-s3 --mode=delete`; on complete it removes the finalizer.
- **Never wedges namespace deletion** (the finalizer-trap lesson, Principle #10): drops the finalizer *without* purging when there's nothing to purge (never uploaded / no s3 config) or no way to (snapshot-s3 image unconfigured).

`deletionPolicy (Delete|Retain)` is **PR 4**; until then Tier C deletion always purges (the implicit default).

### Safety checks done
- **RBAC verified, no new grant:** `pods` has `list,watch` (PR 2's `JobTransferReport` relies on it — confirmed, no W7/W8 starvation); `batch/jobs` includes `delete`.
- **No `RunAsNonRoot` admission trap:** the `snapshot-s3` image is `USER 65534`; the delete Job sets `RunAsUser: 65534` explicitly so it can't trip a numeric-uid admission check.

### Tests
`runDelete` (prefix-scoped + orphan-preserving + empty-prefix guard) + `validate`; `buildDeleteJob` (args / no-mount / node-agnostic / non-root / creds); `handleS3Deletion` (create → complete-removes → failed-retains → nothing-to-purge → no-image → dispatch). No CRD change. `go build ./...`, `go vet`, full suite pass.

### Cluster note
The actual S3 purge only runs against a real bucket — covered by the post-retention mini-walkthrough (MinIO). This PR rebuilds the **snapshot-s3 image** (Go change in `cmd/`).

Next: PR 4 (`deletionPolicy: Delete | Retain`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)