### PR TITLE
feat(gpu/qemu): back guest RAM with a shared memfd (share=on) — QEMU analog of #165

### DIFF
--- a/rust/swift-qemu-client/src/config.rs
+++ b/rust/swift-qemu-client/src/config.rs
@@ -64,14 +64,31 @@ impl QemuConfig {
             "-name".to_string(),
             format!("guest={},debug-threads=on", self.guest_id),
             "-enable-kvm".to_string(),
+            // memory-backend=ram0 routes the machine's main RAM to a shared
+            // memfd backend (defined below) instead of QEMU's default private
+            // anonymous mmap. share=on makes guest RAM host-visible/shared --
+            // the QEMU analog of Cloud Hypervisor's `--memory shared=on`. It is
+            // required for clean VFIO/GPU passthrough (the IOMMU pins guest RAM
+            // for device DMA) and is the standard backing for snapshot/live-
+            // migration-capable guests. Tier-1 PCIe GPUs run on Cloud Hypervisor
+            // (already shared via #165); this covers the QEMU path used by
+            // Tier-2/3 HGX GPUs (and non-GPU QEMU via the hypervisor override).
             "-machine".to_string(),
-            "q35,accel=kvm".to_string(),
+            "q35,accel=kvm,memory-backend=ram0".to_string(),
             "-cpu".to_string(),
             "host".to_string(),
             "-smp".to_string(),
             self.cpus.max(1).to_string(),
             "-m".to_string(),
             format!("{}M", self.memory_mib.max(128)),
+            // Shared memfd backend for the main RAM (referenced by -machine
+            // above). size MUST match -m. No prealloc here: VFIO pins on device
+            // attach, and non-GPU guests keep lazy allocation.
+            "-object".to_string(),
+            format!(
+                "memory-backend-memfd,id=ram0,size={}M,share=on",
+                self.memory_mib.max(128)
+            ),
         ];
 
         // OVMF firmware: code (read-only) + vars (writable, per-VM copy)
@@ -200,6 +217,35 @@ mod tests {
         let joined = args.join(" ");
         assert!(joined.contains("q35,accel=kvm"), "missing q35 machine type");
         assert!(joined.contains("-enable-kvm"), "missing -enable-kvm");
+    }
+
+    #[test]
+    fn test_to_args_memory_shared_memfd() {
+        // Guest RAM must be a shared memfd backend (share=on), the QEMU analog
+        // of CH's --memory shared=on: VFIO/GPU-DMA-friendly + migration/snapshot
+        // capable. The machine must route its main RAM to that backend, and the
+        // backend size must match -m.
+        let cfg = make_config();
+        let mem = cfg.memory_mib.max(128);
+        let joined = cfg.to_args().join(" ");
+        assert!(
+            joined.contains("q35,accel=kvm,memory-backend=ram0"),
+            "machine must reference the ram0 backend: {}",
+            joined
+        );
+        assert!(
+            joined.contains(&format!(
+                "memory-backend-memfd,id=ram0,size={}M,share=on",
+                mem
+            )),
+            "missing shared memfd backend matching -m: {}",
+            joined
+        );
+        assert!(
+            joined.contains(&format!("-m {}M", mem)),
+            "missing -m size: {}",
+            joined
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The QEMU analog of the Cloud Hypervisor `--memory shared=on` fix (#165), for GPU VMs on the QEMU path (Tier-2/3 HGX). Switches the machine's main RAM from QEMU's default private anonymous mmap to a **shared memfd backend**:

```
-machine q35,accel=kvm,memory-backend=ram0
-object memory-backend-memfd,id=ram0,size=<N>M,share=on
```

## Why

- **Tier-1 PCIe GPUs run on Cloud Hypervisor** → already shared via #165. This covers the **QEMU path** (Tier-2/3 HGX GPUs, and non-GPU QEMU via the hypervisor-override).
- For QEMU this is **not** a footprint fix — QEMU's `-m` was already 1× anonymous (not a `MAP_PRIVATE` memfd like CH's `ch_ram`). It makes guest RAM **host-visible/shared**, which is:
  - the clean backing for **VFIO/GPU passthrough** (the IOMMU pins guest RAM for device DMA), and
  - the standard backing for **snapshot / live-migration-capable** guests.
- `size` matches `-m`; **no prealloc** (VFIO pins on device attach; non-GPU guests keep lazy allocation).

## Tests
- `test_to_args_memory_shared_memfd` — asserts `-machine` references `ram0` and the memfd `size` matches `-m`. Full swift-qemu-client suite green (14/14).

## Validation (post-merge)
- `make smoke-test` **qemu-boot** scenario (the QEMU path boots OVMF + cloud-init with the shared memfd backend). Tier-2/3 GPU itself remains hardware-gated (no HGX on the dev cluster), so the VFIO-DMA benefit is asset-gated — but the memfd backing is exercised by every QEMU boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)