### PR TITLE
docs(windows): CH v52.0 boots Windows cleanly — 0xD1 was a CH v51.1 bug (CH-first restored)

### DIFF
--- a/docs/design/windows-guest-support-spike.md
+++ b/docs/design/windows-guest-support-spike.md
@@ -1,11 +1,16 @@
 # Windows Guest Support — Boot Spike Findings
 
-> Status: SPIKE COMPLETE (2026-06-07). Answers the load-bearing unknowns from
-> [`windows-guest-support.md`](windows-guest-support.md) §6 — **before** committing
-> to the phased build. Headline: the image-prep pipeline works and **QEMU+OVMF
-> boots Windows cleanly and stably**, but **Cloud Hypervisor v51.1 is BLOCKED** by a
-> `viostor.sys` `0xD1` bugcheck on its virtio-blk device. This **flips the design's
-> CH-first OQ1 resolution** — see §7.
+> Status: SPIKE COMPLETE (2026-06-07), **+ CH-version follow-up**. Answers the
+> load-bearing unknowns from [`windows-guest-support.md`](windows-guest-support.md)
+> §6 — **before** committing to the phased build.
+>
+> **Headline (updated):** the image-prep pipeline works, **QEMU+OVMF boots Windows
+> cleanly**, and — the decisive follow-up — **Cloud Hypervisor _v52.0_ also boots
+> Windows cleanly and stably.** The `viostor.sys` `0xD1` crash that blocked the
+> first pass was a **CH _v51.1_ virtio-blk bug, fixed in v52.0** (§4.1). So **CH-first
+> stands** for `osType: windows`, conditioned on **bumping the shipped CH v51.1 →
+> v52.0** (a platform-wide change — needs Linux-guest regression validation). The
+> only non-default CH setting Windows needs is `--cpus kvm_hyperv=on`. See §7.
 
 ## 1. Goal & method
 
@@ -50,10 +55,12 @@ convert -O raw`), ~5.4 GiB sparse.
    (serial: `Computer is booting, SAC started and initialized … SAC>`), no crash,
    stable. **The QEMU+OVMF escape hatch is validated.**
 
-## 4. What is BLOCKED ❌ — Cloud Hypervisor v51.1
+## 4. Cloud Hypervisor — BLOCKED on v51.1 ❌, WORKS on v52.0 ✅
 
-CH loads the Windows Boot Manager and the kernel runs, but Windows **bugchecks in
-the virtio-blk driver** and reboot-loops. Established step by step:
+### 4.0 On CH v51.1 (the shipped version): blocked
+
+CH v51.1 loads the Windows Boot Manager and the kernel runs, but Windows
+**bugchecks in the virtio-blk driver** and reboot-loops. Established step by step:
 
 1. **CH firmware → kernel handoff happens.** `CLOUDHV.fd` reaches the OS loader via
    EDK2 **PlatformRecovery** (`\EFI\Boot\bootx64.efi`), then `VirtioRngExitBoot` +
@@ -77,9 +84,28 @@ the virtio-blk driver** and reboot-loops. Established step by step:
    ~2.7 KB SAC serial + 2 resets + exit.)
 4. **Not a config/SMP issue.** The `0xD1` reproduces with **`num_queues=1`** and
    with **a single vCPU (`boot=1`)** — ruling out multi-queue and SMP-race
-   explanations. It is a **fundamental incompatibility between the (stable) viostor
-   driver and CH v51.1's virtio-blk device** (feature-negotiation / virtqueue
-   handling), not something a launch flag fixes.
+   explanations. It is a **virtio-blk-device-side bug in CH v51.1** (the viostor
+   driver is unchanged across the v51.1/v52.0 runs — see §4.1).
+
+### 4.1 On CH v52.0: WORKS — the `0xD1` is fixed ✅
+
+Re-ran the **same virtio-ready image** under **CH v52.0** (latest release;
+`cloud-hypervisor-static`, reusing the v51.1 `CLOUDHV.fd`), `--cpus kvm_hyperv=on`:
+
+- **Stable boot, no crash.** CH stayed alive **>180 s** on the first boot with **no
+  warm-reset and no BSOD** (v51.1 reset within ~60 s every cycle). SAC up
+  (`SAC>`, "CMD command is now available").
+- **Disk-verified real boot.** After the run: `bootstat.dat` rewritten (winload
+  ran), `System.evtx`/`Application.evtx` updated (services started — a complete
+  boot, not an early-SAC hang), and **zero crash dumps** (no `Minidump`, no
+  `MEMORY.DMP`) — the `0xD1` did not occur.
+- **No virtio-blk tuning needed.** v52.0 boots stably with **default queues** (the
+  v51.1-era `num_queues=1` workaround is unnecessary). The **only** non-default CH
+  setting Windows requires is `--cpus kvm_hyperv=on`.
+- v52.0 also **resets in place** on a guest reboot (v51.1 exited on warm-reset, §F8).
+
+Conclusion: the blocker was a **CH v51.1 virtio-blk bug fixed in v52.0**, not a
+viostor/Windows defect. Windows-on-CH is viable on **v52.0**.
 
 ## 5. Findings table
 
@@ -91,8 +117,9 @@ the virtio-blk driver** and reboot-loops. Established step by step:
 | F4 | **QEMU+OVMF boots Windows cleanly & stably** | SAC up, no crash, no loop |
 | F5 | CH needs `kvm_hyperv=on` or the kernel hangs pre-SAC | with/without comparison |
 | F6 | **CH v51.1 bugchecks `0xD1` in viostor → reboot loop** | `MEMORY.DMP` bugcheck `0xD1`, `\Driver\viostor` |
-| F7 | F6 is not SMP/queue-count related | reproduced at `num_queues=1` and `boot=1` |
+| F7 | F6 is not SMP/queue-count related (same viostor across CH versions) | reproduced at `num_queues=1` and `boot=1` |
 | F8 | CH v51.1 exits on guest warm-reset (no reset-in-place) | `DXE ResetSystem2: ResetType Warm` then CH exits |
+| **F9** | **CH v52.0 boots Windows cleanly & stably — the `0xD1` is FIXED** | alive >180 s, no reset/BSOD; `bootstat`+`evtx` updated, **0 crash dumps**; default queues OK; resets in place |
 
 ## 6. Operational notes (for re-running the spike)
 
@@ -113,30 +140,33 @@ the virtio-blk driver** and reboot-loops. Established step by step:
   SAC/EMS on `--serial file=…` are the serial-independent / serial proofs that the
   kernel ran.
 
-## 7. Design implications — OQ1 must be revisited
+## 7. Design implications — OQ1 stays CH-first, gated on a CH v52.0 bump
 
 The design doc resolved **OQ1 (hypervisor) → Cloud Hypervisor default** on the
-premise "CH supports Windows." **This spike does not validate that on CH v51.1**:
-the virtio-blk (`viostor`) `0xD1` bugcheck is a hard blocker, and CH's headless,
-exit-on-reset, no-VGA model also removes the ability to run a graphical
-install/recovery. By contrast **QEMU+OVMF — the design's "escape hatch" — boots
-Windows cleanly and stably today.**
+premise "CH supports Windows." The first pass appeared to refute that (CH v51.1
+`viostor` `0xD1`), but the **CH-version follow-up restores it**: **CH v52.0 boots
+Windows cleanly and stably** (§4.1). So:
 
-Recommendation for the kickoff conversation (the user's call, since this flips a
-decision they previously steered to CH-first):
+- **`osType: windows` stays on Cloud Hypervisor** — principle-consistent, reuses the
+  existing `--kernel CLOUDHV.fd` disk-boot path. **Conditioned on bumping the shipped
+  CH `v51.1 → v52.0`** in the `swiftletd` image. The bump is **platform-wide** (it
+  changes the VMM for Linux guests too), so it must land with **Linux-guest
+  regression validation** — treat it as its own change, not a Windows-only flag.
+- **Required CH settings for Windows:** `--cpus …,kvm_hyperv=on` (Hyper-V
+  enlightenments — mandatory; without it the kernel hangs pre-SAC). No virtio-blk
+  queue tuning needed on v52.0. Plus a **virtio-ready image** + the **headless BCD
+  prep** (§3.3), both hypervisor-agnostic.
+- **QEMU+OVMF reverts to the escape hatch** (its original role) — for graphical
+  install / driver-injection / emulated-device stock images, and as the fallback if
+  the CH bump is deferred. It boots Windows today, so it is the safe interim if v52.0
+  can't be adopted immediately.
+- **Carry-forwards (hypervisor-independent):** the image-prep pipeline (virtio
+  install + viostor injection), the `\EFI\Boot\bootx64.efi` fallback-path boot (no
+  NVRAM seeding), and the headless BCD prep all hold on either VMM.
 
-- **v1 Windows = QEMU+OVMF** (the escape hatch becomes the primary, and for now the
-  only, working path), selected by the `osType: windows` gate — mirrors "QEMU only
-  when the hardware/feature requires it" (here: the guest OS requires it). Most of
-  the design (osType gate, import-step skipping, cloudbase-init over NoCloud, the
-  BCD/virtio image-prep runbook) is **unchanged** — only the hypervisor default
-  flips for `osType: windows`.
-- **CH-for-Windows is a future track**, gated on clearing F6. Untested mitigations,
-  in priority order: (a) a **newer `virtio-win` viostor** (the stable build here may
-  predate CH virtio-blk fixes); (b) a **newer Cloud Hypervisor**; (c) upstream CH
-  virtio-blk/viostor interop work. If (a) or (b) clears F6, CH-first can be
-  reconsidered. The spike's image-prep + `kvm_hyperv=on` + fallback-path findings
-  all carry forward.
+Open items for the build: confirm v52.0 with its **matching `CLOUDHV.fd`** (the
+spike reused the v51.1 firmware), and run the v51.1→v52.0 Linux-guest regression
+pass before shipping the bump.
 
 ## 8. Reproduction artifacts
 

--- a/docs/design/windows-guest-support.md
+++ b/docs/design/windows-guest-support.md
@@ -1,19 +1,21 @@
 # Windows Guest Support
 
-> Status: DESIGN — **spike complete, OQ1 reopened**. First scoping pass for running
-> Windows VMs as SwiftGuests. Greenfield — there is no `osType` concept in the
-> codebase today; several runtime layers assume a Linux guest. Last updated:
-> 2026-06-07.
+> Status: DESIGN — **spike complete, OQ1 RESOLVED → CH-first (on CH v52.0)**. First
+> scoping pass for running Windows VMs as SwiftGuests. Greenfield — there is no
+> `osType` concept in the codebase today; several runtime layers assume a Linux
+> guest. Last updated: 2026-06-07.
 >
 > **Spike result (see [`windows-guest-support-spike.md`](windows-guest-support-spike.md)):**
-> the image-prep pipeline works and **QEMU+OVMF boots Windows cleanly and stably**,
-> but **Cloud Hypervisor v51.1 is BLOCKED** — Windows bugchecks `0xD1` in
-> `viostor.sys` (virtio-blk) and reboot-loops (even at `num_queues=1` / single
-> vCPU; `kvm_hyperv=on` is required just to reach that point). This **flips OQ1**:
-> v1 Windows should run on **QEMU+OVMF** (the former "escape hatch" becomes the
-> primary path), with CH-for-Windows deferred behind a newer `virtio-win`/CH that
-> clears the viostor crash. The rest of the design (the `osType` gate, import-step
-> skipping, cloudbase-init, the virtio+BCD image-prep runbook) stands.
+> the image-prep pipeline works, QEMU+OVMF boots Windows cleanly, and — the decisive
+> follow-up — **Cloud Hypervisor v52.0 boots Windows cleanly and stably**. The
+> `viostor.sys` `0xD1` crash that blocked the first pass was a **CH _v51.1_
+> virtio-blk bug, fixed in v52.0** (verified: stable >180 s, `bootstat`+`evtx`
+> updated, zero crash dumps, default queues). So **`osType: windows` stays on Cloud
+> Hypervisor**, conditioned on **bumping the shipped CH v51.1 → v52.0** (a
+> platform-wide change — needs Linux-guest regression validation). Windows needs
+> `--cpus kvm_hyperv=on` + a virtio-ready image + headless BCD prep. **QEMU+OVMF
+> reverts to the escape hatch.** The rest of the design (`osType` gate, import-step
+> skipping, cloudbase-init, virtio+BCD image-prep runbook) stands.
 
 ## 1. Goal
 
@@ -34,7 +36,7 @@ Linux-only steps and preparing the guest.
 
 | Layer | Linux today | Windows |
 |---|---|---|
-| **Hypervisor** | Cloud Hypervisor (CLOUDHV.fd via `--kernel`) | **QEMU+OVMF for v1** (spike-corrected). CH *loads* the Windows boot manager and runs the kernel, but **CH v51.1 bugchecks `0xD1` in `viostor.sys` and reboot-loops** ([spike](windows-guest-support-spike.md) §4) — so for `osType: windows` the runtime routes to QEMU+OVMF (the same `swift-qemu-client` path used for GPU). "QEMU only when the OS requires it." CH-for-Windows deferred. |
+| **Hypervisor** | Cloud Hypervisor (CLOUDHV.fd via `--kernel`) | **Same — Cloud Hypervisor, on CH v52.0** (spike-confirmed). CH v51.1 bugchecked `0xD1` in `viostor.sys`, but **CH v52.0 boots Windows cleanly and stably** ([spike](windows-guest-support-spike.md) §4.1) — reuse the existing disk-boot path with `--cpus kvm_hyperv=on`. Requires bumping the shipped CH v51.1 → v52.0 (platform-wide). QEMU+OVMF stays the escape hatch. |
 | **Firmware** | CLOUDHV.fd (EDK2 UEFI) for disk boot | **Same CLOUDHV.fd.** Windows is UEFI-only; the existing EDK2 UEFI firmware path already provides it. Not a divergence. |
 | **virtio drivers** | in-tree (Linux ships virtio-blk/net) | The real Windows problem — Windows has **no** virtio drivers OOTB, so a stock image sees neither the virtio-blk disk nor the virtio-net NIC. **This is hypervisor-agnostic** (identical for CH and QEMU; both present virtio devices). §3. |
 | **Provisioning** | cloud-init NoCloud seed.iso | **cloudbase-init** reads the same NoCloud/ConfigDrive seed the runtime already builds. Hypervisor-agnostic. |
@@ -96,14 +98,15 @@ pre-prepare an image.
 
 ## 5. Open decisions (for the kickoff conversation)
 
-- **OQ1 — Hypervisor: REOPENED by the spike → QEMU+OVMF for v1.** The CH-first
-  resolution assumed "CH supports Windows"; the spike shows **CH v51.1 bugchecks
-  `0xD1` in `viostor.sys` and reboot-loops** (details:
-  [`windows-guest-support-spike.md`](windows-guest-support-spike.md) §4/§7), while
-  **QEMU+OVMF boots Windows cleanly and stably**. So for `osType: windows` the
-  hypervisor default flips to **QEMU+OVMF** — consistent with "QEMU only when a
-  feature/OS requires it." CH-for-Windows is a future track gated on a newer
-  `virtio-win` viostor and/or newer CH clearing the crash.
+- **OQ1 — Hypervisor: RESOLVED → Cloud Hypervisor (on CH v52.0).** The first spike
+  pass hit a `0xD1 viostor` bugcheck on **CH v51.1**; the CH-version follow-up showed
+  **CH v52.0 boots Windows cleanly and stably** — the `0xD1` was a v51.1 virtio-blk
+  bug, fixed in v52.0 ([spike](windows-guest-support-spike.md) §4.1). So
+  `osType: windows` **stays on Cloud Hypervisor** (principle-consistent),
+  **conditioned on bumping the shipped CH v51.1 → v52.0** (platform-wide — needs
+  Linux-guest regression validation). Required: `--cpus kvm_hyperv=on`. **QEMU+OVMF
+  is the escape hatch** for graphical-install / emulated-device cases and the interim
+  fallback if the CH bump is deferred.
 - **OQ2 — virtio strategy for v1:** (A) operator-prepped virtio image on CH
   (recommended) vs (B) emulated devices on the QEMU escape hatch for stock
   images.
@@ -123,11 +126,12 @@ Full findings: [`windows-guest-support-spike.md`](windows-guest-support-spike.md
 Ran entirely off-cluster with the **real CH v51.1 binary + `CLOUDHV.fd`** from the
 `swiftletd` image. Answers to the load-bearing unknowns:
 
-1. **Does a virtio-ready Windows guest boot on Cloud Hypervisor?** — **NO, on CH
-   v51.1.** The kernel runs (needs `--cpus kvm_hyperv=on`) and SAC initializes, then
-   Windows bugchecks **`0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL` in `viostor.sys`** (the
-   virtio-blk driver) and reboot-loops. Reproduces at `num_queues=1` and single
-   vCPU → a fundamental viostor↔CH-virtio-blk incompatibility, not a flag.
+1. **Does a virtio-ready Windows guest boot on Cloud Hypervisor?** — **NO on CH
+   v51.1, YES on CH v52.0.** On v51.1 the kernel runs (needs `--cpus kvm_hyperv=on`)
+   and SAC initializes, then Windows bugchecks **`0xD1` in `viostor.sys`** and
+   reboot-loops. The CH-version follow-up showed this is a **v51.1 virtio-blk bug
+   fixed in v52.0**: the same image under **CH v52.0** boots **cleanly and stably**
+   (>180 s, no reset, zero crash dumps, `bootstat`+`evtx` updated; default queues).
 2. **Does QEMU+OVMF boot it?** — **YES, cleanly and stably** (SAC up, no crash). The
    image-prep pipeline (unattended virtio install + headless **BCD prep**: EMS/SAC +
    `recoveryenabled no` + `bootstatuspolicy ignoreallfailures`) is validated here.
@@ -135,28 +139,30 @@ Ran entirely off-cluster with the **real CH v51.1 binary + `CLOUDHV.fd`** from t
    guest; the install used `autounattend.xml`). Carried forward to the QEMU-path
    build (PR 5).
 
-Net: the spike **could** run, and it **flips OQ1** — v1 Windows is **QEMU+OVMF**;
-CH-for-Windows is deferred behind a newer `virtio-win`/CH that clears the viostor
-`0xD1` (untested mitigations listed in the findings doc §7). The image-prep,
-`kvm_hyperv=on`, and `\EFI\Boot\bootx64.efi` fallback-path findings carry forward
-to whichever hypervisor.
+Net: the spike **confirms OQ1 → CH-first on CH v52.0**. The runtime PR routes
+`osType: windows` to the existing CH disk-boot path with `--cpus kvm_hyperv=on`,
+**gated on bumping the shipped CH v51.1 → v52.0** (platform-wide; run the
+Linux-guest regression pass with it). QEMU+OVMF stays the escape hatch (and the
+interim fallback if the bump is deferred). The image-prep, `kvm_hyperv=on`, and
+`\EFI\Boot\bootx64.efi` fallback-path findings carry forward to whichever VMM.
 
-## 7. Phased PR breakdown (refined after the spike — QEMU+OVMF for v1)
+## 7. Phased PR breakdown (refined after the spike — CH-first on CH v52.0)
 
-The spike flipped the runtime target from CH to QEMU+OVMF (§6/OQ1). The
-`osType` gate, import-skip, provisioning, and image-prep PRs are unchanged; only
-the runtime PR's hypervisor flips.
+The spike confirmed CH-first **on CH v52.0** (§6/OQ1). The runtime PR reuses the
+existing CH disk-boot path; a **prerequisite** is the CH v51.1 → v52.0 bump (its
+own change, with the Linux-guest regression pass). The `osType` gate, import-skip,
+provisioning, and image-prep PRs are hypervisor-independent.
 
 | PR | Scope |
 |---|---|
+| 0 | **Prereq: bump CH v51.1 → v52.0** in the `swiftletd` image (+ matching `CLOUDHV.fd`) with a Linux-guest regression pass. Platform-wide; gates the Windows runtime path. |
 | 1 | This design doc (+ spike findings doc). |
 | 2 | `osType` field on SwiftGuest + SwiftImage (+ webhook rules) + resolver wiring. Default `linux` — no behavior change for existing guests. |
 | 3 | Image import: skip GRUB/serial patch + growpart for `osType: windows` (keep qcow2→raw + resize). |
-| 4 | Runtime: `osType: windows` routes to **QEMU+OVMF** (the `swift-qemu-client` path already in `swiftletd` for GPU), boots via the `\EFI\Boot\bootx64.efi` fallback, with Linux-only cmdline/console assumptions gated off. (CH-for-Windows deferred — spike F6.) |
+| 4 | Runtime: `osType: windows` boots on the **existing CH disk-boot path** (CLOUDHV.fd + virtio) via the `\EFI\Boot\bootx64.efi` fallback, adding `--cpus kvm_hyperv=on` and gating off Linux-only cmdline/console assumptions. (Mostly reuse; QEMU+OVMF remains the escape hatch / interim fallback.) |
 | 5 | Provisioning: cloudbase-init userdata over the NoCloud seed (the spike used `autounattend.xml`; cloudbase-init is the runtime path). |
 | 6 | Image-prep tooling/runbook: virtio (viostor/NetKVM) + the **headless BCD prep** (EMS/SAC, `recoveryenabled no`, `bootstatuspolicy ignoreallfailures`) the spike validated; the `autounattend.xml` + `run-install.sh` from the spike are the seed. |
 | 7 | Operator runbook + samples; cluster validation (asset-gated — no Windows license on the dev cluster). |
-| (future) | CH-for-Windows re-spike once a newer `virtio-win`/CH clears the viostor `0xD1`. |
 
 ## 8. Non-goals (v1)
 

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -2606,8 +2606,9 @@ Shipped across 6 PRs (design + 5 build):
   [`docs/design/windows-guest-support.md`](docs/design/windows-guest-support.md),
   [`docs/design/windows-guest-support-spike.md`](docs/design/windows-guest-support-spike.md).
   Greenfield: no `osType` concept exists; several runtime layers assume Linux. The
-  spike ran entirely off-cluster with the **real CH v51.1 binary + `CLOUDHV.fd`**
-  from the `swiftletd` image and **flipped OQ1 (hypervisor)** away from CH-first:
+  spike ran entirely off-cluster with the **real CH binaries + `CLOUDHV.fd`** from
+  the `swiftletd` image. **OQ1 RESOLVED → CH-first on CH v52.0** (the first pass
+  appeared to block CH; a CH-version follow-up restored CH-first):
   - **Image-prep pipeline works** — automatable WS2022 unattended install under
     QEMU/KVM with **viostor (virtio-blk) driver injection** → virtio-ready raw
     image (~3.5 min, repeatable). Windows Setup creates the `\EFI\Boot\bootx64.efi`
@@ -2616,26 +2617,29 @@ Shipped across 6 PRs (design + 5 build):
     `recoveryenabled no` + `bootstatuspolicy ignoreallfailures` (without it a
     fallback-path boot drops into graphical "Automatic Repair"/WinRE that hangs on
     a console-less VMM).
-  - **QEMU+OVMF boots Windows cleanly & stably** (SAC up, no crash) — the design's
-    former "escape hatch" is the **validated v1 path**.
-  - **CH v51.1 is BLOCKED.** CH loads the boot manager and the kernel runs (needs
+  - **QEMU+OVMF boots Windows cleanly & stably** (SAC up, no crash) — the escape
+    hatch works (and is the interim fallback if the CH bump is deferred).
+  - **CH v51.1 blocked, CH v52.0 WORKS.** On **v51.1** the kernel runs (needs
     `--cpus kvm_hyperv=on`, else a silent early-MP/HAL hang), SAC initializes, then
     Windows **bugchecks `0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL` in `viostor.sys`** and
-    reboot-loops. Confirmed from the CH-written `MEMORY.DMP` (bugcheck `0xD1`,
-    `\Driver\viostor`). **Reproduces at `num_queues=1` and single vCPU** → a
-    fundamental viostor↔CH-virtio-blk incompatibility, not a launch flag. (CH v51.1
-    also exits on guest warm-reset rather than resetting in place.)
-  - **Decision implication (user's call — flips the CH-first they previously
-    steered to):** v1 Windows = **QEMU+OVMF** via the `osType: windows` gate
-    (reuses the `swift-qemu-client` path already in swiftletd for GPU). CH-for-
-    Windows is a future track gated on a newer `virtio-win` viostor and/or newer
-    CH clearing the `0xD1`. The `osType` gate, import-step skipping, cloudbase-init,
-    and the virtio+BCD image-prep runbook are unchanged.
-  - **Phased PRs (refined):** PR 2 `osType` field+webhook; PR 3 import-skip; PR 4
-    runtime → **QEMU+OVMF** (was CH); PR 5 cloudbase-init; PR 6 image-prep
-    runbook/tooling (the spike's `autounattend.xml` + `run-install.sh` are the
-    seed); PR 7 runbook+samples (validation asset-gated — no Windows license on the
-    dev cluster).
+    reboot-loops (confirmed from the CH-written `MEMORY.DMP`; reproduces at
+    `num_queues=1` and single vCPU). The CH-version follow-up showed this is a
+    **v51.1 virtio-blk bug FIXED in v52.0**: the **same image under CH v52.0 boots
+    cleanly and stably** — alive >180 s, no reset, **zero crash dumps**,
+    `bootstat.dat`+`evtx` updated, **default queues OK**. The only non-default CH
+    setting Windows needs is `kvm_hyperv=on`. (v52.0 also resets in place; v51.1
+    exited on warm-reset.)
+  - **Decision (user chose "unblock CH first" → it worked):** `osType: windows`
+    **stays on Cloud Hypervisor**, conditioned on **bumping the shipped CH
+    v51.1 → v52.0** in the `swiftletd` image — a **platform-wide** change needing a
+    Linux-guest regression pass (treat as its own PR). Reuses the existing CH
+    disk-boot path; QEMU+OVMF reverts to the escape hatch.
+  - **Phased PRs (refined):** **PR 0 prereq = bump CH → v52.0** (+ matching
+    `CLOUDHV.fd`, Linux regression); PR 2 `osType` field+webhook; PR 3 import-skip;
+    PR 4 runtime → **CH disk-boot path + `kvm_hyperv=on`**; PR 5 cloudbase-init;
+    PR 6 image-prep runbook/tooling (the spike's `autounattend.xml` + `run-install.sh`
+    are the seed); PR 7 runbook+samples (validation asset-gated — no Windows license
+    on the dev cluster).
 
 ### Other Roadmap Items Not Progressed
 - **Multi-NIC + SR-IOV hardware validation** — code shipped, hardware not available


### PR DESCRIPTION
## CH-version follow-up to #148 — CH-first is restored (on CH v52.0)

Follow-up to **#148**, which concluded CH v51.1 was blocked (viostor `0xD1`) and recommended QEMU-first. Per the decision to **"try to unblock CH first,"** I re-ran the **same virtio-ready image** under a newer Cloud Hypervisor. **It works.**

### Result
| | Boot result |
|---|---|
| **CH v51.1** (shipped) | `0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL` in `viostor.sys` → reboot loop (even `num_queues=1` / single vCPU). **Blocked.** |
| **CH v52.0** (latest) | **Boots cleanly and stably.** ✅ |

**CH v52.0 evidence (disk-verified, serial-independent):**
- CH stayed alive **>180 s** on the first boot — **no warm-reset, no BSOD** (v51.1 reset within ~60 s every cycle).
- `bootstat.dat` rewritten + `System.evtx`/`Application.evtx` updated → **services started, a complete boot** (not an early-SAC hang).
- **Zero crash dumps** (no `Minidump`, no `MEMORY.DMP`) → the `0xD1` did not occur.
- **Default virtio-blk queues work** — the v51.1-era `num_queues=1` workaround is unnecessary. The only non-default CH setting Windows needs is `--cpus kvm_hyperv=on`.
- v52.0 also **resets in place** on guest reboot (v51.1 exited on warm-reset).

So the `0xD1` was a **CH v51.1 virtio-blk bug, fixed in v52.0** — not a viostor/Windows defect (the viostor driver was unchanged across both runs).

### Design impact — OQ1 resolves back to CH-first
- **`osType: windows` stays on Cloud Hypervisor** (principle-consistent), **conditioned on bumping the shipped CH v51.1 → v52.0** in the `swiftletd` image. That bump is **platform-wide** (changes the VMM for Linux guests too), so it must land as its own change with a **Linux-guest regression pass** — added as **PR 0 (prereq)** in the breakdown.
- **QEMU+OVMF reverts to the escape hatch** (graphical install / emulated-device) and is the interim fallback if the CH bump is deferred.
- Carry-forwards (hypervisor-independent): the image-prep pipeline (virtio install + viostor injection), the `\EFI\Boot\bootx64.efi` fallback-path boot, the headless BCD prep, and `kvm_hyperv=on`.

### Open items for the build
Confirm v52.0 with its **matching `CLOUDHV.fd`** (the spike reused the v51.1 firmware) and run the v51.1→v52.0 Linux-guest regression before shipping the bump.

### Changes
- `windows-guest-support-spike.md`: status banner; new **§4.1** (v52.0 works) + finding **F9**; **§7** flipped back to CH-first.
- `windows-guest-support.md`: banner, OQ1, §2 hypervisor row, §6, §7 PR table (incl. **PR 0** CH-bump prereq).
- `kubeswift_context.md`: In Progress.

Docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)