### PR TITLE
fix(snapshots): includeMemory is backend-determined, not a flag

### DIFF
--- a/api/snapshot/v1alpha1/swiftsnapshot_types.go
+++ b/api/snapshot/v1alpha1/swiftsnapshot_types.go
@@ -129,8 +129,13 @@ type SwiftSnapshotSpec struct {
 	GuestRef SwiftSnapshotGuestRef `json:"guestRef"`
 	// Backend selects how and where the snapshot is captured.
 	Backend SwiftSnapshotBackend `json:"backend"`
-	// IncludeMemory requests a memory snapshot in addition to disks. Ignored
-	// for the csi-volume-snapshot backend (which is disk-only by definition).
+	// IncludeMemory requests a memory snapshot in addition to disks. NOTE: the
+	// captured set is backend-determined, not controlled by this flag —
+	// local/s3 use a Cloud Hypervisor vm.snapshot, which ALWAYS includes memory,
+	// while csi-volume-snapshot is disk-only by definition. So includeMemory:false
+	// is a no-op on every backend (the webhook surfaces a warning for local/s3);
+	// for a truly disk-only snapshot, use the csi-volume-snapshot backend. The
+	// field remains for forward compatibility and manifest metadata.
 	// +kubebuilder:default=true
 	IncludeMemory bool `json:"includeMemory,omitempty"`
 	// ResumeAfterSnapshot controls whether the source SwiftGuest is resumed

--- a/charts/kubeswift/crds/snapshot.kubeswift.io_swiftsnapshots.yaml
+++ b/charts/kubeswift/crds/snapshot.kubeswift.io_swiftsnapshots.yaml
@@ -163,8 +163,13 @@ spec:
               includeMemory:
                 default: true
                 description: |-
-                  IncludeMemory requests a memory snapshot in addition to disks. Ignored
-                  for the csi-volume-snapshot backend (which is disk-only by definition).
+                  IncludeMemory requests a memory snapshot in addition to disks. NOTE: the
+                  captured set is backend-determined, not controlled by this flag —
+                  local/s3 use a Cloud Hypervisor vm.snapshot, which ALWAYS includes memory,
+                  while csi-volume-snapshot is disk-only by definition. So includeMemory:false
+                  is a no-op on every backend (the webhook surfaces a warning for local/s3);
+                  for a truly disk-only snapshot, use the csi-volume-snapshot backend. The
+                  field remains for forward compatibility and manifest metadata.
                 type: boolean
               resumeAfterSnapshot:
                 default: true

--- a/cmd/swiftctl/snapshot.go
+++ b/cmd/swiftctl/snapshot.go
@@ -83,7 +83,7 @@ func init() {
 	snapshotCreateCmd.Flags().StringVar(&snapshotBackend, "backend", "csi-volume-snapshot", "Snapshot backend: csi-volume-snapshot or local")
 	snapshotCreateCmd.Flags().StringVar(&snapshotVSClass, "vsclass", "", "VolumeSnapshotClass name (csi-volume-snapshot only; default: cluster default)")
 	snapshotCreateCmd.Flags().StringVar(&snapshotHostPath, "hostpath", "", "On-node directory for local backend (required when --backend=local; must be under /var/lib/kubeswift/snapshots/)")
-	snapshotCreateCmd.Flags().BoolVar(&snapshotIncludeMem, "include-memory", true, "Capture memory (ignored on csi-volume-snapshot)")
+	snapshotCreateCmd.Flags().BoolVar(&snapshotIncludeMem, "include-memory", true, "Backend-determined: local/s3 always capture memory, csi is always disk-only; --include-memory=false is a no-op (use --backend=csi-volume-snapshot for disk-only)")
 	snapshotCreateCmd.Flags().BoolVar(&snapshotResumeAfter, "resume", true, "Resume the source VM after snapshot (no-op on csi-volume-snapshot)")
 	_ = snapshotCreateCmd.MarkFlagRequired("guest")
 

--- a/config/crd/bases/snapshot.kubeswift.io_swiftsnapshots.yaml
+++ b/config/crd/bases/snapshot.kubeswift.io_swiftsnapshots.yaml
@@ -163,8 +163,13 @@ spec:
               includeMemory:
                 default: true
                 description: |-
-                  IncludeMemory requests a memory snapshot in addition to disks. Ignored
-                  for the csi-volume-snapshot backend (which is disk-only by definition).
+                  IncludeMemory requests a memory snapshot in addition to disks. NOTE: the
+                  captured set is backend-determined, not controlled by this flag —
+                  local/s3 use a Cloud Hypervisor vm.snapshot, which ALWAYS includes memory,
+                  while csi-volume-snapshot is disk-only by definition. So includeMemory:false
+                  is a no-op on every backend (the webhook surfaces a warning for local/s3);
+                  for a truly disk-only snapshot, use the csi-volume-snapshot backend. The
+                  field remains for forward compatibility and manifest metadata.
                 type: boolean
               resumeAfterSnapshot:
                 default: true

--- a/internal/webhook/swiftsnapshot/validator.go
+++ b/internal/webhook/swiftsnapshot/validator.go
@@ -48,7 +48,7 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 	if !ok {
 		return nil, fmt.Errorf("expected SwiftSnapshot, got %T", obj)
 	}
-	return deletionPolicyWarnings(snap), v.validateSwiftSnapshot(ctx, snap)
+	return advisoryWarnings(snap), v.validateSwiftSnapshot(ctx, snap)
 }
 
 func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
@@ -70,7 +70,17 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	if !specsEqual(&oldSnap.Spec, &snap.Spec) {
 		return nil, fmt.Errorf("SwiftSnapshot spec is immutable")
 	}
-	return deletionPolicyWarnings(snap), nil
+	return advisoryWarnings(snap), nil
+}
+
+// backendCapturesMemory reports whether the backend takes a Cloud Hypervisor
+// memory snapshot (vm.snapshot always includes guest RAM). The
+// csi-volume-snapshot backend is disk-only. This — NOT the includeMemory flag —
+// is the correct signal for "does this capture memory", because includeMemory
+// defaults to true and is not plumbed into the capture action.
+func backendCapturesMemory(snap *snapshotv1alpha1.SwiftSnapshot) bool {
+	return snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendLocal ||
+		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3
 }
 
 // deletionPolicyWarnings surfaces the OQ3 advisory: spec.deletionPolicy is a
@@ -79,15 +89,25 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 // applied to every snapshot) happens to match the no-op, so warning on it would
 // fire on every CSI snapshot. Retain is the operator choice that is silently
 // not honored — the case worth flagging.
-func deletionPolicyWarnings(snap *snapshotv1alpha1.SwiftSnapshot) admission.Warnings {
+func advisoryWarnings(snap *snapshotv1alpha1.SwiftSnapshot) admission.Warnings {
+	var w admission.Warnings
 	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot &&
 		snap.Spec.DeletionPolicy == snapshotv1alpha1.SnapshotDeletionPolicyRetain {
-		return admission.Warnings{
-			"spec.deletionPolicy is ignored for csi-volume-snapshot backends; " +
-				"the VolumeSnapshotClass deletionPolicy governs the underlying VolumeSnapshot",
-		}
+		w = append(w,
+			"spec.deletionPolicy is ignored for csi-volume-snapshot backends; "+
+				"the VolumeSnapshotClass deletionPolicy governs the underlying VolumeSnapshot")
 	}
-	return nil
+	// includeMemory:false is a no-op on the local/s3 backends — a Cloud
+	// Hypervisor snapshot always captures guest RAM. Surface it rather than
+	// silently capturing memory the operator asked to skip (Principle #6). For a
+	// truly disk-only snapshot, use the csi-volume-snapshot backend.
+	if backendCapturesMemory(snap) && !snap.Spec.IncludeMemory {
+		w = append(w,
+			"spec.includeMemory:false is ignored for the "+string(snap.Spec.Backend.Type)+
+				" backend — a Cloud Hypervisor snapshot always captures memory; "+
+				"use the csi-volume-snapshot backend for a disk-only snapshot")
+	}
+	return w
 }
 
 func (v *Validator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
@@ -98,10 +118,14 @@ func (v *Validator) validateSwiftSnapshot(ctx context.Context, snap *snapshotv1a
 	if err := validateShape(snap); err != nil {
 		return err
 	}
-	// Source-guest-dependent rules (memory + VFIO/QEMU/SR-IOV). Only
-	// applied when IncludeMemory=true — disk-only captures are unaffected
-	// by these constraints (CSI VolumeSnapshot doesn't pause the VM).
-	if snap.Spec.IncludeMemory && v.Client != nil {
+	// Source-guest-dependent rules (memory + VFIO/QEMU/SR-IOV). Gated on the
+	// BACKEND, not the includeMemory flag: only the local/s3 backends capture
+	// memory (a CH vm.snapshot always includes RAM), while csi-volume-snapshot
+	// is disk-only and doesn't pause the VM. Gating on the flag was wrong twice
+	// over: includeMemory defaults to true, so a csi disk-only snapshot of a GPU
+	// guest was wrongly rejected; and includeMemory:false on a local/s3 snapshot
+	// bypassed the check while the capture included memory anyway.
+	if backendCapturesMemory(snap) && v.Client != nil {
 		return v.validateMemoryCaptureCompat(ctx, snap)
 	}
 	return nil

--- a/internal/webhook/swiftsnapshot/validator_test.go
+++ b/internal/webhook/swiftsnapshot/validator_test.go
@@ -63,9 +63,10 @@ func TestValidate_DeletionPolicyWarning(t *testing.T) {
 	}
 
 	localRetain := makeSnap(snapshotv1alpha1.SnapshotBackendLocal)
+	localRetain.Spec.IncludeMemory = true // production default; avoid the includeMemory no-op warning
 	localRetain.Spec.DeletionPolicy = snapshotv1alpha1.SnapshotDeletionPolicyRetain
 	if w, _ := v.ValidateCreate(context.Background(), localRetain); len(w) != 0 {
-		t.Errorf("local + Retain is honored, must NOT warn; got %v", w)
+		t.Errorf("local + Retain (honored) must NOT warn; got %v", w)
 	}
 }
 
@@ -343,16 +344,72 @@ func TestValidate_MemoryCapture_NoClient_SkipsLookup(t *testing.T) {
 }
 
 func TestValidate_DiskOnlyCapture_BypassesMemoryRules(t *testing.T) {
-	// includeMemory=false (disk-only / CSI path) doesn't trigger the
-	// VFIO/QEMU rules even when the guest has them.
+	// csi-volume-snapshot is disk-only — the VFIO/QEMU memory rules don't apply
+	// even for a GPU guest. Gated on the BACKEND, not the includeMemory flag.
 	guest := makeSourceGuest("g1", "default")
 	guest.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "h200"}
 
 	v := validatorWithGuest(t, guest)
 	snap := makeSnap(snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot)
 	snap.Spec.GuestRef.Name = "g1"
-	// Note: IncludeMemory left as default (false) for CSI snaps.
 	if _, err := v.ValidateCreate(context.Background(), snap); err != nil {
-		t.Errorf("disk-only capture should bypass GPU rule: %v", err)
+		t.Errorf("disk-only (csi) capture should bypass GPU rule: %v", err)
+	}
+}
+
+// TestValidate_CSIWithDefaultIncludeMemory_GPUGuest_NotRejected reproduces the
+// production false-positive: includeMemory defaults to true, so a csi disk-only
+// snapshot of a GPU guest used to be wrongly rejected. Backend-gating fixes it.
+func TestValidate_CSIWithDefaultIncludeMemory_GPUGuest_NotRejected(t *testing.T) {
+	guest := makeSourceGuest("g1", "default")
+	guest.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "h200"}
+	v := validatorWithGuest(t, guest)
+	snap := makeSnap(snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot)
+	snap.Spec.GuestRef.Name = "g1"
+	snap.Spec.IncludeMemory = true // the apiserver default
+	if _, err := v.ValidateCreate(context.Background(), snap); err != nil {
+		t.Errorf("csi (disk-only) snapshot of a GPU guest must NOT be rejected: %v", err)
+	}
+}
+
+// TestValidate_LocalIncludeMemoryFalse_GPUGuest_StillRejected proves the bypass
+// is closed: a local snapshot captures memory regardless of the flag, so the
+// VFIO compat check must fire even when includeMemory:false.
+func TestValidate_LocalIncludeMemoryFalse_GPUGuest_StillRejected(t *testing.T) {
+	guest := makeSourceGuest("g1", "default")
+	guest.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "h200"}
+	v := validatorWithGuest(t, guest)
+	snap := makeSnap(snapshotv1alpha1.SnapshotBackendLocal)
+	snap.Spec.GuestRef.Name = "g1"
+	snap.Spec.IncludeMemory = false // must NOT bypass — local always captures memory
+	if _, err := v.ValidateCreate(context.Background(), snap); err == nil {
+		t.Error("local + includeMemory:false on a GPU guest must still be rejected (memory is captured anyway)")
+	}
+}
+
+// TestValidate_IncludeMemoryFalse_LocalWarns: a no-op includeMemory:false on a
+// memory backend surfaces a warning (not a rejection).
+func TestValidate_IncludeMemoryFalse_LocalWarns(t *testing.T) {
+	v := &Validator{} // no client — shape + warning only
+	snap := makeSnap(snapshotv1alpha1.SnapshotBackendLocal)
+	snap.Spec.IncludeMemory = false
+	w, err := v.ValidateCreate(context.Background(), snap)
+	if err != nil {
+		t.Fatalf("includeMemory:false must warn, not reject: %v", err)
+	}
+	found := false
+	for _, s := range w {
+		if strings.Contains(s, "includeMemory:false is ignored") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an includeMemory no-op warning; got %v", w)
+	}
+	// csi + includeMemory:true (the default) does NOT warn.
+	csi := makeSnap(snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot)
+	csi.Spec.IncludeMemory = true
+	if w, _ := v.ValidateCreate(context.Background(), csi); len(w) != 0 {
+		t.Errorf("csi + includeMemory:true must not warn; got %v", w)
 	}
 }


### PR DESCRIPTION
Closes the Phase 5 walkthrough observation: an `s3` snapshot with `includeMemory: false` still captured + uploaded a 2 GiB `memory-ranges` object.

## Root cause
The captured set is determined by the **backend**, not the `includeMemory` flag. `local`/`s3` use a Cloud Hypervisor `vm.snapshot` which **always** includes guest RAM; `csi-volume-snapshot` is disk-only. The flag is never plumbed into the capture action (`captureArgs` has no `include_memory` field), so `includeMemory: false` was silently ignored.

## Two concrete defects, both from keying on the flag
1. **Safety bypass** — the VFIO/QEMU memory-compat check gated on `if snap.Spec.IncludeMemory`. A `local`/`s3` snapshot with `includeMemory:false` **skipped** the check while the capture included memory anyway — exactly the VFIO+memory case the check exists to reject.
2. **Production false-positive** — `includeMemory` defaults to `true`, so a `csi` (disk-only) snapshot of a **GPU guest** got `includeMemory:true` and was **wrongly rejected** by the memory-compat check. Unit tests missed it by constructing csi snaps with the zero-value `false`, bypassing the apiserver default (the W5 pattern).

## Fix
- Gate `validateMemoryCaptureCompat` on **`backendCapturesMemory(snap)`** (local/s3), not the flag — fixes both defects.
- Add a non-blocking webhook **warning** when `includeMemory:false` is set on a memory backend — surfaces the no-op without breaking valid configs (mirrors the deletionPolicy-CSI warning from #133, Principle #6).
- Clarify the `IncludeMemory` field doc + the `swiftctl --include-memory` flag help.

## Tests
- `csi` + default `includeMemory:true` + GPU guest → **passes** (false-positive fixed).
- `local` + `includeMemory:false` + GPU guest → **still rejected** (bypass closed — memory is captured regardless).
- `includeMemory:false` on `local` → **warns** (not rejected).
- Updated the existing memory-compat + deletionPolicy tests to set the production `includeMemory` default.

`make generate` + chart sync; `go build`, `vet`, full suite pass. Rebuilds the controller-manager image (webhook code).

This closes the last snapshot gap before the **CronSnapshot / keep-N** phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)