### PR TITLE
feat(migration): downtime metrics — drop deprecated alias + appliedDowntimeMs echo [#4 PR2]

### DIFF
--- a/api/migration/v1alpha1/swiftmigration_types.go
+++ b/api/migration/v1alpha1/swiftmigration_types.go
@@ -549,10 +549,9 @@ type SwiftMigrationStatus struct {
 	// Read from the kubeswift.io/migration-pause-window-ms annotation
 	// that swiftletd writes alongside migration-status=complete
 	// (rust/swiftletd/src/action.rs::write_migration_status). Stamped
-	// by stopandcopy_live's substateSrcCompleted handler per W27b;
-	// in Phase 3b PR 1 the same stamping path dual-writes both
-	// ObservedTransferDuration and the deprecated ObservedPauseWindow
-	// alias from a single source value.
+	// by stopandcopy_live's substateSrcCompleted handler per W27b.
+	// (The deprecated ObservedPauseWindow alias was removed in the
+	// CH-v52 observability work; this is the canonical field.)
 	//
 	// Empirical baseline from Phase 3b spike Q2 on Calico VXLAN pod
 	// networking: ~38s for a 4Gi RAM guest with no memory-dirtying
@@ -563,30 +562,24 @@ type SwiftMigrationStatus struct {
 	// (the 1.05 factor accounts for the ~5% CH orchestration overhead
 	// measured in spike Q4.)
 	//
-	// Replaces ObservedPauseWindow (deprecated alias, will be removed
-	// in Phase 3b+1).
-	//
 	// Not populated for status.mode=offline migrations; offline
 	// migration shuts down the source guest and restarts it on the
 	// destination, with no memory transfer RPC involved.
 	// +optional
 	ObservedTransferDuration *metav1.Duration `json:"observedTransferDuration,omitempty"`
-	// ObservedPauseWindow is a deprecated alias for
-	// ObservedTransferDuration. The original name misleadingly
-	// suggested "vCPU pause window" — see ObservedTransferDuration's
-	// docstring for the actual semantics (full vm.send-migration RPC
-	// duration, most of which is NOT vCPU-paused). Phase 3b PR 1
-	// dual-writes both fields from a single source value to give
-	// operator tooling one full release cycle to migrate.
-	//
-	// Not populated for status.mode=offline migrations; offline
-	// migration shuts down the source guest and restarts it on the
-	// destination, with no memory transfer RPC involved.
-	//
-	// Will be removed in Phase 3b+1. Operator tooling should migrate
-	// to ObservedTransferDuration.
+	// AppliedDowntimeMs is the Cloud Hypervisor `downtime_ms` ceiling the
+	// controller actually sent on vm.send-migration (from
+	// spec.downtimeTarget; CH >= v52). It is a BOUND, not a measurement:
+	// CH converges pre-copy so the final vCPU stop-and-copy fits under it,
+	// so the real "guest frozen" window is <= this value — but CH v52 does
+	// not report the achieved downtime (vm.send-migration returns 204 with
+	// no body, and CH logs no migration telemetry at its default level), so
+	// the achieved window is not directly measurable here. The only ground
+	// truth is an external observer (e.g. an L2 sibling pinging the guest;
+	// Tracked Follow-up #1). Nil when spec.downtimeTarget was unset (CH used
+	// its native behaviour) or for mode=offline.
 	// +optional
-	ObservedPauseWindow *metav1.Duration `json:"observedPauseWindow,omitempty"`
+	AppliedDowntimeMs *int64 `json:"appliedDowntimeMs,omitempty"`
 
 	// TransferProgress is the live-migration pre-copy progress estimate, an
 	// integer percentage 0-100, surfaced from the swiftletd-on-source

--- a/api/migration/v1alpha1/swiftmigration_types_test.go
+++ b/api/migration/v1alpha1/swiftmigration_types_test.go
@@ -2,23 +2,21 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TestObservedTransferDuration_RoundTrip verifies the new Phase 3b
-// status field can be set, marshaled to JSON, and unmarshaled back
-// without loss. Companion to W27b's pause-window stamping plumbing
-// in stopandcopy_live; the controller dual-writes both
-// ObservedTransferDuration (canonical) and ObservedPauseWindow
-// (deprecated alias) from a single source value.
+// TestObservedTransferDuration_RoundTrip verifies the status field can
+// be set, marshaled to JSON, and unmarshaled back without loss. (The
+// deprecated ObservedPauseWindow alias was removed in the CH-v52
+// observability work; ObservedTransferDuration is the canonical field.)
 func TestObservedTransferDuration_RoundTrip(t *testing.T) {
 	dur := metav1.Duration{Duration: 38200 * time.Millisecond}
 	status := SwiftMigrationStatus{
 		ObservedTransferDuration: &dur,
-		ObservedPauseWindow:      &dur,
 	}
 
 	data, err := json.Marshal(status)
@@ -38,12 +36,25 @@ func TestObservedTransferDuration_RoundTrip(t *testing.T) {
 		t.Errorf("ObservedTransferDuration = %v, want %v",
 			got.ObservedTransferDuration.Duration, dur.Duration)
 	}
-	if got.ObservedPauseWindow == nil {
-		t.Fatalf("ObservedPauseWindow (deprecated alias) nil after round-trip")
+}
+
+// TestAppliedDowntimeMs_RoundTrip verifies the downtime_ms bound echo
+// survives a JSON round-trip under its canonical key.
+func TestAppliedDowntimeMs_RoundTrip(t *testing.T) {
+	ms := int64(300)
+	data, err := json.Marshal(SwiftMigrationStatus{AppliedDowntimeMs: &ms})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
 	}
-	if got.ObservedPauseWindow.Duration != dur.Duration {
-		t.Errorf("ObservedPauseWindow = %v, want %v",
-			got.ObservedPauseWindow.Duration, dur.Duration)
+	if !strings.Contains(string(data), `"appliedDowntimeMs":300`) {
+		t.Errorf("JSON %s missing appliedDowntimeMs:300", data)
+	}
+	var got SwiftMigrationStatus
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.AppliedDowntimeMs == nil || *got.AppliedDowntimeMs != ms {
+		t.Errorf("AppliedDowntimeMs = %v, want %d", got.AppliedDowntimeMs, ms)
 	}
 }
 

--- a/api/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/api/migration/v1alpha1/zz_generated.deepcopy.go
@@ -188,9 +188,9 @@ func (in *SwiftMigrationStatus) DeepCopyInto(out *SwiftMigrationStatus) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
-	if in.ObservedPauseWindow != nil {
-		in, out := &in.ObservedPauseWindow, &out.ObservedPauseWindow
-		*out = new(v1.Duration)
+	if in.AppliedDowntimeMs != nil {
+		in, out := &in.AppliedDowntimeMs, &out.AppliedDowntimeMs
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TransferProgress != nil {

--- a/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
+++ b/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
@@ -210,6 +210,21 @@ spec:
           status:
             description: SwiftMigrationStatus is the observed state of a SwiftMigration.
             properties:
+              appliedDowntimeMs:
+                description: |-
+                  AppliedDowntimeMs is the Cloud Hypervisor `downtime_ms` ceiling the
+                  controller actually sent on vm.send-migration (from
+                  spec.downtimeTarget; CH >= v52). It is a BOUND, not a measurement:
+                  CH converges pre-copy so the final vCPU stop-and-copy fits under it,
+                  so the real "guest frozen" window is <= this value — but CH v52 does
+                  not report the achieved downtime (vm.send-migration returns 204 with
+                  no body, and CH logs no migration telemetry at its default level), so
+                  the achieved window is not directly measurable here. The only ground
+                  truth is an external observer (e.g. an L2 sibling pinging the guest;
+                  Tracked Follow-up #1). Nil when spec.downtimeTarget was unset (CH used
+                  its native behaviour) or for mode=offline.
+                format: int64
+                type: integer
               completedAt:
                 description: CompletedAt is when the migration reached a terminal
                   state.
@@ -422,23 +437,6 @@ spec:
                   surfaced today (W28 candidate per Tracked Follow-up #7
                   close-out — capture per-phase timing from CH internals).
                 type: string
-              observedPauseWindow:
-                description: |-
-                  ObservedPauseWindow is a deprecated alias for
-                  ObservedTransferDuration. The original name misleadingly
-                  suggested "vCPU pause window" — see ObservedTransferDuration's
-                  docstring for the actual semantics (full vm.send-migration RPC
-                  duration, most of which is NOT vCPU-paused). Phase 3b PR 1
-                  dual-writes both fields from a single source value to give
-                  operator tooling one full release cycle to migrate.
-
-                  Not populated for status.mode=offline migrations; offline
-                  migration shuts down the source guest and restarts it on the
-                  destination, with no memory transfer RPC involved.
-
-                  Will be removed in Phase 3b+1. Operator tooling should migrate
-                  to ObservedTransferDuration.
-                type: string
               observedTransferDuration:
                 description: |-
                   ObservedTransferDuration is the swiftletd-reported elapsed time
@@ -452,10 +450,9 @@ spec:
                   Read from the kubeswift.io/migration-pause-window-ms annotation
                   that swiftletd writes alongside migration-status=complete
                   (rust/swiftletd/src/action.rs::write_migration_status). Stamped
-                  by stopandcopy_live's substateSrcCompleted handler per W27b;
-                  in Phase 3b PR 1 the same stamping path dual-writes both
-                  ObservedTransferDuration and the deprecated ObservedPauseWindow
-                  alias from a single source value.
+                  by stopandcopy_live's substateSrcCompleted handler per W27b.
+                  (The deprecated ObservedPauseWindow alias was removed in the
+                  CH-v52 observability work; this is the canonical field.)
 
                   Empirical baseline from Phase 3b spike Q2 on Calico VXLAN pod
                   networking: ~38s for a 4Gi RAM guest with no memory-dirtying
@@ -465,9 +462,6 @@ spec:
                     (guest_RAM × 1.05) / pod_network_bandwidth
                   (the 1.05 factor accounts for the ~5% CH orchestration overhead
                   measured in spike Q4.)
-
-                  Replaces ObservedPauseWindow (deprecated alias, will be removed
-                  in Phase 3b+1).
 
                   Not populated for status.mode=offline migrations; offline
                   migration shuts down the source guest and restarts it on the

--- a/cmd/swiftctl/migration.go
+++ b/cmd/swiftctl/migration.go
@@ -319,10 +319,16 @@ func renderMigrationDescribe(out io.Writer, m *migrationv1alpha1.SwiftMigration,
 	if m.Status.ObservedDowntime != nil {
 		fmt.Fprintf(out, "Downtime:       %s\n", m.Status.ObservedDowntime.Duration.Truncate(1e9))
 	}
-	// Transfer duration (live mode only — offline leaves it nil). Renamed
-	// from the deprecated observedPauseWindow; see CRD docstring.
+	// Transfer duration: the full vm.send-migration RPC window (live mode
+	// only — offline leaves it nil).
 	if m.Status.ObservedTransferDuration != nil {
 		fmt.Fprintf(out, "Transfer:       %s\n", m.Status.ObservedTransferDuration.Duration.Truncate(1e9))
+	}
+	// Applied downtime ceiling (CH downtime_ms; live mode, when
+	// spec.downtimeTarget was set). A BOUND on the vCPU-stop window, not a
+	// measurement — CH v52 does not report the achieved value.
+	if m.Status.AppliedDowntimeMs != nil {
+		fmt.Fprintf(out, "Downtime cap:   %dms (target; achieved <= this, not measured)\n", *m.Status.AppliedDowntimeMs)
 	}
 	if m.Status.FailureMessage != "" {
 		fmt.Fprintf(out, "Failure:        %s\n", m.Status.FailureMessage)

--- a/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
+++ b/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
@@ -210,6 +210,21 @@ spec:
           status:
             description: SwiftMigrationStatus is the observed state of a SwiftMigration.
             properties:
+              appliedDowntimeMs:
+                description: |-
+                  AppliedDowntimeMs is the Cloud Hypervisor `downtime_ms` ceiling the
+                  controller actually sent on vm.send-migration (from
+                  spec.downtimeTarget; CH >= v52). It is a BOUND, not a measurement:
+                  CH converges pre-copy so the final vCPU stop-and-copy fits under it,
+                  so the real "guest frozen" window is <= this value — but CH v52 does
+                  not report the achieved downtime (vm.send-migration returns 204 with
+                  no body, and CH logs no migration telemetry at its default level), so
+                  the achieved window is not directly measurable here. The only ground
+                  truth is an external observer (e.g. an L2 sibling pinging the guest;
+                  Tracked Follow-up #1). Nil when spec.downtimeTarget was unset (CH used
+                  its native behaviour) or for mode=offline.
+                format: int64
+                type: integer
               completedAt:
                 description: CompletedAt is when the migration reached a terminal
                   state.
@@ -422,23 +437,6 @@ spec:
                   surfaced today (W28 candidate per Tracked Follow-up #7
                   close-out — capture per-phase timing from CH internals).
                 type: string
-              observedPauseWindow:
-                description: |-
-                  ObservedPauseWindow is a deprecated alias for
-                  ObservedTransferDuration. The original name misleadingly
-                  suggested "vCPU pause window" — see ObservedTransferDuration's
-                  docstring for the actual semantics (full vm.send-migration RPC
-                  duration, most of which is NOT vCPU-paused). Phase 3b PR 1
-                  dual-writes both fields from a single source value to give
-                  operator tooling one full release cycle to migrate.
-
-                  Not populated for status.mode=offline migrations; offline
-                  migration shuts down the source guest and restarts it on the
-                  destination, with no memory transfer RPC involved.
-
-                  Will be removed in Phase 3b+1. Operator tooling should migrate
-                  to ObservedTransferDuration.
-                type: string
               observedTransferDuration:
                 description: |-
                   ObservedTransferDuration is the swiftletd-reported elapsed time
@@ -452,10 +450,9 @@ spec:
                   Read from the kubeswift.io/migration-pause-window-ms annotation
                   that swiftletd writes alongside migration-status=complete
                   (rust/swiftletd/src/action.rs::write_migration_status). Stamped
-                  by stopandcopy_live's substateSrcCompleted handler per W27b;
-                  in Phase 3b PR 1 the same stamping path dual-writes both
-                  ObservedTransferDuration and the deprecated ObservedPauseWindow
-                  alias from a single source value.
+                  by stopandcopy_live's substateSrcCompleted handler per W27b.
+                  (The deprecated ObservedPauseWindow alias was removed in the
+                  CH-v52 observability work; this is the canonical field.)
 
                   Empirical baseline from Phase 3b spike Q2 on Calico VXLAN pod
                   networking: ~38s for a 4Gi RAM guest with no memory-dirtying
@@ -465,9 +462,6 @@ spec:
                     (guest_RAM × 1.05) / pod_network_bandwidth
                   (the 1.05 factor accounts for the ~5% CH orchestration overhead
                   measured in spike Q4.)
-
-                  Replaces ObservedPauseWindow (deprecated alias, will be removed
-                  in Phase 3b+1).
 
                   Not populated for status.mode=offline migrations; offline
                   migration shuts down the source guest and restarts it on the

--- a/docs/design/live-migration-ch-v52-observability.md
+++ b/docs/design/live-migration-ch-v52-observability.md
@@ -132,8 +132,53 @@ Each PR validates on the dev cluster (miles + boba, kernel-boot + RWX/Block
 disk-boot live-migratable guests):
 - PR 1: downtime targets sweep + convergence + achieved-downtime feasibility.
 - PR 2: metric values match the spike measurements; deprecated alias gone;
-  `kubectl explain` clean; Grafana panel renders.
+  `kubectl explain` clean.
 - PR 3: throughput sweep (1/2/4 connections); regression that single-connection
   (default) is unchanged.
+
+## 8. PR 1 spike results (cluster-validated, 2026-06-08)
+
+Ran on the dev cluster (kernel-boot faas-minimal 2Gi guest, miles↔boba,
+CH v52.0, image `sha-d0b4ef1`). Migrations at `downtimeTarget` =
+100/300/1000ms + baseline:
+
+| downtimeTarget | result | observedDowntime | observedTransfer |
+|---|---|---|---|
+| 100ms | Completed | 2.36s | 19.39s |
+| 300ms | Completed | 2.32s | 19.38s |
+| 1000ms | Completed | 1.99s | 19.39s |
+| (unset) | Completed | 3.67s | 19.40s |
+| 5ms | **webhook-rejected** ("outside [10ms, 10s]") | — | — |
+
+**Resolved open questions:**
+1. **Does CH v52 report achieved downtime? → NO.** `vm.send-migration`
+   returns 204 (empty body) and CH runs at default WARN verbosity (no INFO
+   migration telemetry). **W28 is therefore BOUND-ONLY**: PR 2 echoes the
+   applied `downtime_ms` ceiling into `status.appliedDowntimeMs` and
+   documents that the achieved vCPU-stop is ≤ the ceiling but not directly
+   measurable here (an external L2 ping observer — TFU #1 — is the only
+   ground truth). No `stop_and_copy_seconds` histogram is added (no data
+   source; documented, not silently skipped).
+2. **`observedDowntime` is scheduling-dominated cluster-cutover time**
+   (1.99–3.67s of pod-swap noise across runs), confirmed NOT the vCPU-stop —
+   PR 2 does NOT relabel it "guest frozen."
+3. **Default `downtimeTarget`: stays unset (opt-in).** Defaulting to 300ms is
+   deferred — the convergence-under-load behaviour is unproven (below).
+
+**Unvalidated (asset-gated, TFU #13):** the faas-minimal kernel-boot guest
+does not dirty memory, so `observedTransfer` is a constant ~19.4s (one 2Gi
+pass) regardless of target — the `downtime_ms` *convergence* effect (does it
+shorten the frozen window for a dirtying guest, trading more pre-copy
+iterations for a smaller stop-and-copy?) could not be measured. Needs a
+`stress-ng` rand-set workload on a disk-boot guest. The mechanism is sound
+(CH iterates until estimate < target); the empirical proof waits on that
+setup.
+
+### PR 2 shape (revised by the spike)
+- Remove the deprecated `status.observedPauseWindow` alias (TFU #11 done).
+- Add `status.appliedDowntimeMs` (`*int64`) — the ceiling echo, stamped by the
+  controller when it sends `downtime_ms`; `swiftctl migration describe` shows
+  it as "Downtime cap".
+- NO new Prometheus histogram (W28 has no measured value to record).
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/internal/controller/swiftmigration/cancel_live.go
+++ b/internal/controller/swiftmigration/cancel_live.go
@@ -31,7 +31,7 @@ const (
 	// written alongside `migration-status=complete` at send-complete
 	// (rust/swiftletd/src/action.rs::write_migration_status). Read by
 	// stopandcopy_live's substateSendComplete handler and stamped into
-	// status.ObservedPauseWindow per W27b.
+	// status.ObservedTransferDuration per W27b.
 	AnnotationMigrationPauseWindowMs = "kubeswift.io/migration-pause-window-ms"
 	// AnnotationMigrationProgressEstimate is the swiftletd-on-src-emitted
 	// pre-copy progress estimate (an integer percentage 0-100, a bandwidth

--- a/internal/controller/swiftmigration/resuming_live.go
+++ b/internal/controller/swiftmigration/resuming_live.go
@@ -73,12 +73,10 @@ const (
 //     60s for mode=live (PR B1).
 //  8. Compute and stamp:
 //     - status.ObservedDowntime = now - status.ResumingStartedAt
-//     - status.ObservedPauseWindow: NOT computed by B2.3. The design
-//     (§6, ObservedPauseWindow doc) specifies it's parsed from src
-//     pod's migration-status-detail annotation by B3 during
-//     StopAndCopy-live; B2.3 leaves it as-is (B3's commit will
-//     populate it). If status.ObservedPauseWindow is already set
-//     (B3 has run), preserve.
+//     - status.ObservedTransferDuration: NOT computed here. It is
+//     parsed from the src pod's migration-pause-window-ms annotation
+//     by stopandcopy_live during StopAndCopy-live; the Resuming
+//     handler leaves it as-is (preserve whatever was already stamped).
 //  9. Set status.CompletedAt, transition to Completed.
 //
 // **shouldCheckSourcePodUID returns False here** — Resuming is
@@ -209,10 +207,10 @@ func (r *SwiftMigrationReconciler) handleResumingLive(
 			"observedDowntime not computed: status.CutoverStep2DispatchedAt is nil at Resuming completion (state-machine invariant violation; W27a)",
 			"migration", mig.Name)
 	}
-	// status.ObservedPauseWindow is stamped by stopandcopy_live's
+	// status.ObservedTransferDuration is stamped by stopandcopy_live's
 	// substateSendComplete handler (W27b fix) reading the src pod's
-	// kubeswift.io/migration-pause-window-ms annotation. B2.3 leaves
-	// it as-is — preserves whatever StopAndCopy wrote.
+	// kubeswift.io/migration-pause-window-ms annotation. The Resuming
+	// handler leaves it as-is — preserves whatever StopAndCopy wrote.
 
 	status.CompletedAt = &now
 	setPhase(status, migrationv1alpha1.SwiftMigrationPhaseCompleted)

--- a/internal/controller/swiftmigration/resuming_live_test.go
+++ b/internal/controller/swiftmigration/resuming_live_test.go
@@ -341,22 +341,16 @@ func TestResumingLive_SwiftGuestDeleted_FailsWithOther(t *testing.T) {
 	}
 }
 
-func TestResumingLive_PreservesObservedPauseWindow(t *testing.T) {
-	// B3's substateSrcCompleted handler dual-writes both
-	// status.ObservedTransferDuration (Phase 3b canonical) AND
-	// status.ObservedPauseWindow (deprecated alias) during StopAndCopy
-	// from the src pod's kubeswift.io/migration-pause-window-ms
-	// annotation. B2.3 must NOT overwrite or clear either value.
-	//
-	// Test name retained for now (not renamed in Phase 3b PR 1); will
-	// be more natural to rename when ObservedPauseWindow is dropped in
-	// Phase 3b+1.
+func TestResumingLive_PreservesObservedTransferDuration(t *testing.T) {
+	// B3's substateSrcCompleted handler stamps
+	// status.ObservedTransferDuration during StopAndCopy from the src
+	// pod's kubeswift.io/migration-pause-window-ms annotation. The
+	// Resuming handler must NOT overwrite or clear it.
 	scheme := testScheme(t)
 	mig, guest, dst := resumingLiveFixture(t)
 	setGuestRunningTrue(guest)
 	preset := metav1.Duration{Duration: 1500 * time.Millisecond}
 	mig.Status.ObservedTransferDuration = &preset
-	mig.Status.ObservedPauseWindow = &preset
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -372,9 +366,6 @@ func TestResumingLive_PreservesObservedPauseWindow(t *testing.T) {
 	}
 	if status.ObservedTransferDuration == nil || status.ObservedTransferDuration.Duration != preset.Duration {
 		t.Errorf("ObservedTransferDuration modified; want %v, got %+v", preset, status.ObservedTransferDuration)
-	}
-	if status.ObservedPauseWindow == nil || status.ObservedPauseWindow.Duration != preset.Duration {
-		t.Errorf("ObservedPauseWindow alias modified; want %v, got %+v", preset, status.ObservedPauseWindow)
 	}
 }
 

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -433,12 +433,18 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 		if r.MigrationMTLSEnabled {
 			targetURL = fmt.Sprintf("tcp:127.0.0.1:%d", migrationLocalPlaintextPort)
 		}
+		dtMs := downtimeMs(mig)
 		args := migrationSendArgs{
 			TargetURL:      targetURL,
 			TimeoutSeconds: migrationActionTimeoutSeconds,
 			GuestRAMMiB:    guestRAMMiB(ctx, r, &guest),
-			DowntimeMs:     downtimeMs(mig),
+			DowntimeMs:     dtMs,
 		}
+		// Echo the downtime_ms ceiling we actually sent into status so
+		// operators can see the bound that governed this migration.
+		// AppliedDowntimeMs is a BOUND, not a measurement — CH v52 does
+		// not report the achieved vCPU-stop (see the field docstring).
+		status.AppliedDowntimeMs = dtMs
 		argsJSON, err := json.Marshal(args)
 		if err != nil {
 			return phaseFailure(fmt.Sprintf("marshal send args: %v", err), migrationv1alpha1.FailureReasonOther)
@@ -625,10 +631,11 @@ const AnnotationMigrationActionArgs = "kubeswift.io/migration-action-args"
 
 // stampTransferDuration reads the swiftletd-on-src reported
 // vm.send-migration RPC duration from the src pod's
-// kubeswift.io/migration-pause-window-ms annotation and dual-writes
-// it into BOTH status.ObservedTransferDuration (Phase 3b canonical)
-// AND status.ObservedPauseWindow (deprecated alias, removed in
-// Phase 3b+1). swiftletd writes the annotation alongside
+// kubeswift.io/migration-pause-window-ms annotation and writes it into
+// status.ObservedTransferDuration. (The deprecated
+// status.ObservedPauseWindow alias was removed in the CH-v52
+// observability work — operator tooling reads ObservedTransferDuration.)
+// swiftletd writes the annotation alongside
 // migration-status=complete via write_migration_status
 // (rust/swiftletd/src/action.rs:1383-1407). The value reflects the
 // CH-internal pause-and-send window, NOT the controller-orchestration
@@ -675,12 +682,7 @@ func stampTransferDuration(
 		return
 	}
 	d := metav1.Duration{Duration: time.Duration(ms) * time.Millisecond}
-	// Phase 3b PR 1 Commit E: dual-write. Both fields land on the
-	// same status patch (caller already runs status patching after
-	// returning from this helper); operators reading either field
-	// see the same value.
 	status.ObservedTransferDuration = &d
-	status.ObservedPauseWindow = &d
 }
 
 // stampTransferProgress surfaces the swiftletd-on-src

--- a/internal/controller/swiftmigration/stopandcopy_live_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_live_test.go
@@ -854,14 +854,12 @@ func TestStopAndCopyLive_LeaderHandoverMidRecvIssued_ReentrantNoDuplicateWrite(t
 	}
 }
 
-// W27b + Phase 3b PR 1 Commit E: stampTransferDuration (renamed from
-// stampObservedPauseWindow) reads the swiftletd-on-src reported
-// pause window from the src pod's
-// kubeswift.io/migration-pause-window-ms annotation and DUAL-WRITES
-// both status.ObservedTransferDuration (canonical) and
-// status.ObservedPauseWindow (deprecated alias). Verifies the
-// happy-path dual-write.
-func TestStampTransferDuration_HappyPath_DualWrite(t *testing.T) {
+// stampTransferDuration reads the swiftletd-on-src reported pause
+// window from the src pod's kubeswift.io/migration-pause-window-ms
+// annotation and writes status.ObservedTransferDuration. (The
+// deprecated ObservedPauseWindow alias was removed in the CH-v52
+// observability work.)
+func TestStampTransferDuration_HappyPath(t *testing.T) {
 	mig := &migrationv1alpha1.SwiftMigration{}
 	status := &migrationv1alpha1.SwiftMigrationStatus{}
 	src := &corev1.Pod{
@@ -870,29 +868,11 @@ func TestStampTransferDuration_HappyPath_DualWrite(t *testing.T) {
 		},
 	}
 	stampTransferDuration(context.Background(), mig, status, src)
-	// Canonical field
 	if status.ObservedTransferDuration == nil {
 		t.Fatalf("ObservedTransferDuration not stamped")
 	}
 	if got := status.ObservedTransferDuration.Duration; got != 312*time.Millisecond {
 		t.Errorf("ObservedTransferDuration: want 312ms, got %v", got)
-	}
-	// Deprecated alias (Phase 3b release ships both; alias dropped in
-	// Phase 3b+1)
-	if status.ObservedPauseWindow == nil {
-		t.Fatalf("ObservedPauseWindow (deprecated alias) not stamped")
-	}
-	if got := status.ObservedPauseWindow.Duration; got != 312*time.Millisecond {
-		t.Errorf("ObservedPauseWindow alias: want 312ms, got %v", got)
-	}
-	// Both fields read from the same source value, so they must
-	// match. If a future refactor breaks the dual-write coupling
-	// (e.g., introduces a second source for one field), this
-	// assertion fires.
-	if status.ObservedTransferDuration.Duration != status.ObservedPauseWindow.Duration {
-		t.Errorf("dual-write fields diverged: canonical=%v alias=%v",
-			status.ObservedTransferDuration.Duration,
-			status.ObservedPauseWindow.Duration)
 	}
 }
 
@@ -916,16 +896,11 @@ func TestStampTransferDuration_SpikeQ2BaselineValue(t *testing.T) {
 		t.Errorf("ObservedTransferDuration: want %v (spike Q2 baseline), got %v",
 			want, status.ObservedTransferDuration)
 	}
-	if status.ObservedPauseWindow == nil || status.ObservedPauseWindow.Duration != want {
-		t.Errorf("ObservedPauseWindow alias: want %v, got %v",
-			want, status.ObservedPauseWindow)
-	}
 }
 
-// W27b defensive: malformed annotation leaves BOTH fields nil
-// (operators see a missing field, never a wrong one). Same posture
-// as W27a's defensive nil-check on missing CutoverStep2DispatchedAt.
-func TestStampTransferDuration_ParseFailure_LeavesBothFieldsNil(t *testing.T) {
+// W27b defensive: malformed annotation leaves the field nil
+// (operators see a missing field, never a wrong one).
+func TestStampTransferDuration_ParseFailure_LeavesFieldNil(t *testing.T) {
 	mig := &migrationv1alpha1.SwiftMigration{}
 	status := &migrationv1alpha1.SwiftMigrationStatus{}
 	src := &corev1.Pod{
@@ -938,15 +913,11 @@ func TestStampTransferDuration_ParseFailure_LeavesBothFieldsNil(t *testing.T) {
 		t.Errorf("ObservedTransferDuration should be nil on parse failure; got %v",
 			status.ObservedTransferDuration)
 	}
-	if status.ObservedPauseWindow != nil {
-		t.Errorf("ObservedPauseWindow alias should be nil on parse failure; got %v",
-			status.ObservedPauseWindow)
-	}
 }
 
 // W27b: missing annotation (older swiftletd version, unexpected pod
-// state) is silent — no log spam, both fields stay nil.
-func TestStampTransferDuration_MissingAnnotation_LeavesBothFieldsNil(t *testing.T) {
+// state) is silent — no log spam, the field stays nil.
+func TestStampTransferDuration_MissingAnnotation_LeavesFieldNil(t *testing.T) {
 	mig := &migrationv1alpha1.SwiftMigration{}
 	status := &migrationv1alpha1.SwiftMigrationStatus{}
 	src := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: nil}}
@@ -954,10 +925,6 @@ func TestStampTransferDuration_MissingAnnotation_LeavesBothFieldsNil(t *testing.
 	if status.ObservedTransferDuration != nil {
 		t.Errorf("ObservedTransferDuration should be nil when annotation absent; got %v",
 			status.ObservedTransferDuration)
-	}
-	if status.ObservedPauseWindow != nil {
-		t.Errorf("ObservedPauseWindow alias should be nil when annotation absent; got %v",
-			status.ObservedPauseWindow)
 	}
 }
 


### PR DESCRIPTION
## Summary

**PR 2 of the #4 observability arc**, reshaped by PR 1's on-cluster spike.

**Spike result (cluster, CH v52):** `vm.send-migration` returns 204 (empty body) and CH logs no migration telemetry at its default level → **CH v52 does NOT expose an achieved-downtime value.** So W28's "real vCPU-stop metric" is **not first-party deliverable** — it becomes **bound-only**. `observedDowntime` was also confirmed to be scheduling-dominated cluster-cutover time (1.99–3.67s of pod-swap noise), not the vCPU-stop.

## Changes
- **TFU #11 — remove the deprecated `status.observedPauseWindow` alias** (its Phase-3b+1 removal is now due). `stampTransferDuration` writes only `status.observedTransferDuration`; tests + comments updated; CRD regenerated + chart synced.
- **W28 (bound-only) — add `status.appliedDowntimeMs`** (`*int64`): the CH `downtime_ms` ceiling the controller actually sent (from `spec.downtimeTarget`), stamped at the send-args build site. It is a **bound, not a measurement** — the achieved vCPU-stop is ≤ this but CH doesn't report it (external L2 ping observer, TFU #1, is the only ground truth — documented on the field).
- **`swiftctl migration describe`** surfaces it as `Downtime cap: 300ms (target; achieved <= this, not measured)`.
- **No `stop_and_copy_seconds` histogram** — there's no data source for it (documented in the design doc, *not* silently skipped).
- **Design doc** updated (`docs/design/live-migration-ch-v52-observability.md` §8) with the PR 1 spike results + this reshape.

## Tests
- `TestObservedTransferDuration_RoundTrip` (alias dropped), new `TestAppliedDowntimeMs_RoundTrip`, the `stampTransferDuration` tests de-dual-written, `TestResumingLive_PreservesObservedTransferDuration`. Full Go suite green.

## Breaking change note
`status.observedPauseWindow` is **removed** (it was a deprecated alias of `observedTransferDuration` since Phase 3b). Operator tooling already on `observedTransferDuration` is unaffected; anything still reading `observedPauseWindow` must switch.

## Not in this PR
Convergence-under-load (does `downtime_ms` shorten the frozen window for a *dirtying* guest?) stays unvalidated — the faas-minimal kernel-boot guest doesn't dirty memory (constant ~19.4s transfer). Needs a `stress-ng` workload (**TFU #13**). The mechanism is sound; the empirical proof is asset-gated. PR 3 (`parallelConnections → connections`) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)