### PR TITLE
docs(snapshots): Grafana dashboard + observability runbook — Phase 5 (6/6)

### DIFF
--- a/config/grafana/kubeswift-snapshots.json
+++ b/config/grafana/kubeswift-snapshots.json
@@ -1,0 +1,227 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source scraping the KubeSwift controller-manager /metrics endpoint",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": ["kubeswift", "snapshot", "restore"],
+  "title": "KubeSwift — Snapshots & Restore",
+  "uid": "kubeswift-snapshots",
+  "time": { "from": "now-24h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Snapshots by result (range)",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (result) (increase(kubeswift_snapshot_total[$__range]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Snapshot success ratio (range)",
+      "type": "gauge",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
+      "fieldConfig": { "defaults": { "min": 0, "max": 1, "unit": "percentunit" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(kubeswift_snapshot_total{result=\"ready\"}[$__range])) / clamp_min(sum(increase(kubeswift_snapshot_total[$__range])), 1)",
+          "legendFormat": "success"
+        }
+      ]
+    },
+    {
+      "title": "Restores by result (range)",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 0 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (result) (increase(kubeswift_restore_total[$__range]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Snapshots by backend + result (total)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (backend, result) (kubeswift_snapshot_total)",
+          "legendFormat": "{{backend}}/{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "cloneFromSnapshot guests by result (total)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (result) (kubeswift_clone_total)",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Capture latency quantiles by backend",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum by (le, backend) (rate(kubeswift_snapshot_capture_seconds_bucket[1h])))",
+          "legendFormat": "p50 {{backend}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (le, backend) (rate(kubeswift_snapshot_capture_seconds_bucket[1h])))",
+          "legendFormat": "p95 {{backend}}"
+        }
+      ]
+    },
+    {
+      "title": "Restore latency quantiles",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(kubeswift_restore_seconds_bucket[1h])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(kubeswift_restore_seconds_bucket[1h])))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(kubeswift_restore_seconds_bucket[1h])))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "title": "Memory pause window p95 by backend",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (le, backend) (rate(kubeswift_snapshot_pause_window_seconds_bucket[1h])))",
+          "legendFormat": "p95 {{backend}}"
+        }
+      ]
+    },
+    {
+      "title": "Tier C upload latency quantiles",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(kubeswift_snapshot_upload_seconds_bucket[1h])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(kubeswift_snapshot_upload_seconds_bucket[1h])))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "title": "Tier C bytes moved (rate)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
+      "fieldConfig": { "defaults": { "unit": "Bps" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(kubeswift_snapshot_upload_bytes_total[5m])",
+          "legendFormat": "upload"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(kubeswift_restore_download_bytes_total[5m])",
+          "legendFormat": "download"
+        }
+      ]
+    },
+    {
+      "title": "Snapshot size distribution (heatmap)",
+      "type": "heatmap",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
+      "options": { "calculate": false, "yAxis": { "unit": "bytes" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (le) (increase(kubeswift_snapshot_size_bytes_bucket[$__interval]))",
+          "legendFormat": "{{le}}",
+          "format": "heatmap"
+        }
+      ]
+    }
+  ]
+}

--- a/config/grafana/servicemonitor.yaml
+++ b/config/grafana/servicemonitor.yaml
@@ -1,0 +1,32 @@
+# Prometheus Operator ServiceMonitor for the KubeSwift controller-manager
+# /metrics endpoint. Apply ONLY if your cluster runs the Prometheus Operator
+# (the monitoring.coreos.com CRDs must exist) — it is intentionally NOT part of
+# `make deploy` / the Helm chart, since most clusters scrape via their own
+# Prometheus config instead.
+#
+#   kubectl apply -f config/grafana/servicemonitor.yaml
+#
+# Adjust namespace + the release label selector to match your install.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubeswift-controller-manager
+  namespace: kubeswift-system
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: controller-manager
+    # Some Prometheus Operator installs select ServiceMonitors by a `release`
+    # label — set it to your kube-prometheus-stack release if so:
+    # release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - kubeswift-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubeswift
+      app.kubernetes.io/component: controller-manager
+  endpoints:
+    - port: metrics # the named port on kubeswift-controller-manager-metrics (8080)
+      interval: 30s
+      path: /metrics

--- a/docs/snapshots/observability.md
+++ b/docs/snapshots/observability.md
@@ -1,0 +1,96 @@
+# Snapshot & Restore Observability
+
+> Snapshot Phase 5. The KubeSwift controller-manager exports Prometheus metrics
+> for the snapshot / restore / clone machinery. This page lists the metrics, the
+> shipped Grafana dashboard, how to scrape them, and a few example queries.
+
+## Where the metrics live
+
+The controller-manager exposes `/metrics` on the
+`kubeswift-controller-manager-metrics` Service (port **8080**, named `metrics`).
+All snapshot metrics are registered on the controller-runtime registry alongside
+the existing guest / image / migration metrics.
+
+## Metric reference
+
+Recorded once per resource on the **non-terminal → terminal transition**
+(mirroring the migration metrics). Labels are deliberately low-cardinality —
+`backend` × `result` only; no per-namespace label on the `result`-bearing series.
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `kubeswift_snapshot_total` | counter | `backend`, `result` (`ready`/`failed`) | SwiftSnapshots that reached a terminal phase |
+| `kubeswift_snapshot_capture_seconds` | histogram | `backend` | capture latency (`capturedAt − creationTimestamp`) |
+| `kubeswift_snapshot_pause_window_seconds` | histogram | `backend` | source-VM pause window during a memory capture (`observedPauseWindowMs`; local/s3 only) |
+| `kubeswift_snapshot_upload_seconds` | histogram | — | Tier C upload latency (`s3.uploadedAt − capturedAt`) |
+| `kubeswift_snapshot_size_bytes` | histogram | `backend` | total snapshot size at Ready (`totalSizeBytes`) |
+| `kubeswift_snapshot_upload_bytes_total` | counter | — | artifact bytes pushed to S3 (wire traffic, excludes resume-skips) |
+| `kubeswift_restore_total` | counter | `result` (`ready`/`failed`) | SwiftRestores that reached a terminal phase |
+| `kubeswift_restore_seconds` | histogram | — | restore latency (`completedAt − startedAt`) |
+| `kubeswift_restore_download_bytes_total` | counter | — | artifact bytes pulled from S3 by Tier C restore/clone downloads |
+| `kubeswift_clone_total` | counter | `result` (`running`/`failed`) | cloneFromSnapshot SwiftGuests by terminal result |
+
+> **Status vs metric for bytes.** `status.s3.uploadedBytes` /
+> `SwiftRestore.status.downloadedBytes` carry the snapshot's S3 **footprint**
+> (the full artifact size, stable across resumed transfers). The
+> `…_bytes_total` counters carry the **wire traffic** (bytes actually moved,
+> excluding objects skipped on a resumed Job). They differ on a resumed
+> transfer.
+
+## Grafana dashboard
+
+[`config/grafana/kubeswift-snapshots.json`](../../config/grafana/kubeswift-snapshots.json)
+— import it into Grafana and pick your Prometheus data source. Panels: snapshot
+result rate + success ratio, restores by result, snapshots by backend, clones by
+result, capture / restore / upload latency quantiles, memory pause-window p95,
+Tier C bytes-moved rate, and a snapshot-size heatmap. (The companion live-
+migration dashboard is
+[`config/grafana/kubeswift-migrations.json`](../../config/grafana/kubeswift-migrations.json).)
+
+## Scraping
+
+Most clusters scrape the metrics Service via their existing Prometheus config.
+If you run the **Prometheus Operator**, a ready-made (operator-gated, NOT part of
+`make deploy`) ServiceMonitor is at
+[`config/grafana/servicemonitor.yaml`](../../config/grafana/servicemonitor.yaml):
+
+```bash
+kubectl apply -f config/grafana/servicemonitor.yaml   # requires the monitoring.coreos.com CRDs
+```
+
+## Example queries
+
+```promql
+# Snapshot success ratio over the dashboard range
+sum(increase(kubeswift_snapshot_total{result="ready"}[$__range]))
+  / clamp_min(sum(increase(kubeswift_snapshot_total[$__range])), 1)
+
+# p95 capture latency by backend (last hour)
+histogram_quantile(0.95, sum by (le, backend) (rate(kubeswift_snapshot_capture_seconds_bucket[1h])))
+
+# Tier C egress (upload) bandwidth
+rate(kubeswift_snapshot_upload_bytes_total[5m])
+```
+
+### Suggested alerts
+
+```promql
+# Snapshots failing
+sum(increase(kubeswift_snapshot_total{result="failed"}[15m])) > 0
+
+# Restores failing
+sum(increase(kubeswift_restore_total{result="failed"}[15m])) > 0
+```
+
+## Retention visibility
+
+TTL-driven retention (`spec.ttl`) surfaces a **`RetentionBlocked`** condition on
+the SwiftSnapshot when a TTL has elapsed but the snapshot is still referenced by
+a `cloneFromSnapshot` SwiftGuest or an in-flight SwiftRestore:
+
+```bash
+kubectl get swiftsnapshot <name> -o jsonpath='{.status.conditions[?(@.type=="RetentionBlocked")]}'
+```
+
+A `RetentionBlocked=True` snapshot is not deleted until the references clear
+(an operator-initiated `kubectl delete` is never blocked).


### PR DESCRIPTION
## Snapshot Phase 5 — PR 6/6: dashboards + observability runbook

The last Phase 5 build piece — **assets + docs, no code**. Surfaces the metrics shipped in PRs 1–5.

### What's in it
- **`config/grafana/kubeswift-snapshots.json`** — Grafana dashboard over the Phase 5 snapshot/restore/clone metrics: result rate + success-ratio gauge, snapshots-by-backend, clones-by-result, capture / restore / upload latency quantiles, memory pause-window p95, Tier C bytes-moved rate, and a snapshot-size heatmap. Mirrors the existing `kubeswift-migrations.json` structure (same datasource var, schema, panel shapes).
- **`config/grafana/servicemonitor.yaml`** — operator-gated Prometheus `ServiceMonitor` sample, intentionally **not** part of `make deploy` / the Helm chart (most clusters scrape via their own Prometheus config). Selects the controller-manager metrics Service (port 8080, named `metrics`).
- **`docs/snapshots/observability.md`** — metric reference table (the 10 Phase 5 metrics + labels/semantics), the **footprint-vs-wire-traffic** note for the byte surfaces, dashboard + scraping instructions, example PromQL/alerts, and how to read the `RetentionBlocked` condition.

### Verification
- Dashboard JSON + ServiceMonitor YAML both parse.
- **Every dashboard metric name cross-checked** against the registered metrics (all 10 ✓).

### Phase 5 status after this
All six PRs land the design (#129): metrics → byte gauges → S3 cleanup → deletionPolicy → ttl+GC → dashboards. **Next is the cluster mini-walkthrough** (the W5-catch stage) exercising the full retention surface end-to-end on the dev cluster: a Tier C snapshot round-trip with byte reporting, a `deletionPolicy: Delete` purge against MinIO, a `Retain` skip, and a `ttl` expiry (+ the reference-block). I'll do that once these PRs are deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)