### PR TITLE
feat(snapshots): swiftctl schedule + samples + runbook — Phase 6 (6/7)

### DIFF
--- a/cmd/swiftctl/root.go
+++ b/cmd/swiftctl/root.go
@@ -43,6 +43,7 @@ func init() {
 	rootCmd.AddCommand(debugCmd)
 	rootCmd.AddCommand(snapshotCmd)
 	rootCmd.AddCommand(restoreCmd)
+	rootCmd.AddCommand(scheduleCmd)
 	rootCmd.AddCommand(migrateCmd)
 	rootCmd.AddCommand(migrationCmd)
 }

--- a/cmd/swiftctl/schedule.go
+++ b/cmd/swiftctl/schedule.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+)
+
+var (
+	scheduleGuestRef    string
+	scheduleCron        string
+	scheduleBackend     string
+	scheduleVSClass     string
+	scheduleHostPath    string
+	scheduleIncludeMem  bool
+	scheduleKeepLast    int
+	scheduleSuspend     bool
+	scheduleConcurrency string
+	scheduleListAllNS   bool
+)
+
+var scheduleCmd = &cobra.Command{
+	Use:   "schedule",
+	Short: "Manage SwiftSnapshotSchedule resources (cron-scheduled snapshots + keep-N retention)",
+	RunE:  func(cmd *cobra.Command, args []string) error { return cmd.Help() },
+}
+
+var scheduleCreateCmd = &cobra.Command{
+	Use:          "create [name]",
+	Short:        "Create a SwiftSnapshotSchedule",
+	SilenceUsage: true,
+	Long: `Create a SwiftSnapshotSchedule: snapshot a SwiftGuest on a cron schedule,
+keeping only the most recent --keep-last.
+
+Backends mirror 'swiftctl snapshot create' (csi-volume-snapshot default, or
+local). For the s3 backend, apply a YAML manifest (it needs bucket/endpoint/
+credentials). NOTE: the local backend writes a fixed --hostpath, so scheduled
+local snapshots overwrite each other — use csi-volume-snapshot (or s3) for
+scheduling.`,
+	Example: `  swiftctl schedule create nightly-db --guest db --schedule "0 2 * * *" --keep-last 7
+  swiftctl schedule create hourly --guest web --schedule "0 * * * *" --keep-last 24 --vsclass csi-hostpath-snapclass`,
+	Args: cobra.ExactArgs(1),
+	RunE: runScheduleCreate,
+}
+
+var scheduleListCmd = &cobra.Command{
+	Use:          "list",
+	Aliases:      []string{"ls"},
+	Short:        "List SwiftSnapshotSchedules",
+	SilenceUsage: true,
+	RunE:         runScheduleList,
+}
+
+var scheduleDescribeCmd = &cobra.Command{
+	Use:          "describe [name]",
+	Short:        "Print human-readable details of a SwiftSnapshotSchedule",
+	SilenceUsage: true,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runScheduleDescribe,
+}
+
+var scheduleDeleteCmd = &cobra.Command{
+	Use:          "delete [name]",
+	Short:        "Delete a SwiftSnapshotSchedule (its snapshots are cascade-deleted)",
+	SilenceUsage: true,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runScheduleDelete,
+}
+
+func init() {
+	scheduleCreateCmd.Flags().StringVar(&scheduleGuestRef, "guest", "", "SwiftGuest to snapshot (required)")
+	scheduleCreateCmd.Flags().StringVar(&scheduleCron, "schedule", "", "5-field cron expression, UTC (required), e.g. \"0 2 * * *\"")
+	scheduleCreateCmd.Flags().StringVar(&scheduleBackend, "backend", "csi-volume-snapshot", "Snapshot backend: csi-volume-snapshot or local")
+	scheduleCreateCmd.Flags().StringVar(&scheduleVSClass, "vsclass", "", "VolumeSnapshotClass name (csi-volume-snapshot only)")
+	scheduleCreateCmd.Flags().StringVar(&scheduleHostPath, "hostpath", "", "On-node directory for local backend (under /var/lib/kubeswift/snapshots/)")
+	scheduleCreateCmd.Flags().BoolVar(&scheduleIncludeMem, "include-memory", true, "Backend-determined (no-op on csi-volume-snapshot, which is disk-only)")
+	scheduleCreateCmd.Flags().IntVar(&scheduleKeepLast, "keep-last", 0, "Keep only the most recent N Ready snapshots (0 = keep all; rely on per-snapshot ttl)")
+	scheduleCreateCmd.Flags().BoolVar(&scheduleSuspend, "suspend", false, "Create the schedule suspended")
+	scheduleCreateCmd.Flags().StringVar(&scheduleConcurrency, "concurrency", "Forbid", "Concurrency policy: Forbid (skip while a prior capture runs) or Allow")
+	_ = scheduleCreateCmd.MarkFlagRequired("guest")
+	_ = scheduleCreateCmd.MarkFlagRequired("schedule")
+
+	scheduleListCmd.Flags().BoolVarP(&scheduleListAllNS, "all-namespaces", "A", false, "List across all namespaces")
+
+	scheduleCmd.AddCommand(scheduleCreateCmd, scheduleListCmd, scheduleDescribeCmd, scheduleDeleteCmd)
+}
+
+func runScheduleCreate(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	ns := getNamespace()
+	c, err := newSnapshotClient()
+	if err != nil {
+		return err
+	}
+	backend, err := parseBackendFlag(scheduleBackend)
+	if err != nil {
+		return err
+	}
+	tmpl := snapshotv1alpha1.SwiftSnapshotSpec{
+		GuestRef:      snapshotv1alpha1.SwiftSnapshotGuestRef{Name: scheduleGuestRef},
+		Backend:       snapshotv1alpha1.SwiftSnapshotBackend{Type: backend},
+		IncludeMemory: scheduleIncludeMem,
+	}
+	switch backend {
+	case snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot:
+		tmpl.Backend.CSIVolumeSnapshot = &snapshotv1alpha1.CSIVolumeSnapshotBackend{VolumeSnapshotClassName: scheduleVSClass}
+		if scheduleHostPath != "" {
+			return fmt.Errorf("--hostpath is only valid for --backend=local")
+		}
+	case snapshotv1alpha1.SnapshotBackendLocal:
+		if scheduleHostPath == "" {
+			return fmt.Errorf("--hostpath is required for --backend=local")
+		}
+		tmpl.Backend.Local = &snapshotv1alpha1.LocalBackend{HostPath: scheduleHostPath}
+	}
+
+	sched := &snapshotv1alpha1.SwiftSnapshotSchedule{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: snapshotv1alpha1.SwiftSnapshotScheduleSpec{
+			Schedule:          scheduleCron,
+			Suspend:           scheduleSuspend,
+			ConcurrencyPolicy: snapshotv1alpha1.SnapshotConcurrencyPolicy(scheduleConcurrency),
+			Template:          snapshotv1alpha1.SnapshotTemplate{Spec: tmpl},
+		},
+	}
+	if scheduleKeepLast > 0 {
+		sched.Spec.Retention = &snapshotv1alpha1.SnapshotScheduleRetention{KeepLast: ptr.To(int32(scheduleKeepLast))}
+	}
+	if err := c.Create(context.Background(), sched); err != nil {
+		return fmt.Errorf("create SwiftSnapshotSchedule: %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Created SwiftSnapshotSchedule %s/%s (guest=%s, schedule=%q, keepLast=%d)\n",
+		ns, name, scheduleGuestRef, scheduleCron, scheduleKeepLast)
+	return nil
+}
+
+func runScheduleList(cmd *cobra.Command, _ []string) error {
+	c, err := newSnapshotClient()
+	if err != nil {
+		return err
+	}
+	var list snapshotv1alpha1.SwiftSnapshotScheduleList
+	opts := []client.ListOption{}
+	if !scheduleListAllNS {
+		opts = append(opts, client.InNamespace(getNamespace()))
+	}
+	if err := c.List(context.Background(), &list, opts...); err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAMESPACE\tNAME\tSCHEDULE\tSUSPEND\tGUEST\tKEEP\tLAST-SCHEDULE\tAGE")
+	for _, s := range list.Items {
+		keep := "-"
+		if s.Spec.Retention != nil && s.Spec.Retention.KeepLast != nil {
+			keep = fmt.Sprintf("%d", *s.Spec.Retention.KeepLast)
+		}
+		last := "-"
+		if s.Status.LastScheduleTime != nil {
+			last = cliAge(s.Status.LastScheduleTime.Time)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%t\t%s\t%s\t%s\t%s\n",
+			s.Namespace, s.Name, s.Spec.Schedule, s.Spec.Suspend,
+			s.Spec.Template.Spec.GuestRef.Name, keep, last, cliAge(s.CreationTimestamp.Time))
+	}
+	return w.Flush()
+}
+
+func runScheduleDescribe(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	ns := getNamespace()
+	c, err := newSnapshotClient()
+	if err != nil {
+		return err
+	}
+	var s snapshotv1alpha1.SwiftSnapshotSchedule
+	if err := c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: ns}, &s); err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("SwiftSnapshotSchedule %s/%s not found", ns, name)
+		}
+		return err
+	}
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Name:               %s\n", s.Name)
+	fmt.Fprintf(out, "Namespace:          %s\n", s.Namespace)
+	fmt.Fprintf(out, "Schedule:           %s\n", s.Spec.Schedule)
+	fmt.Fprintf(out, "Suspend:            %t\n", s.Spec.Suspend)
+	fmt.Fprintf(out, "ConcurrencyPolicy:  %s\n", s.Spec.ConcurrencyPolicy)
+	if s.Spec.StartingDeadlineSeconds != nil {
+		fmt.Fprintf(out, "StartingDeadline:   %ds\n", *s.Spec.StartingDeadlineSeconds)
+	}
+	if s.Spec.Retention != nil && s.Spec.Retention.KeepLast != nil {
+		fmt.Fprintf(out, "KeepLast:           %d\n", *s.Spec.Retention.KeepLast)
+	}
+	fmt.Fprintf(out, "Template Guest:     %s\n", s.Spec.Template.Spec.GuestRef.Name)
+	fmt.Fprintf(out, "Template Backend:   %s\n", s.Spec.Template.Spec.Backend.Type)
+	fmt.Fprintf(out, "Template Memory:    %t\n", s.Spec.Template.Spec.IncludeMemory)
+	if s.Status.LastScheduleTime != nil {
+		fmt.Fprintf(out, "Last Schedule:      %s\n", s.Status.LastScheduleTime.Time.Format("2006-01-02 15:04:05 MST"))
+	}
+	if s.Status.LastSuccessfulTime != nil {
+		fmt.Fprintf(out, "Last Successful:    %s\n", s.Status.LastSuccessfulTime.Time.Format("2006-01-02 15:04:05 MST"))
+	}
+	fmt.Fprintf(out, "Active snapshots:   %d\n", len(s.Status.Active))
+	for _, a := range s.Status.Active {
+		fmt.Fprintf(out, "  - %s\n", a)
+	}
+	return nil
+}
+
+func runScheduleDelete(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	ns := getNamespace()
+	c, err := newSnapshotClient()
+	if err != nil {
+		return err
+	}
+	s := &snapshotv1alpha1.SwiftSnapshotSchedule{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+	if err := c.Delete(context.Background(), s); err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("SwiftSnapshotSchedule %s/%s not found", ns, name)
+		}
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Deleted SwiftSnapshotSchedule %s/%s\n", ns, name)
+	return nil
+}

--- a/config/samples/snapshot-schedule/01-schedule-csi.yaml
+++ b/config/samples/snapshot-schedule/01-schedule-csi.yaml
@@ -1,0 +1,24 @@
+# Daily disk-only (CSI) snapshot of a SwiftGuest at 02:00 UTC, keeping the 7
+# most recent. csi-volume-snapshot is the recommended scheduling backend: each
+# tick takes a fresh per-snapshot VolumeSnapshot (no shared hostPath), and the
+# capture is crash-consistent without pausing the VM.
+apiVersion: snapshot.kubeswift.io/v1alpha1
+kind: SwiftSnapshotSchedule
+metadata:
+  name: nightly-db
+  namespace: default
+spec:
+  schedule: "0 2 * * *"            # 5-field cron, UTC
+  concurrencyPolicy: Forbid        # skip a tick while a prior capture is still running
+  retention:
+    keepLast: 7                    # keep the 7 most recent Ready snapshots; prune older
+  template:
+    metadata:
+      labels: {tier: db}           # merged onto every created SwiftSnapshot
+    spec:
+      guestRef:
+        name: db
+      backend:
+        type: csi-volume-snapshot
+        # csiVolumeSnapshot:
+        #   volumeSnapshotClassName: csi-hostpath-snapclass   # optional; default class if unset

--- a/config/samples/snapshot-schedule/02-schedule-s3-ttl.yaml
+++ b/config/samples/snapshot-schedule/02-schedule-s3-ttl.yaml
@@ -1,0 +1,33 @@
+# Hourly memory snapshot exported to S3 (Tier C), keeping the 24 most recent AND
+# auto-expiring any older than 7 days. keep-N (count) and ttl (age) compose:
+# whichever bound a snapshot crosses first deletes it (honoring deletionPolicy).
+# Requires an S3 credentials Secret + bucket (see config/samples/s3-snapshots/).
+apiVersion: snapshot.kubeswift.io/v1alpha1
+kind: SwiftSnapshotSchedule
+metadata:
+  name: hourly-web-s3
+  namespace: default
+spec:
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600      # after an outage, skip a tick missed by >10m
+  retention:
+    keepLast: 24
+  template:
+    spec:
+      guestRef:
+        name: web
+      backend:
+        type: s3
+        s3:
+          bucket: kubeswift-snapshots
+          prefix: scheduled
+          endpoint: minio.minio.svc:9000
+          forcePathStyle: true
+          insecure: true            # demo MinIO over HTTP; UNSAFE — drop for TLS endpoints
+          region: us-east-1
+          credentialsSecretRef:
+            name: s3-creds
+      includeMemory: true
+      deletionPolicy: Delete        # each pruned/expired snapshot purges its S3 objects
+      ttl: 7d                       # per-snapshot max age, composes with keepLast

--- a/docs/snapshots/scheduled-snapshots.md
+++ b/docs/snapshots/scheduled-snapshots.md
@@ -1,0 +1,95 @@
+# Scheduled Snapshots (`SwiftSnapshotSchedule`) + keep-N Retention
+
+> Snapshot Phase 6. Snapshot a SwiftGuest on a cron schedule and keep only the
+> most recent N. Builds entirely on the existing SwiftSnapshot machinery — it
+> adds no new capture mechanism.
+
+## At a glance
+
+```yaml
+apiVersion: snapshot.kubeswift.io/v1alpha1
+kind: SwiftSnapshotSchedule
+metadata:
+  name: nightly-db
+spec:
+  schedule: "0 2 * * *"        # 5-field cron, UTC
+  concurrencyPolicy: Forbid    # Forbid (default) | Allow
+  retention:
+    keepLast: 7                # keep the 7 most recent Ready snapshots
+  template:
+    spec:                      # a SwiftSnapshotSpec — same fields as a hand-written SwiftSnapshot
+      guestRef: {name: db}
+      backend: {type: csi-volume-snapshot}
+```
+
+Each tick the controller creates a SwiftSnapshot named `<schedule>-<unix>`,
+owned by the schedule and labelled `snapshot.kubeswift.io/schedule=<name>`.
+
+## swiftctl
+
+```bash
+swiftctl schedule create nightly-db --guest db --schedule "0 2 * * *" --keep-last 7
+swiftctl schedule list
+swiftctl schedule describe nightly-db
+swiftctl schedule delete nightly-db          # cascade-deletes the schedule's snapshots
+```
+
+For the **s3** backend, apply a YAML manifest (it needs bucket/endpoint/
+credentials) — see [`config/samples/snapshot-schedule/02-schedule-s3-ttl.yaml`](../../config/samples/snapshot-schedule/02-schedule-s3-ttl.yaml).
+
+## Semantics
+
+- **Cron** is standard 5-field, evaluated in **UTC**. After a controller outage
+  the schedule fires **at most one** catch-up snapshot (the most recent missed
+  tick), never a backlog.
+- **`concurrencyPolicy: Forbid`** (default) skips a tick while a prior scheduled
+  snapshot is still capturing/uploading — captures are heavy; this prevents them
+  stacking. `Allow` lets them overlap.
+- **`startingDeadlineSeconds`** skips a tick missed by more than this (e.g. after
+  an outage) instead of firing it late.
+- **`suspend: true`** pauses firing without deleting the schedule or its snapshots.
+
+## Retention — keep-N vs ttl
+
+Two independent bounds that **compose** (whichever a snapshot crosses first
+deletes it):
+
+| | What | Where |
+|---|---|---|
+| **keep-N** | Keep the most recent N **Ready** snapshots of this schedule; prune older. | `SwiftSnapshotSchedule.spec.retention.keepLast` |
+| **ttl** | Delete any snapshot older than its age. | `template.spec.ttl` (per-snapshot, Phase 5) |
+
+keep-N safety:
+- Only **Ready** snapshots count toward the budget and are eligible for pruning.
+  A still-capturing snapshot is never deleted; a **Failed** one is left for
+  inspection (it doesn't count toward `keepLast`).
+- A snapshot still referenced by a `cloneFromSnapshot` SwiftGuest or an
+  in-flight `SwiftRestore` is **skipped** by keep-N (and ttl) — pruned later once
+  the reference clears (the shared reference-block gate).
+- A pruned snapshot is deleted like any other, so its **`deletionPolicy`** runs:
+  `Delete` purges the backend artifacts (hostPath / S3 objects), `Retain` keeps
+  them.
+
+## Backend guidance
+
+- **csi-volume-snapshot** (recommended for scheduling): per-tick VolumeSnapshot,
+  no shared state, crash-consistent, no VM pause.
+- **s3**: per-tick object-store export; great for periodic offsite backups. Pair
+  with `keepLast` and/or `ttl` + `deletionPolicy: Delete` to bound bucket growth.
+- **local**: ⚠️ writes a **fixed `hostPath`**, so scheduled local snapshots
+  overwrite each other — **don't schedule the local backend**; use csi or s3.
+
+## Observability
+
+`kubeswift_snapshot_schedule_pruned_total` counts keep-N deletions. Scheduled
+snapshots also feed the standard `kubeswift_snapshot_total{backend,result}` and
+latency/size metrics (see [`observability.md`](observability.md)).
+
+## Constraints
+
+- **`metadata.name` ≤ 40 characters** — the webhook enforces this so the derived
+  snapshot and Job names (`<schedule>-<unix>-s3-delete`, …) stay within
+  Kubernetes' 63-character limit.
+- The cron expression and the `template.spec` are validated at schedule-create
+  by the admission webhook (a bad template is rejected up front, not at the
+  first tick).


### PR DESCRIPTION
## Snapshot Phase 6 — PR 6/7: operator surface

### `swiftctl schedule`
`create` / `list` / `describe` / `delete`. `create` mirrors `snapshot create` (csi-volume-snapshot default, or local; reuses `parseBackendFlag`/`newSnapshotClient`) and adds `--schedule`, `--keep-last`, `--suspend`, `--concurrency`. s3 schedules go via YAML (they need bucket/endpoint/creds). `list`/`describe` surface schedule/suspend/keepLast + `lastScheduleTime`/`lastSuccessfulTime`/`active`.

```bash
swiftctl schedule create nightly-db --guest db --schedule "0 2 * * *" --keep-last 7
swiftctl schedule list
swiftctl schedule describe nightly-db
swiftctl schedule delete nightly-db
```

### Samples (`config/samples/snapshot-schedule/`)
- `01-schedule-csi.yaml` — daily CSI, `keepLast: 7`.
- `02-schedule-s3-ttl.yaml` — hourly S3 combining `keepLast: 24` + `ttl: 7d` + `deletionPolicy: Delete` (shows count- and age-bounds composing).

### Runbook (`docs/snapshots/scheduled-snapshots.md`)
Cron/concurrency/startingDeadline semantics, **keep-N vs ttl composition**, the reference-block + deletionPolicy interaction, backend guidance (**local is NOT for scheduling** — fixed hostPath overwrites; use csi/s3), observability, and the `name ≤ 40` constraint.

No `api`/CRD change. `go build`, `go vet`, cmd tests pass; `swiftctl schedule` wired into root.

Next: **PR 7 — the cluster mini-walkthrough** (short cron → watch ticks fire + keep-N prune + reference-block), then all snapshot work is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)