### PR TITLE
feat(migration): wire downtimeTarget → CH downtime_ms (v52 convergence) [#4 PR1]

### DIFF
--- a/api/migration/v1alpha1/swiftmigration_types.go
+++ b/api/migration/v1alpha1/swiftmigration_types.go
@@ -267,10 +267,14 @@ type SwiftMigrationSpec struct {
 	// the webhook rejects live; auto resolves to offline.
 	// +kubebuilder:default=auto
 	Mode SwiftMigrationMode `json:"mode,omitempty"`
-	// DowntimeTarget is the Cloud Hypervisor downtime_ms target. Ignored in
-	// Phase 1 (offline migration's downtime is bounded by storage detach +
-	// VM boot, not by CH's downtime budget). Carried in the spec for forward
-	// compatibility with live mode.
+	// DowntimeTarget is the Cloud Hypervisor `downtime_ms` target for
+	// mode=live on CH >= v52: CH iterates pre-copy until the estimated final
+	// stop-and-copy (the vCPU-paused window) fits under this budget, then
+	// commits — classical dirty-rate convergence, superseding v51.1's
+	// hardcoded 5-iteration cap. Unset means CH keeps its native behaviour
+	// (the controller omits downtime_ms from the send). The webhook bounds it
+	// to [10ms, 10s] for mode=live. Ignored for mode=offline (offline
+	// downtime is bounded by storage detach + VM boot, not a CH budget).
 	// +optional
 	DowntimeTarget *metav1.Duration `json:"downtimeTarget,omitempty"`
 	// ParallelConnections is the number of TCP connections CH uses for the

--- a/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
+++ b/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
@@ -114,10 +114,14 @@ spec:
                 type: boolean
               downtimeTarget:
                 description: |-
-                  DowntimeTarget is the Cloud Hypervisor downtime_ms target. Ignored in
-                  Phase 1 (offline migration's downtime is bounded by storage detach +
-                  VM boot, not by CH's downtime budget). Carried in the spec for forward
-                  compatibility with live mode.
+                  DowntimeTarget is the Cloud Hypervisor `downtime_ms` target for
+                  mode=live on CH >= v52: CH iterates pre-copy until the estimated final
+                  stop-and-copy (the vCPU-paused window) fits under this budget, then
+                  commits — classical dirty-rate convergence, superseding v51.1's
+                  hardcoded 5-iteration cap. Unset means CH keeps its native behaviour
+                  (the controller omits downtime_ms from the send). The webhook bounds it
+                  to [10ms, 10s] for mode=live. Ignored for mode=offline (offline
+                  downtime is bounded by storage detach + VM boot, not a CH budget).
                 type: string
               guestRef:
                 description: GuestRef references the SwiftGuest to migrate (same namespace).

--- a/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
+++ b/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
@@ -114,10 +114,14 @@ spec:
                 type: boolean
               downtimeTarget:
                 description: |-
-                  DowntimeTarget is the Cloud Hypervisor downtime_ms target. Ignored in
-                  Phase 1 (offline migration's downtime is bounded by storage detach +
-                  VM boot, not by CH's downtime budget). Carried in the spec for forward
-                  compatibility with live mode.
+                  DowntimeTarget is the Cloud Hypervisor `downtime_ms` target for
+                  mode=live on CH >= v52: CH iterates pre-copy until the estimated final
+                  stop-and-copy (the vCPU-paused window) fits under this budget, then
+                  commits — classical dirty-rate convergence, superseding v51.1's
+                  hardcoded 5-iteration cap. Unset means CH keeps its native behaviour
+                  (the controller omits downtime_ms from the send). The webhook bounds it
+                  to [10ms, 10s] for mode=live. Ignored for mode=offline (offline
+                  downtime is bounded by storage detach + VM boot, not a CH budget).
                 type: string
               guestRef:
                 description: GuestRef references the SwiftGuest to migrate (same namespace).

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -79,6 +79,31 @@ type migrationSendArgs struct {
 	// path — wired here. Best-effort: a nil value (memory unresolvable)
 	// just disables the estimate; it never fails the migration.
 	GuestRAMMiB *uint32 `json:"guest_ram_mib,omitempty"`
+	// DowntimeMs is the Cloud Hypervisor `downtime_ms` target for
+	// vm.send-migration (CH >= v52): CH iterates pre-copy until the
+	// estimated final stop-and-copy fits under this vCPU-pause budget,
+	// then commits (classical convergence, superseding v51.1's hardcoded
+	// 5-iteration cap). Derived from SwiftMigration.spec.downtimeTarget;
+	// nil (operator did not set downtimeTarget) omits the field so CH
+	// uses its native default. Maps to MigrationSendArgs.downtime_ms in
+	// rust/swiftletd/src/action.rs -> swift_ch_client::send_migration.
+	DowntimeMs *int64 `json:"downtime_ms,omitempty"`
+}
+
+// downtimeMs converts SwiftMigration.spec.downtimeTarget to a CH
+// `downtime_ms` value (milliseconds). Returns nil when unset or
+// non-positive so the send-args omit it and CH keeps its native
+// behaviour (operator opt-in; defaulting is deferred pending the
+// PR 1 convergence spike). Live-mode only.
+func downtimeMs(mig *migrationv1alpha1.SwiftMigration) *int64 {
+	if mig.Spec.DowntimeTarget == nil {
+		return nil
+	}
+	ms := mig.Spec.DowntimeTarget.Milliseconds()
+	if ms <= 0 {
+		return nil
+	}
+	return &ms
 }
 
 // guestRAMMiB returns the guest's RAM in MiB from its SwiftGuestClass,
@@ -412,6 +437,7 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 			TargetURL:      targetURL,
 			TimeoutSeconds: migrationActionTimeoutSeconds,
 			GuestRAMMiB:    guestRAMMiB(ctx, r, &guest),
+			DowntimeMs:     downtimeMs(mig),
 		}
 		argsJSON, err := json.Marshal(args)
 		if err != nil {

--- a/internal/webhook/swiftmigration/validator.go
+++ b/internal/webhook/swiftmigration/validator.go
@@ -71,6 +71,14 @@ const (
 	// realistic live-migration uses without leaving room for resource
 	// abuse via the Phase 3 controller when it lands.
 	MaxParallelConnections = 16
+	// MinDowntimeTarget / MaxDowntimeTarget bound spec.downtimeTarget,
+	// the CH `downtime_ms` vCPU-pause budget (CH >= v52). Below ~10ms a
+	// guest with any meaningful dirty rate can never converge under the
+	// target and the migration just runs to spec.timeout; above ~10s the
+	// "live" migration's frozen window stops being meaningfully live (use
+	// offline). Live-mode only; ignored for offline.
+	MinDowntimeTarget = 10 * time.Millisecond
+	MaxDowntimeTarget = 10 * time.Second
 	// MaxReasonLen bounds the free-form reason string. Long enough for
 	// a meaningful audit-trail entry, short enough that the field
 	// can't host a payload.
@@ -296,6 +304,16 @@ func validateShape(mig *migrationv1alpha1.SwiftMigration) error {
 	}
 	if mig.Spec.ParallelConnections < 0 {
 		return fmt.Errorf("spec.parallelConnections=%d must be non-negative", mig.Spec.ParallelConnections)
+	}
+	// downtimeTarget bound (CH downtime_ms, live mode). Only meaningful for
+	// live mode; offline migration's downtime is storage-detach + boot
+	// bound, not a CH vCPU-pause budget. Enforced whenever set so a stray
+	// value on an auto/offline migration is still caught.
+	if dt := mig.Spec.DowntimeTarget; dt != nil && dt.Duration != 0 {
+		if dt.Duration < MinDowntimeTarget || dt.Duration > MaxDowntimeTarget {
+			return fmt.Errorf("spec.downtimeTarget=%s is outside the allowed range [%s, %s]",
+				dt.Duration, MinDowntimeTarget, MaxDowntimeTarget)
+		}
 	}
 	if len(mig.Spec.Reason) > MaxReasonLen {
 		return fmt.Errorf("spec.reason length %d exceeds maximum %d characters", len(mig.Spec.Reason), MaxReasonLen)

--- a/internal/webhook/swiftmigration/validator_test.go
+++ b/internal/webhook/swiftmigration/validator_test.go
@@ -301,6 +301,39 @@ func TestValidateShape_RejectParallelConnectionsOverMax(t *testing.T) {
 	}
 }
 
+func TestValidateShape_DowntimeTargetBounds(t *testing.T) {
+	cases := []struct {
+		name   string
+		dt     time.Duration
+		reject bool
+	}{
+		{"too-low", MinDowntimeTarget - time.Millisecond, true},
+		{"too-high", MaxDowntimeTarget + time.Second, true},
+		{"min-ok", MinDowntimeTarget, false},
+		{"max-ok", MaxDowntimeTarget, false},
+		{"typical-300ms", 300 * time.Millisecond, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mig := newSwiftMigration("m", "default")
+			mig.Spec.DowntimeTarget = &metav1.Duration{Duration: tc.dt}
+			err := validateShape(mig)
+			if tc.reject && (err == nil || !strings.Contains(err.Error(), "downtimeTarget")) {
+				t.Errorf("downtimeTarget=%s should reject; got %v", tc.dt, err)
+			}
+			if !tc.reject && err != nil {
+				t.Errorf("downtimeTarget=%s should be accepted; got %v", tc.dt, err)
+			}
+		})
+	}
+	// Unset is always fine (CH keeps native behaviour).
+	mig := newSwiftMigration("m", "default")
+	mig.Spec.DowntimeTarget = nil
+	if err := validateShape(mig); err != nil {
+		t.Errorf("nil downtimeTarget must be accepted; got %v", err)
+	}
+}
+
 func TestValidateShape_RejectParallelConnectionsNegative(t *testing.T) {
 	mig := newSwiftMigration("m", "default")
 	mig.Spec.ParallelConnections = -1

--- a/rust/swift-ch-client/src/methods.rs
+++ b/rust/swift-ch-client/src/methods.rs
@@ -161,11 +161,26 @@ impl ApiClient {
     ///
     /// See `docs/design/live-migration-phase-2.md` §4.1 for the full
     /// blocking-semantics rationale.
-    pub fn send_migration(&self, destination_url: &str) -> Result<(), ApiError> {
-        let body = serde_json::to_vec(&serde_json::json!({
+    /// `downtime_ms`, when `Some`, sets CH's `downtime_ms` target (CH >=
+    /// v52): CH runs pre-copy iterations until the estimated final
+    /// stop-and-copy fits under this vCPU-pause budget, then commits —
+    /// classical dirty-rate convergence, replacing v51.1's hardcoded
+    /// 5-iteration cap. `None` omits the field so CH keeps its native
+    /// behaviour (on v51.x the field is unknown and would be ignored/
+    /// rejected, so callers on older CH must pass `None`).
+    pub fn send_migration(
+        &self,
+        destination_url: &str,
+        downtime_ms: Option<u64>,
+    ) -> Result<(), ApiError> {
+        let mut body = serde_json::json!({
             "destination_url": destination_url,
-        }))
-        .map_err(|e| ApiError::Malformed(format!("send_migration body serialize: {}", e)))?;
+        });
+        if let Some(ms) = downtime_ms {
+            body["downtime_ms"] = serde_json::json!(ms);
+        }
+        let body = serde_json::to_vec(&body)
+            .map_err(|e| ApiError::Malformed(format!("send_migration body serialize: {}", e)))?;
         self.request_ok("PUT", "/api/v1/vm.send-migration", Some(&body))
             .map(drop)
     }
@@ -398,13 +413,30 @@ mod tests {
     fn send_migration_sends_destination_url_in_body() {
         let server = MockServer::spawn(no_content());
         let client = ApiClient::new(server.path.clone());
-        client.send_migration("tcp:10.0.0.5:6789").unwrap();
+        client.send_migration("tcp:10.0.0.5:6789", None).unwrap();
         let req = String::from_utf8(server.collect_request()).unwrap();
         assert!(req.starts_with("PUT /api/v1/vm.send-migration HTTP/1.1\r\n"));
         assert!(req.contains("Content-Type: application/json\r\n"));
         let (_, body) = req.split_once("\r\n\r\n").unwrap();
         let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
         assert_eq!(parsed["destination_url"], "tcp:10.0.0.5:6789");
+        // None -> downtime_ms omitted entirely (CH keeps native behaviour;
+        // v51.x would reject an unknown field).
+        assert!(parsed.get("downtime_ms").is_none());
+    }
+
+    #[test]
+    fn send_migration_includes_downtime_ms_when_set() {
+        let server = MockServer::spawn(no_content());
+        let client = ApiClient::new(server.path.clone());
+        client
+            .send_migration("tcp:10.0.0.5:6789", Some(300))
+            .unwrap();
+        let req = String::from_utf8(server.collect_request()).unwrap();
+        let (_, body) = req.split_once("\r\n\r\n").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed["destination_url"], "tcp:10.0.0.5:6789");
+        assert_eq!(parsed["downtime_ms"], 300);
     }
 
     #[test]
@@ -419,7 +451,9 @@ mod tests {
                 .to_vec(),
         );
         let client = ApiClient::new(server.path.clone());
-        let err = client.send_migration("tcp:10.0.0.5:6789").unwrap_err();
+        let err = client
+            .send_migration("tcp:10.0.0.5:6789", None)
+            .unwrap_err();
         match err {
             ApiError::Status(resp) => {
                 assert_eq!(resp.status, 500);

--- a/rust/swiftletd/src/action.rs
+++ b/rust/swiftletd/src/action.rs
@@ -711,6 +711,15 @@ struct MigrationSendArgs {
     /// demo callers set it directly in the action-args annotation.
     #[serde(default)]
     guest_ram_mib: Option<u32>,
+    /// Cloud Hypervisor `downtime_ms` target for vm.send-migration
+    /// (CH >= v52). CH iterates pre-copy until the estimated final
+    /// stop-and-copy fits under this vCPU-pause budget, then commits
+    /// (classical convergence, superseding v51.1's hardcoded 5-iter
+    /// cap). When absent, swiftletd omits it from the send body and CH
+    /// keeps its native behaviour. Set by the controller from
+    /// SwiftMigration.spec.downtimeTarget.
+    #[serde(default)]
+    downtime_ms: Option<u64>,
 }
 
 /// Args parsed from `kubeswift.io/migration-action-args` for the
@@ -931,7 +940,7 @@ async fn dispatch_migration_send(
     let _progress = spawn_progress_emitter(action.id.clone(), args.guest_ram_mib);
 
     let started = std::time::Instant::now();
-    if let Err(e) = client.send_migration(&args.target_url) {
+    if let Err(e) = client.send_migration(&args.target_url, args.downtime_ms) {
         return Err(format!(
             "send_migration: {}",
             sanitize_ch_error(&format!("{:?}", e))


### PR DESCRIPTION
## Summary

**PR 1 of the #4 live-migration observability arc** (design: `docs/design/live-migration-ch-v52-observability.md`).

CH v52's `vm.send-migration` accepts **`downtime_ms`** — a vCPU-pause target. CH iterates pre-copy until the *estimated* final stop-and-copy fits under the budget, then commits: **classical dirty-rate convergence**, superseding v51.1's hardcoded 5-iteration cap (**supersedes Phase 2 Decision 4**).

`SwiftMigration.spec.downtimeTarget` already existed (forward-compat, "Ignored in Phase 1"). This wires it end-to-end now that v52 supports it.

## Changes
- **swift-ch-client**: `send_migration(dest, downtime_ms: Option<u64>)` adds `downtime_ms` to the PUT body **only when `Some`** — `None` omits it so CH keeps native behaviour (v51.x would reject an unknown field).
- **swiftletd**: `MigrationSendArgs` gains `downtime_ms`; `dispatch_migration_send` passes it through.
- **Controller**: `migrationSendArgs.downtime_ms` populated from `spec.downtimeTarget` via `downtimeMs()` — **nil when unset/non-positive → omitted** (operator opt-in; defaulting deferred pending the convergence spike).
- **Webhook**: bounds `spec.downtimeTarget` to **[10ms, 10s]**; offline ignores it.
- **Field doc** rewritten (dropped "Ignored in Phase 1"); CRD regenerated + chart synced.

## Tests
- `send_migration_includes_downtime_ms_when_set` + the `None`-omits assertion (swift-ch-client).
- `TestValidateShape_DowntimeTargetBounds` (webhook, table-driven).
- Full Go + Rust suites green.

## On-cluster spike (post-merge — this PR's validation)
- Live migrations at `downtimeTarget` = **100 / 300 / 1000ms** on a baseline guest and a `stress-ng`-dirtied guest.
- Measure `observedTransferDuration`, `observedDowntime`, convergence behaviour, and **crucially whether CH reports the achieved downtime** (response body or logs) — this answers **W28 feasibility** for PR 2.
- Confirm the conservative default (omit when unset) leaves existing migrations unchanged.

## Notes
- Live-mode only; offline path untouched. Composes with Phase 3c mTLS unchanged (the target_url is the local stunnel either way).
- PR 2 (metrics: TFU #11 + W28) and PR 3 (parallelConnections → connections) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)