### PR TITLE
docs(windows): boot spike — CH v51.1 blocked (viostor 0xD1), QEMU+OVMF validated

### DIFF
--- a/docs/design/windows-guest-support-spike.md
+++ b/docs/design/windows-guest-support-spike.md
@@ -1,0 +1,156 @@
+# Windows Guest Support — Boot Spike Findings
+
+> Status: SPIKE COMPLETE (2026-06-07). Answers the load-bearing unknowns from
+> [`windows-guest-support.md`](windows-guest-support.md) §6 — **before** committing
+> to the phased build. Headline: the image-prep pipeline works and **QEMU+OVMF
+> boots Windows cleanly and stably**, but **Cloud Hypervisor v51.1 is BLOCKED** by a
+> `viostor.sys` `0xD1` bugcheck on its virtio-blk device. This **flips the design's
+> CH-first OQ1 resolution** — see §7.
+
+## 1. Goal & method
+
+Validate, end to end and entirely off-cluster (the dev cluster has no Windows
+image/license), whether a virtio-ready Windows Server guest boots on **Cloud
+Hypervisor** via the existing `--kernel CLOUDHV.fd` disk-boot path, and whether
+the **QEMU+OVMF escape hatch** boots it. Everything ran locally with the **real
+CH v51.1 binary + `CLOUDHV.fd`** extracted from the `swiftletd` image, so the CH
+result reflects exactly what KubeSwift ships.
+
+## 2. Environment
+
+| Component | Version / detail |
+|---|---|
+| Cloud Hypervisor | **v51.1** (binary + `CLOUDHV.fd` extracted from `swiftletd:sha-5c3bc95`) |
+| QEMU (install + escape-hatch) | `/usr/bin/qemu-system-x86_64` 8.2.2 (Debian) — VNC + slirp + std-VGA |
+| QEMU (kata-static, rejected) | `/opt/kata/bin/...` 9.1.2 — no VNC, no slirp, no VGA romfiles (see §6 W-S1) |
+| Guest OS | Windows Server 2022 Eval (build 20348), `install.wim` index 1 = Standard Core |
+| virtio drivers | `virtio-win.iso` (stable, 0.1.x) — viostor / NetKVM injected at install |
+| Firmware | QEMU: `OVMF_CODE_4M.fd`; CH: `CLOUDHV.fd` (EDK2 UEFI) |
+
+Disk: 40 GiB GPT, ESP(260M)/MSR(128M)/NTFS. Raw conversion for CH (`qemu-img
+convert -O raw`), ~5.4 GiB sparse.
+
+## 3. What works ✅
+
+1. **Unattended virtio install (QEMU/KVM)** — `autounattend.xml` does a UEFI/GPT
+   install **onto a virtio-blk disk** with **viostor injected** during WinPE
+   (`DriverPaths` → `\viostor\2k22\amd64`). Reaches OOBE → auto-logon → first-logon
+   commands → clean self-shutdown. **Repeatable in ~3.5 min.** Proves the
+   driver-injection image-prep pipeline.
+2. **Fallback-path boot** — Windows Setup writes `bootmgfw.efi` to **both**
+   `\EFI\Microsoft\Boot\` *and* the firmware fallback `\EFI\Boot\bootx64.efi`
+   (byte-identical), with the BCD at `\EFI\Microsoft\Boot\BCD`. CH (and any
+   empty-NVRAM firmware) boots via the fallback path — **no NVRAM seeding needed**.
+3. **Headless BCD prep is required and sufficient (for QEMU)** — set in
+   first-logon: `bcdedit /ems {current} on`, `/bootems {bootmgr} on`,
+   `/emssettings EMSPORT:1 EMSBAUDRATE:115200`, **`recoveryenabled no`**,
+   **`bootstatuspolicy ignoreallfailures`**. Without it, a fallback-path boot drops
+   into **graphical "Preparing Automatic Repair" (WinRE)** that hangs on a
+   console-less VMM. With it, the image **boots cleanly under QEMU+OVMF to SAC**
+   (serial: `Computer is booting, SAC started and initialized … SAC>`), no crash,
+   stable. **The QEMU+OVMF escape hatch is validated.**
+
+## 4. What is BLOCKED ❌ — Cloud Hypervisor v51.1
+
+CH loads the Windows Boot Manager and the kernel runs, but Windows **bugchecks in
+the virtio-blk driver** and reboot-loops. Established step by step:
+
+1. **CH firmware → kernel handoff happens.** `CLOUDHV.fd` reaches the OS loader via
+   EDK2 **PlatformRecovery** (`\EFI\Boot\bootx64.efi`), then `VirtioRngExitBoot` +
+   `MpInitChangeApLoopCallback() done!` — i.e. `ExitBootServices` fired and
+   **winload handed off to the NT kernel**. `\Windows\bootstat.dat` is rewritten on
+   CH (serial-independent proof the kernel ran).
+2. **`kvm_hyperv=on` is REQUIRED.** Without `--cpus …,kvm_hyperv=on` the kernel
+   **silently hangs in early MP/HAL init** — serial frozen at the firmware
+   baseline, no SAC, no `bootstat` update. With it, the kernel boots and **SAC
+   initializes** (`SAC>`, "The CMD command is now available").
+3. **Then: `0xD1` in `viostor.sys`.** Shortly after SAC, Windows bugchecks. Pulled
+   directly from the CH-written crash dump:
+   ```
+   BugCheckCode : 0x000000D1   (DRIVER_IRQL_NOT_LESS_OR_EQUAL)
+   Param2       : 0x0A         (IRQL = DISPATCH_LEVEL)
+   faulting drv : \Driver\viostor  (dump_viostor, viostor service)
+   ```
+   `C:\Windows\Minidump\*.dmp` + a 1.4 GB `MEMORY.DMP` are written on the CH disk;
+   `AutoReboot` then warm-resets → **reboot loop**. (CH v51.1 also **exits on guest
+   warm-reset** rather than resetting in place, so each launch shows the same
+   ~2.7 KB SAC serial + 2 resets + exit.)
+4. **Not a config/SMP issue.** The `0xD1` reproduces with **`num_queues=1`** and
+   with **a single vCPU (`boot=1`)** — ruling out multi-queue and SMP-race
+   explanations. It is a **fundamental incompatibility between the (stable) viostor
+   driver and CH v51.1's virtio-blk device** (feature-negotiation / virtqueue
+   handling), not something a launch flag fixes.
+
+## 5. Findings table
+
+| # | Finding | Evidence |
+|---|---|---|
+| F1 | Virtio (viostor) Windows install automatable & fast | install SUCCESS, qcow2 5.5 GB, COM1 sentinel |
+| F2 | Setup creates the `\EFI\Boot\bootx64.efi` fallback (== bootmgfw); BCD present | md5 match; ESP listing |
+| F3 | Headless BCD prep (EMS + disable Auto-Repair) is mandatory for any console-less VMM | empty-NVRAM QEMU repro: pre-prep → "Automatic Repair"; post-prep → SAC |
+| F4 | **QEMU+OVMF boots Windows cleanly & stably** | SAC up, no crash, no loop |
+| F5 | CH needs `kvm_hyperv=on` or the kernel hangs pre-SAC | with/without comparison |
+| F6 | **CH v51.1 bugchecks `0xD1` in viostor → reboot loop** | `MEMORY.DMP` bugcheck `0xD1`, `\Driver\viostor` |
+| F7 | F6 is not SMP/queue-count related | reproduced at `num_queues=1` and `boot=1` |
+| F8 | CH v51.1 exits on guest warm-reset (no reset-in-place) | `DXE ResetSystem2: ResetType Warm` then CH exits |
+
+## 6. Operational notes (for re-running the spike)
+
+- **W-S1 — use the full QEMU, not kata-static.** `/opt/kata/bin/qemu` (9.1.2) has
+  no VNC, no `user` netdev (slirp), and no VGA romfile (`vgabios-stdvga.bin`) — it
+  rejects `-vnc`/`-netdev user` and dies on the default VGA. The Debian
+  `/usr/bin/qemu` (8.2.2) has all three; its **VGA framebuffer is screendump-able
+  over QMP**, which is what made Setup's silent failures diagnosable.
+- **Headless install gotchas:** the UEFI "Press any key to boot from CD" prompt
+  needs a QMP `send-key` spammer (~30 s); the answer file needs
+  `Microsoft-Windows-International-Core-WinPE` to auto-skip the language screen; and
+  **eval media is keyless** — including a `<ProductKey>` (even empty) throws
+  "cannot find the Microsoft Software License Terms".
+- **Success signal without RDP/VNC:** a first-logon `echo …>COM1` sentinel + a
+  `shutdown /s` (detect clean QEMU exit). The slirp `hostfwd` RDP probe gives a
+  **false positive** (the host-side listener accepts immediately).
+- **CH boot signal:** `bootstat.dat` mtime (winload rewrites it every boot) and
+  SAC/EMS on `--serial file=…` are the serial-independent / serial proofs that the
+  kernel ran.
+
+## 7. Design implications — OQ1 must be revisited
+
+The design doc resolved **OQ1 (hypervisor) → Cloud Hypervisor default** on the
+premise "CH supports Windows." **This spike does not validate that on CH v51.1**:
+the virtio-blk (`viostor`) `0xD1` bugcheck is a hard blocker, and CH's headless,
+exit-on-reset, no-VGA model also removes the ability to run a graphical
+install/recovery. By contrast **QEMU+OVMF — the design's "escape hatch" — boots
+Windows cleanly and stably today.**
+
+Recommendation for the kickoff conversation (the user's call, since this flips a
+decision they previously steered to CH-first):
+
+- **v1 Windows = QEMU+OVMF** (the escape hatch becomes the primary, and for now the
+  only, working path), selected by the `osType: windows` gate — mirrors "QEMU only
+  when the hardware/feature requires it" (here: the guest OS requires it). Most of
+  the design (osType gate, import-step skipping, cloudbase-init over NoCloud, the
+  BCD/virtio image-prep runbook) is **unchanged** — only the hypervisor default
+  flips for `osType: windows`.
+- **CH-for-Windows is a future track**, gated on clearing F6. Untested mitigations,
+  in priority order: (a) a **newer `virtio-win` viostor** (the stable build here may
+  predate CH virtio-blk fixes); (b) a **newer Cloud Hypervisor**; (c) upstream CH
+  virtio-blk/viostor interop work. If (a) or (b) clears F6, CH-first can be
+  reconsidered. The spike's image-prep + `kvm_hyperv=on` + fallback-path findings
+  all carry forward.
+
+## 8. Reproduction artifacts
+
+Local, off-repo (`/home/wrkode/win-spike/`, not committed — large ISOs/images):
+`autounattend.xml` (virtio + headless BCD prep), `run-install.sh` (QMP key-spammer,
+COM1 sentinel, exit-detect), `win.qcow2`/`win.raw` (the virtio-ready WS2022 image),
+and the CH crash dump (`MEMORY.DMP` bugcheck `0xD1`/`viostor`). The CH boot command
+that reaches SAC-then-crash:
+
+```
+cloud-hypervisor --kernel CLOUDHV.fd \
+  --disk path=win.raw,num_queues=1 \
+  --cpus boot=2,kvm_hyperv=on \
+  --memory size=4096M --serial file=ch-serial.log --console off
+```
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/design/windows-guest-support.md
+++ b/docs/design/windows-guest-support.md
@@ -1,8 +1,19 @@
 # Windows Guest Support
 
-> Status: DESIGN (pre-spike). First scoping pass for running Windows VMs as
-> SwiftGuests. Greenfield — there is no `osType` concept in the codebase today;
-> several runtime layers assume a Linux guest. Last updated: 2026-06-07.
+> Status: DESIGN — **spike complete, OQ1 reopened**. First scoping pass for running
+> Windows VMs as SwiftGuests. Greenfield — there is no `osType` concept in the
+> codebase today; several runtime layers assume a Linux guest. Last updated:
+> 2026-06-07.
+>
+> **Spike result (see [`windows-guest-support-spike.md`](windows-guest-support-spike.md)):**
+> the image-prep pipeline works and **QEMU+OVMF boots Windows cleanly and stably**,
+> but **Cloud Hypervisor v51.1 is BLOCKED** — Windows bugchecks `0xD1` in
+> `viostor.sys` (virtio-blk) and reboot-loops (even at `num_queues=1` / single
+> vCPU; `kvm_hyperv=on` is required just to reach that point). This **flips OQ1**:
+> v1 Windows should run on **QEMU+OVMF** (the former "escape hatch" becomes the
+> primary path), with CH-for-Windows deferred behind a newer `virtio-win`/CH that
+> clears the viostor crash. The rest of the design (the `osType` gate, import-step
+> skipping, cloudbase-init, the virtio+BCD image-prep runbook) stands.
 
 ## 1. Goal
 
@@ -23,7 +34,7 @@ Linux-only steps and preparing the guest.
 
 | Layer | Linux today | Windows |
 |---|---|---|
-| **Hypervisor** | Cloud Hypervisor (CLOUDHV.fd via `--kernel`) | **Same — Cloud Hypervisor.** Windows is supported on CH; reuse the existing disk-boot path. QEMU is an opt-in escape hatch (see §4) only for graphical-console or emulated-device cases — the same "QEMU only when needed" rule the GPU tiers follow. |
+| **Hypervisor** | Cloud Hypervisor (CLOUDHV.fd via `--kernel`) | **QEMU+OVMF for v1** (spike-corrected). CH *loads* the Windows boot manager and runs the kernel, but **CH v51.1 bugchecks `0xD1` in `viostor.sys` and reboot-loops** ([spike](windows-guest-support-spike.md) §4) — so for `osType: windows` the runtime routes to QEMU+OVMF (the same `swift-qemu-client` path used for GPU). "QEMU only when the OS requires it." CH-for-Windows deferred. |
 | **Firmware** | CLOUDHV.fd (EDK2 UEFI) for disk boot | **Same CLOUDHV.fd.** Windows is UEFI-only; the existing EDK2 UEFI firmware path already provides it. Not a divergence. |
 | **virtio drivers** | in-tree (Linux ships virtio-blk/net) | The real Windows problem — Windows has **no** virtio drivers OOTB, so a stock image sees neither the virtio-blk disk nor the virtio-net NIC. **This is hypervisor-agnostic** (identical for CH and QEMU; both present virtio devices). §3. |
 | **Provisioning** | cloud-init NoCloud seed.iso | **cloudbase-init** reads the same NoCloud/ConfigDrive seed the runtime already builds. Hypervisor-agnostic. |
@@ -85,9 +96,14 @@ pre-prepare an image.
 
 ## 5. Open decisions (for the kickoff conversation)
 
-- **OQ1 — Hypervisor: RESOLVED → Cloud Hypervisor default** (principle-
-  consistent; CH supports Windows). QEMU is the escape hatch for graphical-
-  console / emulated-device cases only. No CH-vs-QEMU default question remains.
+- **OQ1 — Hypervisor: REOPENED by the spike → QEMU+OVMF for v1.** The CH-first
+  resolution assumed "CH supports Windows"; the spike shows **CH v51.1 bugchecks
+  `0xD1` in `viostor.sys` and reboot-loops** (details:
+  [`windows-guest-support-spike.md`](windows-guest-support-spike.md) §4/§7), while
+  **QEMU+OVMF boots Windows cleanly and stably**. So for `osType: windows` the
+  hypervisor default flips to **QEMU+OVMF** — consistent with "QEMU only when a
+  feature/OS requires it." CH-for-Windows is a future track gated on a newer
+  `virtio-win` viostor and/or newer CH clearing the crash.
 - **OQ2 — virtio strategy for v1:** (A) operator-prepped virtio image on CH
   (recommended) vs (B) emulated devices on the QEMU escape hatch for stock
   images.
@@ -101,34 +117,46 @@ pre-prepare an image.
   scope now, or do we ship behind the same "asset not available" caveat as Tier
   2/3 GPU until a Windows image exists?
 
-## 6. Spike (before committing to the full build)
+## 6. Spike — COMPLETE (2026-06-07)
 
-Once OQ2/OQ4/OQ5 are settled, a spike answers the load-bearing unknowns —
-notably **on Cloud Hypervisor**:
+Full findings: [`windows-guest-support-spike.md`](windows-guest-support-spike.md).
+Ran entirely off-cluster with the **real CH v51.1 binary + `CLOUDHV.fd`** from the
+`swiftletd` image. Answers to the load-bearing unknowns:
 
-1. Does a virtio-ready Windows Server eval guest **boot on Cloud Hypervisor**
-   via the existing `--kernel CLOUDHV.fd` + virtio-blk + virtio-net path, and
-   shut down cleanly (ACPI)?
-2. Does cloudbase-init read the existing NoCloud seed.iso and apply hostname /
-   admin password / network?
-3. (Escape hatch, only if doing graphical install in-cluster) does QEMU+OVMF+VNC
-   give a usable install console?
+1. **Does a virtio-ready Windows guest boot on Cloud Hypervisor?** — **NO, on CH
+   v51.1.** The kernel runs (needs `--cpus kvm_hyperv=on`) and SAC initializes, then
+   Windows bugchecks **`0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL` in `viostor.sys`** (the
+   virtio-blk driver) and reboot-loops. Reproduces at `num_queues=1` and single
+   vCPU → a fundamental viostor↔CH-virtio-blk incompatibility, not a flag.
+2. **Does QEMU+OVMF boot it?** — **YES, cleanly and stably** (SAC up, no crash). The
+   image-prep pipeline (unattended virtio install + headless **BCD prep**: EMS/SAC +
+   `recoveryenabled no` + `bootstatuspolicy ignoreallfailures`) is validated here.
+3. **cloudbase-init / NoCloud seed** — **not exercised** (gated behind a booting
+   guest; the install used `autounattend.xml`). Carried forward to the QEMU-path
+   build (PR 5).
 
-If the spike can't run (no Windows image obtainable on this cluster), the design
-ships as "code-complete, asset-gated validation" — explicitly labelled, like
-Tier 2/3 GPU and multi-NIC.
+Net: the spike **could** run, and it **flips OQ1** — v1 Windows is **QEMU+OVMF**;
+CH-for-Windows is deferred behind a newer `virtio-win`/CH that clears the viostor
+`0xD1` (untested mitigations listed in the findings doc §7). The image-prep,
+`kvm_hyperv=on`, and `\EFI\Boot\bootx64.efi` fallback-path findings carry forward
+to whichever hypervisor.
 
-## 7. Phased PR breakdown (provisional — refined after the spike)
+## 7. Phased PR breakdown (refined after the spike — QEMU+OVMF for v1)
+
+The spike flipped the runtime target from CH to QEMU+OVMF (§6/OQ1). The
+`osType` gate, import-skip, provisioning, and image-prep PRs are unchanged; only
+the runtime PR's hypervisor flips.
 
 | PR | Scope |
 |---|---|
-| 1 | This design doc. |
+| 1 | This design doc (+ spike findings doc). |
 | 2 | `osType` field on SwiftGuest + SwiftImage (+ webhook rules) + resolver wiring. Default `linux` — no behavior change for existing guests. |
 | 3 | Image import: skip GRUB/serial patch + growpart for `osType: windows` (keep qcow2→raw + resize). |
-| 4 | Runtime: `osType: windows` boots on the **existing CH disk-boot path** (CLOUDHV.fd + virtio) with the Linux-only cmdline/console assumptions gated off. (Small — it's mostly reuse.) |
-| 5 | Provisioning: cloudbase-init userdata over the NoCloud seed. |
-| 6 | QEMU+OVMF+VNC **escape hatch** (graphical console + emulated device model) for install/driver-injection/stock-image cases. |
-| 7 | Operator runbook (virtio-ready image prep) + samples; spike/cluster validation (asset permitting). |
+| 4 | Runtime: `osType: windows` routes to **QEMU+OVMF** (the `swift-qemu-client` path already in `swiftletd` for GPU), boots via the `\EFI\Boot\bootx64.efi` fallback, with Linux-only cmdline/console assumptions gated off. (CH-for-Windows deferred — spike F6.) |
+| 5 | Provisioning: cloudbase-init userdata over the NoCloud seed (the spike used `autounattend.xml`; cloudbase-init is the runtime path). |
+| 6 | Image-prep tooling/runbook: virtio (viostor/NetKVM) + the **headless BCD prep** (EMS/SAC, `recoveryenabled no`, `bootstatuspolicy ignoreallfailures`) the spike validated; the `autounattend.xml` + `run-install.sh` from the spike are the seed. |
+| 7 | Operator runbook + samples; cluster validation (asset-gated — no Windows license on the dev cluster). |
+| (future) | CH-for-Windows re-spike once a newer `virtio-win`/CH clears the viostor `0xD1`. |
 
 ## 8. Non-goals (v1)
 

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -2602,23 +2602,40 @@ Shipped across 6 PRs (design + 5 build):
   today, OQ6); auto-GC of Failed scheduled snapshots (OQ1 — left for inspection).
 
 ### In Progress
-- **Windows guest support** — design doc started
-  ([`docs/design/windows-guest-support.md`](docs/design/windows-guest-support.md)).
-  Greenfield: no `osType` concept exists; several runtime layers assume Linux.
-  **Design is CH-first** (principle-consistent): Cloud Hypervisor already
-  supports Windows, and a Windows guest reuses the existing CH disk-boot path
-  (`--kernel CLOUDHV.fd` EDK2 UEFI + virtio) — ~5 of the 6 layers are
-  hypervisor-agnostic. The real Windows-specific work: an `osType: linux|windows`
-  gate, skipping the Linux-only import steps (GRUB/serial patch, growpart), a
-  virtio-ready image for v1 (virtio drivers are needed on CH *and* QEMU alike),
-  and cloudbase-init over the existing NoCloud seed. The one genuine CH gap is
-  the **console** (CH is serial/headless) — v1 runs headless + RDP; **QEMU +
-  OVMF + VNC is the opt-in escape hatch** for graphical install / driver
-  injection / emulated-device stock images (the same "QEMU only when needed"
-  rule as the GPU tiers). OQ1 (hypervisor) resolved to CH-first; remaining open:
-  virtio strategy, provisioning, console-in-v1, validation-asset gap.
-  Spike-then-phased-PRs after. Validation constraint: the dev cluster has no
-  Windows image/license (may ship asset-gated like Tier 2/3 GPU).
+- **Windows guest support** — design doc + **boot spike COMPLETE** (2026-06-07):
+  [`docs/design/windows-guest-support.md`](docs/design/windows-guest-support.md),
+  [`docs/design/windows-guest-support-spike.md`](docs/design/windows-guest-support-spike.md).
+  Greenfield: no `osType` concept exists; several runtime layers assume Linux. The
+  spike ran entirely off-cluster with the **real CH v51.1 binary + `CLOUDHV.fd`**
+  from the `swiftletd` image and **flipped OQ1 (hypervisor)** away from CH-first:
+  - **Image-prep pipeline works** — automatable WS2022 unattended install under
+    QEMU/KVM with **viostor (virtio-blk) driver injection** → virtio-ready raw
+    image (~3.5 min, repeatable). Windows Setup creates the `\EFI\Boot\bootx64.efi`
+    firmware **fallback** (== bootmgfw; BCD present), so **no NVRAM seeding** is
+    needed. A **headless BCD prep** is mandatory: EMS/SAC on serial +
+    `recoveryenabled no` + `bootstatuspolicy ignoreallfailures` (without it a
+    fallback-path boot drops into graphical "Automatic Repair"/WinRE that hangs on
+    a console-less VMM).
+  - **QEMU+OVMF boots Windows cleanly & stably** (SAC up, no crash) — the design's
+    former "escape hatch" is the **validated v1 path**.
+  - **CH v51.1 is BLOCKED.** CH loads the boot manager and the kernel runs (needs
+    `--cpus kvm_hyperv=on`, else a silent early-MP/HAL hang), SAC initializes, then
+    Windows **bugchecks `0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL` in `viostor.sys`** and
+    reboot-loops. Confirmed from the CH-written `MEMORY.DMP` (bugcheck `0xD1`,
+    `\Driver\viostor`). **Reproduces at `num_queues=1` and single vCPU** → a
+    fundamental viostor↔CH-virtio-blk incompatibility, not a launch flag. (CH v51.1
+    also exits on guest warm-reset rather than resetting in place.)
+  - **Decision implication (user's call — flips the CH-first they previously
+    steered to):** v1 Windows = **QEMU+OVMF** via the `osType: windows` gate
+    (reuses the `swift-qemu-client` path already in swiftletd for GPU). CH-for-
+    Windows is a future track gated on a newer `virtio-win` viostor and/or newer
+    CH clearing the `0xD1`. The `osType` gate, import-step skipping, cloudbase-init,
+    and the virtio+BCD image-prep runbook are unchanged.
+  - **Phased PRs (refined):** PR 2 `osType` field+webhook; PR 3 import-skip; PR 4
+    runtime → **QEMU+OVMF** (was CH); PR 5 cloudbase-init; PR 6 image-prep
+    runbook/tooling (the spike's `autounattend.xml` + `run-install.sh` are the
+    seed); PR 7 runbook+samples (validation asset-gated — no Windows license on the
+    dev cluster).
 
 ### Other Roadmap Items Not Progressed
 - **Multi-NIC + SR-IOV hardware validation** — code shipped, hardware not available


### PR DESCRIPTION
## Windows guest support — boot spike findings

Ran the Windows-on-Cloud-Hypervisor boot spike **entirely off-cluster** with the **real CH v51.1 binary + `CLOUDHV.fd`** extracted from the `swiftletd` image (so the CH result is exactly what KubeSwift ships). Full writeup: [`docs/design/windows-guest-support-spike.md`](docs/design/windows-guest-support-spike.md).

### Headline
The image-prep pipeline works and **QEMU+OVMF boots Windows cleanly and stably**, but **Cloud Hypervisor v51.1 is BLOCKED** — Windows bugchecks `0xD1` in `viostor.sys` and reboot-loops. This **flips the design's CH-first OQ1 resolution** → v1 Windows should run on **QEMU+OVMF** (the former "escape hatch" becomes the primary path).

### What works ✅
- **Automatable virtio install** — WS2022 unattended install under QEMU/KVM with **viostor (virtio-blk) injected** during WinPE → virtio-ready raw image, ~3.5 min, repeatable.
- **Fallback-path boot** — Windows Setup writes `bootmgfw.efi` to the firmware fallback `\EFI\Boot\bootx64.efi` (== the Microsoft path; BCD present), so **no NVRAM seeding is needed**.
- **Headless BCD prep is mandatory** — EMS/SAC on serial + `recoveryenabled no` + `bootstatuspolicy ignoreallfailures`. Without it, a fallback-path boot drops into graphical **"Preparing Automatic Repair"/WinRE** that hangs on a console-less VMM.
- **QEMU+OVMF boots Windows cleanly and stably** (SAC up, no crash).

### What is blocked ❌ — CH v51.1
1. CH reaches the OS loader (EDK2 PlatformRecovery → `bootx64.efi`) and **winload hands off to the kernel** (`bootstat.dat` rewritten on CH).
2. **`--cpus kvm_hyperv=on` is required** — without it the kernel silently hangs in early MP/HAL init; with it, **SAC initializes**.
3. **Then `0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL` in `viostor.sys`** → auto-reboot loop. Pulled from the CH-written `MEMORY.DMP`:
   ```
   BugCheckCode : 0x000000D1   (DRIVER_IRQL_NOT_LESS_OR_EQUAL)
   Param2       : 0x0A         (IRQL = DISPATCH_LEVEL)
   faulting drv : \Driver\viostor
   ```
4. **Not a config/SMP issue** — reproduces at `num_queues=1` and single vCPU. Fundamental viostor↔CH-virtio-blk incompatibility. (CH v51.1 also exits on guest warm-reset.)

### Decision implication (your call)
This flips the CH-first hypervisor decision you previously steered to. Recommendation:
- **v1 Windows = QEMU+OVMF** via the `osType: windows` gate (reuses the `swift-qemu-client` path already in swiftletd for GPU). Everything else in the design (osType gate, import-skip, cloudbase-init, virtio+BCD image-prep runbook) is unchanged.
- **CH-for-Windows = future track**, gated on a newer `virtio-win` viostor and/or newer CH clearing the `0xD1` (untested mitigations in findings §7).

### Changes
- **New:** `docs/design/windows-guest-support-spike.md` (full findings + evidence).
- **Updated:** `windows-guest-support.md` (status banner, OQ1, §6 spike, §7 PR table, §2 hypervisor row) and `kubeswift_context.md` (In Progress).

Docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)