### PR TITLE
feat(windows): provisioning via cloudbase-init over the NoCloud seed (Windows guest support — PR 5)

### DIFF
--- a/config/samples/windows/README.md
+++ b/config/samples/windows/README.md
@@ -1,0 +1,55 @@
+# Windows guest samples
+
+Running a Windows guest as a SwiftGuest. **Windows runs on Cloud Hypervisor**
+(v52.0+) via the same disk-boot path Linux uses — the `osType: windows` gate is
+the single decision point.
+
+> **Asset-gated / illustrative.** These manifests are not cluster-validated (no
+> Windows image/license on the dev cluster), the same caveat as Tier 2/3 GPU. The
+> boot path itself is spike-proven: see
+> [`docs/design/windows-guest-support-spike.md`](../../../docs/design/windows-guest-support-spike.md).
+> The image URL is a placeholder — point it at your own virtio-ready image.
+
+## The three pieces
+
+| File | What it does |
+|---|---|
+| `swiftimage-windows.yaml` | `SwiftImage` with `osType: windows` — import skips the Linux-only GRUB/serial patch (PR 3), keeps `qcow2→raw`. Source **must** be an operator-prepared, virtio-ready image. |
+| `swiftseedprofile-windows.yaml` | `SwiftSeedProfile` (NoCloud) consumed by **cloudbase-init** — the *same* `cidata` seed mechanism cloud-init uses (no new datasource). |
+| `swiftguest-windows.yaml` | `SwiftGuest` with `osType: windows` → CH disk-boot + `--cpus kvm_hyperv=on` (PR 4). |
+
+```sh
+kubectl apply -f swiftimage-windows.yaml -f swiftseedprofile-windows.yaml -f swiftguest-windows.yaml
+```
+
+## Prerequisites (operator-prepared image)
+
+A **stock Windows ISO will not boot on virtio.** The image referenced by the
+`SwiftImage` must be prepared off-cluster (PR 6 runbook; the spike's
+`autounattend.xml` + `run-install.sh` are the seed for that tooling):
+
+1. **virtio drivers** pre-installed — `viostor` (boot disk) + `NetKVM` (NIC).
+2. **Headless BCD prep** — EMS/SAC on serial, Automatic Repair disabled
+   (`recoveryenabled no` + `bootstatuspolicy ignoreallfailures`), so a fallback-
+   path boot goes straight to the OS instead of a graphical recovery screen that
+   hangs on a console-less VMM.
+3. **cloudbase-init** installed and configured for the **NoCloud `cidata`**
+   metadata service, so it discovers the seed disk this `SwiftSeedProfile`
+   produces.
+
+## Provisioning model
+
+KubeSwift's seed pipeline is **OS-agnostic**: it builds a NoCloud `seed.iso`
+(volume label `cidata`) with flat `user-data` / `meta-data` / `network-config`
+files. cloud-init reads it on Linux; **cloudbase-init reads the identical seed on
+Windows** — so there is no Windows-specific seed code. The sample sets the
+hostname from `meta-data: local-hostname` and runs a PowerShell `user-data`
+(`#ps1_sysnative`) to enable RDP on first boot. cloudbase-init accepts a subset
+of cloud-config plus plain scripts (PowerShell / cmd).
+
+## Console & management
+
+Windows on CH is **headless** (serial/EMS). Manage over **RDP** (enabled by the
+seed above) or WinRM; `swiftctl console` (serial) shows SAC and is best-effort.
+GPU passthrough, live migration, and snapshots of Windows guests are **not** v1
+targets.

--- a/config/samples/windows/swiftguest-windows.yaml
+++ b/config/samples/windows/swiftguest-windows.yaml
@@ -1,0 +1,21 @@
+# A Windows SwiftGuest. `osType: windows` routes the guest to the Cloud
+# Hypervisor disk-boot path with `--cpus kvm_hyperv=on` (the one runtime setting
+# Windows needs on CH v52; see PR 4). Windows is disk-boot only -- kernelRef and
+# gpuProfileRef are rejected by the webhook for osType: windows in v1.
+#
+# guestClassRef sizing: Windows Server needs >= 2Gi RAM; the "default" class
+# (4Gi) is fine. The class's storage/CPU apply as usual.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: win-guest
+  namespace: default
+spec:
+  osType: windows
+  imageRef:
+    name: windows-server-2022 # the osType MUST match the image's osType
+  guestClassRef:
+    name: default
+  seedProfileRef:
+    name: windows-seed # cloudbase-init reads this over the NoCloud seed
+  runPolicy: Running

--- a/config/samples/windows/swiftimage-windows.yaml
+++ b/config/samples/windows/swiftimage-windows.yaml
@@ -1,0 +1,24 @@
+# A Windows SwiftImage. `osType: windows` gates the Linux-only import steps (the
+# GRUB/serial-console patch) -- the import keeps only qcow2->raw + size
+# measurement, and the import Job runs unprivileged (no loop-mount needed). See
+# PR 3 / docs/design/windows-guest-support.md.
+#
+# IMPORTANT: the source must be an OPERATOR-PREPARED, virtio-ready Windows image:
+#   - virtio drivers pre-installed (viostor for the boot disk, NetKVM for the NIC)
+#   - headless BCD prep (EMS/SAC on serial + Automatic Repair disabled)
+# A stock Windows ISO will NOT boot on virtio. See the image-prep runbook (PR 6)
+# and docs/design/windows-guest-support-spike.md (the spike's autounattend.xml +
+# run-install.sh are the seed for that tooling).
+apiVersion: image.kubeswift.io/v1alpha1
+kind: SwiftImage
+metadata:
+  name: windows-server-2022
+  namespace: default
+spec:
+  osType: windows
+  format: qcow2 # operator-prepped image; the import converts it to raw
+  rootDisk:
+    size: "40Gi"
+  source:
+    http:
+      url: https://example.internal/images/winserver2022-virtio-ready.qcow2 # operator-hosted

--- a/config/samples/windows/swiftseedprofile-windows.yaml
+++ b/config/samples/windows/swiftseedprofile-windows.yaml
@@ -1,0 +1,28 @@
+# Windows provisioning reuses the SAME NoCloud seed.iso (volume label "cidata")
+# that cloud-init uses on Linux -- KubeSwift's seed pipeline is OS-agnostic
+# passthrough, so there is no new mechanism. cloudbase-init (in the
+# operator-prepped image) reads this seed.
+#
+# Requirements on the image (PR 6 image-prep runbook):
+#   - cloudbase-init installed and configured with the NoCloud "cidata"
+#     metadata service (config-drive/NoCloud), so it discovers this seed disk.
+#
+# cloudbase-init accepts a subset of cloud-config AND plain scripts. This sample
+# uses a PowerShell user-data (the `#ps1_sysnative` marker) to enable RDP on
+# first boot; the hostname comes from meta-data `local-hostname`
+# (cloudbase-init's SetHostNamePlugin).
+apiVersion: seed.kubeswift.io/v1alpha1
+kind: SwiftSeedProfile
+metadata:
+  name: windows-seed
+  namespace: default
+spec:
+  datasource: NoCloud
+  userData: |
+    #ps1_sysnative
+    # cloudbase-init runs this PowerShell on first boot. Enable RDP + firewall.
+    Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name fDenyTSConnections -Value 0
+    Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'
+  metaData: |
+    instance-id: kubeswift-win-001
+    local-hostname: win-guest

--- a/docs/design/windows-guest-support.md
+++ b/docs/design/windows-guest-support.md
@@ -160,7 +160,7 @@ provisioning, and image-prep PRs are hypervisor-independent.
 | 2 | `osType` field on SwiftGuest + SwiftImage (+ webhook rules) + resolver wiring. Default `linux` — no behavior change for existing guests. |
 | 3 | Image import: skip GRUB/serial patch + growpart for `osType: windows` (keep qcow2→raw + resize). |
 | 4 | Runtime: `osType: windows` boots on the **existing CH disk-boot path** (CLOUDHV.fd + virtio) via the `\EFI\Boot\bootx64.efi` fallback, adding `--cpus kvm_hyperv=on` and gating off Linux-only cmdline/console assumptions. (Mostly reuse; QEMU+OVMF remains the escape hatch / interim fallback.) |
-| 5 | Provisioning: cloudbase-init userdata over the NoCloud seed (the spike used `autounattend.xml`; cloudbase-init is the runtime path). |
+| 5 | Provisioning: cloudbase-init userdata over the NoCloud seed. **No seed-mechanism change needed** — the pipeline already builds a NoCloud `seed.iso` (volume label `cidata`) of OS-agnostic passthrough `user-data`/`meta-data`/`network-config`, which cloudbase-init reads identically to cloud-init. PR 5 = a Windows sample set (`config/samples/windows/`) + docs + load-bearing comments marking the seed's OS-agnosticism. Image-side cloudbase-init config is PR 6. |
 | 6 | Image-prep tooling/runbook: virtio (viostor/NetKVM) + the **headless BCD prep** (EMS/SAC, `recoveryenabled no`, `bootstatuspolicy ignoreallfailures`) the spike validated; the `autounattend.xml` + `run-install.sh` from the spike are the seed. |
 | 7 | Operator runbook + samples; cluster validation (asset-gated — no Windows license on the dev cluster). |
 

--- a/internal/resolved/types.go
+++ b/internal/resolved/types.go
@@ -107,7 +107,12 @@ type Networks struct {
 	InterfaceModel string `json:"interfaceModel"`
 }
 
-// Seed holds materialization inputs for cloud-init.
+// Seed holds materialization inputs for the guest's first-boot provisioner.
+// The seed pipeline is OS-AGNOSTIC by design: it produces a NoCloud seed.iso
+// (volume label "cidata") with flat user-data/meta-data/network-config files,
+// read by cloud-init on Linux AND by cloudbase-init on Windows (osType: windows)
+// — the same mechanism, no Windows-specific branch. Do not inject OS-specific
+// content here; keep it operator-provided passthrough so both consumers work.
 // UserData, MetaData, NetworkData are inline strings. When *From is set, the renderer fetches from Secret/ConfigMap.
 type Seed struct {
 	Datasource      string                          `json:"datasource"`

--- a/rust/swiftletd/src/main.rs
+++ b/rust/swiftletd/src/main.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 
 /// Creates NoCloud seed ISO from directory. CH expects disk image, not directory.
 /// Passes meta-data, user-data, network-config explicitly for correct root-level layout.
-/// -volid cidata: cloud-init identifies NoCloud datasource by this volume label.
+/// -volid cidata: the NoCloud datasource volume label. cloud-init (Linux) AND
+///   cloudbase-init (Windows, osType: windows) both discover the seed by this
+///   label — the seed is OS-agnostic, so keep "cidata" for both consumers.
 /// -rock: Rock Ridge extensions, preserves full lowercase filenames (meta-data not META_DAT.).
 /// -joliet: Joliet extensions, additional filename compatibility.
 fn create_seed_iso(seed_dir: &Path, output_iso: &Path) -> Result<(), String> {


### PR DESCRIPTION
## PR 5 of Windows guest support — provisioning

**The seed pipeline needed no change.** KubeSwift already builds a NoCloud `seed.iso` (volume label **`cidata`**) of OS-agnostic passthrough `user-data`/`meta-data`/`network-config` — and `cidata` + NoCloud is exactly what **cloudbase-init** reads on Windows, identically to cloud-init on Linux. That's the design's "least new mechanism" provisioning choice realized, so PR 5 is the **sample set + docs + load-bearing comments** that make it usable and lock in the OS-agnosticism.

### What's in it
- **`config/samples/windows/`** — a complete, dry-run-validated set:
  - `SwiftImage` (`osType: windows`)
  - `SwiftSeedProfile` (NoCloud) — a PowerShell `#ps1_sysnative` user-data to enable RDP on first boot + `meta-data: local-hostname` for the hostname (cloudbase-init's `SetHostNamePlugin`)
  - `SwiftGuest` (`osType: windows`)
  - `README.md` covering the cloudbase-init model and the operator-prepped-image prerequisites (virtio drivers, headless BCD prep, cloudbase-init configured for the NoCloud `cidata` datasource — the **image side is PR 6**)
- **Load-bearing doc comments** — `resolved.Seed` and swiftletd's `create_seed_iso` `cidata` volid now state the seed is read by **both** cloud-init and cloudbase-init, so a future change doesn't inject OS-specific content and silently break Windows (the W26-class "name the load-bearing property" discipline).
- **Design-doc** PR-table row 5 records the no-seed-mechanism-change finding.

### Validation
All three samples apply cleanly under `kubectl apply --dry-run=server` against the live CRDs — `osType` accepted on image + guest, and `windows`+`imageRef` passes the PR 2 webhook. `go build` + `cargo fmt` clean. **No code-logic or CRD change.** End-to-end Windows provisioning is asset-gated (no Windows image/license on the dev cluster); the boot path is spike-proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)