### PR TITLE
feat(snapshots): SwiftSnapshotSchedule keep-N retention — Phase 6 (4/7)

### DIFF
--- a/internal/controller/swiftsnapshot/retention.go
+++ b/internal/controller/swiftsnapshot/retention.go
@@ -75,8 +75,18 @@ func (r *SwiftSnapshotReconciler) handleRetention(ctx context.Context, snap *sna
 // referenced (and so must NOT be TTL-deleted): a cloneFromSnapshot SwiftGuest,
 // or a non-terminal SwiftRestore, in the same namespace.
 func (r *SwiftSnapshotReconciler) retentionBlocker(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot) (string, error) {
+	return ReferenceBlocker(ctx, r.Client, snap)
+}
+
+// ReferenceBlocker returns a non-empty human reason when a snapshot is still
+// referenced (and so must NOT be auto-deleted by TTL or keep-N retention): a
+// cloneFromSnapshot SwiftGuest, or a non-terminal SwiftRestore, in the same
+// namespace. Exported so the SwiftSnapshotSchedule keep-N controller reuses the
+// exact same gate (Phase 6, OQ4). An operator-initiated `kubectl delete` is
+// never gated by this — it only governs controller-driven retention deletes.
+func ReferenceBlocker(ctx context.Context, c client.Reader, snap *snapshotv1alpha1.SwiftSnapshot) (string, error) {
 	var guests swiftv1alpha1.SwiftGuestList
-	if err := r.List(ctx, &guests, client.InNamespace(snap.Namespace)); err != nil {
+	if err := c.List(ctx, &guests, client.InNamespace(snap.Namespace)); err != nil {
 		return "", err
 	}
 	for i := range guests.Items {
@@ -86,7 +96,7 @@ func (r *SwiftSnapshotReconciler) retentionBlocker(ctx context.Context, snap *sn
 		}
 	}
 	var restores snapshotv1alpha1.SwiftRestoreList
-	if err := r.List(ctx, &restores, client.InNamespace(snap.Namespace)); err != nil {
+	if err := c.List(ctx, &restores, client.InNamespace(snap.Namespace)); err != nil {
 		return "", err
 	}
 	for i := range restores.Items {

--- a/internal/controller/swiftsnapshotschedule/controller.go
+++ b/internal/controller/swiftsnapshotschedule/controller.go
@@ -103,6 +103,14 @@ func (r *SwiftSnapshotScheduleReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
+	// keep-N retention: prune the oldest Ready snapshots beyond keepLast. Runs
+	// every reconcile (the Owns(SwiftSnapshot) watch fires this as children
+	// reach Ready), not just on a tick. Uses the pre-create child list — a
+	// just-created snapshot is still Capturing, so never a prune candidate.
+	if err := r.pruneKeepN(ctx, &sched, children); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{RequeueAfter: requeueToNext(cronSched, now)}, nil
 }
 

--- a/internal/controller/swiftsnapshotschedule/controller_test.go
+++ b/internal/controller/swiftsnapshotschedule/controller_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
 )
 
 // fixed minute boundary for deterministic cron math.
@@ -29,8 +30,13 @@ func schedScheme(t *testing.T) *runtime.Scheme {
 	s.AddKnownTypes(gv,
 		&snapshotv1alpha1.SwiftSnapshot{}, &snapshotv1alpha1.SwiftSnapshotList{},
 		&snapshotv1alpha1.SwiftSnapshotSchedule{}, &snapshotv1alpha1.SwiftSnapshotScheduleList{},
+		&snapshotv1alpha1.SwiftRestore{}, &snapshotv1alpha1.SwiftRestoreList{},
 	)
 	metav1.AddToGroupVersion(s, gv)
+	// ReferenceBlocker (keep-N) lists SwiftGuests + SwiftRestores.
+	gvSwift := schema.GroupVersion{Group: "swift.kubeswift.io", Version: "v1alpha1"}
+	s.AddKnownTypes(gvSwift, &swiftv1alpha1.SwiftGuest{}, &swiftv1alpha1.SwiftGuestList{})
+	metav1.AddToGroupVersion(s, gvSwift)
 	return s
 }
 

--- a/internal/controller/swiftsnapshotschedule/retention.go
+++ b/internal/controller/swiftsnapshotschedule/retention.go
@@ -1,0 +1,74 @@
+package swiftsnapshotschedule
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftsnapshot"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
+)
+
+// pruneKeepN deletes the schedule's oldest snapshots beyond
+// spec.retention.keepLast. Only Ready, not-already-deleting snapshots count
+// toward the budget and are eligible for pruning (a non-terminal capture is
+// never deleted; a Failed one is left for inspection — OQ1). A snapshot still
+// referenced by a cloneFromSnapshot guest / in-flight restore is skipped and
+// pruned on a later reconcile (the shared ReferenceBlocker gate — OQ4). The
+// delete is a normal SwiftSnapshot delete, so its deletionPolicy purge runs.
+func (r *SwiftSnapshotScheduleReconciler) pruneKeepN(
+	ctx context.Context,
+	sched *snapshotv1alpha1.SwiftSnapshotSchedule,
+	children []snapshotv1alpha1.SwiftSnapshot,
+) error {
+	if sched.Spec.Retention == nil || sched.Spec.Retention.KeepLast == nil {
+		return nil
+	}
+	keep := int(*sched.Spec.Retention.KeepLast)
+
+	ready := make([]snapshotv1alpha1.SwiftSnapshot, 0, len(children))
+	for i := range children {
+		c := children[i]
+		if c.Status.Phase == snapshotv1alpha1.SwiftSnapshotPhaseReady && c.DeletionTimestamp == nil {
+			ready = append(ready, c)
+		}
+	}
+	if len(ready) <= keep {
+		return nil
+	}
+
+	// Newest first, so ready[keep:] are the oldest beyond the budget.
+	sort.Slice(ready, func(i, j int) bool { return snapTime(ready[i]).After(snapTime(ready[j])) })
+
+	logger := log.FromContext(ctx)
+	for i := keep; i < len(ready); i++ {
+		old := ready[i]
+		blocker, err := swiftsnapshot.ReferenceBlocker(ctx, r.Client, &old)
+		if err != nil {
+			return err
+		}
+		if blocker != "" {
+			logger.Info("keep-N: deferring prune of referenced snapshot", "snapshot", old.Name, "reason", blocker)
+			continue
+		}
+		if err := r.Delete(ctx, &old); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		logger.Info("keep-N: pruned snapshot", "snapshot", old.Name, "keepLast", keep)
+		metrics.SnapshotSchedulePrunedTotal.Inc()
+	}
+	return nil
+}
+
+// snapTime is a snapshot's effective age key: capturedAt if Ready, else the
+// creation timestamp.
+func snapTime(s snapshotv1alpha1.SwiftSnapshot) time.Time {
+	if s.Status.CapturedAt != nil {
+		return s.Status.CapturedAt.Time
+	}
+	return s.CreationTimestamp.Time
+}

--- a/internal/controller/swiftsnapshotschedule/retention_test.go
+++ b/internal/controller/swiftsnapshotschedule/retention_test.go
@@ -1,0 +1,143 @@
+package swiftsnapshotschedule
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// readyChild builds a Ready snapshot owned (by label) by "nightly", captured at
+// the given time.
+func readyChild(name string, capturedAt time.Time) *snapshotv1alpha1.SwiftSnapshot {
+	ct := metav1.NewTime(capturedAt)
+	return &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "ns",
+			Labels:            map[string]string{snapshotv1alpha1.ScheduleLabel: "nightly"},
+			CreationTimestamp: ct,
+		},
+		Spec:   snapshotv1alpha1.SwiftSnapshotSpec{GuestRef: snapshotv1alpha1.SwiftSnapshotGuestRef{Name: "g1"}},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{Phase: snapshotv1alpha1.SwiftSnapshotPhaseReady, CapturedAt: &ct},
+	}
+}
+
+func keepLastSched(n int32) *snapshotv1alpha1.SwiftSnapshotSchedule {
+	return schedule(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		s.Spec.Retention = &snapshotv1alpha1.SnapshotScheduleRetention{KeepLast: &n}
+	})
+}
+
+func snapNames(t *testing.T, c client.Client) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	for _, s := range listSnaps(t, c) {
+		if s.DeletionTimestamp == nil {
+			out[s.Name] = true
+		}
+	}
+	return out
+}
+
+func TestPruneKeepN_DeletesOldestBeyondBudget(t *testing.T) {
+	s := keepLastSched(2)
+	c1 := readyChild("s1", baseTime.Add(-3*time.Minute))
+	c2 := readyChild("s2", baseTime.Add(-2*time.Minute))
+	c3 := readyChild("s3", baseTime.Add(-1*time.Minute))
+	c4 := readyChild("s4", baseTime) // newest
+	r, c := newSched(t, baseTime, s, c1, c2, c3, c4)
+
+	if err := r.pruneKeepN(context.Background(), s, []snapshotv1alpha1.SwiftSnapshot{*c1, *c2, *c3, *c4}); err != nil {
+		t.Fatal(err)
+	}
+	got := snapNames(t, c)
+	// Keep the 2 newest (s3, s4); prune s1, s2.
+	if !got["s3"] || !got["s4"] {
+		t.Errorf("newest 2 must survive; got %v", got)
+	}
+	if got["s1"] || got["s2"] {
+		t.Errorf("oldest 2 must be pruned; got %v", got)
+	}
+}
+
+func TestPruneKeepN_UnderBudget_NoOp(t *testing.T) {
+	s := keepLastSched(5)
+	c1 := readyChild("s1", baseTime.Add(-time.Minute))
+	c2 := readyChild("s2", baseTime)
+	r, c := newSched(t, baseTime, s, c1, c2)
+	if err := r.pruneKeepN(context.Background(), s, []snapshotv1alpha1.SwiftSnapshot{*c1, *c2}); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(snapNames(t, c)); n != 2 {
+		t.Errorf("under budget must prune nothing; got %d", n)
+	}
+}
+
+func TestPruneKeepN_NoRetention_NoOp(t *testing.T) {
+	s := schedule(nil) // no spec.retention
+	c1 := readyChild("s1", baseTime.Add(-time.Minute))
+	c2 := readyChild("s2", baseTime)
+	r, c := newSched(t, baseTime, s, c1, c2)
+	if err := r.pruneKeepN(context.Background(), s, []snapshotv1alpha1.SwiftSnapshot{*c1, *c2}); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(snapNames(t, c)); n != 2 {
+		t.Errorf("no retention must prune nothing; got %d", n)
+	}
+}
+
+func TestPruneKeepN_NonReadyNotCounted(t *testing.T) {
+	// keepLast=1; two Ready + one Capturing. Only the 2 Ready count; prune the
+	// older Ready, keep the newer Ready and leave the Capturing one alone.
+	s := keepLastSched(1)
+	rOld := readyChild("ready-old", baseTime.Add(-2*time.Minute))
+	rNew := readyChild("ready-new", baseTime)
+	capturing := readyChild("capturing", baseTime.Add(-time.Minute))
+	capturing.Status.Phase = snapshotv1alpha1.SwiftSnapshotPhaseCapturing
+	r, c := newSched(t, baseTime, s, rOld, rNew, capturing)
+	if err := r.pruneKeepN(context.Background(), s, []snapshotv1alpha1.SwiftSnapshot{*rOld, *rNew, *capturing}); err != nil {
+		t.Fatal(err)
+	}
+	got := snapNames(t, c)
+	if got["ready-old"] {
+		t.Error("older Ready snapshot should be pruned")
+	}
+	if !got["ready-new"] || !got["capturing"] {
+		t.Errorf("newest Ready + the in-flight capture must survive; got %v", got)
+	}
+}
+
+func TestPruneKeepN_SkipsReferenced(t *testing.T) {
+	// keepLast=1; the oldest (prune candidate) is referenced by a clone guest →
+	// skipped (not deleted); the next-oldest unreferenced one is still pruned.
+	s := keepLastSched(1)
+	cOld := readyChild("ref-old", baseTime.Add(-2*time.Minute)) // referenced, beyond budget
+	cMid := readyChild("plain-mid", baseTime.Add(-time.Minute)) // unreferenced, beyond budget
+	cNew := readyChild("keep-new", baseTime)                    // newest, kept
+	cloneGuest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-x", Namespace: "ns"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			CloneFromSnapshot: &swiftv1alpha1.CloneFromSnapshotSource{SnapshotRef: corev1.LocalObjectReference{Name: "ref-old"}},
+		},
+	}
+	r, c := newSched(t, baseTime, s, cOld, cMid, cNew, cloneGuest)
+	if err := r.pruneKeepN(context.Background(), s, []snapshotv1alpha1.SwiftSnapshot{*cOld, *cMid, *cNew}); err != nil {
+		t.Fatal(err)
+	}
+	got := snapNames(t, c)
+	if !got["ref-old"] {
+		t.Error("a referenced snapshot must be skipped by keep-N, not deleted")
+	}
+	if got["plain-mid"] {
+		t.Error("an unreferenced over-budget snapshot must still be pruned")
+	}
+	if !got["keep-new"] {
+		t.Error("the newest snapshot must be kept")
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -191,6 +191,16 @@ var (
 			Help: "Artifact bytes pulled from S3 by Tier C restore/clone downloads (excludes skipped)",
 		},
 	)
+
+	// SnapshotSchedulePrunedTotal counts snapshots a SwiftSnapshotSchedule
+	// deleted by keep-N retention (excludes those skipped because still
+	// referenced).
+	SnapshotSchedulePrunedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "kubeswift_snapshot_schedule_pruned_total",
+			Help: "Snapshots deleted by SwiftSnapshotSchedule keep-N retention",
+		},
+	)
 )
 
 // cloneDownloadObserved dedupes the per-(node,snapshot) clone download byte
@@ -224,5 +234,6 @@ func init() {
 		CloneTotal,
 		SnapshotUploadBytesTotal,
 		RestoreDownloadBytesTotal,
+		SnapshotSchedulePrunedTotal,
 	)
 }


### PR DESCRIPTION
## Snapshot Phase 6 — PR 4/7: keep-N retention

Prunes a schedule's oldest snapshots beyond `spec.retention.keepLast`.

### Shared gate (OQ4)
Exports **`ReferenceBlocker(ctx, client.Reader, snap)`** from `swiftsnapshot` (the existing `retentionBlocker` method now delegates to it), so keep-N uses the **exact same** reference check the ttl path uses — it never deletes a snapshot a `cloneFromSnapshot` guest or in-flight `SwiftRestore` still references.

### `pruneKeepN`
- Of the **Ready, not-already-deleting** children sorted newest-first by `capturedAt`, deletes those beyond `keepLast`.
- **Skips** any `ReferenceBlocker` flags (pruned on a later reconcile once the reference clears).
- **Non-terminal captures and Failed snapshots don't count** toward the budget and aren't pruned (OQ1).
- The delete is a normal `SwiftSnapshot` delete → its **`deletionPolicy` purge runs** (Tier B/C cleanup).
- Runs **every reconcile** (the `Owns(SwiftSnapshot)` watch fires it as children reach Ready), using the pre-create child list (a just-created snapshot is Capturing, never a candidate).

### Metric
`kubeswift_snapshot_schedule_pruned_total`.

### Scope
No `api/`/CRD change. Tests: oldest-beyond-budget pruned, under-budget no-op, no-retention no-op, non-Ready not counted, referenced-skipped. `go build`, `go vet`, full suite pass. Rebuilds the controller-manager image.

Next: PR 5 (the `vswiftsnapshotschedule` validation webhook — cron parse, `keepLast>=1`, reuse `validateShape` on the template, per-operation discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)