### PR TITLE
feat(snapshot): CH v52 auto-resume-on-restore — remove resumeCloneIfNeeded (Bug #73)

### DIFF
--- a/internal/controller/swiftguest/clone.go
+++ b/internal/controller/swiftguest/clone.go
@@ -149,6 +149,10 @@ func cloneRestoreAnnotations(
 		AnnotationRestoreRuntimeDirFromPrefix: clonecommon.RuntimeDirPrefix(source.Namespace, source.Name),
 		AnnotationRestoreRuntimeDirToPrefix:   clonecommon.RuntimeDirPrefix(guest.Namespace, guest.Name),
 		AnnotationRestoreNullifyHostMAC:       "true",
+		// CH v52: resume the clone on restore (it loads paused otherwise) so we
+		// don't need the resumeCloneIfNeeded action round-trip (Bug #73). Only
+		// the cloneFromSnapshot path sets this; SwiftRestore drives resume itself.
+		AnnotationRestoreAutoResume: "true",
 	}
 	if cloneRegenIncludesNonMAC(guest.Spec.CloneFromSnapshot) {
 		annos[AnnotationRestoreAppendCmdlineMarker] = "true"
@@ -197,36 +201,6 @@ func cloneAnnotationsMatch(have, want map[string]string) bool {
 func cloneDownloadJobName(snap *snapshotv1alpha1.SwiftSnapshot, node string) string {
 	sum := sha256.Sum256([]byte(snap.Namespace + "/" + snap.Name + "@" + node))
 	return "clone-dl-" + hex.EncodeToString(sum[:8])
-}
-
-// swiftletd action-loop annotation surface (mirrors the snapshot/restore
-// controllers): the controller writes these onto the launcher pod and swiftletd
-// dedupes by action-id.
-const (
-	cloneActionKey     = "kubeswift.io/snapshot-action"
-	cloneActionIDKey   = "kubeswift.io/snapshot-action-id"
-	cloneActionArgsKey = "kubeswift.io/snapshot-action-args"
-	cloneVerbResume    = "resume"
-)
-
-// resumeCloneIfNeeded sends the one-shot resume action to a cloneFromSnapshot
-// clone's launcher pod. CH --restore loads the guest PAUSED; swiftletd's action
-// loop unpauses it when this annotation appears. Idempotent: a stable action-id
-// means swiftletd resumes exactly once (and we skip re-patching once it's set).
-// Without this the clone reports GuestRunning but its vCPUs never start.
-func (r *SwiftGuestReconciler) resumeCloneIfNeeded(ctx context.Context, pod *corev1.Pod, guest *swiftv1alpha1.SwiftGuest) error {
-	id := guest.Name + "-clone-resume"
-	if pod.Annotations[cloneActionIDKey] == id {
-		return nil // already sent
-	}
-	patch := client.MergeFrom(pod.DeepCopy())
-	if pod.Annotations == nil {
-		pod.Annotations = map[string]string{}
-	}
-	pod.Annotations[cloneActionKey] = cloneVerbResume
-	pod.Annotations[cloneActionIDKey] = id
-	pod.Annotations[cloneActionArgsKey] = "{}"
-	return r.Patch(ctx, pod, patch)
 }
 
 // ensureCloneDownloadJob creates (idempotently) a node-pinned download Job that

--- a/internal/controller/swiftguest/clone_test.go
+++ b/internal/controller/swiftguest/clone_test.go
@@ -288,25 +288,22 @@ func TestCloneRegenIncludesNonMAC(t *testing.T) {
 	}
 }
 
-func TestResumeCloneIfNeeded(t *testing.T) {
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "clone-a", Namespace: "ns"}}
-	r := poolCloneReconciler(t, pod)
-	g := cloneGuest()
-
-	// First call: stamps the resume action onto the pod.
-	if err := r.resumeCloneIfNeeded(context.Background(), pod, g); err != nil {
-		t.Fatal(err)
+func TestCloneRestoreAnnotations_SetsAutoResume(t *testing.T) {
+	annos := cloneRestoreAnnotations(
+		cloneGuest(),
+		&snapshotv1alpha1.SwiftSnapshot{ObjectMeta: metav1.ObjectMeta{Name: "snap", Namespace: "ns"}},
+		sourceGuest(),
+		"/var/lib/kubeswift/snapshots/ns-snap",
+		"node-a",
+	)
+	// CH v52 auto-resume replaces the resumeCloneIfNeeded action round-trip
+	// (Bug #73): the clone's restore-receive carries auto-resume so swiftletd
+	// passes resume=true to CH --restore and the clone comes up running.
+	if annos[AnnotationRestoreAutoResume] != "true" {
+		t.Errorf("clone restore annotations must set auto-resume=true; got %q", annos[AnnotationRestoreAutoResume])
 	}
-	if pod.Annotations[cloneActionKey] != cloneVerbResume || pod.Annotations[cloneActionIDKey] != "clone-a-clone-resume" {
-		t.Fatalf("resume action not stamped: %+v", pod.Annotations)
-	}
-	// Second call (action-id already set): no-op (idempotent).
-	before := pod.Annotations[cloneActionIDKey]
-	if err := r.resumeCloneIfNeeded(context.Background(), pod, g); err != nil {
-		t.Fatal(err)
-	}
-	if pod.Annotations[cloneActionIDKey] != before {
-		t.Errorf("resume should be idempotent once the action-id is set")
+	if annos[AnnotationRestoreMode] != RestoreModeClone {
+		t.Errorf("clone restore should be clone mode; got %q", annos[AnnotationRestoreMode])
 	}
 }
 

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -251,6 +251,7 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if params, ok := RestoreParamsFromAnnotations(guest.Annotations); ok {
 		intent.Restore = &runtimeintent.RestoreIntent{
 			SnapshotPath: params.InPodSnapshotPath(),
+			AutoResume:   params.AutoResume,
 		}
 	}
 	intentJSON, err := runtimeintent.Serialize(intent)
@@ -462,17 +463,11 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Pod exists; update status from pod
 		podForMetrics = &existingPod
 		MapPodToStatus(&existingPod, status)
-		// cloneFromSnapshot (Snapshot Phase 4): CH loaded the snapshot PAUSED
-		// (GuestRunning is reported once the API socket is up, but the vCPUs are
-		// stopped). Send the one-shot resume action so swiftletd unpauses the VM
-		// — a clone has no SwiftRestore controller to drive its Resuming phase.
-		if guest.UsesCloneFromSnapshot() &&
-			status.Phase == swiftv1alpha1.SwiftGuestPhaseRunning &&
-			rg.GetLifecycle() != "stop" {
-			if err := r.resumeCloneIfNeeded(ctx, &existingPod, &guest); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
+		// cloneFromSnapshot (Snapshot Phase 4): CH loads the snapshot PAUSED,
+		// but swiftletd now passes `resume=true` on `--restore` (CH v52) when the
+		// restore intent's AutoResume is set, so the clone comes up RUNNING with
+		// no controller-driven resume round-trip needed (replaces the former
+		// resumeCloneIfNeeded; Bug #73 / CH v52 capabilities assessment).
 		// If guest is running but IP not yet discovered, requeue to catch annotation update
 		if status.Phase == swiftv1alpha1.SwiftGuestPhaseRunning &&
 			(status.Network == nil || status.Network.PrimaryIP == "") {

--- a/internal/controller/swiftguest/restore.go
+++ b/internal/controller/swiftguest/restore.go
@@ -105,6 +105,12 @@ const (
 	// to the source's saved value (cloud-hypervisor v51.1
 	// net_util/src/open_tap.rs sets the tap MAC when host_mac is Some).
 	AnnotationRestoreNullifyHostMAC = "snapshot.kubeswift.io/restore-nullify-host-mac"
+	// AnnotationRestoreAutoResume, when "true", makes swiftletd pass
+	// `resume=true` on the CH `--restore` (CH v52) so the guest comes up
+	// RUNNING. Set ONLY by the cloneFromSnapshot path (no SwiftRestore
+	// controller drives a Resuming phase there) — it replaces the
+	// resumeCloneIfNeeded action round-trip (Bug #73).
+	AnnotationRestoreAutoResume = "snapshot.kubeswift.io/restore-auto-resume"
 )
 
 // Restore mode values for AnnotationRestoreMode.
@@ -159,6 +165,10 @@ type RestoreParams struct {
 	// RuntimeDirToPrefix is the clone pod's runtime_dir prefix
 	// (must end in '/') that source paths are rewritten to.
 	RuntimeDirToPrefix string
+	// AutoResume makes swiftletd pass `resume=true` to CH `--restore` so the
+	// guest comes up running (cloneFromSnapshot only; replaces Bug #73's
+	// resumeCloneIfNeeded). SwiftRestore leaves it false and drives resume.
+	AutoResume bool
 	// NullifyHostMAC asks the stager to set net[].host_mac to null in
 	// config.json. Required for clones (see configjson.PatchOptions).
 	NullifyHostMAC bool
@@ -462,5 +472,6 @@ func RestoreParamsFromAnnotations(annotations map[string]string) (RestoreParams,
 		RuntimeDirFromPrefix: annotations[AnnotationRestoreRuntimeDirFromPrefix],
 		RuntimeDirToPrefix:   annotations[AnnotationRestoreRuntimeDirToPrefix],
 		NullifyHostMAC:       annotations[AnnotationRestoreNullifyHostMAC] == "true",
+		AutoResume:           annotations[AnnotationRestoreAutoResume] == "true",
 	}, true
 }

--- a/internal/runtimeintent/types.go
+++ b/internal/runtimeintent/types.go
@@ -39,6 +39,13 @@ type RestoreIntent struct {
 	// SnapshotPath is the absolute in-pod path of the snapshot directory
 	// (the dir CH reads config.json, state.json, and memory-ranges from).
 	SnapshotPath string `json:"snapshotPath"`
+	// AutoResume makes swiftletd pass `resume=true` on the CH `--restore`
+	// (CH v52) so the restored guest comes up RUNNING instead of paused.
+	// Set ONLY for cloneFromSnapshot (which has no SwiftRestore controller to
+	// drive a Resuming phase) — it replaces the resumeCloneIfNeeded action
+	// round-trip (Bug #73). SwiftRestore-driven restores leave it false and
+	// keep driving resume themselves.
+	AutoResume bool `json:"autoResume,omitempty"`
 }
 
 // NICIntent describes a single network interface for the VM.

--- a/rust/swift-ch-client/src/spawn.rs
+++ b/rust/swift-ch-client/src/spawn.rs
@@ -62,11 +62,15 @@ pub fn spawn_ch(config: &VmConfig) -> Result<Child, std::io::Error> {
 ///
 /// CH brings the VM up in **Paused** state — the action handler must
 /// issue a [`crate::ApiClient::resume`] to start CPUs.
-pub fn spawn_ch_restore(api_socket: &Path, source_url: &str) -> Result<Child, std::io::Error> {
+pub fn spawn_ch_restore(
+    api_socket: &Path,
+    source_url: &str,
+    auto_resume: bool,
+) -> Result<Child, std::io::Error> {
     let binary =
         std::env::var("KUBESWIFT_CH_BINARY").unwrap_or_else(|_| DEFAULT_CH_BINARY.to_string());
     rm_stale_api_socket(api_socket);
-    let args = restore_args(api_socket, source_url);
+    let args = restore_args(api_socket, source_url, auto_resume);
     std::process::Command::new(&binary).args(&args).spawn()
 }
 
@@ -111,13 +115,19 @@ fn receive_args(api_socket: &Path) -> Vec<String> {
 /// Build the argv for a restore-receive CH invocation. Split out from
 /// [`spawn_ch_restore`] so the argv shape is unit-testable without
 /// actually spawning CH.
-fn restore_args(api_socket: &Path, source_url: &str) -> Vec<String> {
+fn restore_args(api_socket: &Path, source_url: &str, auto_resume: bool) -> Vec<String> {
+    // CH expects --restore as a separate flag, with `source_url=...` as its
+    // single value (no equals after the flag itself). `resume=true` (CH v52)
+    // brings the guest up RUNNING instead of paused — set for cloneFromSnapshot
+    // so no controller-driven resume is needed (Bug #73).
+    let mut restore = format!("source_url={}", source_url);
+    if auto_resume {
+        restore.push_str(",resume=true");
+    }
     vec![
         format!("--api-socket={}", api_socket.display()),
-        // CH expects --restore as a separate flag, with `source_url=...`
-        // as its single value (no equals after the flag itself).
         "--restore".to_string(),
-        format!("source_url={}", source_url),
+        restore,
     ]
 }
 
@@ -182,10 +192,12 @@ mod tests {
         let args = restore_args(
             Path::new("/run/foo/ch.sock"),
             "file:///var/lib/kubeswift/snapshots/default-snap1/",
+            false,
         );
         assert_eq!(args.len(), 3);
         assert_eq!(args[0], "--api-socket=/run/foo/ch.sock");
         assert_eq!(args[1], "--restore");
+        // auto_resume=false (SwiftRestore): no resume= suffix.
         assert_eq!(
             args[2],
             "source_url=file:///var/lib/kubeswift/snapshots/default-snap1/"
@@ -193,8 +205,19 @@ mod tests {
     }
 
     #[test]
+    fn restore_args_auto_resume_adds_resume_true() {
+        // cloneFromSnapshot: resume=true so CH brings the guest up running
+        // (replaces the resumeCloneIfNeeded round-trip, Bug #73).
+        let args = restore_args(Path::new("/run/ch.sock"), "file:///snap/", true);
+        assert_eq!(args[2], "source_url=file:///snap/,resume=true");
+        // and false omits it.
+        let args = restore_args(Path::new("/run/ch.sock"), "file:///snap/", false);
+        assert!(!args[2].contains("resume="));
+    }
+
+    #[test]
     fn restore_args_relative_socket_path() {
-        let args = restore_args(Path::new("ch.sock"), "file:///snap");
+        let args = restore_args(Path::new("ch.sock"), "file:///snap", false);
         assert_eq!(args[0], "--api-socket=ch.sock");
     }
 
@@ -205,7 +228,7 @@ mod tests {
         // CLI flags. Asserting the absence here protects against a
         // future regression where someone tries to "helpfully" pass
         // disks or networks through.
-        let args = restore_args(Path::new("/run/ch.sock"), "file:///snap");
+        let args = restore_args(Path::new("/run/ch.sock"), "file:///snap", false);
         let joined = args.join(" ");
         assert!(!joined.contains("--disk"), "argv leaked --disk: {}", joined);
         assert!(!joined.contains("--net"), "argv leaked --net: {}", joined);
@@ -255,6 +278,7 @@ mod tests {
         let mut child = spawn_ch_restore(
             Path::new("/run/foo/ch.sock"),
             "file:///var/lib/kubeswift/snapshots/x/",
+            false,
         )
         .expect("spawn fake CH");
         let status = child.wait().expect("wait fake CH");

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -76,6 +76,12 @@ pub struct RestoreIntent {
     /// here as readOnly. CH reads `config.json`, `state.json`, and
     /// `memory-ranges` from this directory.
     pub snapshot_path: String,
+    /// When true, swiftletd passes `resume=true` on the CH `--restore` (CH v52)
+    /// so the guest comes up RUNNING instead of paused. Set only for
+    /// cloneFromSnapshot (replaces the resumeCloneIfNeeded round-trip, Bug #73);
+    /// SwiftRestore leaves it false and drives resume via its Resuming phase.
+    #[serde(default)]
+    pub auto_resume: bool,
 }
 
 /// Live-migration role (Phase 2). When `role == "receiver"`, swiftletd
@@ -294,6 +300,16 @@ impl RuntimeIntent {
             Some(r) if !r.snapshot_path.is_empty() => &r.snapshot_path,
             _ => "",
         }
+    }
+
+    /// Returns true when the restore should pass `resume=true` to CH (CH v52)
+    /// so the guest comes up running (cloneFromSnapshot; replaces Bug #73's
+    /// resumeCloneIfNeeded). False for SwiftRestore-driven restores.
+    pub fn restore_auto_resume(&self) -> bool {
+        self.restore
+            .as_ref()
+            .map(|r| r.auto_resume)
+            .unwrap_or(false)
     }
 
     /// Returns the snapshot URL CH expects on `--restore source_url=`.
@@ -526,6 +542,18 @@ mod tests {
             intent.restore_source_url(),
             "file:///var/lib/kubeswift/snapshots/default-snap1/"
         );
+        // autoResume absent -> false (SwiftRestore path).
+        assert!(!intent.restore_auto_resume());
+    }
+
+    #[test]
+    fn test_intent_restore_auto_resume() {
+        // cloneFromSnapshot sets autoResume -> swiftletd passes resume=true.
+        let intent: RuntimeIntent = serde_json::from_str(
+            r#"{"rootDisk":{"path":"","format":""},"seedPath":"","cpu":2,"memory":2048,"lifecycle":"start","guestId":"default/clone","restore":{"snapshotPath":"/snap/","autoResume":true}}"#,
+        )
+        .unwrap();
+        assert!(intent.restore_auto_resume());
     }
 
     #[test]

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -191,7 +191,7 @@ where
         api_socket.display(),
         source_url
     );
-    let mut child = spawn_ch_restore(&api_socket, &source_url)
+    let mut child = spawn_ch_restore(&api_socket, &source_url, intent.restore_auto_resume())
         .map_err(|e| format!("failed to spawn cloud-hypervisor (restore): {}", e))?;
     let pid = child.id();
 


### PR DESCRIPTION
## CH v52 quick win 2/2 — auto-resume-on-restore

CH v52 adds a **`resume=true`** option on `--restore` that brings the guest up **running** instead of paused. A `cloneFromSnapshot` guest has no SwiftRestore controller to drive a Resuming phase, so **Bug #73** added `resumeCloneIfNeeded` — a one-shot `snapshot-action: resume` annotation round-trip once the clone pod is Running. With auto-resume, that workaround is gone.

### Scoped to cloneFromSnapshot only
SwiftRestore keeps driving resume via its own Resuming phase. Since **both** cloneFromSnapshot and SwiftRestore-clone use `RestoreModeClone`, mode can't distinguish them — so a dedicated annotation isolates the clone path:
- `clone.go` sets `snapshot.kubeswift.io/restore-auto-resume=true` (cloneFromSnapshot only).
- `restore.go`: `RestoreParams.AutoResume` reads it → `controller.go` sets `RestoreIntent.AutoResume`; the `resumeCloneIfNeeded` call + the post-Running clone-resume block are removed.
- **swiftletd**: `RestoreIntent.auto_resume` + `intent.restore_auto_resume()`; `launch` passes it to `spawn_ch_restore`, which appends `,resume=true` to the `--restore source_url`. Absent/false → no suffix (SwiftRestore unchanged).
- Removed `resumeCloneIfNeeded` + the now-dead `cloneAction*`/`cloneVerbResume` consts; `TestResumeCloneIfNeeded` replaced by a `cloneRestoreAnnotations` test.

### Risk & validation
- **No CRD change** — `RestoreIntent` is internal JSON; the signal is a pod annotation.
- Tests: Go (clone annotation sets auto-resume; `RestoreParams` reads it), Rust (`restore_args` appends `resume=true` iff `auto_resume`; intent deserializes `autoResume`). `go build`/`vet`/`test` + `cargo build`/`test`/`clippy`/`fmt` green.
- **Validation gate:** this changes the **cluster-validated cloneFromSnapshot resume mechanism**, so a `cloneFromSnapshot` guest must be re-validated to come up **Running** (not paused) after the swiftletd image rebuilds. That needs a memory snapshot + clone (more involved than the smoke-test). **SwiftRestore in-place/clone is unaffected.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)