### PR TITLE
feat(windows): osType field on SwiftGuest + SwiftImage (Windows guest support — PR 2)

### DIFF
--- a/api/image/v1alpha1/swiftimage_types.go
+++ b/api/image/v1alpha1/swiftimage_types.go
@@ -99,6 +99,21 @@ type PreparedArtifactRef struct {
 	Size   *resource.Quantity  `json:"size,omitempty"`
 }
 
+// OSType is the operating-system family the image contains: "linux"
+// (default) or "windows". It gates the Linux-only import steps (GRUB/serial
+// patch, growpart resize expectation) in the import pipeline. For a Windows
+// image the operator supplies a virtio-ready disk (viostor pre-installed); the
+// import keeps qcow2->raw + resize but skips the Linux-only steps. Default
+// linux. (Defined per-API-group to avoid a cross-group import; mirrors
+// api/swift/v1alpha1.OSType.)
+// +kubebuilder:validation:Enum=linux;windows
+type OSType string
+
+const (
+	OSTypeLinux   OSType = "linux"
+	OSTypeWindows OSType = "windows"
+)
+
 // DiskFormat is the disk image format.
 // +kubebuilder:validation:Enum=raw;qcow2
 type DiskFormat string
@@ -120,6 +135,13 @@ type SwiftImageSpec struct {
 	Source   ImageSource             `json:"source"`
 	Format   DiskFormat              `json:"format"`
 	RootDisk *SwiftImageRootDiskSpec `json:"rootDisk,omitempty"`
+	// OSType is the OS family this image contains: "linux" (default) or
+	// "windows". Gates the Linux-only import steps (GRUB/serial patch,
+	// growpart resize expectation). Default linux; existing images are
+	// unaffected. (Windows guest support — see docs/design/windows-guest-support.md.)
+	// +kubebuilder:default=linux
+	// +optional
+	OSType OSType `json:"osType,omitempty"`
 	// CloneStrategy controls how per-guest root disk PVCs are produced.
 	// Defaults to "copy" for backward compatibility — existing images keep
 	// working without changes. "snapshot" requires a snapshot-capable CSI

--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -16,6 +16,18 @@ const (
 	RunPolicyAlways           RunPolicy = "Always"
 )
 
+// OSType is the guest operating-system family. It gates the Linux-only
+// provisioning datasource and, for windows, the Cloud Hypervisor runtime
+// settings (kvm_hyperv on the disk-boot path). Default "linux" — existing
+// guests are unaffected. See docs/design/windows-guest-support.md.
+// +kubebuilder:validation:Enum=linux;windows
+type OSType string
+
+const (
+	OSTypeLinux   OSType = "linux"
+	OSTypeWindows OSType = "windows"
+)
+
 // ConditionGPUAllocated is set on SwiftGuest when the SwiftGPU controller has
 // allocated GPU devices and the guest is ready to be scheduled.
 const ConditionGPUAllocated = "GPUAllocated"
@@ -105,6 +117,15 @@ type SwiftGuestSpec struct {
 	// validation webhook rejects migrations of pinned guests.
 	// +optional
 	Migration *MigrationSpec `json:"migration,omitempty"`
+	// OSType is the guest OS family: "linux" (default) or "windows". For a
+	// disk boot the referenced SwiftImage's osType is authoritative and this
+	// field, when set, must agree with it (the resolver cross-checks). windows
+	// requires disk boot (imageRef) — kernel boot is Linux-only — and is not
+	// supported with gpuProfileRef in v1. Default linux; existing guests are
+	// unaffected. (Windows guest support — see docs/design/windows-guest-support.md.)
+	// +kubebuilder:default=linux
+	// +optional
+	OSType OSType `json:"osType,omitempty"`
 	// Storage overrides the SwiftGuestClass storage defaults for PVCs
 	// the controller creates for this guest (today: the root-disk clone).
 	// Per-field merge: each non-empty field overrides the same field on

--- a/charts/kubeswift/crds/image.kubeswift.io_swiftimages.yaml
+++ b/charts/kubeswift/crds/image.kubeswift.io_swiftimages.yaml
@@ -66,6 +66,17 @@ spec:
                 - raw
                 - qcow2
                 type: string
+              osType:
+                default: linux
+                description: |-
+                  OSType is the OS family this image contains: "linux" (default) or
+                  "windows". Gates the Linux-only import steps (GRUB/serial patch,
+                  growpart resize expectation). Default linux; existing images are
+                  unaffected. (Windows guest support — see docs/design/windows-guest-support.md.)
+                enum:
+                - linux
+                - windows
+                type: string
               rootDisk:
                 description: SwiftImageRootDiskSpec specifies root disk options for
                   the import PVC.

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
@@ -412,6 +412,19 @@ spec:
                           webhook enforces NodeName == status.GPU.NodeName. The pod builder
                           refuses to build with a Resolved=False condition if they disagree.
                         type: string
+                      osType:
+                        default: linux
+                        description: |-
+                          OSType is the guest OS family: "linux" (default) or "windows". For a
+                          disk boot the referenced SwiftImage's osType is authoritative and this
+                          field, when set, must agree with it (the resolver cross-checks). windows
+                          requires disk boot (imageRef) — kernel boot is Linux-only — and is not
+                          supported with gpuProfileRef in v1. Default linux; existing guests are
+                          unaffected. (Windows guest support — see docs/design/windows-guest-support.md.)
+                        enum:
+                        - linux
+                        - windows
+                        type: string
                       runPolicy:
                         description: RunPolicy defines the desired run state of a
                           guest.

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -344,6 +344,19 @@ spec:
                   webhook enforces NodeName == status.GPU.NodeName. The pod builder
                   refuses to build with a Resolved=False condition if they disagree.
                 type: string
+              osType:
+                default: linux
+                description: |-
+                  OSType is the guest OS family: "linux" (default) or "windows". For a
+                  disk boot the referenced SwiftImage's osType is authoritative and this
+                  field, when set, must agree with it (the resolver cross-checks). windows
+                  requires disk boot (imageRef) — kernel boot is Linux-only — and is not
+                  supported with gpuProfileRef in v1. Default linux; existing guests are
+                  unaffected. (Windows guest support — see docs/design/windows-guest-support.md.)
+                enum:
+                - linux
+                - windows
+                type: string
               runPolicy:
                 description: RunPolicy defines the desired run state of a guest.
                 enum:

--- a/config/crd/bases/image.kubeswift.io_swiftimages.yaml
+++ b/config/crd/bases/image.kubeswift.io_swiftimages.yaml
@@ -66,6 +66,17 @@ spec:
                 - raw
                 - qcow2
                 type: string
+              osType:
+                default: linux
+                description: |-
+                  OSType is the OS family this image contains: "linux" (default) or
+                  "windows". Gates the Linux-only import steps (GRUB/serial patch,
+                  growpart resize expectation). Default linux; existing images are
+                  unaffected. (Windows guest support — see docs/design/windows-guest-support.md.)
+                enum:
+                - linux
+                - windows
+                type: string
               rootDisk:
                 description: SwiftImageRootDiskSpec specifies root disk options for
                   the import PVC.

--- a/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
@@ -412,6 +412,19 @@ spec:
                           webhook enforces NodeName == status.GPU.NodeName. The pod builder
                           refuses to build with a Resolved=False condition if they disagree.
                         type: string
+                      osType:
+                        default: linux
+                        description: |-
+                          OSType is the guest OS family: "linux" (default) or "windows". For a
+                          disk boot the referenced SwiftImage's osType is authoritative and this
+                          field, when set, must agree with it (the resolver cross-checks). windows
+                          requires disk boot (imageRef) — kernel boot is Linux-only — and is not
+                          supported with gpuProfileRef in v1. Default linux; existing guests are
+                          unaffected. (Windows guest support — see docs/design/windows-guest-support.md.)
+                        enum:
+                        - linux
+                        - windows
+                        type: string
                       runPolicy:
                         description: RunPolicy defines the desired run state of a
                           guest.

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -344,6 +344,19 @@ spec:
                   webhook enforces NodeName == status.GPU.NodeName. The pod builder
                   refuses to build with a Resolved=False condition if they disagree.
                 type: string
+              osType:
+                default: linux
+                description: |-
+                  OSType is the guest OS family: "linux" (default) or "windows". For a
+                  disk boot the referenced SwiftImage's osType is authoritative and this
+                  field, when set, must agree with it (the resolver cross-checks). windows
+                  requires disk boot (imageRef) — kernel boot is Linux-only — and is not
+                  supported with gpuProfileRef in v1. Default linux; existing guests are
+                  unaffected. (Windows guest support — see docs/design/windows-guest-support.md.)
+                enum:
+                - linux
+                - windows
+                type: string
               runPolicy:
                 description: RunPolicy defines the desired run state of a guest.
                 enum:

--- a/internal/resolved/merge.go
+++ b/internal/resolved/merge.go
@@ -60,6 +60,16 @@ func Merge(
 	// Storage: per-field merge — guest > class > system defaults.
 	rg.Storage = MergeStorage(guest, guestClass)
 
+	// OSType: the SwiftImage defines the guest OS for a disk boot. Kernel boot
+	// (image == nil) is always Linux — there is no Windows bzImage. Default
+	// "linux" so legacy guests/images (osType unset) are unaffected. The
+	// guest's spec.osType, when set, is cross-checked against the image in the
+	// resolver (resolveDiskBoot).
+	rg.OSType = string(swiftv1alpha1.OSTypeLinux)
+	if image != nil && image.Spec.OSType != "" {
+		rg.OSType = string(image.Spec.OSType)
+	}
+
 	return rg
 }
 

--- a/internal/resolved/merge_test.go
+++ b/internal/resolved/merge_test.go
@@ -25,6 +25,31 @@ func TestMerge_GuestRunPolicyOverridesSystemDefault(t *testing.T) {
 	}
 }
 
+func TestMerge_OSType(t *testing.T) {
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "ns", UID: "uid"},
+		Spec:       swiftv1alpha1.SwiftGuestSpec{ImageRef: &corev1.LocalObjectReference{Name: "img"}, GuestClassRef: corev1.LocalObjectReference{Name: "gc"}},
+	}
+	guestClass := &swiftv1alpha1.SwiftGuestClass{Spec: swiftv1alpha1.SwiftGuestClassSpec{CPU: resource.MustParse("2"), Memory: resource.MustParse("2Gi"), RootDisk: swiftv1alpha1.RootDiskSpec{Size: resource.MustParse("10Gi"), Format: swiftv1alpha1.DiskFormatRaw}}}
+
+	// Windows image -> rg.OSType=windows (image is authoritative for disk boot).
+	winImage := &imagev1alpha1.SwiftImage{Spec: imagev1alpha1.SwiftImageSpec{OSType: imagev1alpha1.OSTypeWindows}, Status: imagev1alpha1.SwiftImageStatus{Phase: imagev1alpha1.SwiftImagePhaseReady, PreparedArtifact: &imagev1alpha1.PreparedArtifactRef{Format: imagev1alpha1.DiskFormatRaw}}}
+	if rg := Merge(guest, guestClass, winImage, nil); rg.GetOSType() != "windows" || !rg.IsWindows() {
+		t.Errorf("windows image: OSType=%q IsWindows=%v, want windows/true", rg.GetOSType(), rg.IsWindows())
+	}
+
+	// Image with osType unset -> linux (legacy, no behaviour change).
+	linImage := &imagev1alpha1.SwiftImage{Status: imagev1alpha1.SwiftImageStatus{Phase: imagev1alpha1.SwiftImagePhaseReady, PreparedArtifact: &imagev1alpha1.PreparedArtifactRef{Format: imagev1alpha1.DiskFormatRaw}}}
+	if rg := Merge(guest, guestClass, linImage, nil); rg.GetOSType() != "linux" || rg.IsWindows() {
+		t.Errorf("unset image osType: OSType=%q, want linux", rg.GetOSType())
+	}
+
+	// Kernel boot (image == nil) -> always linux.
+	if rg := Merge(guest, guestClass, nil, nil); rg.GetOSType() != "linux" {
+		t.Errorf("kernel boot: OSType=%q, want linux", rg.GetOSType())
+	}
+}
+
 func TestMerge_ClassCPUUsedWhenGuestNoOverride(t *testing.T) {
 	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "ns"}, Spec: swiftv1alpha1.SwiftGuestSpec{ImageRef: &corev1.LocalObjectReference{Name: "img"}, GuestClassRef: corev1.LocalObjectReference{Name: "gc"}}}
 	guestClass := &swiftv1alpha1.SwiftGuestClass{Spec: swiftv1alpha1.SwiftGuestClassSpec{CPU: resource.MustParse("4"), Memory: resource.MustParse("4Gi"), RootDisk: swiftv1alpha1.RootDiskSpec{Size: resource.MustParse("20Gi"), Format: swiftv1alpha1.DiskFormatRaw}}}

--- a/internal/resolved/resolver.go
+++ b/internal/resolved/resolver.go
@@ -2,6 +2,7 @@ package resolved
 
 import (
 	"context"
+	"fmt"
 
 	imagev1alpha1 "github.com/projectbeskar/kubeswift/api/image/v1alpha1"
 	kernelv1alpha1 "github.com/projectbeskar/kubeswift/api/kernel/v1alpha1"
@@ -121,6 +122,20 @@ func (r *resolver) resolveDiskBoot(ctx context.Context, guest *swiftv1alpha1.Swi
 	image := &imagev1alpha1.SwiftImage{}
 	if err := r.client.Get(ctx, types.NamespacedName{Namespace: guest.Namespace, Name: guest.Spec.ImageRef.Name}, image); err != nil {
 		return nil, &ResolutionError{Reason: "SwiftImage not found: " + err.Error(), AffectedResource: guest.Spec.ImageRef.Name}
+	}
+
+	// osType cross-check: the image is authoritative (it defines the OS); the
+	// guest's spec.osType, when set, must agree. Legacy guests/images leave
+	// osType unset and skip the check (and inherit "linux" via Merge). A
+	// mismatch (e.g. a linux guest pointed at a windows image) surfaces as a
+	// Resolved=False condition rather than a confusing boot failure later.
+	if guest.Spec.OSType != "" && image.Spec.OSType != "" &&
+		string(guest.Spec.OSType) != string(image.Spec.OSType) {
+		return nil, &ResolutionError{
+			Reason: fmt.Sprintf("osType mismatch: guest declares %q but image %q is %q",
+				guest.Spec.OSType, image.Name, image.Spec.OSType),
+			AffectedResource: image.Name,
+		}
 	}
 
 	// Fetch SeedProfile if referenced

--- a/internal/resolved/resolver_test.go
+++ b/internal/resolved/resolver_test.go
@@ -3,6 +3,7 @@ package resolved
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	imagev1alpha1 "github.com/projectbeskar/kubeswift/api/image/v1alpha1"
@@ -59,6 +60,39 @@ func TestResolve_FailsWhenSwiftImageDoesNotExist(t *testing.T) {
 	}
 	if re.AffectedResource != "missing" {
 		t.Errorf("AffectedResource = %q, want missing", re.AffectedResource)
+	}
+}
+
+func TestResolve_OSTypeMismatchRejected(t *testing.T) {
+	scheme := testScheme()
+	guestClass := &swiftv1alpha1.SwiftGuestClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "gc"},
+		Spec:       swiftv1alpha1.SwiftGuestClassSpec{CPU: resource.MustParse("2"), Memory: resource.MustParse("2Gi"), RootDisk: swiftv1alpha1.RootDiskSpec{Size: resource.MustParse("10Gi"), Format: swiftv1alpha1.DiskFormatRaw}},
+	}
+	// Linux image, but the guest declares windows -> mismatch (the cross-check
+	// fires before the heavier existence/compat validation).
+	image := &imagev1alpha1.SwiftImage{
+		ObjectMeta: metav1.ObjectMeta{Name: "img", Namespace: "ns"},
+		Spec:       imagev1alpha1.SwiftImageSpec{OSType: imagev1alpha1.OSTypeLinux},
+		Status:     imagev1alpha1.SwiftImageStatus{Phase: imagev1alpha1.SwiftImagePhaseReady},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guestClass, image).Build()
+	resolver := NewResolver(client)
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "ns"},
+		Spec:       swiftv1alpha1.SwiftGuestSpec{ImageRef: &corev1.LocalObjectReference{Name: "img"}, GuestClassRef: corev1.LocalObjectReference{Name: "gc"}, OSType: swiftv1alpha1.OSTypeWindows},
+	}
+
+	rg, err := resolver.Resolve(context.Background(), guest)
+	if rg != nil {
+		t.Fatal("expected nil ResolvedGuest on osType mismatch")
+	}
+	var re *ResolutionError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected ResolutionError, got %T: %v", err, err)
+	}
+	if !strings.Contains(re.Reason, "osType mismatch") {
+		t.Errorf("Reason = %q, want osType mismatch", re.Reason)
 	}
 }
 

--- a/internal/resolved/types.go
+++ b/internal/resolved/types.go
@@ -46,6 +46,12 @@ type ResolvedGuest struct {
 	// Interfaces from SwiftGuest spec, used for multi-NIC support.
 	// Nil or empty means single default NIC (backward compatible).
 	Interfaces []swiftv1alpha1.GuestInterface `json:"interfaces,omitempty"`
+	// OSType is the resolved guest OS family ("linux" or "windows"). For a
+	// disk boot it is taken from the SwiftImage (the image defines the OS);
+	// kernel boot is always "linux". Empty resolves to "linux" via GetOSType.
+	// Consumed by the runtime layer (PR 4: windows adds kvm_hyperv on the CH
+	// disk-boot path) and provisioning (PR 5: cloudbase-init vs cloud-init).
+	OSType string `json:"osType,omitempty"`
 }
 
 // GuestSettings holds architecture, firmware, bus, interface model, shutdown method.
@@ -229,6 +235,20 @@ func (r *ResolvedGuest) GetLifecycle() string {
 // GetHypervisor returns the hypervisor override, or empty string for default (Cloud Hypervisor).
 func (r *ResolvedGuest) GetHypervisor() string {
 	return r.Hypervisor
+}
+
+// GetOSType returns the resolved guest OS family ("linux" or "windows"),
+// defaulting to "linux" when unset (legacy guests / kernel boot).
+func (r *ResolvedGuest) GetOSType() string {
+	if r.OSType == "" {
+		return "linux"
+	}
+	return r.OSType
+}
+
+// IsWindows reports whether the resolved guest is a Windows guest.
+func (r *ResolvedGuest) IsWindows() bool {
+	return r.GetOSType() == string(swiftv1alpha1.OSTypeWindows)
 }
 
 // GetGuestID returns a unique ID for the guest (namespace/name).

--- a/internal/webhook/swiftguest/validator.go
+++ b/internal/webhook/swiftguest/validator.go
@@ -78,5 +78,25 @@ func validateSwiftGuest(g *swiftv1alpha1.SwiftGuest) error {
 	if spec.RunPolicy != "" && !validPolicies[spec.RunPolicy] {
 		return fmt.Errorf("spec.runPolicy must be Running, Stopped, RestartOnFailure, or Always, got %q", spec.RunPolicy)
 	}
+
+	// osType (Windows guest support). The enum is enforced by the CRD schema;
+	// re-check defensively (the webhook may run against objects the schema
+	// hasn't defaulted), then apply the v1 rules.
+	switch spec.OSType {
+	case "", swiftv1alpha1.OSTypeLinux, swiftv1alpha1.OSTypeWindows:
+	default:
+		return fmt.Errorf("spec.osType must be linux or windows, got %q", spec.OSType)
+	}
+	if spec.OSType == swiftv1alpha1.OSTypeWindows {
+		// Windows is disk-boot only — there is no Windows bzImage for kernel boot.
+		if hasKernel {
+			return fmt.Errorf("spec.osType: windows requires disk boot (spec.imageRef); kernel boot (spec.kernelRef) is Linux-only")
+		}
+		// GPU passthrough to Windows is out of scope for v1 (a non-goal in
+		// docs/design/windows-guest-support.md).
+		if spec.GPUProfileRef != nil {
+			return fmt.Errorf("spec.osType: windows with spec.gpuProfileRef is not supported in v1 (GPU passthrough to Windows is out of scope)")
+		}
+	}
 	return nil
 }

--- a/internal/webhook/swiftguest/validator_test.go
+++ b/internal/webhook/swiftguest/validator_test.go
@@ -67,6 +67,40 @@ func TestValidate_BootSourceExclusivity(t *testing.T) {
 	})), "exactly one of spec.imageRef")
 }
 
+func TestValidate_OSType(t *testing.T) {
+	// default (unset) osType + imageRef: OK (no behaviour change for existing guests).
+	if err := validateSwiftGuest(guest(nil)); err != nil {
+		t.Errorf("unset osType should be valid: %v", err)
+	}
+	// explicit linux + imageRef: OK.
+	if err := validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.OSType = swiftv1alpha1.OSTypeLinux
+	})); err != nil {
+		t.Errorf("linux + imageRef should be valid: %v", err)
+	}
+	// windows + imageRef (disk boot): OK.
+	if err := validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.OSType = swiftv1alpha1.OSTypeWindows
+	})); err != nil {
+		t.Errorf("windows + imageRef should be valid: %v", err)
+	}
+	// windows + kernelRef: rejected (Windows is disk-boot only).
+	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.ImageRef = nil
+		g.Spec.KernelRef = &corev1.LocalObjectReference{Name: "k"}
+		g.Spec.OSType = swiftv1alpha1.OSTypeWindows
+	})), "windows requires disk boot")
+	// windows + gpuProfileRef: rejected (GPU-to-Windows out of scope v1).
+	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.OSType = swiftv1alpha1.OSTypeWindows
+		g.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu"}
+	})), "gpuProfileRef is not supported")
+	// invalid enum value: rejected (defense-in-depth beyond the CRD schema).
+	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.OSType = swiftv1alpha1.OSType("bsd")
+	})), "spec.osType must be linux or windows")
+}
+
 func TestValidate_CloneFromSnapshotRules(t *testing.T) {
 	cloneGuest := func(mut func(*swiftv1alpha1.SwiftGuest)) *swiftv1alpha1.SwiftGuest {
 		return guest(func(g *swiftv1alpha1.SwiftGuest) {

--- a/internal/webhook/swiftimage/validator.go
+++ b/internal/webhook/swiftimage/validator.go
@@ -82,6 +82,12 @@ func validateSwiftImage(img *imagev1alpha1.SwiftImage) error {
 	if img.Spec.Format == "" {
 		return fmt.Errorf("spec.format is required (raw or qcow2)")
 	}
+	// osType enum (defense-in-depth; the CRD schema also enforces it).
+	switch img.Spec.OSType {
+	case "", imagev1alpha1.OSTypeLinux, imagev1alpha1.OSTypeWindows:
+	default:
+		return fmt.Errorf("spec.osType must be linux or windows, got %q", img.Spec.OSType)
+	}
 	if err := validateCloneStrategy(img); err != nil {
 		return err
 	}
@@ -118,7 +124,11 @@ func validateSwiftImageUpdate(oldImg, img *imagev1alpha1.SwiftImage) error {
 		return err
 	}
 	if oldImg.Status.Phase == imagev1alpha1.SwiftImagePhaseReady {
-		if oldImg.Spec.Source != img.Spec.Source || oldImg.Spec.Format != img.Spec.Format {
+		// osType is a value (string) compare, so unlike Spec.Source it does not
+		// have the pointer-identity foot-gun (TFU-17/23) — a Ready image's OS is
+		// fixed by what was imported, so it is immutable.
+		if oldImg.Spec.Source != img.Spec.Source || oldImg.Spec.Format != img.Spec.Format ||
+			oldImg.Spec.OSType != img.Spec.OSType {
 			return fmt.Errorf("SwiftImage spec is immutable when status.phase is Ready")
 		}
 	}


### PR DESCRIPTION
## PR 2 of Windows guest support — the `osType` gate

Adds `osType` (`linux` | `windows`, **default `linux`**) — the single decision point the rest of the Windows work hangs off (mirrors how `gpuProfileRef.tier` drives CH-vs-QEMU). **Default `linux` ⇒ zero behaviour change for existing guests.** This PR is the **field + validation + resolver wiring only**; the runtime routing (CH disk-boot + `kvm_hyperv`) is PR 4 and import-skip is PR 3.

### Changes
- **API:** `SwiftGuestSpec.OSType` + `SwiftImageSpec.OSType` (enum, `+kubebuilder:default=linux`). `OSType` is defined per-API-group (swift + image) to avoid a cross-group import — the codebase's existing duplication pattern.
- **Resolver:** the **SwiftImage is authoritative** for a disk boot — `Merge` sets `ResolvedGuest.OSType` from `image.Spec.OSType` (kernel boot is always `linux`); adds `GetOSType()`/`IsWindows()`. `resolveDiskBoot` **cross-checks** the guest's declared `osType` against the image and fails resolution with a clear `Resolved=False` message on a mismatch (before the heavier existence/compat checks).
- **Webhook (SwiftGuest):** `windows` requires disk boot (reject `windows`+`kernelRef`); `windows`+`gpuProfileRef` rejected (GPU-to-Windows is a v1 non-goal); enum defense-in-depth.
- **Webhook (SwiftImage):** `osType` enum + immutable on a `Ready` image (value compare — no pointer foot-gun à la TFU-17/23).
- **Generate:** CRDs regenerated (swiftguests, swiftimages, **and the swiftguestpools template** all carry `osType` default `linux`) + chart copy. No `deepcopy` change (string value type).

### Tests
- SwiftGuest webhook: `windows`+`kernelRef` rejected, `windows`+`gpuProfileRef` rejected, invalid enum rejected, valid `windows`+`imageRef` and default-unset allowed.
- `Merge`: windows image → `windows`; unset image / kernel boot → `linux`.
- Resolver: guest/image `osType` mismatch → `ResolutionError`.

`go build`, `go vet`, `gofmt`, and the full `go test ./...` all pass; `make generate` is clean (`verify-crd-sync` OK).

Context-doc "osType shipped" note deferred to avoid churn with the in-flight CH-bump / assessment / roadmap PRs (#150–#152) that also touch `kubeswift_context.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)