### PR TITLE
feat(windows): skip Linux-only import steps for osType=windows (Windows guest support — PR 3)

### DIFF
--- a/internal/controller/swiftimage/controller_test.go
+++ b/internal/controller/swiftimage/controller_test.go
@@ -173,4 +173,48 @@ func TestStartImport_HTTPSourceScriptPatchesGRUBForUEFI(t *testing.T) {
 			t.Errorf("import script missing %q", want)
 		}
 	}
+	// Linux import is privileged (the GRUB patch needs a loop-mount).
+	if sc := job.Spec.Template.Spec.Containers[0].SecurityContext; sc == nil || sc.Privileged == nil || !*sc.Privileged {
+		t.Errorf("linux import Job should be privileged, got %+v", sc)
+	}
+}
+
+func TestStartImport_WindowsSkipsGRUBPatchAndPrivileged(t *testing.T) {
+	scheme := testScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &SwiftImageReconciler{Client: client, Scheme: scheme}
+	img := &imagev1alpha1.SwiftImage{
+		ObjectMeta: metav1.ObjectMeta{Name: "win", Namespace: "default"},
+		Spec: imagev1alpha1.SwiftImageSpec{
+			Format: imagev1alpha1.DiskFormatQcow2,
+			OSType: imagev1alpha1.OSTypeWindows,
+			Source: imagev1alpha1.ImageSource{
+				HTTP: &imagev1alpha1.HTTPSource{URL: "https://example.com/windows.qcow2"},
+			},
+		},
+	}
+	if _, err := r.StartImport(context.Background(), img); err != nil {
+		t.Fatalf("StartImport: %v", err)
+	}
+	var job batchv1.Job
+	if err := client.Get(context.Background(), types.NamespacedName{Name: importJobNamePrefix + "win", Namespace: "default"}, &job); err != nil {
+		t.Fatalf("Job not created: %v", err)
+	}
+	script := job.Spec.Template.Spec.Containers[0].Command[2]
+	// The Linux-only GRUB/serial patch and its loop-mount must be absent.
+	for _, unwanted := range []string{"patch_grub", "console=ttyS0", "mount -o loop"} {
+		if strings.Contains(script, unwanted) {
+			t.Errorf("windows import script should not contain %q", unwanted)
+		}
+	}
+	// OS-agnostic steps stay: qcow2->raw convert + size measurement.
+	for _, want := range []string{"qemu-img convert", ".size"} {
+		if !strings.Contains(script, want) {
+			t.Errorf("windows import script should still contain %q", want)
+		}
+	}
+	// Privileged is dropped for windows (no loop-mount needed).
+	if sc := job.Spec.Template.Spec.Containers[0].SecurityContext; sc == nil || sc.Privileged == nil || *sc.Privileged {
+		t.Errorf("windows import Job should be non-privileged, got %+v", sc)
+	}
 }

--- a/internal/controller/swiftimage/import.go
+++ b/internal/controller/swiftimage/import.go
@@ -30,7 +30,12 @@ const (
 // Per-guest disk sizing happens during the root disk clone step in the SwiftGuest controller.
 // Patches GRUB to add console=ttyS0 for serial console (firmware boot uses disk's cmdline).
 // Supports Ubuntu, Debian, Fedora, Rocky Linux, and common layouts.
-func importScript(sourceURL, sourceFormat string) string {
+//
+// osType gates the Linux-only GRUB/serial patch: "windows" skips it entirely
+// (Windows has no GRUB — it boots bootmgfw from the ESP and manages serial via
+// EMS/SAC in the operator-prepped image), keeping only the OS-agnostic
+// qcow2->raw convert + size measurement. (Windows guest support — PR 3.)
+func importScript(sourceURL, sourceFormat, osType string) string {
 	base := importVolumeMountPath
 	source := base + "/" + importSourceFile
 	output := base + "/" + importOutputFile
@@ -84,6 +89,11 @@ for offset in $GPT_OFFSETS $FALLBACK_OFFSETS; do
 done
 rmdir /mnt/disk 2>/dev/null || true
 `
+	// Windows: no GRUB to patch, and the loop-mount the patch needs is
+	// pointless on an NTFS/Windows layout. Skip the whole block.
+	if osType == string(imagev1alpha1.OSTypeWindows) {
+		grubPatch = ""
+	}
 	if sourceFormat == "qcow2" {
 		return fmt.Sprintf("set -e\nOUTPUT=%q\napt-get update -qq && apt-get install -y -qq curl qemu-utils util-linux >/dev/null\ncurl -fsSL -o %q %q\nqemu-img convert -f qcow2 -O raw %q \"$OUTPUT\"%s\nstat -c %%s \"$OUTPUT\" > \"$OUTPUT.size\"\necho \"Image size: $(cat $OUTPUT.size) bytes\"", output, source, sourceURL, source, grubPatch)
 	}
@@ -146,7 +156,12 @@ func (r *SwiftImageReconciler) importHTTP(ctx context.Context, img *imagev1alpha
 	// Per-guest disk sizing happens during the root disk clone step.
 	sourceURL := img.Spec.Source.HTTP.URL
 	sourceFormat := string(img.Spec.Format)
-	script := importScript(sourceURL, sourceFormat)
+	script := importScript(sourceURL, sourceFormat, string(img.Spec.OSType))
+	// The import Job needs privileged ONLY for the loop-mount the Linux GRUB
+	// serial-console patch performs. Windows skips that patch (no GRUB), so its
+	// import runs unprivileged (Design Principle: no privileged unless required).
+	// RunAsUser 0 is still needed either way for apt-get in the ubuntu image.
+	privileged := img.Spec.OSType != imagev1alpha1.OSTypeWindows
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: img.Namespace},
 		Spec: batchv1.JobSpec{
@@ -154,7 +169,7 @@ func (r *SwiftImageReconciler) importHTTP(ctx context.Context, img *imagev1alpha
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyOnFailure,
 					SecurityContext: &corev1.PodSecurityContext{
-						// Required for mount -o loop when patching GRUB
+						// Root is needed for apt-get (and, on Linux, the loop-mount).
 						RunAsUser: ptr.To(int64(0)),
 					},
 					Containers: []corev1.Container{{
@@ -162,7 +177,9 @@ func (r *SwiftImageReconciler) importHTTP(ctx context.Context, img *imagev1alpha
 						Image:   "ubuntu:22.04",
 						Command: []string{"sh", "-c", script},
 						SecurityContext: &corev1.SecurityContext{
-							Privileged: ptr.To(true),
+							// Privileged only for the Linux GRUB-patch loop-mount;
+							// false for Windows imports (no patch, no mount).
+							Privileged: ptr.To(privileged),
 						},
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "data",


### PR DESCRIPTION
## PR 3 of Windows guest support — image import

The only Linux-only step in the SwiftImage import is the **GRUB serial-console patch** (`importScript`: `patch_grub()` + the loop-mount over each GPT partition that rewrites `grub.cfg` to add `console=ttyS0` + a serial terminal). Windows has no GRUB — it boots `bootmgfw` from the ESP and the operator-prepped image manages serial via EMS/SAC — so the whole block is skipped for `osType: windows`.

### Changes (all in `internal/controller/swiftimage/import.go`)
- **`importScript(sourceURL, sourceFormat, osType)`** — the `grubPatch` block (and its loop-mount) is emptied when `osType == windows`. Keeps the OS-agnostic `curl` + `qemu-img convert -f qcow2 -O raw` + size measurement.
- **Import Job drops `Privileged` for Windows** — the `privileged` flag existed *only* for the GRUB-patch loop-mount. No patch → no mount → the Windows import runs **unprivileged** (Design Principle: no privileged unless required). `RunAsUser: 0` stays for `apt-get`, both OSes.

### Deliberately not touched
- **`qcow2 → raw` convert** — every OS needs raw at runtime.
- **`qemu-img resize` + `sgdisk -e`** — these are at the per-guest **clone** step (`swiftguest/rootdisk.go`), disk-level/OS-agnostic (the spike confirmed Windows boots from the resized GPT disk).
- **`growpart`** — guest-side cloud-init, never in the import (Windows extends via diskpart/unattend).
- **`importPVCClone` / `upload`** — both are stubs ("not yet implemented").

### Risk / tests / validation
- **Zero behaviour change for Linux** — gated on `osType == windows` (default `linux`); existing imports are byte-identical and stay privileged.
- **Tests:** Windows import script omits `patch_grub`/`console=ttyS0`/`mount -o loop` and keeps `qemu-img convert` + size; its Job is non-privileged. The Linux path keeps the patch and stays privileged.
- **Validation:** unit-only — **asset-gated** (no Windows image/license on the dev cluster), same caveat as Tier 2/3 GPU. The spike already proved the virtio-ready image boots; this just wires the import to produce one without mangling it.

`go build`/`vet`/`gofmt`/full `go test ./...` all pass. No API/CRD change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)