### PR TITLE
feat(snapshots): deletionPolicy Delete|Retain on SwiftSnapshot — Phase 5 (4/6)

### DIFF
--- a/api/snapshot/v1alpha1/swiftsnapshot_types.go
+++ b/api/snapshot/v1alpha1/swiftsnapshot_types.go
@@ -39,6 +39,21 @@ const (
 	SwiftSnapshotConditionReady = "Ready"
 )
 
+// SnapshotDeletionPolicy controls whether deleting a SwiftSnapshot also purges
+// its backend artifacts.
+// +kubebuilder:validation:Enum=Delete;Retain
+type SnapshotDeletionPolicy string
+
+const (
+	// SnapshotDeletionPolicyDelete purges the backend artifacts (local hostPath
+	// / s3 objects) when the SwiftSnapshot is deleted. The default.
+	SnapshotDeletionPolicyDelete SnapshotDeletionPolicy = "Delete"
+	// SnapshotDeletionPolicyRetain leaves the backend artifacts in place when
+	// the SwiftSnapshot is deleted (the finalizer is dropped without a purge),
+	// for out-of-band archival.
+	SnapshotDeletionPolicyRetain SnapshotDeletionPolicy = "Retain"
+)
+
 // SwiftSnapshotGuestRef references the SwiftGuest to snapshot.
 type SwiftSnapshotGuestRef struct {
 	Name string `json:"name"`
@@ -120,6 +135,16 @@ type SwiftSnapshotSpec struct {
 	// stops the VM gracefully and restarts it iff this is true).
 	// +kubebuilder:default=true
 	ResumeAfterSnapshot bool `json:"resumeAfterSnapshot,omitempty"`
+
+	// DeletionPolicy controls whether deleting this SwiftSnapshot also purges
+	// its backend artifacts. Delete (default) purges the local hostPath / s3
+	// objects; Retain leaves them in place (the cleanup finalizer is dropped
+	// without a purge) for out-of-band archival. Ignored for
+	// csi-volume-snapshot — the VolumeSnapshotClass deletionPolicy governs the
+	// underlying VolumeSnapshot.
+	// +kubebuilder:default=Delete
+	// +optional
+	DeletionPolicy SnapshotDeletionPolicy `json:"deletionPolicy,omitempty"`
 }
 
 // SnapshotDiskRef records one captured disk (root or data) by role + handle.

--- a/charts/kubeswift/crds/snapshot.kubeswift.io_swiftsnapshots.yaml
+++ b/charts/kubeswift/crds/snapshot.kubeswift.io_swiftsnapshots.yaml
@@ -138,6 +138,19 @@ spec:
                 required:
                 - type
                 type: object
+              deletionPolicy:
+                default: Delete
+                description: |-
+                  DeletionPolicy controls whether deleting this SwiftSnapshot also purges
+                  its backend artifacts. Delete (default) purges the local hostPath / s3
+                  objects; Retain leaves them in place (the cleanup finalizer is dropped
+                  without a purge) for out-of-band archival. Ignored for
+                  csi-volume-snapshot — the VolumeSnapshotClass deletionPolicy governs the
+                  underlying VolumeSnapshot.
+                enum:
+                - Delete
+                - Retain
+                type: string
               guestRef:
                 description: GuestRef points at the SwiftGuest in the same namespace
                   to snapshot.

--- a/config/crd/bases/snapshot.kubeswift.io_swiftsnapshots.yaml
+++ b/config/crd/bases/snapshot.kubeswift.io_swiftsnapshots.yaml
@@ -138,6 +138,19 @@ spec:
                 required:
                 - type
                 type: object
+              deletionPolicy:
+                default: Delete
+                description: |-
+                  DeletionPolicy controls whether deleting this SwiftSnapshot also purges
+                  its backend artifacts. Delete (default) purges the local hostPath / s3
+                  objects; Retain leaves them in place (the cleanup finalizer is dropped
+                  without a purge) for out-of-band archival. Ignored for
+                  csi-volume-snapshot — the VolumeSnapshotClass deletionPolicy governs the
+                  underlying VolumeSnapshot.
+                enum:
+                - Delete
+                - Retain
+                type: string
               guestRef:
                 description: GuestRef points at the SwiftGuest in the same namespace
                   to snapshot.

--- a/internal/controller/swiftsnapshot/cleanup.go
+++ b/internal/controller/swiftsnapshot/cleanup.go
@@ -116,6 +116,13 @@ func (r *SwiftSnapshotReconciler) handleDeletion(
 	}
 }
 
+// retainArtifacts reports whether the snapshot's deletionPolicy is Retain — in
+// which case the deletion handlers drop the cleanup finalizer WITHOUT purging.
+// An empty policy (snapshots created before the field existed) means Delete.
+func retainArtifacts(snap *snapshotv1alpha1.SwiftSnapshot) bool {
+	return snap.Spec.DeletionPolicy == snapshotv1alpha1.SnapshotDeletionPolicyRetain
+}
+
 // handleLocalDeletion runs the Tier B hostPath cleanup pod on the source node;
 // once it reports Succeeded, removes HostPathFinalizer.
 func (r *SwiftSnapshotReconciler) handleLocalDeletion(
@@ -125,6 +132,10 @@ func (r *SwiftSnapshotReconciler) handleLocalDeletion(
 	if !hasFinalizer(snap, HostPathFinalizer) {
 		// Nothing to do — apiserver will GC the resource.
 		return true, nil
+	}
+	// deletionPolicy: Retain — leave the hostPath, just drop the finalizer.
+	if retainArtifacts(snap) {
+		return r.removeFinalizer(ctx, snap)
 	}
 	// CSI-backed snapshots wouldn't have HostPathFinalizer in the first
 	// place, but guard the cleanup logic against bad state where one
@@ -277,14 +288,18 @@ func (r *SwiftSnapshotReconciler) removeNamedFinalizer(ctx context.Context, snap
 // wedge namespace deletion on a snapshot we cannot clean (the finalizer-trap
 // lesson, Design Principle #10).
 //
-// NOTE: deletionPolicy (Delete|Retain) lands in the next PR; until then a Tier C
-// snapshot deletion always purges (the implicit default).
+// deletionPolicy: Retain short-circuits the purge (drop the finalizer, keep the
+// objects); Delete (the default) purges.
 func (r *SwiftSnapshotReconciler) handleS3Deletion(
 	ctx context.Context,
 	snap *snapshotv1alpha1.SwiftSnapshot,
 ) (bool, error) {
 	if !hasFinalizer(snap, S3ObjectFinalizer) {
 		return true, nil
+	}
+	// deletionPolicy: Retain — leave the S3 objects, just drop the finalizer.
+	if retainArtifacts(snap) {
+		return r.removeNamedFinalizer(ctx, snap, S3ObjectFinalizer)
 	}
 	// Nothing to purge: never uploaded, or no s3 config. Drop the finalizer.
 	if snap.Status.S3 == nil || snap.Spec.Backend.S3 == nil || snap.Spec.Backend.S3.Bucket == "" {

--- a/internal/controller/swiftsnapshot/cleanup_test.go
+++ b/internal/controller/swiftsnapshot/cleanup_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -177,6 +178,33 @@ func TestHandleDeletion_CreatesCleanupPod(t *testing.T) {
 	// Defense check: must not rm the parent.
 	if strings.Contains(args, "rm -rf "+HostPathBaseMount+" ") || strings.HasSuffix(args, "rm -rf "+HostPathBaseMount) {
 		t.Errorf("cleanup args targets parent mount, not subdir: %q", args)
+	}
+}
+
+// TestHandleLocalDeletion_Retain drops the finalizer WITHOUT running a cleanup
+// pod when deletionPolicy: Retain.
+func TestHandleLocalDeletion_Retain(t *testing.T) {
+	snap := makeLocalSnap("snap1", "default", "g1")
+	now := metav1.Now()
+	snap.DeletionTimestamp = &now
+	snap.Finalizers = []string{HostPathFinalizer}
+	snap.Status.NodeName = "boba"
+	snap.Spec.DeletionPolicy = snapshotv1alpha1.SnapshotDeletionPolicyRetain
+	r, c := newReconciler(t, snap)
+
+	done, err := r.handleDeletion(context.Background(), snap)
+	if err != nil || !done {
+		t.Fatalf("Retain should drop the finalizer immediately; done=%v err=%v", done, err)
+	}
+	var pod corev1.Pod
+	if err := c.Get(context.Background(), client.ObjectKey{Name: cleanupPodName(snap), Namespace: "default"}, &pod); !apierrors.IsNotFound(err) {
+		t.Errorf("Retain must NOT create a cleanup pod; err=%v", err)
+	}
+	// Dropping the last finalizer on a deletion-stamped object lets it GC —
+	// the snapshot is now gone, proving the finalizer was removed without a purge.
+	var got snapshotv1alpha1.SwiftSnapshot
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(snap), &got); !apierrors.IsNotFound(err) {
+		t.Errorf("Retain should drop the finalizer and let the snapshot GC; get err=%v", err)
 	}
 }
 

--- a/internal/controller/swiftsnapshot/s3_cleanup_test.go
+++ b/internal/controller/swiftsnapshot/s3_cleanup_test.go
@@ -7,6 +7,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -154,6 +155,26 @@ func TestHandleS3Deletion_NoImage_DropsFinalizer(t *testing.T) {
 	}
 	if hasFin(t, c, snap, S3ObjectFinalizer) {
 		t.Error("finalizer should be dropped when the snapshot-s3 image is unconfigured")
+	}
+}
+
+// TestHandleS3Deletion_Retain drops the finalizer WITHOUT a purge Job when
+// deletionPolicy: Retain.
+func TestHandleS3Deletion_Retain(t *testing.T) {
+	snap := s3SnapReady("snap1", "team-a")
+	snap.Spec.DeletionPolicy = snapshotv1alpha1.SnapshotDeletionPolicyRetain
+	r, c := newReconciler(t, snap)
+	r.SnapshotS3Image = "img"
+	done, err := r.handleS3Deletion(context.Background(), snap)
+	if err != nil || !done {
+		t.Fatalf("Retain should drop the finalizer immediately; done=%v err=%v", done, err)
+	}
+	if hasFin(t, c, snap, S3ObjectFinalizer) {
+		t.Error("Retain must drop the S3 finalizer")
+	}
+	var job batchv1.Job
+	if err := c.Get(context.Background(), client.ObjectKey{Name: s3DeleteJobName(snap), Namespace: snap.Namespace}, &job); !apierrors.IsNotFound(err) {
+		t.Errorf("Retain must NOT create a delete Job; err=%v", err)
 	}
 }
 

--- a/internal/webhook/swiftsnapshot/validator.go
+++ b/internal/webhook/swiftsnapshot/validator.go
@@ -48,7 +48,7 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 	if !ok {
 		return nil, fmt.Errorf("expected SwiftSnapshot, got %T", obj)
 	}
-	return nil, v.validateSwiftSnapshot(ctx, snap)
+	return deletionPolicyWarnings(snap), v.validateSwiftSnapshot(ctx, snap)
 }
 
 func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
@@ -65,10 +65,29 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	}
 	// Spec is immutable after creation: snapshots are point-in-time
 	// captures, mutating them would break the contract callers rely on.
+	// (deletionPolicy is deliberately NOT part of specsEqual — an operator
+	// may flip it before deleting.)
 	if !specsEqual(&oldSnap.Spec, &snap.Spec) {
 		return nil, fmt.Errorf("SwiftSnapshot spec is immutable")
 	}
-	return nil, nil
+	return deletionPolicyWarnings(snap), nil
+}
+
+// deletionPolicyWarnings surfaces the OQ3 advisory: spec.deletionPolicy is a
+// no-op for csi-volume-snapshot (the VolumeSnapshotClass governs the
+// VolumeSnapshot lifecycle). Only Retain is warned: Delete (the CRD default,
+// applied to every snapshot) happens to match the no-op, so warning on it would
+// fire on every CSI snapshot. Retain is the operator choice that is silently
+// not honored — the case worth flagging.
+func deletionPolicyWarnings(snap *snapshotv1alpha1.SwiftSnapshot) admission.Warnings {
+	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot &&
+		snap.Spec.DeletionPolicy == snapshotv1alpha1.SnapshotDeletionPolicyRetain {
+		return admission.Warnings{
+			"spec.deletionPolicy is ignored for csi-volume-snapshot backends; " +
+				"the VolumeSnapshotClass deletionPolicy governs the underlying VolumeSnapshot",
+		}
+	}
+	return nil
 }
 
 func (v *Validator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {

--- a/internal/webhook/swiftsnapshot/validator_test.go
+++ b/internal/webhook/swiftsnapshot/validator_test.go
@@ -42,6 +42,33 @@ func TestValidate_CSIBackend_OK(t *testing.T) {
 	}
 }
 
+// TestValidate_DeletionPolicyWarning: Retain on a CSI snapshot warns (it's
+// ignored there); Delete on CSI and Retain on local/s3 do not warn.
+func TestValidate_DeletionPolicyWarning(t *testing.T) {
+	v := &Validator{}
+	csiRetain := makeSnap(snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot)
+	csiRetain.Spec.DeletionPolicy = snapshotv1alpha1.SnapshotDeletionPolicyRetain
+	w, err := v.ValidateCreate(context.Background(), csiRetain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(w) == 0 || !strings.Contains(w[0], "ignored for csi-volume-snapshot") {
+		t.Errorf("CSI + Retain should warn; got %v", w)
+	}
+
+	csiDelete := makeSnap(snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot)
+	csiDelete.Spec.DeletionPolicy = snapshotv1alpha1.SnapshotDeletionPolicyDelete
+	if w, _ := v.ValidateCreate(context.Background(), csiDelete); len(w) != 0 {
+		t.Errorf("CSI + Delete (the no-op default) should NOT warn; got %v", w)
+	}
+
+	localRetain := makeSnap(snapshotv1alpha1.SnapshotBackendLocal)
+	localRetain.Spec.DeletionPolicy = snapshotv1alpha1.SnapshotDeletionPolicyRetain
+	if w, _ := v.ValidateCreate(context.Background(), localRetain); len(w) != 0 {
+		t.Errorf("local + Retain is honored, must NOT warn; got %v", w)
+	}
+}
+
 func TestValidate_LocalBackend_OK(t *testing.T) {
 	v := &Validator{}
 	if _, err := v.ValidateCreate(context.Background(), makeSnap(snapshotv1alpha1.SnapshotBackendLocal)); err != nil {


### PR DESCRIPTION
## Snapshot Phase 5 — PR 4/6: `deletionPolicy: Delete | Retain`

Gates the Tier B / Tier C artifact purge (PR 3) behind an operator policy.

### API
`SwiftSnapshot.spec.deletionPolicy` — enum `Delete | Retain`, `+kubebuilder:default=Delete`.
- **`Delete`** (default): purges the backend artifacts (hostPath / s3 objects) on deletion.
- **`Retain`**: drops the cleanup finalizer **without** purging (out-of-band archival).
- Empty (snapshots created before the field) is treated as `Delete` — backward-compatible.

### Controller
`retainArtifacts()` short-circuits **both** deletion handlers (`handleLocalDeletion` + `handleS3Deletion`): on `Retain`, drop the finalizer immediately — no cleanup pod, no delete Job.

### Webhook (OQ3 advisory)
`deletionPolicy` is a no-op for `csi-volume-snapshot` (the VolumeSnapshotClass governs the underlying VolumeSnapshot). The `vswiftsnapshot` webhook warns **only on CSI + `Retain`**: `Delete` is the default applied to *every* snapshot (warning on it would fire on every CSI snapshot), so `Retain` — the operator intent that's silently not honored — is the case worth flagging.

`deletionPolicy` stays **mutable** (`specsEqual` deliberately excludes it; an operator may flip `Retain`→`Delete` before deleting).

### Tests
- Local + S3 `Retain`: drops the finalizer, creates **no** pod/Job; the deletion-stamped object GCs once the finalizer clears (proving deletion proceeds without a purge).
- Webhook warning matrix: CSI+Retain warns; CSI+Delete and local+Retain do not.
- `make generate` + chart sync. `go build`, `vet`, full suite pass.

This is a Go-types change → rebuilds the **controller-manager image** (not snapshot-s3). The Retain-skips-purge and the CSI warning are validated in the post-retention mini-walkthrough.

Next: PR 5 (`spec.ttl` + reference-aware GC loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)