### PR TITLE
docs(windows): operator overview + mark Windows v1 code-complete (Windows guest support — PR 7)

### DIFF
--- a/docs/design/windows-guest-support.md
+++ b/docs/design/windows-guest-support.md
@@ -1,9 +1,13 @@
 # Windows Guest Support
 
-> Status: DESIGN — **spike complete, OQ1 RESOLVED → CH-first (on CH v52.0)**. First
-> scoping pass for running Windows VMs as SwiftGuests. Greenfield — there is no
-> `osType` concept in the codebase today; several runtime layers assume a Linux
-> guest. Last updated: 2026-06-07.
+> Status: **IMPLEMENTED — v1 code-complete (CH-first on CH v52.0), validation
+> asset-gated.** All phased PRs shipped (PR 0 CH bump → PR 2 `osType` → PR 3
+> import-skip → PR 4 runtime+`kvm_hyperv` → PR 5 cloudbase-init provisioning →
+> PR 6 image-prep tooling → PR 7 overview). Operator entry point:
+> [`docs/windows/overview.md`](../windows/overview.md). The boot path is
+> spike+locally-validated end-to-end (a virtio-ready image boots on CH v52.0);
+> only *in-cluster* cloudbase-init provisioning remains untested (no Windows
+> license on the dev cluster). Last updated: 2026-06-08.
 >
 > **Spike result (see [`windows-guest-support-spike.md`](windows-guest-support-spike.md)):**
 > the image-prep pipeline works, QEMU+OVMF boots Windows cleanly, and — the decisive

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,11 @@ KubeSwift runs Linux VMs on Kubernetes using [Cloud Hypervisor](https://www.clou
 - [SwiftKernel reference](swiftkernel.md) — Full reference: node setup, building profiles, OCI packaging, usage
 - [Kernel boot quickstart](kernel-boot-quickstart.md) — Boot a kernel VM in five steps
 
+### Windows Guests
+
+- [Running Windows guests](windows/overview.md) — Overview: `osType: windows`, the end-to-end lifecycle, RDP management, limitations
+- [Windows image prep](windows/image-prep.md) — Operator runbook: build a virtio-ready, CH-bootable Windows image
+
 ### Installation
 
 - [Local cluster](install/local-cluster.md) — kind, minikube, build and deploy

--- a/docs/windows/overview.md
+++ b/docs/windows/overview.md
@@ -1,0 +1,81 @@
+# Running Windows guests
+
+KubeSwift runs **Windows** VMs as first-class SwiftGuests on **Cloud Hypervisor**
+(the same default runtime as Linux), gated by a single field: `osType: windows`.
+This page is the operator entry point; the deep dives are linked inline.
+
+> **Status: v1 code-complete, validation asset-gated.** Every layer is implemented
+> and individually validated (unit tests + a local boot spike); the only untested
+> piece is *in-cluster* cloudbase-init provisioning, which needs a Windows
+> image/license the dev cluster doesn't have — the same "asset not available"
+> caveat as Tier 2/3 GPU. The boot path itself is proven end-to-end: a virtio-ready
+> Windows Server 2022 image boots cleanly on **Cloud Hypervisor v52.0**. See the
+> [boot spike](../design/windows-guest-support-spike.md) and the
+> [design doc](../design/windows-guest-support.md).
+
+## How it works — `osType: windows`
+
+`osType` (on **SwiftGuest** and **SwiftImage**, default `linux`) is the single
+decision point — it mirrors how `gpuProfileRef.tier` selects CH-vs-QEMU. With
+`osType: windows`:
+
+| Layer | What changes |
+|---|---|
+| **Hypervisor** | Cloud Hypervisor disk-boot path (CLOUDHV.fd + virtio), **plus `--cpus kvm_hyperv=on`** — the one runtime setting Windows needs (without it the kernel hangs early). Added automatically. |
+| **Image import** | Skips the Linux-only GRUB/serial patch; keeps `qcow2→raw` + size. The import Job runs **unprivileged**. |
+| **Provisioning** | **cloudbase-init** reads the *same* NoCloud `seed.iso` (label `cidata`) cloud-init uses on Linux — the seed pipeline is OS-agnostic, no new mechanism. |
+| **Console** | Headless (serial/EMS). Manage over **RDP/WinRM**; `swiftctl console` shows SAC, best-effort. |
+
+Webhook rules: `osType: windows` requires disk boot (`imageRef`) — `kernelRef` and
+`gpuProfileRef` are rejected in v1 — and the guest's `osType` must match the
+referenced image's.
+
+## End-to-end lifecycle
+
+```
+1. Prepare a virtio-ready image  ──►  2. Host it (HTTP)  ──►  3. SwiftImage (osType: windows)
+        (off-cluster, runbook)                                         │
+                                                                       ▼
+6. Manage over RDP  ◄──  5. SwiftGuest boots on CH+kvm_hyperv  ◄──  4. SwiftSeedProfile (cloudbase-init)
+```
+
+1. **Prepare a virtio-ready image** — a stock Windows ISO will **not** boot on
+   virtio. Build one with the [image-prep runbook](image-prep.md) + the
+   [`tools/windows-image-prep/`](../../tools/windows-image-prep/) tooling: it
+   injects viostor/NetKVM, applies the headless BCD prep, and (Part B) installs
+   cloudbase-init for the NoCloud datasource.
+2. **Host** the resulting `qcow2` on an HTTP server the cluster can reach.
+3. **`SwiftImage`** with `osType: windows`, `source.http.url` → your image.
+4. **`SwiftSeedProfile`** (`datasource: NoCloud`) with cloudbase-init user-data
+   (hostname, RDP, scripts).
+5. **`SwiftGuest`** with `osType: windows`, `imageRef`, `seedProfileRef`.
+6. **Manage over RDP** — discover the guest IP in `status.network.primaryIP`.
+
+Ready-to-edit manifests: [`config/samples/windows/`](../../config/samples/windows/).
+
+```sh
+kubectl apply -f config/samples/windows/   # after editing the image URL + password
+kubectl get swiftguest win-guest -o wide    # watch phase + primaryIP
+```
+
+## Requirements
+
+- **Cloud Hypervisor v52.0+** (KubeSwift ships it). v51.1 bugchecks Windows'
+  `viostor` driver (`0xD1`); v52.0 fixes it.
+- An **operator-prepared, virtio-ready** image (viostor/NetKVM + headless BCD prep
+  + cloudbase-init). The runbook automates this.
+- Sizing: Windows Server needs ≥ 2 GiB RAM (the default SwiftGuestClass is 4 GiB).
+
+## Limitations (v1 non-goals)
+
+- **GPU passthrough to Windows** — rejected (`osType: windows` + `gpuProfileRef`).
+- **Live migration** of Windows guests — not a v1 target.
+- **Snapshots** of Windows guests — should work mechanically, but not a v1
+  validation target.
+- **Kernel boot** — Windows is disk-boot only.
+
+## See also
+
+- [Windows image prep runbook](image-prep.md)
+- [Windows samples](../../config/samples/windows/)
+- [Design doc](../design/windows-guest-support.md) · [boot spike](../design/windows-guest-support-spike.md)

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -2614,10 +2614,12 @@ Shipped across 6 PRs (design + 5 build):
   today, OQ6); auto-GC of Failed scheduled snapshots (OQ1 — left for inspection).
 
 ### In Progress
-- **Windows guest support** — design doc + **boot spike COMPLETE** (2026-06-07):
+- **Windows guest support — v1 CODE-COMPLETE** (2026-06-08; design + boot spike
+  2026-06-07). Operator entry point:
+  [`docs/windows/overview.md`](docs/windows/overview.md). Design + spike:
   [`docs/design/windows-guest-support.md`](docs/design/windows-guest-support.md),
   [`docs/design/windows-guest-support-spike.md`](docs/design/windows-guest-support-spike.md).
-  Greenfield: no `osType` concept exists; several runtime layers assume Linux. The
+  Greenfield: no `osType` concept existed; several runtime layers assumed Linux. The
   spike ran entirely off-cluster with the **real CH binaries + `CLOUDHV.fd`** from
   the `swiftletd` image. **OQ1 RESOLVED → CH-first on CH v52.0** (the first pass
   appeared to block CH; a CH-version follow-up restored CH-first):
@@ -2646,12 +2648,19 @@ Shipped across 6 PRs (design + 5 build):
     v51.1 → v52.0** in the `swiftletd` image — a **platform-wide** change needing a
     Linux-guest regression pass (treat as its own PR). Reuses the existing CH
     disk-boot path; QEMU+OVMF reverts to the escape hatch.
-  - **Phased PRs (refined):** **PR 0 prereq = bump CH → v52.0** (+ matching
-    `CLOUDHV.fd`, Linux regression); PR 2 `osType` field+webhook; PR 3 import-skip;
-    PR 4 runtime → **CH disk-boot path + `kvm_hyperv=on`**; PR 5 cloudbase-init;
-    PR 6 image-prep runbook/tooling (the spike's `autounattend.xml` + `run-install.sh`
-    are the seed); PR 7 runbook+samples (validation asset-gated — no Windows license
-    on the dev cluster).
+  - **v1 CODE-COMPLETE 2026-06-08 — all PRs shipped:** PR 0 CH bump → v52.0
+    (#150, smoke-test-validated); PR 2 `osType` field+webhook+resolver (#153);
+    PR 3 import-skip + unprivileged Windows import Job (#155); PR 4 runtime →
+    CH disk-boot + `kvm_hyperv=on` (#156, Go intent + Rust swift-ch-client);
+    PR 5 cloudbase-init provisioning over the existing NoCloud `cidata` seed
+    (#157 — **no seed-mechanism change needed**; samples + load-bearing comments);
+    PR 6 image-prep tooling + runbook (#158 — `tools/windows-image-prep/`; the
+    productized installer was re-validated end-to-end: produces a virtio-ready
+    image that boots on CH v52.0 to SAC, no viostor crash); PR 7 operator overview
+    [`docs/windows/overview.md`](docs/windows/overview.md) + docs index.
+    **Validation asset-gated:** every layer is unit/spike/locally validated; only
+    *in-cluster* cloudbase-init-over-NoCloud provisioning is untested (no Windows
+    license on the dev cluster — same caveat as Tier 2/3 GPU).
 
 ### CH v52.0-Unlocked Capabilities (roadmap)
 


### PR DESCRIPTION
## PR 7 of Windows guest support — consolidation

The final PR ties the Windows pieces into one operator entry point and records **v1 as code-complete**.

- **`docs/windows/overview.md`** (NEW) — *"Running Windows guests"*: how `osType: windows` routes each layer (hypervisor + `kvm_hyperv`, import-skip, cloudbase-init provisioning, headless/RDP console), the **end-to-end lifecycle** (prep image → host → SwiftImage → SwiftSeedProfile → SwiftGuest → RDP), requirements, the v1 limitations (no GPU / live-migration / snapshots), and an honest validation-status note.
- **`docs/index.md`** — new "Windows Guests" section linking the overview + the image-prep runbook.
- **`docs/design/windows-guest-support.md`** — status banner flipped **DESIGN → IMPLEMENTED** (v1 code-complete, asset-gated validation); all phased PRs shipped.
- **`kubeswift_context.md`** — Windows entry retitled **"v1 CODE-COMPLETE"** with the full PR map.

### Windows v1 is now code-complete
`osType` gate (#153) → unprivileged import-skip (#155) → CH disk-boot + `kvm_hyperv=on` (#156) → cloudbase-init over the NoCloud seed (#157) → image-prep tooling (#158, validated end-to-end) — all on the v52.0 CH bump (#150, smoke-validated). Every layer is unit/spike/locally validated; the **only** gap is *in-cluster* cloudbase-init-over-NoCloud provisioning, which is **asset-gated** (no Windows license on the dev cluster — same caveat as Tier 2/3 GPU).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)