### PR TITLE
feat(snapshot): userfaultfd demand-paged restore (memory_restore_mode) [efficiency PR2]

### DIFF
--- a/api/snapshot/v1alpha1/swiftrestore_types.go
+++ b/api/snapshot/v1alpha1/swiftrestore_types.go
@@ -87,6 +87,21 @@ type SwiftRestoreSpec struct {
 	// node).
 	// +optional
 	TargetNode string `json:"targetNode,omitempty"`
+	// MemoryRestoreMode selects Cloud Hypervisor's `memory_restore_mode`
+	// (CH >= v52) for the restore-receive launcher:
+	//   copy     — eager: read the entire memory image before resuming
+	//              (default; predictable, the conservative DR posture).
+	//   ondemand — userfaultfd demand paging: resume immediately and fault
+	//              pages in lazily, cutting restore-to-resume latency for
+	//              large guests. Safe here because the snapshot memory file
+	//              is local + mounted read-only for the pod's lifetime.
+	// cloneFromSnapshot always uses ondemand (fast pool scale-up); this field
+	// is the opt-in for SwiftRestore. Only meaningful for memory snapshots
+	// (local / s3 backends); ignored for csi-volume-snapshot (disk-only).
+	// +kubebuilder:validation:Enum=copy;ondemand
+	// +kubebuilder:default=copy
+	// +optional
+	MemoryRestoreMode string `json:"memoryRestoreMode,omitempty"`
 }
 
 // SwiftRestoreGuestRef is the SwiftGuest the SwiftRestore produced (or

--- a/charts/kubeswift/crds/snapshot.kubeswift.io_swiftrestores.yaml
+++ b/charts/kubeswift/crds/snapshot.kubeswift.io_swiftrestores.yaml
@@ -76,6 +76,24 @@ spec:
                       type: string
                     type: array
                 type: object
+              memoryRestoreMode:
+                default: copy
+                description: |-
+                  MemoryRestoreMode selects Cloud Hypervisor's `memory_restore_mode`
+                  (CH >= v52) for the restore-receive launcher:
+                    copy     — eager: read the entire memory image before resuming
+                               (default; predictable, the conservative DR posture).
+                    ondemand — userfaultfd demand paging: resume immediately and fault
+                               pages in lazily, cutting restore-to-resume latency for
+                               large guests. Safe here because the snapshot memory file
+                               is local + mounted read-only for the pod's lifetime.
+                  cloneFromSnapshot always uses ondemand (fast pool scale-up); this field
+                  is the opt-in for SwiftRestore. Only meaningful for memory snapshots
+                  (local / s3 backends); ignored for csi-volume-snapshot (disk-only).
+                enum:
+                - copy
+                - ondemand
+                type: string
               resumeAfterRestore:
                 default: true
                 description: |-

--- a/config/crd/bases/snapshot.kubeswift.io_swiftrestores.yaml
+++ b/config/crd/bases/snapshot.kubeswift.io_swiftrestores.yaml
@@ -76,6 +76,24 @@ spec:
                       type: string
                     type: array
                 type: object
+              memoryRestoreMode:
+                default: copy
+                description: |-
+                  MemoryRestoreMode selects Cloud Hypervisor's `memory_restore_mode`
+                  (CH >= v52) for the restore-receive launcher:
+                    copy     — eager: read the entire memory image before resuming
+                               (default; predictable, the conservative DR posture).
+                    ondemand — userfaultfd demand paging: resume immediately and fault
+                               pages in lazily, cutting restore-to-resume latency for
+                               large guests. Safe here because the snapshot memory file
+                               is local + mounted read-only for the pod's lifetime.
+                  cloneFromSnapshot always uses ondemand (fast pool scale-up); this field
+                  is the opt-in for SwiftRestore. Only meaningful for memory snapshots
+                  (local / s3 backends); ignored for csi-volume-snapshot (disk-only).
+                enum:
+                - copy
+                - ondemand
+                type: string
               resumeAfterRestore:
                 default: true
                 description: |-

--- a/docs/design/snapshot-ch-v52-efficiency.md
+++ b/docs/design/snapshot-ch-v52-efficiency.md
@@ -126,8 +126,17 @@ A memory-snapshot round-trip on the dev cluster (the existing snapshot e2e):
 | PR | Scope | Gate |
 |---|---|---|
 | 1 | This scoping doc. | — |
-| 2 | userfaultfd restore: `RestoreIntent.memoryRestoreMode` plumbing (Go+Rust); `cloneFromSnapshot` defaults `ondemand`; `SwiftRestore.spec.memoryRestoreMode` opt-in (default `copy`). | After PR #161 cluster-validated |
+| 2 | **SHIPPED** — userfaultfd restore: `RestoreIntent.memoryRestoreMode` plumbing (Go+Rust); `spawn_ch_restore` appends `,memory_restore_mode=<mode>`; `cloneFromSnapshot` defaults `ondemand`; `SwiftRestore.spec.memoryRestoreMode` opt-in (enum `copy`/`ondemand`, default `copy`). | After PR #161 cluster-validated (done; the #165 `shared=on` fix unblocked the memory-snapshot path) |
 | 3 | (follow-up) Tier C upload compression (§3 option A) — `snapshot-s3` stream-compress + manifest suffix. | — |
 | — | Sparse snapshots: **no PR** (automatic on v52); confirmed in the PR 2 validation round-trip. | — |
+
+> **PR 2 plumbing summary:** controller sets the
+> `snapshot.kubeswift.io/restore-memory-mode` annotation (cloneFromSnapshot →
+> `ondemand` in `cloneRestoreAnnotations`; SwiftRestore → `restore.Spec.MemoryRestoreMode`
+> when non-default in `restoreAnnotations`) → `RestoreParamsFromAnnotations` →
+> `RuntimeIntent.Restore.MemoryRestoreMode` → swiftletd `RestoreIntent.memory_restore_mode`
+> → `spawn_ch_restore(..., memory_restore_mode)` → `,memory_restore_mode=<mode>` on
+> `--restore`. Empty/`copy` omits the suffix (CH eager default). The CRD enum
+> rejects bad values at admission (no webhook rule needed).
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/internal/controller/swiftguest/clone.go
+++ b/internal/controller/swiftguest/clone.go
@@ -153,6 +153,11 @@ func cloneRestoreAnnotations(
 		// don't need the resumeCloneIfNeeded action round-trip (Bug #73). Only
 		// the cloneFromSnapshot path sets this; SwiftRestore drives resume itself.
 		AnnotationRestoreAutoResume: "true",
+		// CH v52: userfaultfd demand-paged restore. cloneFromSnapshot defaults
+		// to ondemand — fast pool scale-up is the goal and the latency win is
+		// the point; the snapshot file is local + mounted read-only for the
+		// pod's lifetime, so lazy paging is safe (snapshot-ch-v52-efficiency.md).
+		AnnotationRestoreMemoryMode: "ondemand",
 	}
 	if cloneRegenIncludesNonMAC(guest.Spec.CloneFromSnapshot) {
 		annos[AnnotationRestoreAppendCmdlineMarker] = "true"

--- a/internal/controller/swiftguest/clone_test.go
+++ b/internal/controller/swiftguest/clone_test.go
@@ -302,6 +302,11 @@ func TestCloneRestoreAnnotations_SetsAutoResume(t *testing.T) {
 	if annos[AnnotationRestoreAutoResume] != "true" {
 		t.Errorf("clone restore annotations must set auto-resume=true; got %q", annos[AnnotationRestoreAutoResume])
 	}
+	// CH v52 userfaultfd: cloneFromSnapshot defaults to ondemand (fast pool
+	// scale-up; snapshot file is local + RO, so lazy paging is safe).
+	if annos[AnnotationRestoreMemoryMode] != "ondemand" {
+		t.Errorf("clone restore must set memory-mode=ondemand; got %q", annos[AnnotationRestoreMemoryMode])
+	}
 	if annos[AnnotationRestoreMode] != RestoreModeClone {
 		t.Errorf("clone restore should be clone mode; got %q", annos[AnnotationRestoreMode])
 	}

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -250,8 +250,9 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// CH/QEMU spawn. See rust/swiftletd/src/launch.rs run_ch_restore.
 	if params, ok := RestoreParamsFromAnnotations(guest.Annotations); ok {
 		intent.Restore = &runtimeintent.RestoreIntent{
-			SnapshotPath: params.InPodSnapshotPath(),
-			AutoResume:   params.AutoResume,
+			SnapshotPath:      params.InPodSnapshotPath(),
+			AutoResume:        params.AutoResume,
+			MemoryRestoreMode: params.MemoryRestoreMode,
 		}
 	}
 	intentJSON, err := runtimeintent.Serialize(intent)

--- a/internal/controller/swiftguest/restore.go
+++ b/internal/controller/swiftguest/restore.go
@@ -111,6 +111,12 @@ const (
 	// controller drives a Resuming phase there) — it replaces the
 	// resumeCloneIfNeeded action round-trip (Bug #73).
 	AnnotationRestoreAutoResume = "snapshot.kubeswift.io/restore-auto-resume"
+	// AnnotationRestoreMemoryMode selects CH's `memory_restore_mode` (CH
+	// v52): "ondemand" (userfaultfd lazy paging — lower restore-to-resume
+	// latency) or "copy" (eager default). Empty/absent omits the field.
+	// cloneFromSnapshot sets "ondemand"; SwiftRestore from
+	// spec.memoryRestoreMode.
+	AnnotationRestoreMemoryMode = "snapshot.kubeswift.io/restore-memory-mode"
 )
 
 // Restore mode values for AnnotationRestoreMode.
@@ -169,6 +175,10 @@ type RestoreParams struct {
 	// guest comes up running (cloneFromSnapshot only; replaces Bug #73's
 	// resumeCloneIfNeeded). SwiftRestore leaves it false and drives resume.
 	AutoResume bool
+	// MemoryRestoreMode selects CH's `memory_restore_mode` ("ondemand" |
+	// "copy"). Empty omits the field (CH default copy). cloneFromSnapshot
+	// sets "ondemand"; SwiftRestore from spec.memoryRestoreMode.
+	MemoryRestoreMode string
 	// NullifyHostMAC asks the stager to set net[].host_mac to null in
 	// config.json. Required for clones (see configjson.PatchOptions).
 	NullifyHostMAC bool
@@ -473,5 +483,6 @@ func RestoreParamsFromAnnotations(annotations map[string]string) (RestoreParams,
 		RuntimeDirToPrefix:   annotations[AnnotationRestoreRuntimeDirToPrefix],
 		NullifyHostMAC:       annotations[AnnotationRestoreNullifyHostMAC] == "true",
 		AutoResume:           annotations[AnnotationRestoreAutoResume] == "true",
+		MemoryRestoreMode:    annotations[AnnotationRestoreMemoryMode],
 	}, true
 }

--- a/internal/controller/swiftrestore/local.go
+++ b/internal/controller/swiftrestore/local.go
@@ -518,6 +518,13 @@ func (r *SwiftRestoreReconciler) restoreAnnotations(
 		swiftguestctrl.AnnotationRestoreNodeName:     nodeName,
 		swiftguestctrl.AnnotationRestoreMode:         mode,
 	}
+	// CH v52 memory_restore_mode (userfaultfd opt-in). Pass through when the
+	// operator set it; empty/"copy" omits the annotation so swiftletd uses
+	// CH's eager default. Only meaningful for memory backends (the restore-
+	// receive launcher this drives is local/s3 only).
+	if m := restore.Spec.MemoryRestoreMode; m != "" && m != "copy" {
+		annos[swiftguestctrl.AnnotationRestoreMemoryMode] = m
+	}
 	if !inPlace {
 		// Clone: append cmdline marker so cloud-init bootcmd
 		// regenerates machine-id / SSH keys / hostname on first wake.
@@ -714,6 +721,7 @@ func (r *SwiftRestoreReconciler) unstampGuestRestoreAnnotations(
 				swiftguestctrl.AnnotationRestoreRuntimeDirFromPrefix: nil,
 				swiftguestctrl.AnnotationRestoreRuntimeDirToPrefix:   nil,
 				swiftguestctrl.AnnotationRestoreNullifyHostMAC:       nil,
+				swiftguestctrl.AnnotationRestoreMemoryMode:           nil,
 			},
 		},
 	}

--- a/internal/runtimeintent/types.go
+++ b/internal/runtimeintent/types.go
@@ -46,6 +46,13 @@ type RestoreIntent struct {
 	// round-trip (Bug #73). SwiftRestore-driven restores leave it false and
 	// keep driving resume themselves.
 	AutoResume bool `json:"autoResume,omitempty"`
+	// MemoryRestoreMode selects CH's `memory_restore_mode` (CH v52):
+	// "ondemand" registers guest memory with userfaultfd so the VM resumes
+	// immediately and pages fault in lazily (lower restore-to-resume
+	// latency for large guests); "copy" is the eager default. Empty omits
+	// the field (CH default). cloneFromSnapshot sets "ondemand"; SwiftRestore
+	// from spec.memoryRestoreMode.
+	MemoryRestoreMode string `json:"memoryRestoreMode,omitempty"`
 }
 
 // NICIntent describes a single network interface for the VM.

--- a/rust/swift-ch-client/src/spawn.rs
+++ b/rust/swift-ch-client/src/spawn.rs
@@ -66,11 +66,12 @@ pub fn spawn_ch_restore(
     api_socket: &Path,
     source_url: &str,
     auto_resume: bool,
+    memory_restore_mode: Option<&str>,
 ) -> Result<Child, std::io::Error> {
     let binary =
         std::env::var("KUBESWIFT_CH_BINARY").unwrap_or_else(|_| DEFAULT_CH_BINARY.to_string());
     rm_stale_api_socket(api_socket);
-    let args = restore_args(api_socket, source_url, auto_resume);
+    let args = restore_args(api_socket, source_url, auto_resume, memory_restore_mode);
     std::process::Command::new(&binary).args(&args).spawn()
 }
 
@@ -115,7 +116,12 @@ fn receive_args(api_socket: &Path) -> Vec<String> {
 /// Build the argv for a restore-receive CH invocation. Split out from
 /// [`spawn_ch_restore`] so the argv shape is unit-testable without
 /// actually spawning CH.
-fn restore_args(api_socket: &Path, source_url: &str, auto_resume: bool) -> Vec<String> {
+fn restore_args(
+    api_socket: &Path,
+    source_url: &str,
+    auto_resume: bool,
+    memory_restore_mode: Option<&str>,
+) -> Vec<String> {
     // CH expects --restore as a separate flag, with `source_url=...` as its
     // single value (no equals after the flag itself). `resume=true` (CH v52)
     // brings the guest up RUNNING instead of paused — set for cloneFromSnapshot
@@ -123,6 +129,16 @@ fn restore_args(api_socket: &Path, source_url: &str, auto_resume: bool) -> Vec<S
     let mut restore = format!("source_url={}", source_url);
     if auto_resume {
         restore.push_str(",resume=true");
+    }
+    // memory_restore_mode (CH v52): `ondemand` registers guest memory with
+    // userfaultfd so the VM resumes immediately and pages fault in lazily —
+    // cutting restore-to-resume latency for large guests vs the default
+    // eager `copy`. Safe because every KubeSwift restore keeps the snapshot
+    // memory file local + mounted read-only for the pod's lifetime. None
+    // omits the field so CH uses its native default (copy); on v51.x the
+    // field is unknown, so callers on older CH must pass None.
+    if let Some(mode) = memory_restore_mode {
+        restore.push_str(&format!(",memory_restore_mode={}", mode));
     }
     vec![
         format!("--api-socket={}", api_socket.display()),
@@ -193,11 +209,12 @@ mod tests {
             Path::new("/run/foo/ch.sock"),
             "file:///var/lib/kubeswift/snapshots/default-snap1/",
             false,
+            None,
         );
         assert_eq!(args.len(), 3);
         assert_eq!(args[0], "--api-socket=/run/foo/ch.sock");
         assert_eq!(args[1], "--restore");
-        // auto_resume=false (SwiftRestore): no resume= suffix.
+        // auto_resume=false (SwiftRestore), no memory mode: bare source_url.
         assert_eq!(
             args[2],
             "source_url=file:///var/lib/kubeswift/snapshots/default-snap1/"
@@ -208,16 +225,41 @@ mod tests {
     fn restore_args_auto_resume_adds_resume_true() {
         // cloneFromSnapshot: resume=true so CH brings the guest up running
         // (replaces the resumeCloneIfNeeded round-trip, Bug #73).
-        let args = restore_args(Path::new("/run/ch.sock"), "file:///snap/", true);
+        let args = restore_args(Path::new("/run/ch.sock"), "file:///snap/", true, None);
         assert_eq!(args[2], "source_url=file:///snap/,resume=true");
         // and false omits it.
-        let args = restore_args(Path::new("/run/ch.sock"), "file:///snap/", false);
+        let args = restore_args(Path::new("/run/ch.sock"), "file:///snap/", false, None);
         assert!(!args[2].contains("resume="));
     }
 
     #[test]
+    fn restore_args_memory_restore_mode() {
+        // ondemand (cloneFromSnapshot default): userfaultfd lazy paging.
+        let args = restore_args(
+            Path::new("/run/ch.sock"),
+            "file:///snap/",
+            true,
+            Some("ondemand"),
+        );
+        assert_eq!(
+            args[2],
+            "source_url=file:///snap/,resume=true,memory_restore_mode=ondemand"
+        );
+        // None omits it (CH default copy); explicit copy is also honored.
+        let args = restore_args(Path::new("/run/ch.sock"), "file:///snap/", false, None);
+        assert!(!args[2].contains("memory_restore_mode"));
+        let args = restore_args(
+            Path::new("/run/ch.sock"),
+            "file:///snap/",
+            false,
+            Some("copy"),
+        );
+        assert_eq!(args[2], "source_url=file:///snap/,memory_restore_mode=copy");
+    }
+
+    #[test]
     fn restore_args_relative_socket_path() {
-        let args = restore_args(Path::new("ch.sock"), "file:///snap", false);
+        let args = restore_args(Path::new("ch.sock"), "file:///snap", false, None);
         assert_eq!(args[0], "--api-socket=ch.sock");
     }
 
@@ -228,7 +270,7 @@ mod tests {
         // CLI flags. Asserting the absence here protects against a
         // future regression where someone tries to "helpfully" pass
         // disks or networks through.
-        let args = restore_args(Path::new("/run/ch.sock"), "file:///snap", false);
+        let args = restore_args(Path::new("/run/ch.sock"), "file:///snap", false, None);
         let joined = args.join(" ");
         assert!(!joined.contains("--disk"), "argv leaked --disk: {}", joined);
         assert!(!joined.contains("--net"), "argv leaked --net: {}", joined);
@@ -279,6 +321,7 @@ mod tests {
             Path::new("/run/foo/ch.sock"),
             "file:///var/lib/kubeswift/snapshots/x/",
             false,
+            None,
         )
         .expect("spawn fake CH");
         let status = child.wait().expect("wait fake CH");

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -82,6 +82,14 @@ pub struct RestoreIntent {
     /// SwiftRestore leaves it false and drives resume via its Resuming phase.
     #[serde(default)]
     pub auto_resume: bool,
+    /// Cloud Hypervisor `memory_restore_mode` (CH v52): "ondemand"
+    /// registers guest memory with userfaultfd so the VM resumes
+    /// immediately and pages fault in lazily (cuts restore-to-resume
+    /// latency for large guests); "copy" is the eager default. None
+    /// omits the field. Set by the controller — cloneFromSnapshot
+    /// defaults to "ondemand"; SwiftRestore from spec.memoryRestoreMode.
+    #[serde(default)]
+    pub memory_restore_mode: Option<String>,
 }
 
 /// Live-migration role (Phase 2). When `role == "receiver"`, swiftletd
@@ -310,6 +318,16 @@ impl RuntimeIntent {
             .as_ref()
             .map(|r| r.auto_resume)
             .unwrap_or(false)
+    }
+
+    /// Returns the CH `memory_restore_mode` ("ondemand"/"copy") when set,
+    /// else None (CH uses its native default). cloneFromSnapshot defaults
+    /// to "ondemand" (userfaultfd lazy paging); SwiftRestore is driven by
+    /// spec.memoryRestoreMode.
+    pub fn restore_memory_mode(&self) -> Option<&str> {
+        self.restore
+            .as_ref()
+            .and_then(|r| r.memory_restore_mode.as_deref())
     }
 
     /// Returns the snapshot URL CH expects on `--restore source_url=`.

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -191,8 +191,13 @@ where
         api_socket.display(),
         source_url
     );
-    let mut child = spawn_ch_restore(&api_socket, &source_url, intent.restore_auto_resume())
-        .map_err(|e| format!("failed to spawn cloud-hypervisor (restore): {}", e))?;
+    let mut child = spawn_ch_restore(
+        &api_socket,
+        &source_url,
+        intent.restore_auto_resume(),
+        intent.restore_memory_mode(),
+    )
+    .map_err(|e| format!("failed to spawn cloud-hypervisor (restore): {}", e))?;
     let pid = child.id();
 
     wait_for_socket(&api_socket, Duration::from_secs(30))?;


### PR DESCRIPTION
## Summary

The **snapshot-efficiency implementation** (PR 2 of `docs/design/snapshot-ch-v52-efficiency.md`), now unblocked — the memory-snapshot path is validated end-to-end after the #165 `--memory shared=on` fix and the cloneFromSnapshot round-trip.

CH v52's `--restore` accepts `memory_restore_mode=copy|ondemand`. **`ondemand`** registers the restored guest memory with **userfaultfd** so the VM resumes immediately and pages fault in lazily — cutting **restore-to-resume latency** for large guests vs the eager `copy` default. **Safe in KubeSwift:** every restore keeps the snapshot memory file local + mounted **read-only for the pod's lifetime**, so there's no "source disappeared mid-fault" hazard.

## Plumbing (mirrors PR #161's `resume=true` path)
- **swift-ch-client**: `spawn_ch_restore`/`restore_args` gain `memory_restore_mode: Option<&str>` → append `,memory_restore_mode=<mode>` to `--restore` when `Some` (`None` omits → CH eager default; v51.x callers pass `None`).
- **swiftletd**: `RestoreIntent.memory_restore_mode` + `restore_memory_mode()`; `launch.rs` passes it through.
- **Go**: `RuntimeIntent.Restore.MemoryRestoreMode`; `RestoreParams.MemoryRestoreMode` read from the new `snapshot.kubeswift.io/restore-memory-mode` annotation.
- **cloneFromSnapshot** defaults the annotation to **`ondemand`** (fast pool scale-up; snapshot is local) — `clone.go`.
- **`SwiftRestore.spec.memoryRestoreMode`** (enum `copy|ondemand`, **default `copy`**) is the **opt-in** for the conservative DR path; `swiftrestore/local.go` sets the annotation when the operator chooses `ondemand` (and clears it in the cleanup patch). The CRD enum rejects bad values at admission — no webhook rule needed.

## Scope notes
- **Sparse snapshots**: no code — automatic on v52 (confirm the `du` ≪ `st_size` drop in the validation round-trip).
- **Tier C upload compression** is the §3 follow-up (PR 3).

## Tests
- `restore_args_memory_restore_mode` (swift-ch-client: ondemand suffix / None omits / explicit copy); clone-default-`ondemand` assertion (swiftguest). Full Go + Rust suites green.

## Validation (post-merge)
- **cloneFromSnapshot** clone comes up **Running** via `ondemand` (the `--restore` carries `memory_restore_mode=ondemand`); source sentinel byte-identical.
- **in-place SwiftRestore** (default `copy`) unchanged; opt-in `ondemand` restore works.
- Sparse: confirm the Tier B memory file's `du` ≪ logical size on v52.
- The *latency speedup* of ondemand vs copy is most visible on large guests — measurable, but the mechanism + correctness are the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)