### PR TITLE
chore(swiftletd): bump Cloud Hypervisor v51.1 → v52.0 (platform-wide)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to KubeSwift are documented here.
 
 ## [Unreleased] - 2026-04-05
 
+### Changed (Cloud Hypervisor v51.1 -> v52.0 — platform-wide)
+- Bumped the Cloud Hypervisor static binary in the `swiftletd` image from v51.1 to
+  v52.0 (`images/swiftletd/Containerfile` `CH_VERSION`). v51.1's virtio-blk has a
+  bug that bugchecks Windows' viostor driver (`0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL`)
+  in a reboot loop; v52.0 fixes it and boots Windows cleanly and stably (spike:
+  `docs/design/windows-guest-support-spike.md` §4.1). This unblocks the CH-first
+  path for upcoming Windows guest support.
+- The `CLOUDHV.fd` firmware is **unchanged** (`ch-13b4963ec4`) — the spike-validated
+  pairing with the v52.0 binary. `CurrentHypervisorVersion` is read from CH at
+  runtime (vm.info), so it tracks the new version automatically; no code constant
+  to change.
+- Platform-wide change (the VMM for Linux guests too): a Linux-guest regression pass
+  (smoke-test + the snapshot/migration suites) lands with the redeploy.
+
 ### Fixed (Phase 3a downtime metrics — W27 follow-up)
 - W27a: `status.observedDowntime` previously measured two adjacent `metav1.Now()` calls in the same reconcile invocation, producing sub-millisecond nonsense (34-114µs across all 17 PR #46 + E12 walkthrough runs). Now anchored on new `status.cutoverStep2DispatchedAt` (stamped by `cutoverStep2` on Delete dispatch); reflects the operator-visible cutover-to-resume window. Defensive nil-check leaves the field unset rather than reporting a wrong value if the timestamp is missing.
 - W27b: `status.observedPauseWindow` plumbing was half-implemented — swiftletd-on-src wrote the `kubeswift.io/migration-pause-window-ms` annotation correctly but the controller had zero readers, leaving the field permanently nil. Now stamped at `substateSrcCompleted` (W1 gate observation), mirroring the snapshot controller's parallel pattern. Defensive parse-failure handling.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ SwiftGuest Pod
   |- init: gpu-init      (VFIO bind, FM partition) [GPU path only]
   |- launcher: swiftletd (Rust)
         |
-  Cloud Hypervisor v51.1  (default)
+  Cloud Hypervisor v52.0  (default)
   or QEMU               (GPU Tier 2/3)
         |
   Guest VM

--- a/images/swiftletd/Containerfile
+++ b/images/swiftletd/Containerfile
@@ -63,8 +63,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # qemu-system-x86 package provides /usr/bin/qemu-system-x86_64
 # Both paths are the defaults in swift-qemu-client/src/config.rs
 
-# Cloud Hypervisor static binary (v51.1)
-ARG CH_VERSION=51.1
+# Cloud Hypervisor static binary (v52.0)
+# Bumped v51.1 -> v52.0: v51.1's virtio-blk has a bug that bugchecks Windows'
+# viostor driver (0xD1); v52.0 fixes it and boots Windows cleanly. See
+# docs/design/windows-guest-support-spike.md sec 4.1. The CLOUDHV.fd firmware
+# below (ch-13b4963ec4) is the spike-validated pairing with the v52.0 binary.
+ARG CH_VERSION=52.0
 ARG TARGETARCH=amd64
 RUN CH_ARCH=$(echo "${TARGETARCH}" | sed 's/amd64//;s/arm64/-aarch64/') && \
     curl -sSL -o /usr/local/bin/cloud-hypervisor \

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -81,7 +81,10 @@ Images: `ghcr.io/projectbeskar/kubeswift/` (public packages)
 - Guest OS (disk boot): Ubuntu Noble (24.04) cloud image — all modern distributions supported
 - Guest OS (kernel boot): faas-minimal — Linux 6.6.44 + BusyBox musl
 - Firmware (disk boot): CLOUDHV.fd loaded via `--kernel` flag (NOT `--firmware`)
-- Cloud Hypervisor: v51.1
+- Cloud Hypervisor: **v52.0** (bumped from v51.1 — the swiftletd image ships v52.0;
+  v51.1's virtio-blk bugchecks Windows' viostor driver, fixed in v52.0. CLOUDHV.fd
+  firmware unchanged: `ch-13b4963ec4`, the spike-validated pairing. Linux-guest
+  regression validation lands with the redeploy.)
 - Seed format: NoCloud flat layout
 - DHCP range: 10.244.125.10–20 on br0 (10.244.125.1)
 - ORAS CLI: v1.3.1
@@ -2649,7 +2652,7 @@ Shipped across 6 PRs (design + 5 build):
 ---
 
 ## Hardware Available
-- 3-node k0s cluster (frida control-plane, miles + boba workers), Ubuntu 24.04, CH v51.1, Longhorn 22d
+- 3-node k0s cluster (frida control-plane, miles + boba workers), Ubuntu 24.04, CH v52.0 (swiftletd image; bumped from v51.1 — verify with the redeploy), Longhorn 22d
 - boba has GeForce GTX 1080 (Tier 1 GPU validated)
 - No SR-IOV NICs, no HGX, no multi-NIC servers currently
 


### PR DESCRIPTION
## Bump Cloud Hypervisor v51.1 → v52.0

The PR 0 prereq for Windows guest support (and a routine minor bump for the whole platform). The spike (#148/#149) showed CH **v51.1** bugchecks Windows' `viostor` driver (`0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL`) in a reboot loop, while CH **v52.0** boots Windows **cleanly and stably** — the `0xD1` was a v51.1 virtio-blk bug fixed in v52.0 (findings: [`windows-guest-support-spike.md`](../blob/main/docs/design/windows-guest-support-spike.md) §4.1). KubeSwift is still in development with no other active users, so the bump is platform-wide now rather than Windows-gated.

### Change
- **`images/swiftletd/Containerfile`**: `CH_VERSION` `51.1 → 52.0`. The download URL is `…/releases/download/v${CH_VERSION}/cloud-hypervisor-static`, so this fetches the v52.0 static binary (the exact asset validated in the spike).
- **`CLOUDHV.fd` firmware unchanged** (`ch-13b4963ec4`) — the spike-validated pairing with the v52.0 binary. Binary-only is the minimal validated change; matching-firmware bump is a non-blocking future option.
- **No code constant to update** — `CurrentHypervisorVersion` is read from CH at runtime (`swift-ch-client` vm.info), so it tracks the new version automatically.
- The `v51.1` strings remaining in tests/comments/captured-logs are legitimate **historical/sample data** (e.g. v51.1 snapshot-format fixtures, recorded spike logs, "verified on v51.1" notes) and are intentionally left — they document what was observed on v51.1, not the shipped version.
- Docs: README architecture diagram, `kubeswift_context.md` ("Known working configuration" + "Hardware Available"), `CHANGELOG.md`.

### Validation
Platform-wide (the VMM for Linux guests too). The standard **Linux-guest regression** runs on redeploy: `make smoke-test` + the snapshot/migration suites. The Windows side stays spike-validated only (no Windows image/license on the dev cluster — asset-gated, like Tier 2/3 GPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)