### PR TITLE
fix(snapshot): stop launcher OOM during memory-snapshot capture (O_DIRECT + memory.high)

### DIFF
--- a/rust/swift-ch-client/src/config.rs
+++ b/rust/swift-ch-client/src/config.rs
@@ -119,12 +119,18 @@ impl VmConfig {
             }
 
             if !self.seed_path.is_empty() {
+                // No direct=on: emptyDir/tmpfs-backed; tmpfs rejects O_DIRECT.
                 args.push("--disk".to_string());
                 args.push(format!("path={},image_type=raw", self.seed_path));
             }
             if !self.data_disk_path.is_empty() {
+                // direct=on: PVC-backed data disk, O_DIRECT-capable (see the
+                // disk-boot branch comment for why root/data bypass the cache).
                 args.push("--disk".to_string());
-                args.push(format!("path={},image_type=raw", self.data_disk_path));
+                args.push(format!(
+                    "path={},image_type=raw,direct=on",
+                    self.data_disk_path
+                ));
             }
         } else {
             // --kernel (CLOUDHV.fd UEFI firmware) required for disk boot.
@@ -139,15 +145,35 @@ impl VmConfig {
             // deprecates disk image-type autodetection (removed in a future
             // release). Being explicit avoids the deprecation warning and the
             // autodetection sector-0 probe (W10).
+            //
+            // direct=on (O_DIRECT, KubeVirt cache=none parity) on the ROOT and
+            // DATA disks bypasses the host page cache for guest disk I/O. The
+            // guest already caches its own blocks in guest RAM, so the host copy
+            // is a wasteful double-cache. Left buffered, the root-disk read cache
+            // grows to ~the disk working set and consumes the launcher's memory
+            // overhead, leaving no headroom for a memory-snapshot capture's
+            // page-cache write burst -> the launcher OOMKills during Capturing
+            // (cluster-diagnosed). Root and data disks are always PVC-backed
+            // (ext4 raw file on Filesystem, or a raw block device on Block); both
+            // support O_DIRECT. The SEED disk is deliberately left buffered: it
+            // is emptyDir-backed (often tmpfs), and tmpfs rejects O_DIRECT with
+            // EINVAL -- direct=on there would fail boot (it is a few hundred KB,
+            // not a cache concern). This is per-disk-ROLE, not path-shape
+            // inference -- the opacity contract holds (config.rs never parses the
+            // path string to decide behavior).
             args.push("--disk".to_string());
-            args.push(format!("path={},image_type=raw", self.disk_path));
+            args.push(format!("path={},image_type=raw,direct=on", self.disk_path));
             if !self.seed_path.is_empty() {
                 // Cloud Hypervisor: second disk for cloud-init NoCloud.
                 // CH expects ISO or vfat; we pass directory path (see swift-ch-client README).
+                // No direct=on: emptyDir/tmpfs-backed; tmpfs rejects O_DIRECT.
                 args.push(format!("path={},image_type=raw", self.seed_path));
             }
             if !self.data_disk_path.is_empty() {
-                args.push(format!("path={},image_type=raw", self.data_disk_path));
+                args.push(format!(
+                    "path={},image_type=raw,direct=on",
+                    self.data_disk_path
+                ));
             }
         }
 
@@ -262,6 +288,56 @@ mod tests {
         assert!(joined.contains("path=/data/seed,image_type=raw"));
         assert!(joined.contains("path=/data/extra.raw,image_type=raw"));
         // The VFIO --device path= (none here) must never get image_type.
+    }
+
+    /// O_DIRECT (cache=none) is applied per-disk-ROLE: the ROOT and DATA
+    /// disks (always PVC-backed, O_DIRECT-capable) carry `,direct=on` to
+    /// bypass the host page cache; the SEED disk (emptyDir/tmpfs-backed,
+    /// which rejects O_DIRECT with EINVAL) must NEVER carry it. A future
+    /// refactor that blanket-appends direct=on to every --disk would break
+    /// the seed mount on tmpfs and fail boot — this test pins that invariant.
+    #[test]
+    fn test_disks_direct_io_per_role() {
+        // Disk-boot: root + seed + data.
+        let mut cfg = make_disk_boot_config();
+        cfg.data_disk_path = "/data/extra.raw".to_string();
+        let joined = cfg.to_args().join(" ");
+        // Root (PVC) and data (PVC) bypass the cache.
+        assert!(
+            joined.contains("path=/data/image.raw,image_type=raw,direct=on"),
+            "root disk must carry direct=on: {}",
+            joined
+        );
+        assert!(
+            joined.contains("path=/data/extra.raw,image_type=raw,direct=on"),
+            "data disk must carry direct=on: {}",
+            joined
+        );
+        // Seed (emptyDir/tmpfs) stays buffered — direct=on would EINVAL.
+        assert!(
+            joined.contains("path=/data/seed,image_type=raw")
+                && !joined.contains("path=/data/seed,image_type=raw,direct=on"),
+            "seed disk must NOT carry direct=on (tmpfs rejects O_DIRECT): {}",
+            joined
+        );
+
+        // Kernel-boot: seed + data (no root --disk). Same per-role policy.
+        let mut kcfg = make_disk_boot_config();
+        kcfg.kernel_path = Some("/k/bzImage".to_string());
+        kcfg.firmware_path = None;
+        kcfg.data_disk_path = "/data/extra.raw".to_string();
+        let kjoined = kcfg.to_args().join(" ");
+        assert!(
+            kjoined.contains("path=/data/extra.raw,image_type=raw,direct=on"),
+            "kernel-boot data disk must carry direct=on: {}",
+            kjoined
+        );
+        assert!(
+            kjoined.contains("path=/data/seed,image_type=raw")
+                && !kjoined.contains("path=/data/seed,image_type=raw,direct=on"),
+            "kernel-boot seed disk must NOT carry direct=on: {}",
+            kjoined
+        );
     }
 
     #[test]
@@ -527,9 +603,9 @@ mod tests {
             .expect("--disk flag missing");
         assert!(
             args.get(disk_idx + 1)
-                .map(|v| v == "path=/dev/kubeswift-root,image_type=raw")
+                .map(|v| v == "path=/dev/kubeswift-root,image_type=raw,direct=on")
                 .unwrap_or(false),
-            "first --disk value should be the root device path with image_type=raw; args: {:?}",
+            "first --disk value should be the root device path with image_type=raw,direct=on; args: {:?}",
             args
         );
     }

--- a/rust/swiftletd/scripts/launcher-entrypoint.sh
+++ b/rust/swiftletd/scripts/launcher-entrypoint.sh
@@ -6,6 +6,38 @@ set -e
 INTENT_PATH="${KUBESWIFT_INTENT_PATH:-/var/lib/kubeswift/intent/runtime-intent.json}"
 RUN_DIR="${KUBESWIFT_RUN_DIR:-/var/lib/kubeswift/run}"
 
+# Set cgroup v2 memory.high to ~85% of memory.max so the kernel proactively
+# reclaims reclaimable page cache (chiefly the guest root-disk read cache)
+# BEFORE the container hits the hard memory.max wall. cgroup v2 does no
+# proactive reclaim by default (only the hard limit), so a memory-snapshot
+# capture's page-cache write burst can OOMKill the launcher during Capturing
+# (cluster-diagnosed). memory.high gives the kernel a throttle-and-reclaim band
+# below the wall; combined with direct=on disk I/O (which stops the cache
+# building in the first place) it keeps the snapshot write within budget.
+#
+# Best-effort and MUST NEVER fail the launcher (set -e is on): no-op on
+# cgroup v1, when memory.max is unlimited, or when the cgroup files are not
+# writable (delegation varies by runtime/host -- the spike confirmed they are
+# writable on this cluster, but stay defensive).
+set_memory_high() {
+    cg=/sys/fs/cgroup
+    # cgroup v2 unified hierarchy only (memory.high is v2-only).
+    [ -f "$cg/cgroup.controllers" ] || return 0
+    [ -w "$cg/memory.high" ] || return 0
+    max=$(cat "$cg/memory.max" 2>/dev/null) || return 0
+    # "max" == unlimited -> nothing to throttle against.
+    [ "$max" = "max" ] && return 0
+    # Guard: only proceed if memory.max is a plain integer (bytes).
+    case "$max" in '' | *[!0-9]*) return 0 ;; esac
+    high=$((max * 85 / 100))
+    [ "$high" -gt 0 ] || return 0
+    if echo "$high" > "$cg/memory.high" 2>/dev/null; then
+        echo "launcher: set memory.high=$high (memory.max=$max) for proactive cache reclaim"
+    fi
+    return 0
+}
+set_memory_high || true
+
 network_enabled() {
     [ -f "$INTENT_PATH" ] || return 1
     grep -q '"network"[[:space:]]*:[[:space:]]*true' "$INTENT_PATH" || return 1


### PR DESCRIPTION
## Summary

Memory-snapshot capture (Tier B local **and** Tier C S3), `cloneFromSnapshot`, and memory `SwiftRestore` currently **OOMKill the launcher container** (exit 137) ~4–8s into `Capturing`. This blocks the whole snapshot/clone path **and** the #163 snapshot-efficiency roadmap. Surfaced during cluster validation of the CH v51.1→v52.0 bump (#150) — but the mechanism is version-independent (see attribution below).

## Root cause (cluster-diagnosed, not theorized)

Measured by reading the launcher's **leaf cgroup-v2** files (`memory.current`, `memory.stat`, `memory.reclaim`) during a live capture on `miles` (ubuntu-noble disk-boot, CH v52.0):

1. **NOT a memory balloon / 2× RAM prefault** — `anon` stays **flat** (614Mi for a 1Gi guest) through the entire capture.
2. The launcher reads the guest **root-disk image through the host page cache** (default buffered I/O) → **~900Mi of reclaimable `file` cache** builds during boot. This is a wasteful **double-cache** — the guest already caches the same blocks in its own RAM.
3. That ~900Mi **consumes the entire `LauncherMemoryOverheadMiB = 512`** (launcher limit = guestRAM + 512Mi). At steady state the container sits at **99% of `memory.max`** (1525/1536Mi for a 1Gi guest).
4. The snapshot's **memory-image file write** needs dirty-page headroom; there is none. cgroup v2 has only `memory.max` (a hard wall), **no `memory.high`**, so the kernel never reclaims the clean disk cache *proactively* → hits the wall on the write burst → **OOM** (`cur` 1525→1536→OOM with `dirty` only ~28–39Mi).
5. The disk cache **is** reclaimable: forcing `memory.reclaim` from inside the container freed ~294Mi (file 894→601, cur 1508→1214, anon unchanged).
6. A **reactive** 250ms reclaim loop did **not** prevent the OOM — CH's write burst overruns between ticks. So the fix must be **static headroom or cache-bypass**, not reactive reclaim.

Reproduced at **512Mi / 1Gi / 2Gi** guests — all OOM at limit `RAM+512Mi`. The CH v52 `vm.snapshot` API config (`VmSnapshotConfig`) carries **only `destination_url`** — there is no snapshot memory knob, so the fix is KubeSwift-side.

**Attribution honesty:** the mechanism (disk-cache-eats-overhead + write-has-no-headroom) is version-independent and `anon` is flat, so this is **not confirmed as a v52-specific regression** (I can't A/B-test v51.1 — image gone). Treat the fix as version-independent.

## Fix (staff-architect-reviewed: A + B, reject C)

**A — O_DIRECT on root + data disks** (`swift-ch-client/src/config.rs`): append `,direct=on` (KubeVirt `cache=none` parity) so CH bypasses the host page cache → the ~900Mi double-cache never builds, freeing the overhead for the snapshot write. **Per-disk-ROLE**: the **seed** disk is emptyDir/tmpfs-backed and **tmpfs rejects O_DIRECT (EINVAL)**, so it stays buffered; **root/data** are always PVC-backed (ext4 raw file on Filesystem, raw block device on Block) and support O_DIRECT. Opacity contract preserved (no path-shape inference — decision is by struct field/role).

**B — launcher self-sets cgroup-v2 `memory.high` ≈85% of `memory.max`** (`launcher-entrypoint.sh`): a kernel-enforced static throttle that reclaims page cache *below* the hard wall (not a poll loop). Guarded best-effort — no-op on cgroup v1, unlimited `memory.max`, or non-writable cgroup; **never fails the launcher** (`set -e`-safe). One image-wide change covering **all four** launcher sites (disk-boot, kernel-boot, GPU, restore-receive). The spike proved `memory.reclaim` is writable from inside the container, so `memory.high` will be too on this cluster.

**Rejected C** (bump `LauncherMemoryOverheadMiB`): the disk cache grows to fill any added headroom (the spike's data refutes it), and it would raise every guest's Guaranteed-QoS reservation for a snapshot-only path. Left at 512Mi, untouched.

Independent win: A makes launcher memory **honest and predictable** (today the 512Mi overhead is silently ~all-consumed by cache on *every* guest) and eliminates double-caching node-wide.

## Tests
- New `test_disks_direct_io_per_role` — locks the invariant: root/data carry `direct=on`, **seed never** (a future blanket-append would break the tmpfs seed and fail boot). Covers disk-boot **and** kernel-boot.
- Updated `test_disk_boot_block_device_path` for `direct=on` on the Block root.
- Full Rust workspace green; shell `sh -n` + pure-ASCII verified.

## Validation plan (post-merge, after CI builds the image)
1. `make smoke-test` 5/5 (proves per-disk gating didn't break any boot, esp. the seed mount).
2. **OOM-repro inverted**: ubuntu-noble disk-boot (512Mi/1Gi/2Gi) → Tier B `includeMemory` snapshot reaches **Ready**, not exit 137; watch the leaf cgroup (`file` cache stays low, `memory.high` set, `cur` never reaches `memory.max`).
3. **Round-trip + clone**: in-place restore (sentinel survives) and `cloneFromSnapshot` (clone comes up **Running**, source sentinel byte-identical) — **this also validates #161 auto-resume**, which was blocked by this OOM.
4. RWX+Block guest snapshot (O_DIRECT-on-block + Longhorn alignment corner; W10 WARN unchanged).
5. Longhorn read-throughput non-regression (the one new empirical question O_DIRECT introduces).

## Follow-ups (tracked, not in this PR)
- **QEMU/GPU path** (`swift-qemu-client/src/config.rs`) has the identical defect (QEMU default `cache=writeback`, no cache mode set) — should get the analogous `cache=none` on root/data drives. Lower urgency (GPU+memory-snapshot is admission-rejected today). The restore-receive path opens disks from the snapshot's `config.json` (no `--disk`), so A doesn't govern it; B covers its memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)