### PR TITLE
docs(design): SwiftConfidential (SEV-SNP) + HGX Tier 3 full-passthrough designs

### DIFF
--- a/docs/design/swiftconfidential-sev-snp.md
+++ b/docs/design/swiftconfidential-sev-snp.md
@@ -1,0 +1,209 @@
+# SwiftConfidential — SEV-SNP Confidential VMs
+
+> Status: DESIGN (pre-spike), **hardware-gated**. CH v52.0 can launch AMD SEV-SNP
+> confidential VMs on KVM; this scopes confidential VMs as a first-class KubeSwift
+> workload. No SEV-SNP hardware exists on the dev cluster, so this is design-first
+> — validated when an AMD EPYC SEV-SNP host is available. Last updated: 2026-06-08.
+
+## 1. Goal
+
+Run **confidential VMs** — guests whose memory is hardware-encrypted and
+integrity-protected so the **host, hypervisor, and cluster operator cannot read
+or tamper with guest memory** — as SwiftGuests, with **measured boot** and
+**remote attestation** so a relying party can prove *what* booted before
+releasing secrets to it. This is a potential major differentiator: confidential
+computing as a turnkey Kubernetes-native VM workload.
+
+Out of scope for v1: confidential GPU (SEV-SNP + GPU passthrough), live migration
+of confidential VMs, and snapshots of confidential VMs (all involve encrypted
+guest state and are hard problems — future phases).
+
+## 2. What SEV-SNP gives us
+
+AMD **SEV-SNP** (Secure Encrypted Virtualization — Secure Nested Paging):
+
+- **Memory encryption** — each guest's RAM is encrypted with a per-VM key held in
+  the AMD Secure Processor (PSP/ASP); the host/hypervisor see only ciphertext.
+- **Integrity (SNP)** — a Reverse Map Table (RMP) prevents the host from
+  remapping, replaying, or corrupting guest pages.
+- **Measured boot** — the initial guest image (firmware, kernel, cmdline, initrd)
+  is measured into a launch digest by the PSP.
+- **Attestation** — the guest can request a PSP-signed **attestation report**
+  containing the launch measurement + a guest-supplied `report_data` (nonce). A
+  verifier checks the AMD signature chain + the expected measurement before
+  trusting the guest (e.g. releasing a key).
+
+The trust boundary moves: **KubeSwift, swiftletd, the kernel, and the cluster
+admin are all OUTSIDE the guest's trust boundary.** This changes our threat model
+(§8) and what status we can honestly report.
+
+## 3. CH v52 SEV-SNP launch model (the building blocks)
+
+From the CH v52.0 release (#7942, #8123), a SEV-SNP guest on KVM uses:
+
+- **`guest_memfd`** — KVM-private memory backing the encrypted guest (the host
+  cannot map it). CH allocates guest RAM via `guest_memfd` for SNP guests.
+- **IGVM firmware** — the guest is brought up from an **IGVM** (Independent Guest
+  Virtual Machine) package, e.g. **Oak stage0** or an OVMF-IGVM build, passed via
+  `--firmware`. IGVM carries the initial memory image + the directives the PSP
+  measures.
+- **Measured launch** — kernel, command line, and initrd are reflected in the
+  launch measurement (parity with the QEMU SNP flow).
+- **Signed ID block** — a signed SNP **ID block** can be passed so the guest (or a
+  remote attestor) can verify the launch against an expected identity/author key.
+
+> **Prerequisite finding (grounded):** the shipped `cloud-hypervisor-static`
+> binary's `--help` exposes `--firmware` and `--platform` but **no SEV-SNP-specific
+> flags** — SEV-SNP is behind a Cargo build feature (`sev_snp`). So **a SEV-SNP-
+> enabled CH build is a prerequisite**: the `swiftletd` image would need a
+> CH binary compiled with `--features sev_snp` (and possibly an MSHV vs KVM build
+> consideration), separate from the default static binary we ship today. This is
+> the first thing the spike must produce. The exact `--platform`/payload CLI for
+> SNP (host_data, ID block path, IGVM measurement inputs) is enumerated against
+> that build during the spike — this doc does not guess the flag spelling.
+
+## 4. Node requirements & discovery
+
+A confidential node needs: an **AMD EPYC** CPU with **SEV-SNP** enabled in BIOS,
+a host kernel with SNP + `guest_memfd` support, the AMD PSP/`sev` device, and the
+SEV-SNP-featured CH binary in the launcher image.
+
+- **Node opt-in label:** `kubeswift.io/confidential-node=true` (mirrors the GPU /
+  kernel node opt-in pattern).
+- **Discovery:** a lightweight extension of the existing discovery DaemonSet (or a
+  new `SwiftConfidentialNode` cluster CRD, mirroring `SwiftGPUNode`) surfaces:
+  SNP availability, PSP firmware version, the max SNP ASIDs (the hardware cap on
+  concurrent SNP guests), and the host kernel/CH SNP-build readiness — as a
+  `status.confidentialReady` condition the scheduler/webhook pre-flights (the
+  same pattern as `SwiftGPUNode.status.vfioReady`).
+
+## 5. CRD surface — decision
+
+Two shapes were considered (mirroring the GPU model's two-resource split):
+
+- **(A) A `spec.confidential` block on SwiftGuest (+ SwiftGuestClass default).**
+  Confidential is a *property of the guest*, not a shared device pool — there is
+  nothing to "allocate" the way GPUs are allocated from a node inventory. A spec
+  block is the natural fit and mirrors `osType` / `storage`.
+- **(B) A dedicated `SwiftConfidentialProfile` CRD** (like `SwiftGPUProfile`),
+  referenced by `confidentialProfileRef`. Better if confidential acquires a rich,
+  reusable policy surface (attestation endpoints, allowed measurements, key
+  brokers) shared across many guests.
+
+**Recommendation: start with (A)**, a `spec.confidential` block, and promote to a
+profile CRD (B) only if the attestation-policy surface grows. Sketch:
+
+```yaml
+spec:
+  confidential:
+    enabled: true                 # gate; default false (no behaviour change)
+    type: sev-snp                 # +kubebuilder:validation:Enum=sev-snp (room for tdx later)
+    # Measured-boot inputs the launch measurement covers (kernel boot path):
+    #   the guest MUST boot via kernelRef (measured) — disk boot's bootloader
+    #   chain is not measured by the IGVM launch digest. See gating in section 6.
+    attestation:
+      idBlock:                    # optional signed SNP ID block
+        secretRef: { name: snp-id-block }   # author key + expected id; never inline
+      # hostData is a 32-byte operator value bound into the report (e.g. a policy hash).
+      hostData: ""
+    # policy bits (debug disabled, migration disabled, SMT policy) — SNP guest policy.
+    policy:
+      allowDebug: false
+```
+
+Webhook rules (per-operation discipline, Principle #10): `confidential.enabled`
+requires `type: sev-snp`; rejects `gpuProfileRef` (no confidential GPU in v1);
+requires a measured boot source (§6); rejects live-migration/snapshot opt-ins on
+the guest (§9). Secrets (ID block, keys) are **always** `secretRef`, never inline
+(Principle: credentials in Secrets, never annotations/specs/logs).
+
+## 6. Runtime — RuntimeIntent + swiftletd
+
+- **Resolver/RuntimeIntent:** a `Confidential` intent block (type, IGVM firmware
+  path, ID-block path, host_data, policy) flows to swiftletd, analogous to the
+  `GPU` intent.
+- **swiftletd / swift-ch-client:** a new spawn path builds the SEV-SNP CH
+  invocation — `guest_memfd`-backed memory, `--firmware <IGVM>`, the platform/SNP
+  payload (ID block, host_data, measurement inputs). This is a distinct
+  `VmConfig` shape (no `--disk`-of-unmeasured-rootfs in the measured set;
+  encrypted memory backend).
+- **Boot path constraint:** the launch measurement covers the IGVM + the
+  **kernel/cmdline/initrd**, NOT a disk bootloader chain. So v1 confidential
+  guests boot via **`kernelRef`** (the measured kernel+initramfs path KubeSwift
+  already has) — disk boot's GRUB/bootmgr chain isn't in the measurement and
+  would defeat attestation. The webhook enforces this.
+- **Firmware:** ship/reference an IGVM firmware (Oak stage0 or OVMF-IGVM) in the
+  launcher image, pinned + checksummed like `CLOUDHV.fd`.
+
+## 7. Attestation flow (v1 scope)
+
+KubeSwift's job is to **launch a measured SNP guest and make the measurement
+inputs deterministic + operator-controlled**; consuming the attestation report is
+guest/relying-party side. v1 scope:
+
+1. The operator supplies the expected measurement inputs (kernel/initrd/cmdline
+   are KubeSwift-controlled and reproducible; ID block + host_data via the CRD).
+2. The guest, at boot, fetches its PSP-signed attestation report (in-guest agent
+   over the standard SNP guest interface) and presents it to a **verifier / key
+   broker** (e.g. a KBS — out of KubeSwift's scope) which checks the AMD cert
+   chain + expected measurement, then releases secrets.
+3. KubeSwift **surfaces** the launch measurement / ID it booted with on
+   `status.confidential` (an honest "here is what we measured at launch"), and a
+   `Confidential` condition — but KubeSwift is NOT a trust anchor (it's outside
+   the guest TCB; §8).
+
+A bundled attestation/KBS integration is a **future phase**, not v1.
+
+## 8. Threat model & security (security-engineer)
+
+- **Host/hypervisor/operator are untrusted** for guest *confidentiality + integrity*
+  (that's the whole point). KubeSwift status fields about the guest's *internal*
+  state are therefore advisory only — the authoritative signal is the
+  PSP-signed attestation the guest itself produces.
+- **What KubeSwift still controls** (and must do correctly): the measurement
+  *inputs* (firmware/kernel/cmdline/initrd pinning), the SNP **policy** (debug
+  off, migration off), keeping the ID block/keys in Secrets, and node
+  attestation-readiness pre-flight.
+- **Availability, not confidentiality, is KubeSwift's remaining lever** — a
+  malicious host can deny service (it can't decrypt). Document this boundary
+  prominently so operators don't over-trust controller status.
+- Composes with CH v52's **vCPU core-scheduling** (SMT side-channel mitigation) —
+  a confidential SwiftGuestClass should default SMT-safe scheduling.
+
+## 9. Interactions (out of scope for v1)
+
+- **Confidential + GPU** — confidential GPU needs SEV-SNP + trusted IO (TDISP /
+  the modern iommufd/vfio path). Rejected by the webhook in v1.
+- **Live migration** — SNP guest migration requires encrypted-state transfer +
+  re-attestation; not in v1 (the migration webhook rejects confidential guests).
+- **Snapshots** — encrypted memory snapshots are a hard problem; rejected in v1.
+
+## 10. Open questions / spike plan
+
+When EPYC SEV-SNP hardware exists, the spike answers:
+
+1. **Produce a SEV-SNP CH build** (`--features sev_snp`) and confirm the exact
+   `--platform`/payload CLI for the IGVM firmware, ID block, host_data, and
+   measurement inputs (§3 prerequisite).
+2. Launch a measured SNP guest end-to-end (kernel boot) and fetch a PSP-signed
+   attestation report from inside the guest; confirm the launch measurement is
+   reproducible across boots.
+3. Confirm `guest_memfd` + the host kernel/PSP versions required; settle the node
+   discovery fields (max ASIDs, PSP version).
+4. Decide CRD shape (A vs B) once the attestation-policy surface is concrete.
+
+Until then: **design-complete, asset-gated** — shipped as such, like Tier 2/3 GPU.
+
+## 11. Phased PR breakdown (provisional — after the spike)
+
+| PR | Scope |
+|---|---|
+| 0 | Spike: SEV-SNP CH build + measured-launch + attestation on real EPYC hardware. |
+| 1 | This design doc. |
+| 2 | `spec.confidential` CRD block + webhook (measured-boot/no-GPU/no-migration rules) + resolver wiring. |
+| 3 | Node opt-in label + discovery (`confidentialReady` + SNP capacity) + pre-flight. |
+| 4 | Runtime: SEV-SNP CH spawn path (guest_memfd + IGVM + ID block) in swiftletd; IGVM firmware in the launcher image. |
+| 5 | `status.confidential` (launch measurement / ID) + `Confidential` condition + threat-model docs. |
+| (future) | Attestation/KBS integration; confidential GPU; confidential migration/snapshots. |
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/design/swiftgpu-hgx-tier3.md
+++ b/docs/design/swiftgpu-hgx-tier3.md
@@ -1,0 +1,192 @@
+# SwiftGPU Tier 3 — HGX Full Passthrough (full PCIe hierarchy + in-guest NVSwitch/FM)
+
+> Status: DESIGN (pre-spike), **hardware-gated**. Tier 3 (`tier: hgx-full`) passes
+> an **entire HGX baseboard** — all GPUs **and** all NVSwitches — to a single VM,
+> with the **NVSwitch fabric and Fabric Manager running inside the guest**. The CRD
+> surface already exists (SwiftGPU Phases 1–3); this is the **runtime + discovery +
+> allocation** design. No HGX hardware on the dev cluster — design-first, validated
+> when an HGX host is available. Last updated: 2026-06-08.
+
+## 1. Tier recap
+
+| Tier | `spec.tier` | Hypervisor | Topology | NVSwitch / Fabric Manager |
+|---|---|---|---|---|
+| 1 | `pcie` | Cloud Hypervisor | flat PCI | none (`x_nv_gpudirect_clique`) |
+| 2 | `hgx-shared` | QEMU | `pcie-root-port` per GPU | **host** FM partition (a SLICE of the baseboard) |
+| 3 | `hgx-full` | QEMU | **full PCIe hierarchy** | **in-guest** NVSwitches + FM (the WHOLE baseboard) |
+
+Tiers 1 (Hetzner GTX 1080, validated) and the Tier 2 model shipped in
+SwiftGPU Phases 1–3. The CRD fields for Tier 3 already exist
+(`api/gpu/v1alpha1`): `tier: hgx-full`, `partitionMode: full`,
+`fabricManager.runInGuest: true`, `pcieTopology.{rootPortPerDevice,noMmap}`,
+`numaTopology`, `vcpuPinning`. See [`swiftgpu_design_sketch.md`](../../swiftgpu_design_sketch.md).
+
+## 2. What Tier 3 adds over Tier 2
+
+Tier 2 (`hgx-shared`) carves the baseboard into **partitions** via the **host**
+Fabric Manager and hands a *subset* of GPUs (sharing an NVSwitch slice) to a VM.
+Tier 3 (`hgx-full`) is the opposite extreme — **the whole baseboard goes to ONE
+VM**:
+
+1. **All GPUs (typically 8) + all NVSwitches (4–6)** are VFIO-passed to a single
+   guest.
+2. The **full PCIe hierarchy** of the HGX baseboard (the PCIe switches/bridges
+   wiring GPUs ↔ NVSwitches) is reconstructed in the guest so CUDA + the NVLink
+   fabric see the real topology.
+3. **Fabric Manager runs INSIDE the guest** (`runInGuest: true`) — the guest owns
+   and initializes the NVSwitch fabric. The **host does NOT run FM** for this
+   baseboard (there is no host partition; the baseboard is entirely the guest's).
+4. **No FM-partition handoff** (unlike Tier 2): allocation is whole-baseboard, so
+   there is nothing to partition/deactivate on the host.
+
+This is the configuration NVIDIA documents for full-baseboard passthrough; it is
+what a single large multi-GPU training/inference VM wants.
+
+## 3. The core challenge — the PCIe hierarchy
+
+CUDA + the NVLink/NVSwitch fabric **refuse a flat PCI topology** (the reason Tier
+2/3 need QEMU, not CH, today). For Tier 3, the guest must see a PCIe hierarchy
+that matches the physical baseboard closely enough that:
+
+- the GPUs and NVSwitches enumerate at the right relative positions,
+- NVLink discovery + Fabric Manager can build the routing tables,
+- GPUDirect P2P/RDMA works across the fabric.
+
+Two construction strategies (spike to choose):
+
+- **(A) Synthesize the hierarchy** — build a matching tree of QEMU
+  `pcie-root-port` + `pcie-pci-bridge`/switch elements and attach each GPU /
+  NVSwitch `vfio-pci` at the position mirroring the host topology (read from
+  `lspci -t` / sysfs `/sys/bus/pci/devices/*/`). The baseboard's PCIe switches
+  themselves are *emulated*; only the GPUs + NVSwitches are passed through.
+- **(B) Pass the PCIe switches too** — VFIO-pass the upstream/downstream PCIe
+  switch ports of the baseboard so the guest sees the *real* bridges. Heavier
+  (more IOMMU groups, ACS/peer constraints) but the most faithful.
+
+Recommendation: **spike (A) first** (emulated switches + passthrough leaf
+devices, the lighter path) and fall back to (B) if Fabric Manager rejects the
+synthesized topology.
+
+## 4. CRD surface (already present)
+
+No new CRD is needed — Tier 3 uses the existing `SwiftGPUProfile`:
+
+```yaml
+apiVersion: gpu.kubeswift.io/v1alpha1
+kind: SwiftGPUProfile
+spec:
+  count: 8
+  model: H200-SXM
+  tier: hgx-full                 # -> QEMU + full PCIe hierarchy
+  partitionMode: full            # whole baseboard to one VM
+  pcieTopology:
+    rootPortPerDevice: true
+    noMmap: true                 # large BARs (B200) — x-no-mmap=true
+  numaTopology: { sockets: 2, coresPerSocket: 48, memoryPerSocketMi: 983040 }
+  vcpuPinning: true
+  fabricManager:
+    runInGuest: true             # FM in the guest; no host partition
+    requiredVersion: "<nvidia-open driver version>"   # guest image driver/FM match
+```
+
+The only CRD-adjacent work is a webhook tightening: `tier: hgx-full` ⇒
+`partitionMode: full` and `fabricManager.runInGuest: true` (reject the
+nonsensical combos), and `count` must equal a discovered baseboard's GPU count
+(you can't take *part* of a full-passthrough baseboard).
+
+## 5. Discovery (SwiftGPUNode extension)
+
+The GPU discovery DaemonSet already finds GPUs, NUMA, and **NVSwitches**
+(`SwiftGPUNode.status.nvSwitches`) and the host Fabric Manager. Tier 3 needs the
+**baseboard grouping + PCIe hierarchy**:
+
+- **Baseboard membership** — which GPUs + NVSwitches form one HGX baseboard (so
+  allocation knows the whole-baseboard set). Derive from the NVLink/NVSwitch
+  topology (`nvidia-smi topo`, the FM topology files) + PCIe ancestry.
+- **PCIe hierarchy** — the switch tree (`lspci -t`, sysfs ancestry) needed to
+  synthesize strategy (A), recorded per baseboard.
+- **IOMMU groups** — the full set of devices (GPUs, NVSwitches, switch ports,
+  companions) that must bind to `vfio-pci` together, extending the existing
+  IOMMU-group peer-bind logic (the Tier 1 HD-Audio companion case, generalized to
+  a whole baseboard).
+- A `status` representation of "baseboard N: GPUs[...], NVSwitches[...], free/allocated".
+
+## 6. Allocation (whole-baseboard)
+
+Tier 3 allocation is **coarse-grained**: a guest gets an entire baseboard or
+nothing. The SwiftGPU controller's `findAndAllocate` gains a **baseboard mode** —
+match `count`/model against a *whole free baseboard*, mark all its GPUs +
+NVSwitches `AllocatedTo` the guest, and pin the guest to that node. Release frees
+the whole baseboard. This reuses the Phase 4 `ReserveOnNode`/`ReleaseFromNode`
+primitives (TFU #27) — at baseboard granularity.
+
+## 7. Runtime — the QEMU full-hierarchy builder
+
+In `swift-qemu-client` (the QEMU path already used for Tier 2), Tier 3 generates:
+
+- The **PCIe hierarchy** (strategy A): `-device pcie-root-port,...` +
+  switch/bridge elements mirroring the discovered topology.
+- **All GPUs + NVSwitches** as `vfio-pci` at the mirrored positions; large-BAR
+  GPUs (B200) get `x-no-mmap=true` (`noMmap`).
+- **NUMA + vCPU pinning** — an 8-GPU HGX is dual-socket; the existing
+  `numaTopology`/`vcpuPinning` builder pins vCPUs to the sockets the GPUs hang
+  off and builds matching guest NUMA nodes + 1 GiB hugepages.
+- OVMF firmware (the QEMU path), 1 GiB hugepages (required for GPU workloads).
+
+**CH-on-the-horizon note:** CH v52's `host_mmap_bars` (the native equivalent of
+QEMU `x-no-mmap`), `iommufd`/`vfio-cdev`, sub-page BAR expansion, and lazy GSI
+(many-device guests) could *eventually* let some large-BAR/HGX topologies run on
+**Cloud Hypervisor** instead of QEMU — shrinking the QEMU dependency. Out of
+scope for the first Tier 3 (QEMU is the validated multi-device path), but
+evaluate during the spike now that the v52 knobs exist.
+
+## 8. Fabric Manager in the guest
+
+- The **guest image** ships the `nvidia-open` driver + **Fabric Manager**, with
+  the FM version **exactly matching** the driver (the same host-FM-version
+  discipline, moved into the guest). `fabricManager.requiredVersion` is the gate
+  the controller validates.
+- On boot, the **guest FM** initializes the NVSwitch fabric it now owns. There is
+  **no host FM** for this baseboard.
+- `gpu-init` (the init container) binds the **whole baseboard** (all GPUs +
+  NVSwitches + switch ports + companions) to `vfio-pci` using the two-pass
+  unbind-all-then-bind-all procedure (the PR #93 fix), and does **NOT** activate a
+  host FM partition (Tier 3 has none).
+
+## 9. Interactions / non-goals (v1 Tier 3)
+
+- **Live migration** of a full-baseboard GPU guest — never (VFIO can't
+  live-migrate; offline release-and-reallocate per TFU #27 applies, at baseboard
+  granularity).
+- **Snapshots** of a Tier 3 guest — VFIO state can't be CH-restored; not a target.
+- **Confidential + HGX** — confidential GPU is a separate future track
+  (see [`swiftconfidential-sev-snp.md`](swiftconfidential-sev-snp.md) §9).
+- **Partial baseboard** — that's Tier 2 (`hgx-shared`); Tier 3 is all-or-nothing.
+
+## 10. Open questions / spike plan (on real HGX hardware)
+
+1. Does the **synthesized PCIe hierarchy (A)** satisfy CUDA + in-guest Fabric
+   Manager, or is **switch passthrough (B)** required?
+2. The exact **baseboard IOMMU-group** set + ACS/peer constraints for whole-
+   baseboard VFIO bind.
+3. **Guest FM init** ordering vs the driver, and the driver/FM version matrix per
+   HGX generation (H100/H200/B200).
+4. Can any of it move to **CH v52** (`host_mmap_bars` + `iommufd`), or is QEMU
+   still required for the multi-device PCIe hierarchy?
+5. NUMA/pinning + hugepage sizing for the dual-socket 8-GPU case.
+
+Until then: **design-complete, asset-gated** — like Tier 2 GPU and multi-NIC.
+
+## 11. Phased PR breakdown (provisional — after the spike)
+
+| PR | Scope |
+|---|---|
+| 0 | Spike on real HGX: PCIe-hierarchy strategy (A vs B), in-guest FM init, IOMMU-group set. |
+| 1 | This design doc. |
+| 2 | Discovery: baseboard grouping + PCIe hierarchy + full IOMMU-group set on `SwiftGPUNode`. |
+| 3 | Webhook tightening (`hgx-full` ⇒ `partitionMode: full` + `runInGuest`; `count` = baseboard size); whole-baseboard allocation (reusing the Phase 4 reserve/release primitives). |
+| 4 | Runtime: the `swift-qemu-client` full-hierarchy builder (synthesized PCIe tree + all-device VFIO + NUMA/pinning/hugepages). |
+| 5 | `gpu-init` whole-baseboard bind; in-guest FM image guidance + the driver/FM version gate; operator runbook. |
+| (future) | Evaluate CH v52 (`host_mmap_bars`/`iommufd`) to reduce the QEMU dependency. |
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -2670,12 +2670,33 @@ queued as roadmap candidates (the bump itself shipped in PR #150; the workaround
 *removals* — `image_type=raw`, auto-resume-on-restore, downtime observability,
 sparse/userfaultfd snapshots — are tracked in the assessment doc §5, not here):
 
-- **SwiftConfidential — SEV-SNP confidential VMs (KVM).** CH v52.0 launches
-  AMD SEV-SNP confidential VMs on KVM (`guest_memfd` private memory, IGVM firmware,
-  measured boot + signed ID block for attestation). Potential **major
-  differentiator**: confidential VMs as a first-class workload (a `confidential`
-  SwiftGuestClass or SwiftConfidential CRD). **Blocked on AMD EPYC SEV-SNP
-  hardware** (none on the dev cluster). Architect/design-first when hardware exists.
+- **SwiftConfidential — SEV-SNP confidential VMs (KVM). DESIGN-COMPLETE**
+  ([`docs/design/swiftconfidential-sev-snp.md`](docs/design/swiftconfidential-sev-snp.md)).
+  CH v52.0 launches AMD SEV-SNP confidential VMs on KVM (`guest_memfd` private
+  memory, IGVM firmware, measured boot + signed ID block for attestation).
+  Potential **major differentiator**: confidential VMs as a first-class workload
+  via a **`spec.confidential` block** on SwiftGuest (recommended over a separate
+  CRD; promote to a profile CRD only if the attestation-policy surface grows).
+  Key design findings: (1) **the shipped `cloud-hypervisor-static` has no SEV-SNP
+  CLI** — SEV-SNP is behind a `sev_snp` Cargo feature, so a SEV-SNP CH build is the
+  first spike prerequisite; (2) v1 confidential guests boot via **`kernelRef`**
+  (the measured kernel/initrd path — disk boot's bootloader chain isn't in the
+  launch measurement); (3) KubeSwift is **outside the guest TCB** (host/operator
+  untrusted), so controller status is advisory — the PSP-signed attestation the
+  guest produces is authoritative. **Blocked on AMD EPYC SEV-SNP hardware** (none
+  on the dev cluster); spike → phased PRs when hardware exists.
+- **HGX Tier 3 full passthrough — `hgx-full`. DESIGN-COMPLETE**
+  ([`docs/design/swiftgpu-hgx-tier3.md`](docs/design/swiftgpu-hgx-tier3.md)).
+  Passes an **entire HGX baseboard** (all GPUs + all NVSwitches) to ONE VM with
+  the NVSwitch fabric + Fabric Manager **in the guest** (no host FM partition).
+  The CRD surface already exists (SwiftGPUProfile `tier: hgx-full`,
+  `partitionMode: full`, `fabricManager.runInGuest`, `pcieTopology`) — Tier 3 is
+  **runtime + discovery + allocation**: a QEMU full-PCIe-hierarchy builder
+  (synthesize the switch tree + all-device VFIO; spike chooses emulated-switches
+  vs switch-passthrough), baseboard-grouping discovery on SwiftGPUNode,
+  whole-baseboard allocation (reusing the Phase 4 reserve/release primitives), and
+  `gpu-init` whole-baseboard VFIO bind. CH v52's `host_mmap_bars`/`iommufd` could
+  eventually move some of it off QEMU. **Blocked on HGX hardware.**
 - **Modern VFIO (iommufd / vfio-cdev) + in-guest vIOMMU.** CH v52.0 supports the
   Linux `iommufd` + per-device `vfio-cdev` access model (Linux ≥6.6) with
   accelerated in-guest IOMMU. Modernizes our legacy container/group GPU passthrough;


### PR DESCRIPTION
Two hardware-gated, **design-first** architecture docs (validated when hardware exists) — the next item in the roadmap sequence after the CH v52 quick wins.

## `swiftconfidential-sev-snp.md` — Confidential VMs (SEV-SNP)
Confidential VMs as a first-class KubeSwift workload on CH v52's SEV-SNP support (`guest_memfd` + IGVM firmware + measured boot + signed ID block).

- **CRD shape:** a **`spec.confidential` block** on SwiftGuest (recommended over a separate CRD — confidential is a property of the guest, not an allocatable pool); promote to a profile CRD only if attestation policy grows.
- **Measured boot:** v1 confidential guests boot via **`kernelRef`** — disk boot's bootloader chain isn't in the IGVM launch measurement, which would defeat attestation. Webhook-enforced.
- **Honest threat model:** KubeSwift / host / operator are **outside the guest TCB**, so controller status is advisory — the PSP-signed attestation the guest itself produces is authoritative.
- **Grounded prerequisite:** the shipped `cloud-hypervisor-static` has **no SEV-SNP CLI** (it's behind a `sev_snp` Cargo feature), so producing a SEV-SNP CH build is the first spike step.
- Node opt-in + discovery (`confidentialReady`, SNP ASIDs), security-engineer concerns, phased PRs. **Blocked on AMD EPYC SEV-SNP hardware.**

## `swiftgpu-hgx-tier3.md` — HGX full passthrough (`hgx-full`)
Passes an **entire HGX baseboard** (all GPUs + all NVSwitches) to one VM with the NVSwitch fabric + **Fabric Manager in the guest** (no host FM partition).

- **The CRD surface already exists** (SwiftGPUProfile `tier: hgx-full`, `partitionMode: full`, `fabricManager.runInGuest`, `pcieTopology`) — so Tier 3 is **runtime + discovery + allocation**, not new CRD.
- **The core challenge:** the full PCIe hierarchy. A QEMU full-hierarchy builder synthesizes the switch tree + all-device VFIO (spike chooses emulated-switches vs switch-passthrough); baseboard-grouping discovery on SwiftGPUNode; whole-baseboard allocation reusing the Phase 4 reserve/release primitives; `gpu-init` whole-baseboard VFIO bind.
- Notes CH v52's `host_mmap_bars`/`iommufd` could eventually move some of it off QEMU. **Blocked on HGX hardware.**

Context-doc roadmap entries updated to **DESIGN-COMPLETE** with links. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)