### PR TITLE
feat(snapshots): SwiftSnapshotSchedule controller (cron + creation) — Phase 6 (3/7)

### DIFF
--- a/charts/kubeswift/templates/controller-manager/rbac.yaml
+++ b/charts/kubeswift/templates/controller-manager/rbac.yaml
@@ -92,6 +92,9 @@ rules:
   - apiGroups: ["snapshot.kubeswift.io"]
     resources: ["swiftrestores", "swiftrestores/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["snapshot.kubeswift.io"]
+    resources: ["swiftsnapshotschedules", "swiftsnapshotschedules/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # snapshot.storage.k8s.io VolumeSnapshots — owned by SwiftSnapshot/SwiftImage,
   # read by SwiftRestore. The CSI external-snapshotter owns
   # VolumeSnapshotContent and VolumeSnapshotClass; the controller-manager

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftmigration"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftrestore"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftsnapshot"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftsnapshotschedule"
 	"github.com/projectbeskar/kubeswift/internal/scheme"
 	"github.com/projectbeskar/kubeswift/internal/version"
 	evictionwebhook "github.com/projectbeskar/kubeswift/internal/webhook/eviction"
@@ -191,6 +192,14 @@ func main() {
 		SnapshotS3Image: swiftsnapshot.SnapshotS3Image(),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftRestore controller")
+		os.Exit(1)
+	}
+
+	if err = (&swiftsnapshotschedule.SwiftSnapshotScheduleReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		klog.ErrorS(err, "unable to create SwiftSnapshotSchedule controller")
 		os.Exit(1)
 	}
 

--- a/config/manager/controller-manager-rbac.yaml
+++ b/config/manager/controller-manager-rbac.yaml
@@ -47,6 +47,9 @@ rules:
   - apiGroups: ["snapshot.kubeswift.io"]
     resources: ["swiftrestores", "swiftrestores/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["snapshot.kubeswift.io"]
+    resources: ["swiftsnapshotschedules", "swiftsnapshotschedules/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # SwiftMigration (migration.kubeswift.io). Status patches go through
   # the /status subresource. The controller patches SwiftGuest spec
   # fields (runPolicy, nodeName) using the existing

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0
 	github.com/minio/minio-go/v7 v7.2.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/term v0.43.0
 	k8s.io/api v0.35.0
@@ -51,7 +53,6 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=

--- a/internal/controller/swiftsnapshotschedule/controller.go
+++ b/internal/controller/swiftsnapshotschedule/controller.go
@@ -1,0 +1,256 @@
+// Package swiftsnapshotschedule reconciles SwiftSnapshotSchedule resources:
+// it creates a SwiftSnapshot each time the cron schedule fires (Phase 6).
+// keep-N retention pruning lands in a follow-up (PR 4); this controller does
+// cron evaluation + snapshot creation + concurrency + status only.
+package swiftsnapshotschedule
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+)
+
+const (
+	// maxRequeue caps the wait to the next tick so a far-future schedule still
+	// re-checks periodically (mirrors the ttl re-check cap).
+	maxRequeue = time.Hour
+	// suspendedRequeue is the cheap re-check cadence for a suspended schedule.
+	suspendedRequeue = time.Hour
+	// missedTickCap bounds catch-up after a long outage: the controller fires at
+	// most ONE snapshot (the most recent missed tick), never a backlog.
+	missedTickCap = 100
+)
+
+// SwiftSnapshotScheduleReconciler reconciles SwiftSnapshotSchedule resources.
+type SwiftSnapshotScheduleReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	// now is injectable for tests; defaults to time.Now.
+	now func() time.Time
+}
+
+func (r *SwiftSnapshotScheduleReconciler) clock() time.Time {
+	if r.now != nil {
+		return r.now()
+	}
+	return time.Now()
+}
+
+func (r *SwiftSnapshotScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	var sched snapshotv1alpha1.SwiftSnapshotSchedule
+	if err := r.Get(ctx, req.NamespacedName, &sched); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if sched.Spec.Suspend {
+		return ctrl.Result{RequeueAfter: suspendedRequeue}, nil
+	}
+
+	cronSched, err := cron.ParseStandard(sched.Spec.Schedule)
+	if err != nil {
+		// Invalid cron (the webhook rejects this once it lands). Don't hot-loop —
+		// the schedule is re-reconciled when the spec is fixed.
+		logger.Error(err, "invalid spec.schedule; not scheduling", "schedule", sched.Spec.Schedule)
+		return ctrl.Result{}, nil
+	}
+
+	now := r.clock()
+	status := sched.Status.DeepCopy()
+
+	// Refresh observed status (active + lastSuccessfulTime) from owned snapshots.
+	children, err := r.ownedSnapshots(ctx, &sched)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	updateObservedStatus(status, children)
+
+	// The most recent due tick after the last fire (or the schedule's creation).
+	earliest := sched.CreationTimestamp.Time
+	if status.LastScheduleTime != nil {
+		earliest = status.LastScheduleTime.Time
+	}
+	dueTick, due := mostRecentDue(cronSched, earliest, now)
+	if due {
+		switch {
+		case tooLate(&sched, dueTick, now):
+			logger.Info("skipping tick past startingDeadline", "tick", dueTick)
+			setLastSchedule(status, dueTick)
+		case sched.Spec.ConcurrencyPolicy == snapshotv1alpha1.ConcurrencyForbid && hasInFlight(children):
+			logger.Info("skipping tick: a prior scheduled snapshot is still in flight (Forbid)", "tick", dueTick)
+			setLastSchedule(status, dueTick)
+		default:
+			if cerr := r.createScheduledSnapshot(ctx, &sched, dueTick); cerr != nil {
+				return ctrl.Result{}, cerr
+			}
+			logger.Info("created scheduled snapshot", "tick", dueTick)
+			setLastSchedule(status, dueTick)
+		}
+	}
+
+	if err := r.persistStatus(ctx, &sched, status); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{RequeueAfter: requeueToNext(cronSched, now)}, nil
+}
+
+// mostRecentDue returns the latest scheduled time in (earliest, now], and
+// whether one exists. It fires at most once per reconcile (the most recent
+// missed tick), coalescing a backlog after an outage rather than stampeding.
+func mostRecentDue(sched cron.Schedule, earliest, now time.Time) (time.Time, bool) {
+	var due time.Time
+	found := false
+	t := sched.Next(earliest)
+	for i := 0; !t.After(now); i++ {
+		due, found = t, true
+		if i >= missedTickCap {
+			break
+		}
+		t = sched.Next(t)
+	}
+	return due, found
+}
+
+// tooLate reports whether a due tick is older than startingDeadlineSeconds.
+func tooLate(sched *snapshotv1alpha1.SwiftSnapshotSchedule, tick, now time.Time) bool {
+	d := sched.Spec.StartingDeadlineSeconds
+	return d != nil && now.Sub(tick) > time.Duration(*d)*time.Second
+}
+
+// requeueToNext returns the capped wait until the next scheduled time
+// (computed from the injected now, not the wall clock).
+func requeueToNext(sched cron.Schedule, now time.Time) time.Duration {
+	wait := sched.Next(now).Sub(now)
+	if wait < time.Second {
+		wait = time.Second
+	}
+	if wait > maxRequeue {
+		wait = maxRequeue
+	}
+	return wait
+}
+
+func (r *SwiftSnapshotScheduleReconciler) ownedSnapshots(ctx context.Context, sched *snapshotv1alpha1.SwiftSnapshotSchedule) ([]snapshotv1alpha1.SwiftSnapshot, error) {
+	var list snapshotv1alpha1.SwiftSnapshotList
+	if err := r.List(ctx, &list,
+		client.InNamespace(sched.Namespace),
+		client.MatchingLabels{snapshotv1alpha1.ScheduleLabel: sched.Name},
+	); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// createScheduledSnapshot creates a SwiftSnapshot from the template for a tick.
+// The name is deterministic in the tick (<schedule>-<unix>), so a re-reconcile
+// of the same tick is idempotent (Create returns AlreadyExists).
+func (r *SwiftSnapshotScheduleReconciler) createScheduledSnapshot(ctx context.Context, sched *snapshotv1alpha1.SwiftSnapshotSchedule, tick time.Time) error {
+	snap := &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fmt.Sprintf("%s-%d", sched.Name, tick.Unix()),
+			Namespace:   sched.Namespace,
+			Labels:      mergeLabels(sched.Spec.Template.Metadata.Labels, sched.Name),
+			Annotations: copyMap(sched.Spec.Template.Metadata.Annotations),
+		},
+		Spec: *sched.Spec.Template.Spec.DeepCopy(),
+	}
+	if err := ctrl.SetControllerReference(sched, snap, r.Scheme); err != nil {
+		return err
+	}
+	if err := r.Create(ctx, snap); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// mergeLabels copies the template labels and forces the schedule grouping label.
+func mergeLabels(tmpl map[string]string, scheduleName string) map[string]string {
+	out := map[string]string{}
+	for k, v := range tmpl {
+		out[k] = v
+	}
+	out[snapshotv1alpha1.ScheduleLabel] = scheduleName
+	return out
+}
+
+func copyMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// updateObservedStatus refreshes Active (non-terminal children) and
+// LastSuccessfulTime (newest Ready child's capturedAt) from the owned snapshots.
+func updateObservedStatus(status *snapshotv1alpha1.SwiftSnapshotScheduleStatus, children []snapshotv1alpha1.SwiftSnapshot) {
+	var active []string
+	var lastSuccess *metav1.Time
+	for i := range children {
+		c := &children[i]
+		if !snapshotTerminal(c.Status.Phase) {
+			active = append(active, c.Name)
+		}
+		if c.Status.Phase == snapshotv1alpha1.SwiftSnapshotPhaseReady && c.Status.CapturedAt != nil {
+			if lastSuccess == nil || c.Status.CapturedAt.After(lastSuccess.Time) {
+				lastSuccess = c.Status.CapturedAt.DeepCopy()
+			}
+		}
+	}
+	status.Active = active
+	if lastSuccess != nil {
+		status.LastSuccessfulTime = lastSuccess
+	}
+}
+
+func snapshotTerminal(p snapshotv1alpha1.SwiftSnapshotPhase) bool {
+	return p == snapshotv1alpha1.SwiftSnapshotPhaseReady || p == snapshotv1alpha1.SwiftSnapshotPhaseFailed
+}
+
+func hasInFlight(children []snapshotv1alpha1.SwiftSnapshot) bool {
+	for i := range children {
+		if !snapshotTerminal(children[i].Status.Phase) {
+			return true
+		}
+	}
+	return false
+}
+
+func setLastSchedule(status *snapshotv1alpha1.SwiftSnapshotScheduleStatus, t time.Time) {
+	mt := metav1.NewTime(t)
+	status.LastScheduleTime = &mt
+}
+
+func (r *SwiftSnapshotScheduleReconciler) persistStatus(ctx context.Context, sched *snapshotv1alpha1.SwiftSnapshotSchedule, status *snapshotv1alpha1.SwiftSnapshotScheduleStatus) error {
+	if apiequality.Semantic.DeepEqual(&sched.Status, status) {
+		return nil
+	}
+	sched.Status = *status
+	return r.Status().Update(ctx, sched)
+}
+
+// SetupWithManager registers the reconciler. Owns(SwiftSnapshot) so a child
+// snapshot reaching Ready/Failed re-triggers the schedule (refreshes
+// lastSuccessfulTime + active, and — once PR 4 lands — keep-N pruning).
+func (r *SwiftSnapshotScheduleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&snapshotv1alpha1.SwiftSnapshotSchedule{}).
+		Owns(&snapshotv1alpha1.SwiftSnapshot{}).
+		Named("swiftsnapshotschedule").
+		Complete(r)
+}

--- a/internal/controller/swiftsnapshotschedule/controller_test.go
+++ b/internal/controller/swiftsnapshotschedule/controller_test.go
@@ -1,0 +1,237 @@
+package swiftsnapshotschedule
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+)
+
+// fixed minute boundary for deterministic cron math.
+var baseTime = time.Date(2026, 6, 6, 3, 0, 0, 0, time.UTC)
+
+func schedScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	gv := schema.GroupVersion{Group: "snapshot.kubeswift.io", Version: "v1alpha1"}
+	s.AddKnownTypes(gv,
+		&snapshotv1alpha1.SwiftSnapshot{}, &snapshotv1alpha1.SwiftSnapshotList{},
+		&snapshotv1alpha1.SwiftSnapshotSchedule{}, &snapshotv1alpha1.SwiftSnapshotScheduleList{},
+	)
+	metav1.AddToGroupVersion(s, gv)
+	return s
+}
+
+func newSched(t *testing.T, now time.Time, objs ...client.Object) (*SwiftSnapshotScheduleReconciler, client.Client) {
+	s := schedScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).
+		WithStatusSubresource(&snapshotv1alpha1.SwiftSnapshotSchedule{}).Build()
+	return &SwiftSnapshotScheduleReconciler{Client: c, Scheme: s, now: func() time.Time { return now }}, c
+}
+
+func schedule(mut func(*snapshotv1alpha1.SwiftSnapshotSchedule)) *snapshotv1alpha1.SwiftSnapshotSchedule {
+	s := &snapshotv1alpha1.SwiftSnapshotSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nightly", Namespace: "ns",
+			CreationTimestamp: metav1.NewTime(baseTime.Add(-time.Hour)),
+		},
+		Spec: snapshotv1alpha1.SwiftSnapshotScheduleSpec{
+			Schedule:          "* * * * *",
+			ConcurrencyPolicy: snapshotv1alpha1.ConcurrencyForbid,
+			Template: snapshotv1alpha1.SnapshotTemplate{
+				Metadata: snapshotv1alpha1.SnapshotTemplateMeta{Labels: map[string]string{"tier": "db"}},
+				Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+					GuestRef: snapshotv1alpha1.SwiftSnapshotGuestRef{Name: "g1"},
+					Backend:  snapshotv1alpha1.SwiftSnapshotBackend{Type: snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot},
+				},
+			},
+		},
+	}
+	if mut != nil {
+		mut(s)
+	}
+	return s
+}
+
+func req() ctrl.Request {
+	return ctrl.Request{NamespacedName: client.ObjectKey{Name: "nightly", Namespace: "ns"}}
+}
+
+func listSnaps(t *testing.T, c client.Client) []snapshotv1alpha1.SwiftSnapshot {
+	t.Helper()
+	var l snapshotv1alpha1.SwiftSnapshotList
+	if err := c.List(context.Background(), &l, client.InNamespace("ns")); err != nil {
+		t.Fatal(err)
+	}
+	return l.Items
+}
+
+func TestMostRecentDue(t *testing.T) {
+	sched, _ := cron.ParseStandard("* * * * *")
+	// earliest = T-2min, now = T -> latest due tick is T.
+	due, ok := mostRecentDue(sched, baseTime.Add(-2*time.Minute), baseTime)
+	if !ok || !due.Equal(baseTime) {
+		t.Errorf("due=%v ok=%v, want %v true", due, ok, baseTime)
+	}
+	// next tick is in the future -> nothing due.
+	if _, ok := mostRecentDue(sched, baseTime, baseTime); ok {
+		t.Error("no tick should be due when earliest==now")
+	}
+}
+
+func TestReconcile_FiresDueTick(t *testing.T) {
+	s := schedule(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		lt := metav1.NewTime(baseTime.Add(-2 * time.Minute))
+		s.Status.LastScheduleTime = &lt
+	})
+	r, c := newSched(t, baseTime, s)
+	res, err := r.Reconcile(context.Background(), req())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RequeueAfter <= 0 || res.RequeueAfter > maxRequeue {
+		t.Errorf("requeue = %v, want a capped positive wait", res.RequeueAfter)
+	}
+	snaps := listSnaps(t, c)
+	if len(snaps) != 1 {
+		t.Fatalf("expected exactly 1 scheduled snapshot, got %d", len(snaps))
+	}
+	got := snaps[0]
+	if !strings.HasPrefix(got.Name, "nightly-") {
+		t.Errorf("snapshot name %q should be <schedule>-<ts>", got.Name)
+	}
+	if got.Labels[snapshotv1alpha1.ScheduleLabel] != "nightly" || got.Labels["tier"] != "db" {
+		t.Errorf("labels wrong: %v", got.Labels)
+	}
+	if got.Spec.GuestRef.Name != "g1" || got.Spec.Backend.Type != snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot {
+		t.Errorf("template spec not copied: %+v", got.Spec)
+	}
+	if oc := metav1.GetControllerOf(&got); oc == nil || oc.Kind != "SwiftSnapshotSchedule" || oc.Name != "nightly" {
+		t.Errorf("snapshot must be owned by the schedule; got %+v", got.OwnerReferences)
+	}
+	// status.lastScheduleTime advanced to the tick (==baseTime).
+	var after snapshotv1alpha1.SwiftSnapshotSchedule
+	if err := c.Get(context.Background(), req().NamespacedName, &after); err != nil {
+		t.Fatal(err)
+	}
+	if after.Status.LastScheduleTime == nil || !after.Status.LastScheduleTime.Time.Equal(baseTime) {
+		t.Errorf("lastScheduleTime = %v, want %v", after.Status.LastScheduleTime, baseTime)
+	}
+}
+
+func TestReconcile_Idempotent_SameTickNoDuplicate(t *testing.T) {
+	s := schedule(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		lt := metav1.NewTime(baseTime.Add(-2 * time.Minute))
+		s.Status.LastScheduleTime = &lt
+	})
+	r, c := newSched(t, baseTime, s)
+	if _, err := r.Reconcile(context.Background(), req()); err != nil {
+		t.Fatal(err)
+	}
+	// Reset lastScheduleTime to re-attempt the same tick; the deterministic name
+	// makes Create a no-op (AlreadyExists), so still exactly 1.
+	var sc snapshotv1alpha1.SwiftSnapshotSchedule
+	_ = c.Get(context.Background(), req().NamespacedName, &sc)
+	lt := metav1.NewTime(baseTime.Add(-2 * time.Minute))
+	sc.Status.LastScheduleTime = &lt
+	_ = c.Status().Update(context.Background(), &sc)
+	if _, err := r.Reconcile(context.Background(), req()); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(listSnaps(t, c)); n != 1 {
+		t.Errorf("same tick must not duplicate; got %d snapshots", n)
+	}
+}
+
+func TestReconcile_Suspend_NoFire(t *testing.T) {
+	s := schedule(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) { s.Spec.Suspend = true })
+	r, c := newSched(t, baseTime, s)
+	res, err := r.Reconcile(context.Background(), req())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RequeueAfter != suspendedRequeue {
+		t.Errorf("suspended requeue = %v, want %v", res.RequeueAfter, suspendedRequeue)
+	}
+	if n := len(listSnaps(t, c)); n != 0 {
+		t.Errorf("suspended schedule must not create snapshots; got %d", n)
+	}
+}
+
+func TestReconcile_Forbid_SkipsWhenInFlight(t *testing.T) {
+	s := schedule(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		lt := metav1.NewTime(baseTime.Add(-2 * time.Minute))
+		s.Status.LastScheduleTime = &lt
+	})
+	inflight := &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nightly-old", Namespace: "ns",
+			Labels: map[string]string{snapshotv1alpha1.ScheduleLabel: "nightly"},
+		},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{Phase: snapshotv1alpha1.SwiftSnapshotPhaseCapturing},
+	}
+	r, c := newSched(t, baseTime, s, inflight)
+	if _, err := r.Reconcile(context.Background(), req()); err != nil {
+		t.Fatal(err)
+	}
+	// Forbid: no NEW snapshot — still just the in-flight one.
+	if n := len(listSnaps(t, c)); n != 1 {
+		t.Errorf("Forbid must skip while a prior is in flight; got %d snapshots", n)
+	}
+	// active reflects the in-flight child.
+	var after snapshotv1alpha1.SwiftSnapshotSchedule
+	_ = c.Get(context.Background(), req().NamespacedName, &after)
+	if len(after.Status.Active) != 1 || after.Status.Active[0] != "nightly-old" {
+		t.Errorf("active = %v, want [nightly-old]", after.Status.Active)
+	}
+}
+
+func TestReconcile_StartingDeadline_SkipsTooLate(t *testing.T) {
+	// Daily schedule; controller "wakes" 5min after the midnight tick with a 60s
+	// deadline -> the tick is too late, skip it (no snapshot), advance lastSchedule.
+	at := time.Date(2026, 6, 6, 0, 5, 0, 0, time.UTC) // 00:05
+	s := schedule(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		s.Spec.Schedule = "0 0 * * *"
+		dl := int64(60)
+		s.Spec.StartingDeadlineSeconds = &dl
+		lt := metav1.NewTime(at.Add(-26 * time.Hour)) // before the missed midnight
+		s.Status.LastScheduleTime = &lt
+		s.CreationTimestamp = metav1.NewTime(at.Add(-48 * time.Hour))
+	})
+	r, c := newSched(t, at, s)
+	if _, err := r.Reconcile(context.Background(), req()); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(listSnaps(t, c)); n != 0 {
+		t.Errorf("a tick past startingDeadline must be skipped; got %d snapshots", n)
+	}
+	midnight := time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC)
+	var after snapshotv1alpha1.SwiftSnapshotSchedule
+	_ = c.Get(context.Background(), req().NamespacedName, &after)
+	if after.Status.LastScheduleTime == nil || !after.Status.LastScheduleTime.Time.Equal(midnight) {
+		t.Errorf("skipped tick should still advance lastScheduleTime to %v; got %v", midnight, after.Status.LastScheduleTime)
+	}
+}
+
+func TestMergeLabels(t *testing.T) {
+	out := mergeLabels(map[string]string{"a": "1"}, "sched-x")
+	if out["a"] != "1" || out[snapshotv1alpha1.ScheduleLabel] != "sched-x" {
+		t.Errorf("mergeLabels = %v", out)
+	}
+	// schedule label always wins / is set even with nil template labels.
+	if got := mergeLabels(nil, "s")[snapshotv1alpha1.ScheduleLabel]; got != "s" {
+		t.Errorf("schedule label not set on nil template labels; got %q", got)
+	}
+}


### PR DESCRIPTION
## Snapshot Phase 6 — PR 3/7: the schedule controller

Cron evaluation + snapshot creation + `concurrencyPolicy` + status. keep-N pruning is PR 4.

### Behaviour
- Parses `spec.schedule` with **`robfig/cron/v3`** `ParseStandard` (5-field, UTC — OQ3).
- Computes the most recent due tick after `lastScheduleTime` (or `creationTimestamp`) and fires **at most one** snapshot — coalesces a backlog after an outage rather than stampeding (`missedTickCap=100`).
- Creates from `spec.template`: deterministic name `<schedule>-<unix>` (so a same-tick re-reconcile is an idempotent `AlreadyExists`), **schedule ownerRef**, `ScheduleLabel` + merged template labels/annotations, copied `SwiftSnapshotSpec`.
- **`Forbid`** (default) skips the tick while a prior scheduled snapshot is non-terminal; **`startingDeadlineSeconds`** skips a too-late tick. Both advance `lastScheduleTime` so the tick isn't re-evaluated.
- Status: `lastScheduleTime`, `lastSuccessfulTime` (newest Ready child's `capturedAt`), `active[]` (non-terminal children) — written only on change.
- `Owns(SwiftSnapshot)` so a child reaching Ready/Failed re-triggers the schedule. Injectable clock for tests.

### Wiring
main.go registration + RBAC (`swiftsnapshotschedules` + `/status`, config + chart). No `api/`/CRD change.

### Tests
Due-tick fire (name/ownerRef/label/template/status), same-tick idempotency, suspend, Forbid-skip-when-in-flight, startingDeadline skip, `mostRecentDue` + `mergeLabels`. `go build`, `go vet`, full suite pass. Rebuilds the controller-manager image.

Next: PR 4 (keep-N GC — reuses the exported `ReferenceBlocker` per OQ4, honors `deletionPolicy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)