### PR TITLE
feat(snapshots): SwiftSnapshotSchedule validation webhook — Phase 6 (5/7)

### DIFF
--- a/charts/kubeswift/templates/webhook/validating-webhook.yaml
+++ b/charts/kubeswift/templates/webhook/validating-webhook.yaml
@@ -81,6 +81,20 @@ webhooks:
         apiGroups: ["snapshot.kubeswift.io"]
         apiVersions: ["v1alpha1"]
         resources: ["swiftrestores"]
+  - name: vswiftsnapshotschedule.snapshot.kubeswift.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: Fail
+    clientConfig:
+      service:
+        namespace: {{ .Values.namespace }}
+        name: kubeswift-webhook-service
+        path: /validate-snapshot-kubeswift-io-v1alpha1-swiftsnapshotschedule
+    rules:
+      - operations: [CREATE, UPDATE]
+        apiGroups: ["snapshot.kubeswift.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["swiftsnapshotschedules"]
   - name: vswiftmigration.migration.kubeswift.io
     admissionReviewVersions: ["v1"]
     sideEffects: None

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -40,6 +40,7 @@ import (
 	swiftrestorewebhook "github.com/projectbeskar/kubeswift/internal/webhook/swiftrestore"
 	swiftseedprofilewebhook "github.com/projectbeskar/kubeswift/internal/webhook/swiftseedprofile"
 	swiftsnapshotwebhook "github.com/projectbeskar/kubeswift/internal/webhook/swiftsnapshot"
+	swiftsnapshotschedulewebhook "github.com/projectbeskar/kubeswift/internal/webhook/swiftsnapshotschedule"
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 )
@@ -282,6 +283,12 @@ func main() {
 			WithCustomValidator(&swiftrestorewebhook.Validator{Client: mgr.GetClient()}).
 			Complete(); err != nil {
 			klog.ErrorS(err, "unable to create SwiftRestore webhook")
+			os.Exit(1)
+		}
+		if err = ctrl.NewWebhookManagedBy(mgr, &snapshotv1alpha1.SwiftSnapshotSchedule{}).
+			WithCustomValidator(&swiftsnapshotschedulewebhook.Validator{}).
+			Complete(); err != nil {
+			klog.ErrorS(err, "unable to create SwiftSnapshotSchedule webhook")
 			os.Exit(1)
 		}
 		if err = ctrl.NewWebhookManagedBy(mgr, &migrationv1alpha1.SwiftMigration{}).

--- a/config/webhook/validating-webhook.yaml
+++ b/config/webhook/validating-webhook.yaml
@@ -66,6 +66,20 @@ webhooks:
         apiGroups: ["migration.kubeswift.io"]
         apiVersions: ["v1alpha1"]
         resources: ["swiftmigrations"]
+  - name: vswiftsnapshotschedule.snapshot.kubeswift.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: Fail
+    clientConfig:
+      service:
+        namespace: kubeswift-system
+        name: kubeswift-webhook-service
+        path: /validate-snapshot-kubeswift-io-v1alpha1-swiftsnapshotschedule
+    rules:
+      - operations: [CREATE, UPDATE]
+        apiGroups: ["snapshot.kubeswift.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["swiftsnapshotschedules"]
   # Phase 4 drain integration. Fires on EVERY pod eviction cluster-wide; the
   # handler fast-allows any pod that is not a SwiftGuest launcher pod.
   # failurePolicy: Ignore so a webhook outage never breaks evictions (the

--- a/internal/webhook/swiftsnapshot/validator.go
+++ b/internal/webhook/swiftsnapshot/validator.go
@@ -175,6 +175,14 @@ func (v *Validator) validateMemoryCaptureCompat(ctx context.Context, snap *snaps
 	return nil
 }
 
+// ValidateShape validates the SwiftSnapshot template a SwiftSnapshotSchedule
+// would instantiate (Phase 6): the same client-independent shape rules used at
+// SwiftSnapshot admission, so a bad template is rejected at schedule-create
+// rather than surfacing at the first tick. Exported wrapper over validateShape.
+func ValidateShape(snap *snapshotv1alpha1.SwiftSnapshot) error {
+	return validateShape(snap)
+}
+
 // validateShape covers the rules that depend only on the SwiftSnapshot
 // itself: required fields, backend allowlist, hostPath rules, carrier-
 // field exclusivity. Extracted so unit tests can exercise it without

--- a/internal/webhook/swiftsnapshotschedule/validator.go
+++ b/internal/webhook/swiftsnapshotschedule/validator.go
@@ -1,0 +1,73 @@
+// Package swiftsnapshotschedule contains the admission webhook validator for
+// SwiftSnapshotSchedule (Phase 6). It validates the cron expression and the
+// embedded SwiftSnapshot template — neither of which OpenAPI/CEL can check —
+// plus a name-length guard for the names derived from the schedule.
+package swiftsnapshotschedule
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/robfig/cron/v3"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	swiftsnapshotwebhook "github.com/projectbeskar/kubeswift/internal/webhook/swiftsnapshot"
+)
+
+// maxScheduleNameLen bounds the schedule name so derived resource names stay
+// within Kubernetes' 63-char limit: a scheduled snapshot is "<schedule>-<unix>"
+// (+11), and that snapshot's own Jobs add up to "-s3-delete" (+10) — so
+// len(name)+21 must be <= 63.
+const maxScheduleNameLen = 40
+
+// Validator validates SwiftSnapshotSchedule resources.
+type Validator struct{}
+
+func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	s, ok := obj.(*snapshotv1alpha1.SwiftSnapshotSchedule)
+	if !ok {
+		return nil, fmt.Errorf("expected SwiftSnapshotSchedule, got %T", obj)
+	}
+	return nil, validateSchedule(s)
+}
+
+// ValidateUpdate runs the same rules: every field of the spec is mutable (an
+// operator may retune cadence/retention/template), and all rules are
+// client-independent shape rules, so there is nothing to gate per-operation
+// beyond re-validating the new object (per-operation discipline, Principle #10).
+func (v *Validator) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
+	s, ok := newObj.(*snapshotv1alpha1.SwiftSnapshotSchedule)
+	if !ok {
+		return nil, fmt.Errorf("expected SwiftSnapshotSchedule, got %T", newObj)
+	}
+	return nil, validateSchedule(s)
+}
+
+func (v *Validator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func validateSchedule(s *snapshotv1alpha1.SwiftSnapshotSchedule) error {
+	if _, err := cron.ParseStandard(s.Spec.Schedule); err != nil {
+		return fmt.Errorf("spec.schedule is not a valid 5-field cron expression: %w", err)
+	}
+	if len(s.Name) > maxScheduleNameLen {
+		return fmt.Errorf("metadata.name must be at most %d characters (scheduled snapshot and Job names derive from it); got %d",
+			maxScheduleNameLen, len(s.Name))
+	}
+	if r := s.Spec.Retention; r != nil && r.KeepLast != nil && *r.KeepLast < 1 {
+		return fmt.Errorf("spec.retention.keepLast must be >= 1")
+	}
+	if d := s.Spec.StartingDeadlineSeconds; d != nil && *d < 0 {
+		return fmt.Errorf("spec.startingDeadlineSeconds must be >= 0")
+	}
+	// The template must be a valid SwiftSnapshot (shape rules only — the source
+	// guest need not exist at schedule-create time).
+	tmpl := &snapshotv1alpha1.SwiftSnapshot{Spec: s.Spec.Template.Spec}
+	if err := swiftsnapshotwebhook.ValidateShape(tmpl); err != nil {
+		return fmt.Errorf("spec.template.spec is invalid: %w", err)
+	}
+	return nil
+}

--- a/internal/webhook/swiftsnapshotschedule/validator_test.go
+++ b/internal/webhook/swiftsnapshotschedule/validator_test.go
@@ -1,0 +1,101 @@
+package swiftsnapshotschedule
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+)
+
+func sched(mut func(*snapshotv1alpha1.SwiftSnapshotSchedule)) *snapshotv1alpha1.SwiftSnapshotSchedule {
+	s := &snapshotv1alpha1.SwiftSnapshotSchedule{
+		ObjectMeta: metav1.ObjectMeta{Name: "nightly", Namespace: "ns"},
+		Spec: snapshotv1alpha1.SwiftSnapshotScheduleSpec{
+			Schedule: "0 2 * * *",
+			Template: snapshotv1alpha1.SnapshotTemplate{
+				Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+					GuestRef: snapshotv1alpha1.SwiftSnapshotGuestRef{Name: "g1"},
+					Backend:  snapshotv1alpha1.SwiftSnapshotBackend{Type: snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot},
+				},
+			},
+		},
+	}
+	if mut != nil {
+		mut(s)
+	}
+	return s
+}
+
+func errHas(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("err = %v, want containing %q", err, want)
+	}
+}
+
+func TestValidate_OK(t *testing.T) {
+	v := &Validator{}
+	if _, err := v.ValidateCreate(context.Background(), sched(nil)); err != nil {
+		t.Errorf("valid schedule rejected: %v", err)
+	}
+}
+
+func TestValidate_BadCron(t *testing.T) {
+	v := &Validator{}
+	_, err := v.ValidateCreate(context.Background(), sched(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		s.Spec.Schedule = "not a cron"
+	}))
+	errHas(t, err, "not a valid")
+}
+
+func TestValidate_NameTooLong(t *testing.T) {
+	v := &Validator{}
+	_, err := v.ValidateCreate(context.Background(), sched(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		s.Name = strings.Repeat("x", maxScheduleNameLen+1)
+	}))
+	errHas(t, err, "at most")
+}
+
+func TestValidate_KeepLastAndDeadlineBounds(t *testing.T) {
+	v := &Validator{}
+	_, err := v.ValidateCreate(context.Background(), sched(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		s.Spec.Retention = &snapshotv1alpha1.SnapshotScheduleRetention{KeepLast: ptr.To(int32(0))}
+	}))
+	errHas(t, err, "keepLast must be >= 1")
+
+	_, err = v.ValidateCreate(context.Background(), sched(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		s.Spec.StartingDeadlineSeconds = ptr.To(int64(-5))
+	}))
+	errHas(t, err, "startingDeadlineSeconds must be >= 0")
+}
+
+func TestValidate_BadTemplate(t *testing.T) {
+	v := &Validator{}
+	// Missing guestRef → caught by the reused SwiftSnapshot shape validation.
+	_, err := v.ValidateCreate(context.Background(), sched(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		s.Spec.Template.Spec.GuestRef.Name = ""
+	}))
+	errHas(t, err, "template.spec is invalid")
+
+	// local backend missing hostPath → also a template shape error.
+	_, err = v.ValidateCreate(context.Background(), sched(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		s.Spec.Template.Spec.Backend = snapshotv1alpha1.SwiftSnapshotBackend{Type: snapshotv1alpha1.SnapshotBackendLocal}
+	}))
+	errHas(t, err, "template.spec is invalid")
+}
+
+func TestValidate_UpdateRunsSameRules(t *testing.T) {
+	v := &Validator{}
+	bad := sched(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) { s.Spec.Schedule = "bogus" })
+	if _, err := v.ValidateUpdate(context.Background(), sched(nil), bad); err == nil {
+		t.Error("ValidateUpdate must re-validate the (mutable) spec")
+	}
+	// ValidateDelete is a pass-through.
+	if _, err := v.ValidateDelete(context.Background(), sched(nil)); err != nil {
+		t.Errorf("ValidateDelete should pass through; got %v", err)
+	}
+}


### PR DESCRIPTION
## Snapshot Phase 6 — PR 5/7: the `vswiftsnapshotschedule` webhook

Validates what OpenAPI/CEL can't:
- **`spec.schedule`** parses as a 5-field cron (`robfig/cron` `ParseStandard`).
- **`metadata.name` ≤ 40 chars** — derived names (`<schedule>-<unix>` + `-s3-delete` = +21) must stay within K8s' 63-char limit; prevents a confusing runtime Job-name overflow.
- `spec.retention.keepLast ≥ 1`, `spec.startingDeadlineSeconds ≥ 0` (defense-in-depth over the CRD markers).
- **`spec.template.spec` is a valid SwiftSnapshot** — reuses the SwiftSnapshot webhook's shape validation, exported as `ValidateShape`. A bad template is rejected at **schedule-create**, not at the first tick.

**Per-operation discipline (Principle #10):** all rules are client-independent shape rules, so `ValidateUpdate` re-validates the fully-mutable spec and `ValidateDelete` is a pass-through.

### Wiring
Registered in `main.go` behind `--webhook-enabled`; VWC entry added to **both** the Helm chart and the `config/webhook` kustomize overlay.

> ⚠️ **Pre-existing drift (flagged separately, not widened here):** `config/webhook/validating-webhook.yaml` was already missing the `swiftsnapshot`/`swiftrestore` entries the chart has — so kustomize-based webhook installs silently skip snapshot/restore admission. Spun off as its own task.

### Tests
valid; bad cron; name-too-long; keepLast/deadline bounds; bad template (missing guestRef, local-without-hostPath); update re-validates + delete pass-through. No `api/`/CRD change. `go build`, `go vet`, full suite pass. Rebuilds the controller-manager image.

Next: PR 6 (`swiftctl schedule` create/list/describe/delete + samples + `docs/snapshots/scheduled-snapshots.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)