### PR TITLE
feat(migration): wire parallelConnections → CH connections (multi-stream) [#4 PR3]

### DIFF
--- a/api/migration/v1alpha1/swiftmigration_types.go
+++ b/api/migration/v1alpha1/swiftmigration_types.go
@@ -277,8 +277,13 @@ type SwiftMigrationSpec struct {
 	// downtime is bounded by storage detach + VM boot, not a CH budget).
 	// +optional
 	DowntimeTarget *metav1.Duration `json:"downtimeTarget,omitempty"`
-	// ParallelConnections is the number of TCP connections CH uses for the
-	// migration stream in live mode. Ignored in Phase 1.
+	// ParallelConnections is the number of parallel TCP connections CH uses
+	// for the live-migration memory stream (CH >= v52) — higher throughput
+	// on fast interconnects. 0 or 1 uses a single connection (the default);
+	// values >= 2 are passed through as CH's `connections`. The webhook caps
+	// it (MaxParallelConnections). Below the NIC line rate parallel streams
+	// add little (the single stream already saturates), so this matters on
+	// 10GbE+ interconnects. Ignored for mode=offline (no memory stream).
 	// +optional
 	ParallelConnections int32 `json:"parallelConnections,omitempty"`
 	// Timeout bounds the entire migration operation (StartedAt -> terminal).

--- a/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
+++ b/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
@@ -146,8 +146,13 @@ spec:
                 type: string
               parallelConnections:
                 description: |-
-                  ParallelConnections is the number of TCP connections CH uses for the
-                  migration stream in live mode. Ignored in Phase 1.
+                  ParallelConnections is the number of parallel TCP connections CH uses
+                  for the live-migration memory stream (CH >= v52) — higher throughput
+                  on fast interconnects. 0 or 1 uses a single connection (the default);
+                  values >= 2 are passed through as CH's `connections`. The webhook caps
+                  it (MaxParallelConnections). Below the NIC line rate parallel streams
+                  add little (the single stream already saturates), so this matters on
+                  10GbE+ interconnects. Ignored for mode=offline (no memory stream).
                 format: int32
                 type: integer
               reason:

--- a/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
+++ b/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
@@ -146,8 +146,13 @@ spec:
                 type: string
               parallelConnections:
                 description: |-
-                  ParallelConnections is the number of TCP connections CH uses for the
-                  migration stream in live mode. Ignored in Phase 1.
+                  ParallelConnections is the number of parallel TCP connections CH uses
+                  for the live-migration memory stream (CH >= v52) — higher throughput
+                  on fast interconnects. 0 or 1 uses a single connection (the default);
+                  values >= 2 are passed through as CH's `connections`. The webhook caps
+                  it (MaxParallelConnections). Below the NIC line rate parallel streams
+                  add little (the single stream already saturates), so this matters on
+                  10GbE+ interconnects. Ignored for mode=offline (no memory stream).
                 format: int32
                 type: integer
               reason:

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -88,6 +88,13 @@ type migrationSendArgs struct {
 	// uses its native default. Maps to MigrationSendArgs.downtime_ms in
 	// rust/swiftletd/src/action.rs -> swift_ch_client::send_migration.
 	DowntimeMs *int64 `json:"downtime_ms,omitempty"`
+	// Connections is the Cloud Hypervisor `connections` count for
+	// vm.send-migration (CH >= v52): parallel TCP connections for the
+	// memory stream. Derived from SwiftMigration.spec.parallelConnections;
+	// nil (unset, or 1) omits the field so CH uses a single connection.
+	// Maps to MigrationSendArgs.connections in
+	// rust/swiftletd/src/action.rs -> swift_ch_client::send_migration.
+	Connections *int32 `json:"connections,omitempty"`
 }
 
 // downtimeMs converts SwiftMigration.spec.downtimeTarget to a CH
@@ -104,6 +111,19 @@ func downtimeMs(mig *migrationv1alpha1.SwiftMigration) *int64 {
 		return nil
 	}
 	return &ms
+}
+
+// parallelConnections returns the CH `connections` count from
+// SwiftMigration.spec.parallelConnections. Returns nil for 0 or 1 (a
+// single connection is CH's default and needs no field) so the send-args
+// omit it. Values >= 2 are passed through (the webhook caps at
+// MaxParallelConnections). Live-mode only.
+func parallelConnections(mig *migrationv1alpha1.SwiftMigration) *int32 {
+	if mig.Spec.ParallelConnections < 2 {
+		return nil
+	}
+	n := mig.Spec.ParallelConnections
+	return &n
 }
 
 // guestRAMMiB returns the guest's RAM in MiB from its SwiftGuestClass,
@@ -439,6 +459,7 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 			TimeoutSeconds: migrationActionTimeoutSeconds,
 			GuestRAMMiB:    guestRAMMiB(ctx, r, &guest),
 			DowntimeMs:     dtMs,
+			Connections:    parallelConnections(mig),
 		}
 		// Echo the downtime_ms ceiling we actually sent into status so
 		// operators can see the bound that governed this migration.

--- a/rust/swift-ch-client/src/methods.rs
+++ b/rust/swift-ch-client/src/methods.rs
@@ -168,16 +168,27 @@ impl ApiClient {
     /// 5-iteration cap. `None` omits the field so CH keeps its native
     /// behaviour (on v51.x the field is unknown and would be ignored/
     /// rejected, so callers on older CH must pass `None`).
+    ///
+    /// `connections`, when `Some(n)`, opens `n` parallel TCP connections
+    /// for the memory stream (CH >= v52) — higher throughput on fast
+    /// interconnects. The destination's receive listener accepts the
+    /// extra connections (up to CH's internal cap). `None` (or `Some(1)`)
+    /// uses a single connection. Omitted from the body when `None` so CH
+    /// keeps its native single-connection behaviour.
     pub fn send_migration(
         &self,
         destination_url: &str,
         downtime_ms: Option<u64>,
+        connections: Option<u32>,
     ) -> Result<(), ApiError> {
         let mut body = serde_json::json!({
             "destination_url": destination_url,
         });
         if let Some(ms) = downtime_ms {
             body["downtime_ms"] = serde_json::json!(ms);
+        }
+        if let Some(n) = connections {
+            body["connections"] = serde_json::json!(n);
         }
         let body = serde_json::to_vec(&body)
             .map_err(|e| ApiError::Malformed(format!("send_migration body serialize: {}", e)))?;
@@ -413,16 +424,19 @@ mod tests {
     fn send_migration_sends_destination_url_in_body() {
         let server = MockServer::spawn(no_content());
         let client = ApiClient::new(server.path.clone());
-        client.send_migration("tcp:10.0.0.5:6789", None).unwrap();
+        client
+            .send_migration("tcp:10.0.0.5:6789", None, None)
+            .unwrap();
         let req = String::from_utf8(server.collect_request()).unwrap();
         assert!(req.starts_with("PUT /api/v1/vm.send-migration HTTP/1.1\r\n"));
         assert!(req.contains("Content-Type: application/json\r\n"));
         let (_, body) = req.split_once("\r\n\r\n").unwrap();
         let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
         assert_eq!(parsed["destination_url"], "tcp:10.0.0.5:6789");
-        // None -> downtime_ms omitted entirely (CH keeps native behaviour;
+        // None -> fields omitted entirely (CH keeps native behaviour;
         // v51.x would reject an unknown field).
         assert!(parsed.get("downtime_ms").is_none());
+        assert!(parsed.get("connections").is_none());
     }
 
     #[test]
@@ -430,13 +444,27 @@ mod tests {
         let server = MockServer::spawn(no_content());
         let client = ApiClient::new(server.path.clone());
         client
-            .send_migration("tcp:10.0.0.5:6789", Some(300))
+            .send_migration("tcp:10.0.0.5:6789", Some(300), None)
             .unwrap();
         let req = String::from_utf8(server.collect_request()).unwrap();
         let (_, body) = req.split_once("\r\n\r\n").unwrap();
         let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
         assert_eq!(parsed["destination_url"], "tcp:10.0.0.5:6789");
         assert_eq!(parsed["downtime_ms"], 300);
+    }
+
+    #[test]
+    fn send_migration_includes_connections_when_set() {
+        let server = MockServer::spawn(no_content());
+        let client = ApiClient::new(server.path.clone());
+        client
+            .send_migration("tcp:10.0.0.5:6789", Some(300), Some(4))
+            .unwrap();
+        let req = String::from_utf8(server.collect_request()).unwrap();
+        let (_, body) = req.split_once("\r\n\r\n").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed["downtime_ms"], 300);
+        assert_eq!(parsed["connections"], 4);
     }
 
     #[test]
@@ -452,7 +480,7 @@ mod tests {
         );
         let client = ApiClient::new(server.path.clone());
         let err = client
-            .send_migration("tcp:10.0.0.5:6789", None)
+            .send_migration("tcp:10.0.0.5:6789", None, None)
             .unwrap_err();
         match err {
             ApiError::Status(resp) => {

--- a/rust/swiftletd/src/action.rs
+++ b/rust/swiftletd/src/action.rs
@@ -720,6 +720,12 @@ struct MigrationSendArgs {
     /// SwiftMigration.spec.downtimeTarget.
     #[serde(default)]
     downtime_ms: Option<u64>,
+    /// Cloud Hypervisor `connections` count for vm.send-migration
+    /// (CH >= v52): parallel TCP connections for the memory stream.
+    /// Absent -> single connection. Set by the controller from
+    /// SwiftMigration.spec.parallelConnections (only when >= 2).
+    #[serde(default)]
+    connections: Option<u32>,
 }
 
 /// Args parsed from `kubeswift.io/migration-action-args` for the
@@ -940,7 +946,7 @@ async fn dispatch_migration_send(
     let _progress = spawn_progress_emitter(action.id.clone(), args.guest_ram_mib);
 
     let started = std::time::Instant::now();
-    if let Err(e) = client.send_migration(&args.target_url, args.downtime_ms) {
+    if let Err(e) = client.send_migration(&args.target_url, args.downtime_ms, args.connections) {
         return Err(format!(
             "send_migration: {}",
             sanitize_ch_error(&format!("{:?}", e))


### PR DESCRIPTION
## Summary

**PR 3 (final) of the #4 arc.** CH v52's `vm.send-migration` accepts a `connections` count — the source opens N parallel TCP connections for the memory stream (the destination's receive listener accepts the extras up to CH's internal cap). Higher throughput on fast interconnects.

`SwiftMigration.spec.parallelConnections` already existed (forward-compat, "Ignored in Phase 1"). This wires it end-to-end now that v52 supports it, mirroring PR 1.

## Changes
- **swift-ch-client**: `send_migration(dest, downtime_ms, connections: Option<u32>)` adds `connections` to the PUT body when `Some` (None / single-connection omits it).
- **swiftletd**: `MigrationSendArgs.connections`; `dispatch_migration_send` passes it through.
- **Controller**: `migrationSendArgs.connections` from `spec.parallelConnections` via `parallelConnections()` — **nil for 0/1** (single connection is CH's default), values **≥ 2** passed through. Webhook already caps at `MaxParallelConnections=16`.
- **Field doc** rewritten (dropped "Ignored in Phase 1"); CRD regenerated + chart synced.

## Tests
- `send_migration_includes_connections_when_set` + the `None`-omits assertion (swift-ch-client). Full Rust + Go suites green.

## Validation note (honest)
The dev cluster is **~1GbE**, and a single CH stream already saturates it (Phase 3b Q4: ~902 Mbit/s). So a throughput **speedup** from parallel streams **cannot be demonstrated here** — the post-merge cluster check confirms the **wiring** (`connections` reaches the CH send body; a migration at N=2/4 still completes). The speedup benefit is real on **10GbE+** interconnects.

## Closes the #4 arc
PR 1 (`downtime_ms`) + PR 2 (metrics: TFU #11 + `appliedDowntimeMs`) + PR 3 (`connections`) = full CH v52 send-migration observability + tuning coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)