### PR TITLE
feat(vhost-user-net): operator-backed vhost-user-net interfaces [vhost-user PR3]

### DIFF
--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -336,8 +336,9 @@ type FilesystemSource struct {
 
 // InterfaceType constants for GuestInterface.Type.
 const (
-	InterfaceTypeBridge = "bridge"
-	InterfaceTypeSRIOV  = "sriov"
+	InterfaceTypeBridge    = "bridge"
+	InterfaceTypeSRIOV     = "sriov"
+	InterfaceTypeVhostUser = "vhost-user"
 )
 
 // GuestInterface defines a single network interface for a SwiftGuest.
@@ -346,9 +347,12 @@ type GuestInterface struct {
 	// Used in status reporting and logging.
 	Name string `json:"name"`
 	// Type specifies the interface type.
-	//   bridge: (default) tap+bridge, virtio-net in guest. Used for overlay and standard networks.
-	//   sriov:  SR-IOV VF passthrough via VFIO. Guest sees hardware NIC. Requires SR-IOV NAD.
-	// +kubebuilder:validation:Enum=bridge;sriov
+	//   bridge:     (default) tap+bridge, virtio-net in guest. Used for overlay and standard networks.
+	//   sriov:      SR-IOV VF passthrough via VFIO. Guest sees hardware NIC. Requires SR-IOV NAD.
+	//   vhost-user: virtio-net whose datapath is an operator-provided vhost-user
+	//               backend (DPDK/OVS-DPDK) reached via Socket. Cloud Hypervisor
+	//               only (v1); KubeSwift does not run the backend.
+	// +kubebuilder:validation:Enum=bridge;sriov;vhost-user
 	// +kubebuilder:default=bridge
 	// +optional
 	Type string `json:"type,omitempty"`
@@ -362,6 +366,16 @@ type GuestInterface struct {
 	// adds this resource to the pod's resource limits.
 	// +optional
 	ResourceName string `json:"resourceName,omitempty"`
+	// Socket is the node-local path of the operator-provided vhost-user backend
+	// listener (e.g. /var/run/vhost/fast0.sock). Required when type is
+	// "vhost-user"; its parent directory is mounted into the launcher pod so
+	// Cloud Hypervisor can connect. Not used for bridge/sriov.
+	// +optional
+	Socket string `json:"socket,omitempty"`
+	// MAC optionally pins the interface MAC address. When empty a deterministic
+	// MAC is generated. Honored for vhost-user (and bridge) interfaces.
+	// +optional
+	MAC string `json:"mac,omitempty"`
 }
 
 // NetworkReference references a Multus NetworkAttachmentDefinition.

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
@@ -353,6 +353,11 @@ spec:
                           description: GuestInterface defines a single network interface
                             for a SwiftGuest.
                           properties:
+                            mac:
+                              description: |-
+                                MAC optionally pins the interface MAC address. When empty a deterministic
+                                MAC is generated. Honored for vhost-user (and bridge) interfaces.
+                              type: string
                             name:
                               description: |-
                                 Name is a unique identifier for this interface.
@@ -381,15 +386,26 @@ spec:
                                 Required when type is "sriov". The device plugin allocates a VF and the controller
                                 adds this resource to the pod's resource limits.
                               type: string
+                            socket:
+                              description: |-
+                                Socket is the node-local path of the operator-provided vhost-user backend
+                                listener (e.g. /var/run/vhost/fast0.sock). Required when type is
+                                "vhost-user"; its parent directory is mounted into the launcher pod so
+                                Cloud Hypervisor can connect. Not used for bridge/sriov.
+                              type: string
                             type:
                               default: bridge
                               description: |-
                                 Type specifies the interface type.
-                                  bridge: (default) tap+bridge, virtio-net in guest. Used for overlay and standard networks.
-                                  sriov:  SR-IOV VF passthrough via VFIO. Guest sees hardware NIC. Requires SR-IOV NAD.
+                                  bridge:     (default) tap+bridge, virtio-net in guest. Used for overlay and standard networks.
+                                  sriov:      SR-IOV VF passthrough via VFIO. Guest sees hardware NIC. Requires SR-IOV NAD.
+                                  vhost-user: virtio-net whose datapath is an operator-provided vhost-user
+                                              backend (DPDK/OVS-DPDK) reached via Socket. Cloud Hypervisor
+                                              only (v1); KubeSwift does not run the backend.
                               enum:
                               - bridge
                               - sriov
+                              - vhost-user
                               type: string
                           required:
                           - name

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -285,6 +285,11 @@ spec:
                   description: GuestInterface defines a single network interface for
                     a SwiftGuest.
                   properties:
+                    mac:
+                      description: |-
+                        MAC optionally pins the interface MAC address. When empty a deterministic
+                        MAC is generated. Honored for vhost-user (and bridge) interfaces.
+                      type: string
                     name:
                       description: |-
                         Name is a unique identifier for this interface.
@@ -313,15 +318,26 @@ spec:
                         Required when type is "sriov". The device plugin allocates a VF and the controller
                         adds this resource to the pod's resource limits.
                       type: string
+                    socket:
+                      description: |-
+                        Socket is the node-local path of the operator-provided vhost-user backend
+                        listener (e.g. /var/run/vhost/fast0.sock). Required when type is
+                        "vhost-user"; its parent directory is mounted into the launcher pod so
+                        Cloud Hypervisor can connect. Not used for bridge/sriov.
+                      type: string
                     type:
                       default: bridge
                       description: |-
                         Type specifies the interface type.
-                          bridge: (default) tap+bridge, virtio-net in guest. Used for overlay and standard networks.
-                          sriov:  SR-IOV VF passthrough via VFIO. Guest sees hardware NIC. Requires SR-IOV NAD.
+                          bridge:     (default) tap+bridge, virtio-net in guest. Used for overlay and standard networks.
+                          sriov:      SR-IOV VF passthrough via VFIO. Guest sees hardware NIC. Requires SR-IOV NAD.
+                          vhost-user: virtio-net whose datapath is an operator-provided vhost-user
+                                      backend (DPDK/OVS-DPDK) reached via Socket. Cloud Hypervisor
+                                      only (v1); KubeSwift does not run the backend.
                       enum:
                       - bridge
                       - sriov
+                      - vhost-user
                       type: string
                   required:
                   - name

--- a/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
@@ -353,6 +353,11 @@ spec:
                           description: GuestInterface defines a single network interface
                             for a SwiftGuest.
                           properties:
+                            mac:
+                              description: |-
+                                MAC optionally pins the interface MAC address. When empty a deterministic
+                                MAC is generated. Honored for vhost-user (and bridge) interfaces.
+                              type: string
                             name:
                               description: |-
                                 Name is a unique identifier for this interface.
@@ -381,15 +386,26 @@ spec:
                                 Required when type is "sriov". The device plugin allocates a VF and the controller
                                 adds this resource to the pod's resource limits.
                               type: string
+                            socket:
+                              description: |-
+                                Socket is the node-local path of the operator-provided vhost-user backend
+                                listener (e.g. /var/run/vhost/fast0.sock). Required when type is
+                                "vhost-user"; its parent directory is mounted into the launcher pod so
+                                Cloud Hypervisor can connect. Not used for bridge/sriov.
+                              type: string
                             type:
                               default: bridge
                               description: |-
                                 Type specifies the interface type.
-                                  bridge: (default) tap+bridge, virtio-net in guest. Used for overlay and standard networks.
-                                  sriov:  SR-IOV VF passthrough via VFIO. Guest sees hardware NIC. Requires SR-IOV NAD.
+                                  bridge:     (default) tap+bridge, virtio-net in guest. Used for overlay and standard networks.
+                                  sriov:      SR-IOV VF passthrough via VFIO. Guest sees hardware NIC. Requires SR-IOV NAD.
+                                  vhost-user: virtio-net whose datapath is an operator-provided vhost-user
+                                              backend (DPDK/OVS-DPDK) reached via Socket. Cloud Hypervisor
+                                              only (v1); KubeSwift does not run the backend.
                               enum:
                               - bridge
                               - sriov
+                              - vhost-user
                               type: string
                           required:
                           - name

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -285,6 +285,11 @@ spec:
                   description: GuestInterface defines a single network interface for
                     a SwiftGuest.
                   properties:
+                    mac:
+                      description: |-
+                        MAC optionally pins the interface MAC address. When empty a deterministic
+                        MAC is generated. Honored for vhost-user (and bridge) interfaces.
+                      type: string
                     name:
                       description: |-
                         Name is a unique identifier for this interface.
@@ -313,15 +318,26 @@ spec:
                         Required when type is "sriov". The device plugin allocates a VF and the controller
                         adds this resource to the pod's resource limits.
                       type: string
+                    socket:
+                      description: |-
+                        Socket is the node-local path of the operator-provided vhost-user backend
+                        listener (e.g. /var/run/vhost/fast0.sock). Required when type is
+                        "vhost-user"; its parent directory is mounted into the launcher pod so
+                        Cloud Hypervisor can connect. Not used for bridge/sriov.
+                      type: string
                     type:
                       default: bridge
                       description: |-
                         Type specifies the interface type.
-                          bridge: (default) tap+bridge, virtio-net in guest. Used for overlay and standard networks.
-                          sriov:  SR-IOV VF passthrough via VFIO. Guest sees hardware NIC. Requires SR-IOV NAD.
+                          bridge:     (default) tap+bridge, virtio-net in guest. Used for overlay and standard networks.
+                          sriov:      SR-IOV VF passthrough via VFIO. Guest sees hardware NIC. Requires SR-IOV NAD.
+                          vhost-user: virtio-net whose datapath is an operator-provided vhost-user
+                                      backend (DPDK/OVS-DPDK) reached via Socket. Cloud Hypervisor
+                                      only (v1); KubeSwift does not run the backend.
                       enum:
                       - bridge
                       - sriov
+                      - vhost-user
                       type: string
                   required:
                   - name

--- a/config/samples/vhost-user-net/swiftguest-vhost-user-net.yaml
+++ b/config/samples/vhost-user-net/swiftguest-vhost-user-net.yaml
@@ -1,0 +1,28 @@
+# A guest with a standard bridge NIC plus a vhost-user-net interface whose
+# datapath is an operator-provided DPDK/OVS-DPDK backend. KubeSwift does NOT
+# run the backend — the operator's node-level fast-path exposes a vhost-user
+# listener socket; KubeSwift mounts its directory into the launcher and points
+# Cloud Hypervisor at it. The guest sees an ordinary virtio-net device; the
+# line rate comes from the backend.
+#
+# Asset-gated: the line-rate datapath needs a DPDK NIC + backend on the node.
+# Without one, the wiring is correct but the interface has no traffic source
+# (same posture as SR-IOV: shipped, hardware validation deferred).
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: vhost-user-net
+spec:
+  imageRef:
+    name: ubuntu-noble
+  guestClassRef:
+    name: default
+  seedProfileRef:
+    name: default
+  interfaces:
+    - name: mgmt            # primary bridge NIC (DHCP, SSH, normal pod networking)
+      type: bridge
+    - name: fast0           # high-throughput vhost-user-net interface
+      type: vhost-user
+      socket: /var/run/vhost/fast0.sock   # operator backend listener (node path)
+      # mac: "52:54:00:00:fa:00"          # optional; generated if unset

--- a/docs/virtiofs.md
+++ b/docs/virtiofs.md
@@ -1,9 +1,18 @@
+# vhost-user devices: virtiofs & vhost-user-net
+
+KubeSwift ships two [vhost-user](https://www.qemu.org/docs/master/interop/vhost-user.html)
+devices: **virtiofs** (shared filesystems) and **vhost-user-net** (operator
+DPDK fast-path networking). The architecture and roadmap live in
+[`docs/design/vhost-user-devices.md`](design/vhost-user-devices.md). Both rely on
+shared guest memory, which KubeSwift already maps by default (`--memory shared=on`).
+
+---
+
 # virtiofs shared filesystems (vhost-user-fs)
 
 Share a host directory or a PersistentVolumeClaim into a SwiftGuest as a
 [virtiofs](https://virtio-fs.gitlab.io/) mount. This is the first vhost-user
-device KubeSwift ships; the architecture and roadmap live in
-[`docs/design/vhost-user-devices.md`](design/vhost-user-devices.md).
+device KubeSwift ships.
 
 ## What it is
 
@@ -86,3 +95,54 @@ scratch /mnt/scratch virtiofs defaults,nofail 0 0
   `--sandbox none`; the pod (its mount namespace + the single shared source
   mount) is the boundary. The launcher uses no extra Linux capabilities for
   this — consistent with the project's no-privileged-containers rule.
+
+---
+
+# vhost-user-net (operator DPDK fast-path)
+
+A `vhost-user` interface gives a guest a virtio-net device whose datapath is an
+**operator-provided** vhost-user backend (DPDK / OVS-DPDK). It only beats the
+default tap/bridge path when paired with such a userspace fast-path — which is
+node-level operator infrastructure. **KubeSwift does not run the backend**; it
+mounts the backend's socket into the launcher and points Cloud Hypervisor at it,
+exactly as SR-IOV expects the VFs to be pre-provisioned.
+
+## Requirements
+
+- **Cloud Hypervisor path only** (v1). The webhook rejects a `vhost-user`
+  interface together with `spec.gpuProfileRef` (which may select QEMU).
+- An operator-run vhost-user-net backend on the node exposing a listener socket
+  (e.g. `/var/run/vhost/fast0.sock`). KubeSwift mounts the socket's parent
+  directory into the launcher (hostPath) so CH can connect.
+
+## Fields
+
+```yaml
+spec:
+  interfaces:
+    - name: mgmt          # keep a normal bridge NIC for DHCP/SSH
+      type: bridge
+    - name: fast0
+      type: vhost-user
+      socket: /var/run/vhost/fast0.sock   # required: operator backend listener
+      mac: "52:54:00:00:fa:00"            # optional; generated if unset
+```
+
+Webhook rules: `socket` is required; `networkRef` and `resourceName` are not
+used; not combinable with `gpuProfileRef`. Sockets that share a directory are
+mounted once (deduped). A `vhost-user` NIC is never the primary DHCP interface —
+pair it with a `bridge` NIC for normal pod networking.
+
+The guest sees an ordinary `virtio-net` device — no in-guest configuration
+beyond normal NIC setup. The line rate comes from the backend.
+
+## Validation status
+
+The **wiring** is validated (CH spawns `--net vhost_user=on,socket=...`; the
+webhook accepts/bounds it; the socket dir is mounted). The **line-rate datapath
+is asset-gated** — it needs a DPDK NIC + backend on the node, which the dev
+cluster lacks. This is the same honest posture as the shipped-but-hardware-
+unvalidated SR-IOV path.
+
+Example:
+[`config/samples/vhost-user-net/swiftguest-vhost-user-net.yaml`](../config/samples/vhost-user-net/swiftguest-vhost-user-net.yaml).

--- a/internal/controller/swiftguest/pod.go
+++ b/internal/controller/swiftguest/pod.go
@@ -2,6 +2,7 @@ package swiftguest
 
 import (
 	"fmt"
+	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -40,7 +41,44 @@ func BuildPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGuest, seedC
 	applyNodeName(pod, guest)
 	applyDataDiskRefs(pod, guest)
 	applyFilesystems(pod, guest)
+	applyVhostUserNetVolumes(pod, guest)
 	return pod
+}
+
+// applyVhostUserNetVolumes mounts the node directory holding each vhost-user
+// interface's backend socket into the launcher at the SAME path, so Cloud
+// Hypervisor (running in the launcher container) can connect to the
+// operator-provided listener. KubeSwift does not run the backend — the
+// directory is a hostPath the operator's DPDK/OVS datapath populates (the same
+// posture as SR-IOV expecting pre-provisioned VFs). Directories are deduped so
+// several sockets under one dir share a single mount.
+func applyVhostUserNetVolumes(pod *corev1.Pod, guest *swiftv1alpha1.SwiftGuest) {
+	if len(pod.Spec.Containers) == 0 {
+		return
+	}
+	hostPathType := corev1.HostPathDirectoryOrCreate
+	seen := map[string]string{} // dir -> volume name
+	for _, iface := range guest.Spec.Interfaces {
+		if iface.Type != swiftv1alpha1.InterfaceTypeVhostUser || iface.Socket == "" {
+			continue
+		}
+		dir := filepath.Dir(iface.Socket)
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		volName := fmt.Sprintf("vhost-net-%d", len(seen))
+		seen[dir] = volName
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: volName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{Path: dir, Type: &hostPathType},
+			},
+		})
+		pod.Spec.Containers[0].VolumeMounts = append(
+			pod.Spec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{Name: volName, MountPath: dir},
+		)
+	}
 }
 
 // applyFilesystems adds the source volume + mount for each virtiofs share in

--- a/internal/controller/swiftguest/pod_test.go
+++ b/internal/controller/swiftguest/pod_test.go
@@ -662,3 +662,51 @@ func TestBuildPod_Filesystems(t *testing.T) {
 		t.Errorf("virtiofs-1 mount = %+v, want path=.../claim readOnly=true", m)
 	}
 }
+
+func TestBuildPod_VhostUserNet(t *testing.T) {
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "vu", Namespace: "default"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef:      &corev1.LocalObjectReference{Name: "img"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "class"},
+			Interfaces: []swiftv1alpha1.GuestInterface{
+				{Name: "mgmt"},
+				{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser, Socket: "/var/run/vhost/fast0.sock"},
+				{Name: "fast1", Type: swiftv1alpha1.InterfaceTypeVhostUser, Socket: "/var/run/vhost/fast1.sock"},
+			},
+		},
+	}
+	rg := &resolved.ResolvedGuest{
+		Meta:          resolved.Meta{Namespace: "default", Name: "vu"},
+		Resources:     resolved.Resources{CPU: 2, Memory: 2048},
+		PreparedImage: resolved.PreparedImage{PVCName: "pvc-root"},
+		Network:       true,
+		Interfaces:    guest.Spec.Interfaces,
+	}
+
+	pod := BuildPod(guest, rg, "", "test-intent", nil)
+
+	// Both sockets share /var/run/vhost -> exactly one deduped hostPath volume.
+	var vols []corev1.Volume
+	for _, v := range pod.Spec.Volumes {
+		if v.HostPath != nil && v.HostPath.Path == "/var/run/vhost" {
+			vols = append(vols, v)
+		}
+	}
+	if len(vols) != 1 {
+		t.Fatalf("vhost dir volumes = %d, want 1 (deduped)", len(vols))
+	}
+	if vols[0].HostPath.Type == nil || *vols[0].HostPath.Type != corev1.HostPathDirectoryOrCreate {
+		t.Errorf("vhost volume type = %v, want DirectoryOrCreate", vols[0].HostPath.Type)
+	}
+	// Mounted at the same node path so CH (in-container) can reach the socket.
+	found := false
+	for _, m := range pod.Spec.Containers[0].VolumeMounts {
+		if m.Name == vols[0].Name && m.MountPath == "/var/run/vhost" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("launcher missing /var/run/vhost mount")
+	}
+}

--- a/internal/resolved/types.go
+++ b/internal/resolved/types.go
@@ -300,12 +300,34 @@ func (r *ResolvedGuest) GetNICs() []runtimeintent.NICIntent {
 			continue
 		}
 
+		if ifaceType == swiftv1alpha1.InterfaceTypeVhostUser {
+			// vhost-user-net: operator-provided backend reached via a node
+			// socket. No tap, no bridge, no Multus — just a virtio-net device
+			// whose datapath is the backend. MAC is pinned if set, else
+			// generated. Never the primary DHCP NIC (the backend owns L2).
+			mac := iface.MAC
+			if mac == "" {
+				mac = runtimeintent.GenerateMAC(runtimeintent.InterfaceMACSeed(r.Meta.Namespace, r.Meta.Name, iface.Name))
+			}
+			nics = append(nics, runtimeintent.NICIntent{
+				Name:            iface.Name,
+				Type:            swiftv1alpha1.InterfaceTypeVhostUser,
+				MAC:             mac,
+				VhostUserSocket: iface.Socket,
+			})
+			continue
+		}
+
 		// Bridge type: tap+bridge+virtio-net.
+		mac := iface.MAC
+		if mac == "" {
+			mac = runtimeintent.GenerateMAC(runtimeintent.InterfaceMACSeed(r.Meta.Namespace, r.Meta.Name, iface.Name))
+		}
 		nic := runtimeintent.NICIntent{
 			Name:      iface.Name,
 			Type:      swiftv1alpha1.InterfaceTypeBridge,
 			TapDevice: fmt.Sprintf("tap%d", tapIdx),
-			MAC:       runtimeintent.GenerateMAC(runtimeintent.InterfaceMACSeed(r.Meta.Namespace, r.Meta.Name, iface.Name)),
+			MAC:       mac,
 			Bridge:    fmt.Sprintf("br%d", bridgeIdx),
 		}
 		if iface.NetworkRef == nil {

--- a/internal/resolved/types_test.go
+++ b/internal/resolved/types_test.go
@@ -348,3 +348,37 @@ func TestGetFilesystems_TagDefaultsAndSourcePath(t *testing.T) {
 		t.Errorf("[1] = %+v, want tag=shared readOnly=true", got[1])
 	}
 }
+
+func TestGetNICs_VhostUser(t *testing.T) {
+	rg := &ResolvedGuest{
+		Meta: Meta{Namespace: "ns", Name: "g"},
+		Interfaces: []swiftv1alpha1.GuestInterface{
+			{Name: "mgmt"}, // bridge (default) -> primary
+			{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser, Socket: "/var/run/vhost/fast0.sock"},
+			{Name: "fast1", Type: swiftv1alpha1.InterfaceTypeVhostUser,
+				Socket: "/var/run/vhost/fast1.sock", MAC: "52:54:00:00:00:fe"},
+		},
+	}
+	nics := rg.GetNICs()
+	if len(nics) != 3 {
+		t.Fatalf("len = %d, want 3", len(nics))
+	}
+	if !nics[0].Primary || nics[0].Type != swiftv1alpha1.InterfaceTypeBridge {
+		t.Errorf("nics[0] = %+v, want primary bridge", nics[0])
+	}
+	// vhost-user: carries socket, never primary, no tap/bridge, generated MAC.
+	fu := nics[1]
+	if fu.Type != swiftv1alpha1.InterfaceTypeVhostUser || fu.VhostUserSocket != "/var/run/vhost/fast0.sock" {
+		t.Errorf("nics[1] = %+v, want vhost-user w/ socket", fu)
+	}
+	if fu.Primary || fu.TapDevice != "" || fu.Bridge != "" {
+		t.Errorf("nics[1] = %+v, want non-primary, no tap/bridge", fu)
+	}
+	if fu.MAC == "" {
+		t.Error("nics[1] MAC should be generated when unset")
+	}
+	// Explicit MAC is honored.
+	if nics[2].MAC != "52:54:00:00:00:fe" {
+		t.Errorf("nics[2].MAC = %q, want pinned 52:54:00:00:00:fe", nics[2].MAC)
+	}
+}

--- a/internal/runtimeintent/types.go
+++ b/internal/runtimeintent/types.go
@@ -80,7 +80,8 @@ type RestoreIntent struct {
 type NICIntent struct {
 	// Name is the interface identifier (matches spec.interfaces[].name).
 	Name string `json:"name"`
-	// Type is "bridge" (tap+bridge+virtio-net) or "sriov" (VFIO passthrough).
+	// Type is "bridge" (tap+bridge+virtio-net), "sriov" (VFIO passthrough),
+	// or "vhost-user" (operator-provided vhost-user-net backend).
 	// Defaults to "bridge" if empty.
 	Type string `json:"type"`
 	// TapDevice is the tap device name inside the pod namespace (tap0, tap1, etc.)
@@ -100,6 +101,10 @@ type NICIntent struct {
 	// SRIOVDevice contains SR-IOV VF info for VFIO passthrough.
 	// Only populated when Type is "sriov".
 	SRIOVDevice *SRIOVDeviceIntent `json:"sriovDevice,omitempty"`
+	// VhostUserSocket is the in-pod path of the operator's vhost-user-net
+	// backend listener socket. Only populated when Type is "vhost-user";
+	// swiftletd hands it to CH as `--net vhost_user=on,socket=<path>`.
+	VhostUserSocket string `json:"vhostUserSocket,omitempty"`
 }
 
 // SRIOVDeviceIntent describes an SR-IOV VF to pass through via VFIO.

--- a/internal/webhook/swiftguest/validator.go
+++ b/internal/webhook/swiftguest/validator.go
@@ -102,6 +102,37 @@ func validateSwiftGuest(g *swiftv1alpha1.SwiftGuest) error {
 	if err := validateFilesystems(spec); err != nil {
 		return err
 	}
+	if err := validateInterfaces(spec); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateInterfaces enforces the vhost-user-net constraints: a backend socket
+// is required, the bridge/sriov-only fields are not set, and the v1 scope limit
+// (Cloud Hypervisor only — a gpuProfileRef may select the QEMU runtime, which
+// v1 does not wire for vhost-user). bridge/sriov interfaces are unchanged.
+func validateInterfaces(spec *swiftv1alpha1.SwiftGuestSpec) error {
+	hasVhostUser := false
+	for i := range spec.Interfaces {
+		iface := &spec.Interfaces[i]
+		if iface.Type != swiftv1alpha1.InterfaceTypeVhostUser {
+			continue
+		}
+		hasVhostUser = true
+		if iface.Socket == "" {
+			return fmt.Errorf("spec.interfaces[%d] (type vhost-user) requires a socket path", i)
+		}
+		if iface.NetworkRef != nil {
+			return fmt.Errorf("spec.interfaces[%d]: vhost-user does not use networkRef", i)
+		}
+		if iface.ResourceName != "" {
+			return fmt.Errorf("spec.interfaces[%d]: vhost-user does not use resourceName", i)
+		}
+	}
+	if hasVhostUser && spec.GPUProfileRef != nil {
+		return fmt.Errorf("spec.interfaces: vhost-user is not supported with spec.gpuProfileRef (Cloud Hypervisor only in v1)")
+	}
 	return nil
 }
 

--- a/internal/webhook/swiftguest/validator_test.go
+++ b/internal/webhook/swiftguest/validator_test.go
@@ -200,3 +200,51 @@ func TestValidate_Filesystems(t *testing.T) {
 	})
 	errContains(t, validateSwiftGuest(g), "windows")
 }
+
+func TestValidate_VhostUserInterfaces(t *testing.T) {
+	// Valid: a bridge primary + a vhost-user NIC with a socket.
+	g := guest(func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
+			{Name: "mgmt"},
+			{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser, Socket: "/var/run/vhost/fast0.sock"},
+		}
+	})
+	if err := validateSwiftGuest(g); err != nil {
+		t.Fatalf("valid vhost-user rejected: %v", err)
+	}
+
+	// Missing socket.
+	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
+			{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser},
+		}
+	})
+	errContains(t, validateSwiftGuest(g), "requires a socket")
+
+	// networkRef not allowed.
+	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
+			{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser,
+				Socket: "/s.sock", NetworkRef: &swiftv1alpha1.NetworkReference{Name: "nad"}},
+		}
+	})
+	errContains(t, validateSwiftGuest(g), "networkRef")
+
+	// resourceName not allowed.
+	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
+			{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser,
+				Socket: "/s.sock", ResourceName: "intel.com/sriov"},
+		}
+	})
+	errContains(t, validateSwiftGuest(g), "resourceName")
+
+	// Rejected with gpuProfileRef (CH-only in v1).
+	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
+		g.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu"}
+		g.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
+			{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser, Socket: "/s.sock"},
+		}
+	})
+	errContains(t, validateSwiftGuest(g), "gpuProfileRef")
+}

--- a/rust/swift-ch-client/src/config.rs
+++ b/rust/swift-ch-client/src/config.rs
@@ -6,10 +6,13 @@ pub const DEFAULT_CH_BINARY: &str = "cloud-hypervisor";
 /// Network interface configuration for multi-NIC mode.
 #[derive(Debug, Clone)]
 pub struct NICConfig {
-    /// Tap device name (tap0, tap1, etc.)
+    /// Tap device name (tap0, tap1, etc.). Empty for a vhost-user NIC.
     pub tap_name: String,
     /// MAC address for the interface.
     pub mac: String,
+    /// vhost-user-net backend socket path. When Some, this NIC is emitted as
+    /// `--net vhost_user=on,socket=<path>,mac=<mac>` instead of a tap NIC.
+    pub vhost_user_socket: Option<String>,
 }
 
 /// VFIO device for passthrough (GPU or SR-IOV NIC).
@@ -217,10 +220,15 @@ impl VmConfig {
         }
 
         if !self.nics.is_empty() {
-            // Multi-NIC mode: one --net per NIC with tap and mac.
+            // Multi-NIC mode: one --net per NIC with tap and mac, or a
+            // vhost-user backend socket when set.
             for nic in &self.nics {
                 args.push("--net".to_string());
-                args.push(format!("tap={},mac={}", nic.tap_name, nic.mac));
+                if let Some(ref socket) = nic.vhost_user_socket {
+                    args.push(format!("vhost_user=on,socket={},mac={}", socket, nic.mac));
+                } else {
+                    args.push(format!("tap={},mac={}", nic.tap_name, nic.mac));
+                }
             }
         } else if let Some(ref tap) = self.tap_name {
             // Legacy single-NIC mode.
@@ -506,12 +514,52 @@ mod tests {
         cfg.nics = vec![NICConfig {
             tap_name: "tap0".to_string(),
             mac: "52:54:00:aa:bb:cc".to_string(),
+            vhost_user_socket: None,
         }];
         let args = cfg.to_args();
         let joined = args.join(" ");
         assert!(
             joined.contains("tap=tap0,mac=52:54:00:aa:bb:cc"),
             "single NIC: {}",
+            joined
+        );
+    }
+
+    #[test]
+    fn test_ch_args_vhost_user_nic() {
+        let mut cfg = make_disk_boot_config();
+        cfg.tap_name = None;
+        cfg.nics = vec![
+            NICConfig {
+                tap_name: "tap0".to_string(),
+                mac: "52:54:00:aa:bb:01".to_string(),
+                vhost_user_socket: None,
+            },
+            NICConfig {
+                tap_name: String::new(),
+                mac: "52:54:00:aa:bb:fe".to_string(),
+                vhost_user_socket: Some("/var/run/vhost/fast0.sock".to_string()),
+            },
+        ];
+        let args = cfg.to_args();
+        let joined = args.join(" ");
+        assert_eq!(args.iter().filter(|a| *a == "--net").count(), 2);
+        // Bridge NIC stays tap-based.
+        assert!(
+            joined.contains("tap=tap0,mac=52:54:00:aa:bb:01"),
+            "bridge NIC: {}",
+            joined
+        );
+        // vhost-user NIC emits vhost_user=on,socket=...
+        assert!(
+            joined.contains("vhost_user=on,socket=/var/run/vhost/fast0.sock,mac=52:54:00:aa:bb:fe"),
+            "vhost-user NIC: {}",
+            joined
+        );
+        // No tap= for the vhost-user NIC.
+        assert!(
+            !joined.contains("tap=,"),
+            "vhost-user NIC must not emit an empty tap: {}",
             joined
         );
     }
@@ -524,14 +572,17 @@ mod tests {
             NICConfig {
                 tap_name: "tap0".to_string(),
                 mac: "52:54:00:aa:bb:01".to_string(),
+                vhost_user_socket: None,
             },
             NICConfig {
                 tap_name: "tap1".to_string(),
                 mac: "52:54:00:aa:bb:02".to_string(),
+                vhost_user_socket: None,
             },
             NICConfig {
                 tap_name: "tap2".to_string(),
                 mac: "52:54:00:aa:bb:03".to_string(),
+                vhost_user_socket: None,
             },
         ];
         let args = cfg.to_args();
@@ -601,6 +652,7 @@ mod tests {
         cfg.nics = vec![NICConfig {
             tap_name: "tap0".to_string(),
             mac: "52:54:00:aa:bb:01".to_string(),
+            vhost_user_socket: None,
         }];
         cfg.vfio_devices = vec![VFIODeviceConfig {
             sysfs_path: "/sys/bus/pci/devices/0000:3b:0a.0/".to_string(),

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -210,6 +210,10 @@ pub struct NICIntent {
     /// SR-IOV VF device info for VFIO passthrough. Only set when type=sriov.
     #[serde(default)]
     pub sriov_device: Option<SRIOVDeviceIntent>,
+    /// In-pod path of the operator's vhost-user-net backend listener socket.
+    /// Only set when type=vhost-user; passed to CH as `--net vhost_user=on,socket=`.
+    #[serde(default)]
+    pub vhost_user_socket: Option<String>,
 }
 
 /// SR-IOV VF device info for VFIO passthrough.
@@ -234,6 +238,11 @@ impl NICIntent {
     /// Returns true if this is an SR-IOV NIC (VFIO passthrough).
     pub fn is_sriov(&self) -> bool {
         self.r#type == "sriov"
+    }
+
+    /// Returns true if this is a vhost-user-net NIC (operator backend).
+    pub fn is_vhost_user(&self) -> bool {
+        self.r#type == "vhost-user"
     }
 }
 

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -508,10 +508,25 @@ fn build_ch_nics(
                         );
                     }
                 }
+            } else if n.is_vhost_user() {
+                // vhost-user-net: no tap; CH connects to the operator backend
+                // socket. Skip (with a loud log) if the socket is missing — the
+                // controller/webhook should always populate it.
+                match &n.vhost_user_socket {
+                    Some(sock) => ch_nics.push(NICConfig {
+                        tap_name: String::new(),
+                        mac: n.mac.clone(),
+                        vhost_user_socket: Some(sock.clone()),
+                    }),
+                    None => {
+                        log::error!("vhost-user NIC {} has no backend socket; skipping", n.name)
+                    }
+                }
             } else {
                 ch_nics.push(NICConfig {
                     tap_name: n.tap_device.clone(),
                     mac: n.mac.clone(),
+                    vhost_user_socket: None,
                 });
             }
         }


### PR DESCRIPTION
Implements **PR 3** of the vhost-user arc (design: #173). Adds `GuestInterface.type: vhost-user` — a virtio-net device whose datapath is an **operator-provided** vhost-user backend (DPDK/OVS-DPDK), reached via a node `socket`.

**Stacked on #174 (virtiofs).** Review/merge #174 first; this PR's base is `feat/virtiofs`, so its own diff is just the net additions (retarget to `main` once #174 lands).

## What it does

KubeSwift does **not** run the backend — the operator's node fast-path exposes a vhost-user listener socket; KubeSwift mounts the socket's directory into the launcher and points Cloud Hypervisor at it (`--net vhost_user=on,socket=,mac=`). The guest sees an ordinary `virtio-net` device; the line rate comes from the backend. Same division of labor as SR-IOV (operator pre-provisions the hardware/datapath).

## CRD / API

- `GuestInterface`: `vhost-user` added to the type enum; new `socket` (node listener path) and optional `mac` (now honored for `bridge` too — was always generated before).
- Webhook: `vhost-user` requires `socket`; rejects `networkRef`/`resourceName` on it; rejects `vhost-user` + `gpuProfileRef` (CH-only in v1).

## Runtime

- `resolved.GetNICs`: vhost-user branch → `NICIntent{Type, MAC (pinned or generated), VhostUserSocket}`; never the primary DHCP NIC, no tap/bridge.
- Pod builder: `applyVhostUserNetVolumes` mounts each socket's parent dir (hostPath `DirectoryOrCreate`) into the launcher at the same path, **deduped per directory**, so in-container CH reaches the operator socket.
- swiftletd / swift-ch-client: `NICConfig.vhost_user_socket`; `build_ch_nics` emits it; `to_args` emits `--net vhost_user=on,socket=,mac=` (tap NICs unchanged). `NICIntent.is_vhost_user()`.

## Validation status

**Wiring only.** The `--net vhost_user=on,...` arg, the webhook bounds, and the socket-dir mount are unit-validated. The **line-rate DPDK datapath is asset-gated** — the dev cluster has no DPDK NIC (same honest posture as the shipped-but-hardware-unvalidated SR-IOV path). Unit coverage on GetNICs / webhook / pod-builder / `to_args`. Sample (`config/samples/vhost-user-net/`) + runbook section in `docs/virtiofs.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)