### PR TITLE
fix(snapshot): map guest-RAM memfd shared=on — halve footprint + fix capture OOM (real root cause)

### DIFF
--- a/rust/swift-ch-client/src/config.rs
+++ b/rust/swift-ch-client/src/config.rs
@@ -90,7 +90,20 @@ impl VmConfig {
             "--api-socket".to_string(),
             format!("path={}", self.api_socket),
             "--memory".to_string(),
-            format!("size={}M", self.memory_mib),
+            // shared=on maps the guest-RAM memfd ("ch_ram") MAP_SHARED instead of
+            // CH's default MAP_PRIVATE. Under the default (shared=off), CH still
+            // backs guest RAM with a memfd but maps it copy-on-write, so the
+            // cgroup holds the guest pages TWICE -- once in the memfd (shmem) and
+            // once in CH's CoW-private pages (anon) -- ~2x the touched guest RAM,
+            // all unreclaimable. That left no room for a memory-snapshot capture's
+            // buffered write and OOMKilled the launcher (cluster-diagnosed
+            // 2026-06-08 via /proc/<ch>/smaps: the ch_ram mapping was rw-p with
+            // Private_Dirty == guest RAM). shared=on collapses the double to ~1x
+            // (writes land in the memfd; no CoW copy), which is also the standard
+            // backing for snapshot/live-migration-capable guests (mirrors QEMU's
+            // memory-backend-memfd,share=on) and what the sparse-snapshot /
+            // userfaultfd path (#163) wants.
+            format!("size={}M,shared=on", self.memory_mib),
             "--cpus".to_string(),
             {
                 let mut cpus = format!("boot={}", self.cpus.max(1));
@@ -149,13 +162,15 @@ impl VmConfig {
             // direct=on (O_DIRECT, KubeVirt cache=none parity) on the ROOT and
             // DATA disks bypasses the host page cache for guest disk I/O. The
             // guest already caches its own blocks in guest RAM, so the host copy
-            // is a wasteful double-cache. Left buffered, the root-disk read cache
-            // grows to ~the disk working set and consumes the launcher's memory
-            // overhead, leaving no headroom for a memory-snapshot capture's
-            // page-cache write burst -> the launcher OOMKills during Capturing
-            // (cluster-diagnosed). Root and data disks are always PVC-backed
-            // (ext4 raw file on Filesystem, or a raw block device on Block); both
-            // support O_DIRECT. The SEED disk is deliberately left buffered: it
+            // is a wasteful double-cache; bypassing it makes the launcher's memory
+            // footprint honest and predictable (no ~disk-working-set of reclaimable
+            // page cache silently consuming the overhead). NOTE: this is hygiene,
+            // NOT the memory-snapshot OOM fix -- that root cause was CH backing
+            // guest RAM with a MAP_PRIVATE memfd (~2x footprint), fixed by
+            // `--memory ...,shared=on` above. Root and data disks are always
+            // PVC-backed (ext4 raw file on Filesystem, or a raw block device on
+            // Block); both support O_DIRECT. The SEED disk is deliberately left
+            // buffered: it
             // is emptyDir-backed (often tmpfs), and tmpfs rejects O_DIRECT with
             // EINVAL -- direct=on there would fail boot (it is a few hundred KB,
             // not a cache concern). This is per-disk-ROLE, not path-shape
@@ -259,6 +274,31 @@ mod tests {
             joined.contains("--cpus boot=2,kvm_hyperv=on"),
             "windows --cpus should add kvm_hyperv=on: {}",
             joined
+        );
+    }
+
+    #[test]
+    fn test_memory_carries_shared_on() {
+        // Guest RAM must be memfd-MAP_SHARED (shared=on), not the default
+        // MAP_PRIVATE CoW which doubles the launcher's guest-memory footprint
+        // (~2x touched RAM) and OOMs memory-snapshot captures. Both boot paths.
+        let disk = make_disk_boot_config();
+        assert!(
+            disk.to_args()
+                .join(" ")
+                .contains("--memory size=2048M,shared=on"),
+            "disk-boot --memory must carry shared=on: {}",
+            disk.to_args().join(" ")
+        );
+        let mut kern = make_disk_boot_config();
+        kern.kernel_path = Some("/k/bzImage".to_string());
+        kern.firmware_path = None;
+        assert!(
+            kern.to_args()
+                .join(" ")
+                .contains("--memory size=2048M,shared=on"),
+            "kernel-boot --memory must carry shared=on: {}",
+            kern.to_args().join(" ")
         );
     }
 

--- a/rust/swiftletd/scripts/launcher-entrypoint.sh
+++ b/rust/swiftletd/scripts/launcher-entrypoint.sh
@@ -6,37 +6,13 @@ set -e
 INTENT_PATH="${KUBESWIFT_INTENT_PATH:-/var/lib/kubeswift/intent/runtime-intent.json}"
 RUN_DIR="${KUBESWIFT_RUN_DIR:-/var/lib/kubeswift/run}"
 
-# Set cgroup v2 memory.high to ~85% of memory.max so the kernel proactively
-# reclaims reclaimable page cache (chiefly the guest root-disk read cache)
-# BEFORE the container hits the hard memory.max wall. cgroup v2 does no
-# proactive reclaim by default (only the hard limit), so a memory-snapshot
-# capture's page-cache write burst can OOMKill the launcher during Capturing
-# (cluster-diagnosed). memory.high gives the kernel a throttle-and-reclaim band
-# below the wall; combined with direct=on disk I/O (which stops the cache
-# building in the first place) it keeps the snapshot write within budget.
-#
-# Best-effort and MUST NEVER fail the launcher (set -e is on): no-op on
-# cgroup v1, when memory.max is unlimited, or when the cgroup files are not
-# writable (delegation varies by runtime/host -- the spike confirmed they are
-# writable on this cluster, but stay defensive).
-set_memory_high() {
-    cg=/sys/fs/cgroup
-    # cgroup v2 unified hierarchy only (memory.high is v2-only).
-    [ -f "$cg/cgroup.controllers" ] || return 0
-    [ -w "$cg/memory.high" ] || return 0
-    max=$(cat "$cg/memory.max" 2>/dev/null) || return 0
-    # "max" == unlimited -> nothing to throttle against.
-    [ "$max" = "max" ] && return 0
-    # Guard: only proceed if memory.max is a plain integer (bytes).
-    case "$max" in '' | *[!0-9]*) return 0 ;; esac
-    high=$((max * 85 / 100))
-    [ "$high" -gt 0 ] || return 0
-    if echo "$high" > "$cg/memory.high" 2>/dev/null; then
-        echo "launcher: set memory.high=$high (memory.max=$max) for proactive cache reclaim"
-    fi
-    return 0
-}
-set_memory_high || true
+# NOTE: an earlier attempt set cgroup-v2 memory.high here to dodge the
+# memory-snapshot launcher OOM. It was REMOVED -- cluster validation showed it
+# could not reclaim the unreclaimable guest-RAM footprint (memfd + CoW anon),
+# only throttled CH (70k+ breaches, cgroup stalls) and still OOM'd. The real
+# fix is `--memory ...,shared=on` (swift-ch-client config.rs), which halves the
+# footprint by mapping the guest-RAM memfd MAP_SHARED instead of MAP_PRIVATE.
+# Do NOT reintroduce a memory.high self-write here.
 
 network_enabled() {
     [ -f "$INTENT_PATH" ] || return 1


### PR DESCRIPTION
## Summary

The definitive root cause of the CH v52 memory-snapshot launcher OOM (which blocks Tier B/C snapshots, `cloneFromSnapshot`, memory `SwiftRestore`, and #163), found by inspecting `/proc/<ch>/smaps` on the cluster. This supersedes the partial PR #164 fix.

## Root cause (proven on the cluster)

CH v52 backs guest RAM with a memfd (`/memfd:ch_ram`) but maps it **`MAP_PRIVATE`** by default (`--memory shared=off`). Guest writes are **copy-on-write**, so the launcher cgroup holds the guest pages **twice**:
- once in the memfd → **shmem**
- once in CH's CoW-private pages → **anon**

≈ **2× the touched guest RAM**, all **unreclaimable** (no swap). Measured:
- 1Gi guest: `anon=600 + shmem=597 = ~1197Mi` steady (≈1.17× RAM since it touches ~60%)
- 512Mi guest: `anon=510 + shmem=507 = 1017Mi` of a 1024Mi limit — **OOM'd at steady state, before the snapshot even ran**

The smoking gun: CH fd 28 → `/memfd:ch_ram (deleted)`, mapping `7ca5...-7ca5... rw-p ... /memfd:ch_ram` (**`rw-p` = MAP_PRIVATE**), `Size=1048576kB`, `Private_Dirty=617536kB == guest RAM`. Node-wide `Shmem` == the cgroup's `shmem`, on **no tmpfs mount** — the unmapped memfd.

That left no headroom for the snapshot's buffered memory-file write → OOMKill during `Capturing`.

## Fix

**`--memory size=...,shared=on`** maps the `ch_ram` memfd **`MAP_SHARED`**. Guest writes land in the memfd (no CoW copy) → footprint collapses from ~2× to **~1× guest RAM**, leaving the existing `RAM+512Mi` launcher overhead room for the snapshot write. `shared=on` is also:
- the standard backing for **snapshot / live-migration-capable** guests (mirrors QEMU `memory-backend-memfd,share=on`), and
- what the **sparse-snapshot / userfaultfd** path (#163) wants (the architect's earlier caution was about turning shared *off*, not on).

## Also resolves the two PR #164 cluster-validation follow-ups

- **REMOVE the cgroup `memory.high` self-write** from `launcher-entrypoint.sh`. Cluster validation proved it cannot reclaim the unreclaimable memfd+CoW footprint — it only throttled CH (**70,082** `memory.high` breaches, multi-second cgroup stalls, `kubectl exec` hangs) and **still OOM'd**. Wrong mechanism; removed with a note so it isn't reintroduced.
- **KEEP O_DIRECT** on root/data disks (correct hygiene: no host double-cache, honest launcher memory, validated honored — fd flags `02140002`, `active_file=0`). Corrected its stale comment: O_DIRECT was **not** the snapshot-OOM fix (the memfd CoW double was).

## Why the earlier approaches failed (all cluster-validated)
| Approach | Result |
|---|---|
| O_DIRECT alone (#164 A) | freed ~300Mi disk cache, but disk cache was never the main consumer |
| memory.high (#164 B) | 70k throttles, cgroup wedge, still OOM'd — can't reclaim memfd/anon |
| external `fadvise`+`sync` loop | can't outpace CH's ~250MB/s write burst |
| 2× overhead bump | insufficient — the 2× footprint consumes a 2× limit on its own |
| **memfd `shared=on`** | **halves the footprint at the source — this PR** |

## Tests
- New `test_memory_carries_shared_on` (both boot paths). Existing O_DIRECT/image_type tests unchanged. Full Rust workspace green; shell `sh -n` + pure-ASCII verified.

## Validation plan (post-merge, after CI builds the image)
1. **Footprint halved**: a 1Gi guest's launcher shows the `ch_ram` mapping as `rw-s` (MAP_SHARED), `shmem ≈ 1× RAM`, `anon` small — `memory.current` roughly halved vs today.
2. **Capture succeeds** at **512Mi / 1Gi / 2Gi** (the three that OOM'd) → `SwiftSnapshot` reaches **Ready**; `memory.current` stays below the limit during the write.
3. **cloneFromSnapshot round-trip** → clone reaches **Running** (not Paused), source sentinel byte-identical — **this also closes the #161 auto-resume validation** that the OOM blocked.
4. **Regression**: `make smoke-test` 5/5; a **live migration** sanity (shared=on is the migration-friendly backing, but verify the send/receive path is unaffected); normal boot unchanged.

## Notes
- Unblocks #161 (auto-resume) validation and the #163 efficiency work once validated.
- The ~2× memfd-CoW footprint affected **every** v52 guest (not just snapshots) — so `shared=on` is also a general memory-density improvement (~halves per-guest launcher memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)