### PR TITLE
feat(snapshot): Tier C S3 upload compression (zstd) [efficiency PR3]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ vendor/
 # docs/design/<phase>-spike.md instead. Convention since
 # Phase 3a (2026-05).
 /spike/
+# Build artifacts (go build output in repo root)
+/snapshot-s3

--- a/cmd/snapshot-s3/compress.go
+++ b/cmd/snapshot-s3/compress.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"io"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// Tier C snapshot artifacts are stream-compressed with zstd on upload and
+// decompressed on download (design snapshot-ch-v52-efficiency.md §3). CH v52's
+// sparse memory snapshot shrinks LOCAL disk (holes), but a normal read of the
+// memory file returns zeros for those holes — so the S3 object would otherwise
+// carry the full guest-RAM size of mostly-zeros. zstd collapses the zero runs
+// to almost nothing: the upload win is compression, not on-disk sparseness.
+//
+// The manifest keeps each artifact's ORIGINAL bytes + sha256 (what the restore
+// consumes and verifies); the object stores the COMPRESSED bytes at a
+// codec-suffixed key, and the Artifact.Compression field is the authoritative
+// signal for the download path. Empty Compression (older manifests) means the
+// object is stored uncompressed at the bare path — backward compatible.
+const (
+	compressionZstd = "zstd"
+	zstdSuffix      = ".zst"
+)
+
+// objectKeyFor returns the S3 object key for an artifact relative to the
+// snapshot prefix: the artifact path, plus a codec suffix when compressed.
+// The suffix keeps the bucket self-describing while the manifest's Compression
+// field stays authoritative.
+func objectKeyFor(a Artifact) string {
+	if a.Compression == compressionZstd {
+		return a.Path + zstdSuffix
+	}
+	return a.Path
+}
+
+// compressingReader returns an io.ReadCloser that yields the zstd-compressed
+// bytes of r. Compression runs in a goroutine writing into an io.Pipe so the
+// uploader streams compressed bytes without buffering the whole (multi-GiB)
+// artifact in memory. A compression/read error is surfaced to the consumer via
+// the pipe so the upload fails loudly rather than storing a truncated object.
+func compressingReader(r io.Reader) io.ReadCloser {
+	pr, pw := io.Pipe()
+	go func() {
+		enc, err := zstd.NewWriter(pw)
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		_, copyErr := io.Copy(enc, r)
+		// enc.Close() flushes the zstd footer; the object is only valid if
+		// both the copy and the flush succeed.
+		closeErr := enc.Close()
+		if copyErr == nil {
+			copyErr = closeErr
+		}
+		pw.CloseWithError(copyErr)
+	}()
+	return pr
+}

--- a/cmd/snapshot-s3/manifest.go
+++ b/cmd/snapshot-s3/manifest.go
@@ -25,6 +25,13 @@ type Artifact struct {
 	Path   string `json:"path"`
 	Bytes  int64  `json:"bytes"`
 	SHA256 string `json:"sha256"`
+	// Compression names the codec the S3 object is stored with ("zstd"), or
+	// empty for an uncompressed object at the bare Path. Bytes + SHA256 always
+	// describe the ORIGINAL (decompressed) content the restore consumes and
+	// verifies; the stored object is the compressed stream at Path+suffix (see
+	// objectKeyFor). Additive/optional, so older manifests (no field) parse and
+	// download from the bare Path unchanged.
+	Compression string `json:"compression,omitempty"`
 }
 
 // Manifest is the source of truth for an s3-exported snapshot: the full set of

--- a/cmd/snapshot-s3/transfer.go
+++ b/cmd/snapshot-s3/transfer.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 // transferStats reports how many artifact bytes a transfer moved vs skipped
@@ -37,15 +39,21 @@ func runUpload(ctx context.Context, store objectStore, srcDir, keyPrefix, snapNa
 	log.Printf("snapshot-s3 upload: %d artifact(s), %d bytes total", len(m.Artifacts), m.TotalBytes)
 
 	stats := transferStats{TotalBytes: m.TotalBytes}
-	for _, a := range m.Artifacts {
-		key := path.Join(keyPrefix, a.Path)
-		// Resume only when the existing object matches BOTH size and content
-		// hash. Size alone is unsafe: a memory-ranges file is always exactly the
-		// guest's RAM size, so a stale object left at this key by a prior
-		// same-named snapshot would be silently kept while the manifest records
-		// the new hash — a permanent mismatch the restore then fails on.
-		if size, sha, ok, serr := store.stat(ctx, key); serr == nil && ok && size == a.Bytes && sha == a.SHA256 {
-			log.Printf("  skip %s (already uploaded, %d bytes, sha matches)", a.Path, size)
+	for i := range m.Artifacts {
+		// Mark every artifact zstd-compressed in the manifest we upload, so the
+		// download path knows to fetch the codec-suffixed object and decompress.
+		// (The memory image is mostly zeros — sparse holes read back as zeros —
+		// which zstd collapses; small JSON artifacts compress harmlessly.)
+		m.Artifacts[i].Compression = compressionZstd
+		a := m.Artifacts[i]
+		key := path.Join(keyPrefix, objectKeyFor(a))
+		// Resume on the ORIGINAL content hash (recorded as object metadata at
+		// upload time). sha256 is collision-safe, so hash-match alone is a safe
+		// skip — and unlike PR #118's size+sha check, it composes with
+		// compression: the stored object's size is the COMPRESSED size, not the
+		// artifact's original Bytes, so a size comparison can no longer be used.
+		if _, sha, ok, serr := store.stat(ctx, key); serr == nil && ok && sha == a.SHA256 {
+			log.Printf("  skip %s (already uploaded, sha matches)", a.Path)
 			stats.SkippedBytes += a.Bytes
 			continue
 		}
@@ -53,12 +61,20 @@ func runUpload(ctx context.Context, store objectStore, srcDir, keyPrefix, snapNa
 		if err != nil {
 			return transferStats{}, fmt.Errorf("open artifact %q: %w", a.Path, err)
 		}
-		log.Printf("  put %s (%d bytes)", a.Path, a.Bytes)
-		err = store.put(ctx, key, f, a.Bytes, a.SHA256)
+		log.Printf("  put %s (%d bytes -> zstd)", a.Path, a.Bytes)
+		// size=-1: the compressed length is unknown up front; minio-go streams
+		// and multiparts as needed. The sha256 metadata is the ORIGINAL hash
+		// (for resume + download verification), NOT the compressed object's.
+		cr := compressingReader(f)
+		err = store.put(ctx, key, cr, -1, a.SHA256)
+		cr.Close() // unblock the compress goroutine if put errored mid-stream
 		f.Close()
 		if err != nil {
 			return transferStats{}, fmt.Errorf("upload artifact %q: %w", a.Path, err)
 		}
+		// TransferredBytes/SkippedBytes track LOGICAL artifact bytes (preserving
+		// the transferred+skipped==total invariant the controller relies on);
+		// the compressed wire/storage saving is not surfaced in these counters.
 		stats.TransferredBytes += a.Bytes
 	}
 
@@ -104,7 +120,7 @@ func runDownload(ctx context.Context, store objectStore, dstDir, keyPrefix strin
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 			return transferStats{}, fmt.Errorf("mkdir for %q: %w", a.Path, err)
 		}
-		if err := downloadOne(ctx, store, path.Join(keyPrefix, a.Path), dst); err != nil {
+		if err := downloadOne(ctx, store, path.Join(keyPrefix, objectKeyFor(a)), dst, a.Compression); err != nil {
 			return transferStats{}, err
 		}
 		if err := verifyArtifact(dstDir, a); err != nil {
@@ -142,7 +158,10 @@ func runDelete(ctx context.Context, store objectStore, keyPrefix string) error {
 	return nil
 }
 
-func downloadOne(ctx context.Context, store objectStore, key, dst string) error {
+// downloadOne fetches key into dst, decompressing on the fly when the artifact
+// was stored with a codec. dst always receives the ORIGINAL (decompressed)
+// bytes, which the caller then verifies against the manifest's size + sha256.
+func downloadOne(ctx context.Context, store objectStore, key, dst, compression string) error {
 	rc, err := store.get(ctx, key)
 	if err != nil {
 		return fmt.Errorf("get %q: %w", key, err)
@@ -152,7 +171,20 @@ func downloadOne(ctx context.Context, store objectStore, key, dst string) error 
 	if err != nil {
 		return fmt.Errorf("create %q: %w", dst, err)
 	}
-	_, err = io.Copy(f, rc)
+	var src io.Reader = rc
+	var dec *zstd.Decoder
+	if compression == compressionZstd {
+		dec, err = zstd.NewReader(rc)
+		if err != nil {
+			f.Close()
+			return fmt.Errorf("zstd reader for %q: %w", key, err)
+		}
+		src = dec
+	}
+	_, err = io.Copy(f, src)
+	if dec != nil {
+		dec.Close()
+	}
 	cerr := f.Close()
 	if err != nil {
 		return fmt.Errorf("write %q: %w", dst, err)

--- a/cmd/snapshot-s3/transfer_test.go
+++ b/cmd/snapshot-s3/transfer_test.go
@@ -200,9 +200,16 @@ func TestUpload_ReuploadsStaleSameSizeContent(t *testing.T) {
 		t.Fatalf("second upload: %v", err)
 	}
 
-	// memory.img must now hold the NEW content (re-uploaded), not the stale "M".
-	if got := store.objs["ns/snap/memory.img"]; !bytes.Equal(got, bytes.Repeat([]byte("X"), 4096)) {
-		t.Fatalf("memory.img kept stale content; size-only skip not fixed (len=%d, first byte=%q)", len(got), got[0])
+	// The compressed object (.zst key) must now carry the NEW content's hash
+	// (re-uploaded), not the stale "M". Compressed bytes aren't directly
+	// comparable, so assert via the recorded original-content sha256 metadata —
+	// the same signal the resume-skip keys off.
+	newSHA, _, err := fileSHA256(filepath.Join(src2, "memory.img"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := store.meta["ns/snap/memory.img.zst"]; got != newSHA {
+		t.Fatalf("memory.img kept stale content; sha-resume not fixed (stored sha %q != new %q)", got, newSHA)
 	}
 	// And a fresh download must verify cleanly against the new manifest.
 	dst := t.TempDir()
@@ -237,12 +244,19 @@ func TestDownload_DetectsCorruption(t *testing.T) {
 	store := newFakeStore()
 	_, _ = runUpload(ctx, store, src, "ns/snap", "ns/snap", false)
 
-	// Corrupt one artifact object (size preserved, content changed) so only the
-	// sha256 check can catch it.
-	store.objs["ns/snap/disks/root.raw"] = bytes.Repeat([]byte("X"), 8192)
+	// Corrupt one artifact object: replace the .zst object with a VALID zstd
+	// stream of DIFFERENT content. It decompresses cleanly to the wrong bytes,
+	// so only the sha256 verification (over the decompressed content) can catch
+	// it — exactly the post-compression corruption path.
+	cr := compressingReader(bytes.NewReader(bytes.Repeat([]byte("X"), 8192)))
+	corrupt, err := io.ReadAll(cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.objs["ns/snap/disks/root.raw.zst"] = corrupt
 
 	dst := t.TempDir()
-	_, err := runDownload(ctx, store, dst, "ns/snap")
+	_, err = runDownload(ctx, store, dst, "ns/snap")
 	if err == nil {
 		t.Fatal("download must fail verification on a corrupt artifact")
 	}
@@ -305,5 +319,58 @@ func TestRunArgs_Validate(t *testing.T) {
 		if err := bad.validate(); err == nil {
 			t.Errorf("invalid args accepted: %+v", bad)
 		}
+	}
+}
+
+// TestUpload_CompressesArtifacts verifies Tier C upload compression: artifacts
+// are stored zstd-compressed at a .zst key, the manifest records the codec, a
+// mostly-zero memory image shrinks dramatically on the wire, and the round-trip
+// reproduces the original bytes (verified against the manifest's original hash).
+func TestUpload_CompressesArtifacts(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	// 1 MiB of zeros — the sparse-memory-image case: reads back as zeros, which
+	// zstd collapses to almost nothing.
+	zeros := make([]byte, 1<<20)
+	writeFile(t, dir, "memory.img", zeros)
+	writeFile(t, dir, "config.json", []byte(`{"cpus":2}`))
+	store := newFakeStore()
+
+	if _, err := runUpload(ctx, store, dir, "ns/snap", "ns/snap", true); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	// Stored at the .zst key, not the bare path.
+	comp, ok := store.objs["ns/snap/memory.img.zst"]
+	if !ok {
+		t.Fatal("compressed object ns/snap/memory.img.zst not found")
+	}
+	if _, bare := store.objs["ns/snap/memory.img"]; bare {
+		t.Error("bare (uncompressed) memory.img object should not exist")
+	}
+	// Zeros compress to a tiny fraction of the original 1 MiB.
+	if len(comp) >= (1<<20)/10 {
+		t.Errorf("compressed memory.img = %d bytes; expected << 1 MiB for all-zeros", len(comp))
+	}
+	// Manifest records the codec + the ORIGINAL size/hash (not the compressed).
+	m, err := parseManifest(store.objs["ns/snap/manifest.json"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range m.Artifacts {
+		if a.Compression != compressionZstd {
+			t.Errorf("artifact %s compression = %q, want zstd", a.Path, a.Compression)
+		}
+		if a.Path == "memory.img" && a.Bytes != 1<<20 {
+			t.Errorf("manifest memory.img bytes = %d, want original 1 MiB", a.Bytes)
+		}
+	}
+	// Round-trip reproduces the original bytes (download decompresses + verifies).
+	dst := t.TempDir()
+	if _, err := runDownload(ctx, store, dst, "ns/snap"); err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dst, "memory.img"))
+	if err != nil || !bytes.Equal(got, zeros) {
+		t.Fatalf("round-trip memory.img mismatch (err=%v, len=%d)", err, len(got))
 	}
 }

--- a/docs/design/snapshot-ch-v52-efficiency.md
+++ b/docs/design/snapshot-ch-v52-efficiency.md
@@ -127,7 +127,7 @@ A memory-snapshot round-trip on the dev cluster (the existing snapshot e2e):
 |---|---|---|
 | 1 | This scoping doc. | — |
 | 2 | **SHIPPED** — userfaultfd restore: `RestoreIntent.memoryRestoreMode` plumbing (Go+Rust); `spawn_ch_restore` appends `,memory_restore_mode=<mode>`; `cloneFromSnapshot` defaults `ondemand`; `SwiftRestore.spec.memoryRestoreMode` opt-in (enum `copy`/`ondemand`, default `copy`). | After PR #161 cluster-validated (done; the #165 `shared=on` fix unblocked the memory-snapshot path) |
-| 3 | (follow-up) Tier C upload compression (§3 option A) — `snapshot-s3` stream-compress + manifest suffix. | — |
+| 3 | **SHIPPED** — Tier C upload compression (§3 option A): `snapshot-s3` stream-compresses every artifact with **zstd** on upload (io.Pipe streaming, no buffering), stores it at a `.zst` object key, and records `compression` per-artifact in the manifest (Bytes+SHA256 stay ORIGINAL for download verification). Download decompresses on the fly; verify checks the decompressed content. Resume-skip switched from size+sha to **sha-only** (compressed object size ≠ the artifact's original size; sha256 is content-safe). Backward compatible: empty `compression` (older manifests) → bare-key uncompressed download. Mostly-zero memory images collapse to a tiny fraction on the wire. | — |
 | — | Sparse snapshots: **no PR** (automatic on v52); confirmed in the PR 2 validation round-trip. | — |
 
 > **PR 2 plumbing summary:** controller sets the

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/projectbeskar/kubeswift
 go 1.25.0
 
 require (
+	github.com/klauspost/compress v1.18.6
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0
 	github.com/minio/minio-go/v7 v7.2.0
 	github.com/prometheus/client_golang v1.23.2
@@ -39,7 +40,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.11 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect


### PR DESCRIPTION
## Summary

**Snapshot-efficiency PR 3** (design §3) — closes the `snapshot-ch-v52-efficiency` arc.

CH v52's sparse memory snapshot shrinks **local disk** (holes), but a normal read of the memory file returns **zeros for those holes**, so the S3 object would otherwise carry the full guest-RAM size of mostly-zeros. The Tier C win is **compression**, not on-disk sparseness.

`snapshot-s3` now stream-compresses every artifact with **zstd** on upload and decompresses on download.

## Changes
- **`compress.go`**: zstd `compressingReader` (io.Pipe streaming — never buffers the multi-GiB image in memory) + `objectKeyFor` (codec-suffixed key).
- **Manifest** gains a per-artifact **`compression`** field; `bytes` + `sha256` stay the **original** (decompressed) content the restore consumes and verifies. The object is stored at `<path>.zst`.
- **Download** decompresses on the fly into the node-local cache; `verifyArtifact` checks the **decompressed** content against the manifest size + sha256.
- **Resume-skip** switches from `size+sha` (PR #118) to **sha-only**: the compressed object's size is no longer the artifact's original size, and sha256 is collision-safe so hash-match alone is a safe skip. The original sha is stored as object metadata, so the skip still catches stale same-name objects (PR #118's bug stays fixed).
- **Backward compatible**: empty `compression` (older manifests) → bare-key uncompressed download. `schemaVersion` unchanged (additive field).
- `klauspost/compress` promoted indirect → direct (already vendored via minio-go).

## Notes
- Byte counters (`transferred`/`skipped`/`total`) stay **logical** artifact bytes to preserve the `transferred+skipped==total` invariant the controller relies on; the compressed wire/storage saving isn't surfaced in them (possible follow-up).
- Only the `snapshot-s3` image changes — the controller is untouched (it just invokes the upload/download Jobs).

## Tests
- `TestUpload_CompressesArtifacts` — 1 MiB of zeros collapses to ≪ 1/10, stored at the `.zst` key, manifest records the codec + original size, round-trip reproduces the bytes.
- Existing dedup + corruption tests updated for the `.zst` key (corruption now via a *valid-but-different* zstd stream, so sha256 still catches it). Full suite green.

## Validation (post-merge)
- A Tier C (s3) memory-snapshot round-trip: confirm the uploaded `memory-ranges.zst` object is **much smaller** than the guest RAM, and the cross-node restore/clone reproduces the source state byte-identically (decompress + sha256 verify).
- Backward-compat: an existing uncompressed s3 snapshot still restores (empty `compression` → bare-key path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)