### PR TITLE
feat(network): multi-node L2 control-plane — primary-on-NAD + IP-preservation gate fix [#1 PR1]

### DIFF
--- a/api/swift/v1alpha1/networking_helpers_test.go
+++ b/api/swift/v1alpha1/networking_helpers_test.go
@@ -1,0 +1,48 @@
+package v1alpha1
+
+import "testing"
+
+func ifaceNAD(name string) *NetworkReference { return &NetworkReference{Name: name} }
+
+func TestPrimaryInterface(t *testing.T) {
+	cases := []struct {
+		name  string
+		ifs   []GuestInterface
+		want  string // primary interface name, "" for nil
+		preIP bool   // PrimaryIPPreservedCrossNode
+	}{
+		{"none", nil, "", false},
+		{"single node-local", []GuestInterface{{Name: "mgmt"}}, "mgmt", false},
+		{"node-local + secondary NAD", []GuestInterface{{Name: "mgmt"}, {Name: "data", NetworkRef: ifaceNAD("n")}}, "mgmt", false},
+		{"single NAD (de-facto primary)", []GuestInterface{{Name: "data", NetworkRef: ifaceNAD("n")}}, "data", true},
+		{"explicit primary on NAD", []GuestInterface{{Name: "a"}, {Name: "p", Primary: true, NetworkRef: ifaceNAD("n")}}, "p", true},
+		{"explicit primary node-local", []GuestInterface{{Name: "p", Primary: true}, {Name: "data", NetworkRef: ifaceNAD("n")}}, "p", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &SwiftGuest{Spec: SwiftGuestSpec{Interfaces: tc.ifs}}
+			p := g.PrimaryInterface()
+			got := ""
+			if p != nil {
+				got = p.Name
+			}
+			if got != tc.want {
+				t.Errorf("PrimaryInterface = %q, want %q", got, tc.want)
+			}
+			if g.PrimaryIPPreservedCrossNode() != tc.preIP {
+				t.Errorf("PrimaryIPPreservedCrossNode = %v, want %v", g.PrimaryIPPreservedCrossNode(), tc.preIP)
+			}
+		})
+	}
+}
+
+// vhost-user/sriov are never the fallback primary.
+func TestPrimaryInterface_SkipsNonBridge(t *testing.T) {
+	g := &SwiftGuest{Spec: SwiftGuestSpec{Interfaces: []GuestInterface{
+		{Name: "fast", Type: InterfaceTypeVhostUser, Socket: "/s"},
+		{Name: "rdma", Type: InterfaceTypeSRIOV, NetworkRef: ifaceNAD("sriov")},
+	}}}
+	if p := g.PrimaryInterface(); p != nil {
+		t.Errorf("PrimaryInterface = %q, want nil (no bridge interface)", p.Name)
+	}
+}

--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -261,6 +261,57 @@ func (g *SwiftGuest) UsesCloneFromSnapshot() bool {
 	return g.Spec.CloneFromSnapshot != nil && g.Spec.CloneFromSnapshot.SnapshotRef.Name != ""
 }
 
+// PrimaryInterface returns the guest's primary network interface, or nil when
+// the guest has no interfaces (the default single node-local NIC) or none
+// qualifies. The primary is the interface with Primary=true; if none is marked,
+// it falls back to the first node-local (no networkRef) bridge interface — the
+// legacy rule, matching the resolver's GetNICs primary selection.
+func (g *SwiftGuest) PrimaryInterface() *GuestInterface {
+	isBridge := func(iface *GuestInterface) bool {
+		return iface.Type == "" || iface.Type == InterfaceTypeBridge
+	}
+	// 1. Explicit primary wins.
+	for i := range g.Spec.Interfaces {
+		if g.Spec.Interfaces[i].Primary {
+			return &g.Spec.Interfaces[i]
+		}
+	}
+	// 2. Legacy rule: the first node-local (no networkRef) bridge interface is
+	//    the primary (its IP comes from node-local dnsmasq).
+	for i := range g.Spec.Interfaces {
+		if isBridge(&g.Spec.Interfaces[i]) && g.Spec.Interfaces[i].NetworkRef == nil {
+			return &g.Spec.Interfaces[i]
+		}
+	}
+	// 3. No node-local bridge: the guest's only/main IP is on a NAD. The first
+	//    bridge interface (which therefore rides a networkRef) is the de-facto
+	//    primary. This keeps a single-NAD-interface guest correctly classified
+	//    as IP-preserving.
+	for i := range g.Spec.Interfaces {
+		if isBridge(&g.Spec.Interfaces[i]) {
+			return &g.Spec.Interfaces[i]
+		}
+	}
+	return nil
+}
+
+// PrimaryIPPreservedCrossNode reports whether the guest's primary IP rides a
+// multi-node Multus NAD (the primary interface has a networkRef) and therefore
+// survives a move to another node. Guests on the default node-local bridge
+// return false. The SwiftMigration webhook + controller use this to decide
+// whether cross-node migration changes the guest IP (and thus requires
+// spec.allowIPChange). SR-IOV guests are handled by the VFIO refusal before
+// this is consulted.
+//
+// This replaces the earlier "any interface with networkRef is multi-node"
+// heuristic (which let a node-local-primary + secondary-NAD guest skip
+// allowIPChange even though its primary IP changed). See
+// docs/design/network-architecture-requirements.md §7.
+func (g *SwiftGuest) PrimaryIPPreservedCrossNode() bool {
+	p := g.PrimaryInterface()
+	return p != nil && p.NetworkRef != nil
+}
+
 // CloneIdentityItem names a guest-identity attribute to regenerate on a
 // cloneFromSnapshot clone. Mirrors snapshot.IdentityRegenerationItem but is
 // defined locally to keep the swift and snapshot api groups decoupled.
@@ -407,10 +458,27 @@ type GuestInterface struct {
 	// +optional
 	Type string `json:"type,omitempty"`
 	// NetworkRef references a NetworkAttachmentDefinition for this interface.
-	// If nil, this is the primary interface using KubeSwift's default tap+bridge networking.
+	// If nil, this is a node-local tap+bridge interface.
 	// If set, Multus attaches the pod to the referenced NAD.
 	// +optional
 	NetworkRef *NetworkReference `json:"networkRef,omitempty"`
+	// Primary marks this interface as the guest's primary NIC (its
+	// status.network.primaryIP and the DHCP/management interface). At most one
+	// interface may set primary=true; if none does, the first interface without
+	// a networkRef is the primary (backward compatible).
+	//
+	// When primary=true AND networkRef is set, the primary NIC rides a
+	// multi-node Multus NAD instead of the node-local bridge: KubeSwift skips
+	// tap0+br0 NAT + node-local dnsmasq for it, the guest's IP comes from the
+	// NAD's IPAM, and the IP is discovered by snooping the bridge neighbor
+	// table (there is no node-local DHCP lease). This is what makes the guest's
+	// primary IP portable across nodes (e.g. for IP-preserving live migration —
+	// see docs/design/network-architecture-requirements.md). The operator
+	// putting the primary on a NAD is also the attestation that the NAD is a
+	// genuine multi-node L2 (the SwiftMigration webhook treats such a guest as
+	// IP-preserving).
+	// +optional
+	Primary bool `json:"primary,omitempty"`
 	// ResourceName is the SR-IOV device plugin resource name (e.g., "intel.com/sriov_netdevice").
 	// Required when type is "sriov". The device plugin allocates a VF and the controller
 	// adds this resource to the pod's resource limits.

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
@@ -366,7 +366,7 @@ spec:
                             networkRef:
                               description: |-
                                 NetworkRef references a NetworkAttachmentDefinition for this interface.
-                                If nil, this is the primary interface using KubeSwift's default tap+bridge networking.
+                                If nil, this is a node-local tap+bridge interface.
                                 If set, Multus attaches the pod to the referenced NAD.
                               properties:
                                 name:
@@ -380,6 +380,24 @@ spec:
                               required:
                               - name
                               type: object
+                            primary:
+                              description: |-
+                                Primary marks this interface as the guest's primary NIC (its
+                                status.network.primaryIP and the DHCP/management interface). At most one
+                                interface may set primary=true; if none does, the first interface without
+                                a networkRef is the primary (backward compatible).
+
+                                When primary=true AND networkRef is set, the primary NIC rides a
+                                multi-node Multus NAD instead of the node-local bridge: KubeSwift skips
+                                tap0+br0 NAT + node-local dnsmasq for it, the guest's IP comes from the
+                                NAD's IPAM, and the IP is discovered by snooping the bridge neighbor
+                                table (there is no node-local DHCP lease). This is what makes the guest's
+                                primary IP portable across nodes (e.g. for IP-preserving live migration —
+                                see docs/design/network-architecture-requirements.md). The operator
+                                putting the primary on a NAD is also the attestation that the NAD is a
+                                genuine multi-node L2 (the SwiftMigration webhook treats such a guest as
+                                IP-preserving).
+                              type: boolean
                             resourceName:
                               description: |-
                                 ResourceName is the SR-IOV device plugin resource name (e.g., "intel.com/sriov_netdevice").

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -298,7 +298,7 @@ spec:
                     networkRef:
                       description: |-
                         NetworkRef references a NetworkAttachmentDefinition for this interface.
-                        If nil, this is the primary interface using KubeSwift's default tap+bridge networking.
+                        If nil, this is a node-local tap+bridge interface.
                         If set, Multus attaches the pod to the referenced NAD.
                       properties:
                         name:
@@ -312,6 +312,24 @@ spec:
                       required:
                       - name
                       type: object
+                    primary:
+                      description: |-
+                        Primary marks this interface as the guest's primary NIC (its
+                        status.network.primaryIP and the DHCP/management interface). At most one
+                        interface may set primary=true; if none does, the first interface without
+                        a networkRef is the primary (backward compatible).
+
+                        When primary=true AND networkRef is set, the primary NIC rides a
+                        multi-node Multus NAD instead of the node-local bridge: KubeSwift skips
+                        tap0+br0 NAT + node-local dnsmasq for it, the guest's IP comes from the
+                        NAD's IPAM, and the IP is discovered by snooping the bridge neighbor
+                        table (there is no node-local DHCP lease). This is what makes the guest's
+                        primary IP portable across nodes (e.g. for IP-preserving live migration —
+                        see docs/design/network-architecture-requirements.md). The operator
+                        putting the primary on a NAD is also the attestation that the NAD is a
+                        genuine multi-node L2 (the SwiftMigration webhook treats such a guest as
+                        IP-preserving).
+                      type: boolean
                     resourceName:
                       description: |-
                         ResourceName is the SR-IOV device plugin resource name (e.g., "intel.com/sriov_netdevice").

--- a/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
@@ -366,7 +366,7 @@ spec:
                             networkRef:
                               description: |-
                                 NetworkRef references a NetworkAttachmentDefinition for this interface.
-                                If nil, this is the primary interface using KubeSwift's default tap+bridge networking.
+                                If nil, this is a node-local tap+bridge interface.
                                 If set, Multus attaches the pod to the referenced NAD.
                               properties:
                                 name:
@@ -380,6 +380,24 @@ spec:
                               required:
                               - name
                               type: object
+                            primary:
+                              description: |-
+                                Primary marks this interface as the guest's primary NIC (its
+                                status.network.primaryIP and the DHCP/management interface). At most one
+                                interface may set primary=true; if none does, the first interface without
+                                a networkRef is the primary (backward compatible).
+
+                                When primary=true AND networkRef is set, the primary NIC rides a
+                                multi-node Multus NAD instead of the node-local bridge: KubeSwift skips
+                                tap0+br0 NAT + node-local dnsmasq for it, the guest's IP comes from the
+                                NAD's IPAM, and the IP is discovered by snooping the bridge neighbor
+                                table (there is no node-local DHCP lease). This is what makes the guest's
+                                primary IP portable across nodes (e.g. for IP-preserving live migration —
+                                see docs/design/network-architecture-requirements.md). The operator
+                                putting the primary on a NAD is also the attestation that the NAD is a
+                                genuine multi-node L2 (the SwiftMigration webhook treats such a guest as
+                                IP-preserving).
+                              type: boolean
                             resourceName:
                               description: |-
                                 ResourceName is the SR-IOV device plugin resource name (e.g., "intel.com/sriov_netdevice").

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -298,7 +298,7 @@ spec:
                     networkRef:
                       description: |-
                         NetworkRef references a NetworkAttachmentDefinition for this interface.
-                        If nil, this is the primary interface using KubeSwift's default tap+bridge networking.
+                        If nil, this is a node-local tap+bridge interface.
                         If set, Multus attaches the pod to the referenced NAD.
                       properties:
                         name:
@@ -312,6 +312,24 @@ spec:
                       required:
                       - name
                       type: object
+                    primary:
+                      description: |-
+                        Primary marks this interface as the guest's primary NIC (its
+                        status.network.primaryIP and the DHCP/management interface). At most one
+                        interface may set primary=true; if none does, the first interface without
+                        a networkRef is the primary (backward compatible).
+
+                        When primary=true AND networkRef is set, the primary NIC rides a
+                        multi-node Multus NAD instead of the node-local bridge: KubeSwift skips
+                        tap0+br0 NAT + node-local dnsmasq for it, the guest's IP comes from the
+                        NAD's IPAM, and the IP is discovered by snooping the bridge neighbor
+                        table (there is no node-local DHCP lease). This is what makes the guest's
+                        primary IP portable across nodes (e.g. for IP-preserving live migration —
+                        see docs/design/network-architecture-requirements.md). The operator
+                        putting the primary on a NAD is also the attestation that the NAD is a
+                        genuine multi-node L2 (the SwiftMigration webhook treats such a guest as
+                        IP-preserving).
+                      type: boolean
                     resourceName:
                       description: |-
                         ResourceName is the SR-IOV device plugin resource name (e.g., "intel.com/sriov_netdevice").

--- a/config/samples/multi-node-l2/ovn-l2-nad.yaml
+++ b/config/samples/multi-node-l2/ovn-l2-nad.yaml
@@ -1,0 +1,18 @@
+# Reference OVN-Kubernetes layer-2 NAD: an overlay L2 segment spanning all
+# nodes. Requires OVN-K as the cluster CNI / secondary-network provider.
+# See docs/networking/multi-node-l2.md.
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ovn-l2
+  namespace: default
+spec:
+  config: |
+    {
+      "cniVersion": "0.4.0",
+      "type": "ovn-k8s-cni-overlay",
+      "name": "ovn-l2",
+      "topology": "layer2",
+      "subnets": "10.20.0.0/16",
+      "netAttachDefName": "default/ovn-l2"
+    }

--- a/config/samples/multi-node-l2/swiftguest-primary-on-nad.yaml
+++ b/config/samples/multi-node-l2/swiftguest-primary-on-nad.yaml
@@ -1,0 +1,17 @@
+# A guest whose PRIMARY IP rides a multi-node L2 NAD, so the IP is portable
+# across nodes (e.g. for IP-preserving live migration). Pair with the ovn-l2 NAD.
+#
+# NOTE: the runtime datapath for primary-on-NAD is landing in follow-up PRs; the
+# control-plane (admission + migration IP-preservation classification) is shipped.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: portable-ip-guest
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: default }
+  seedProfileRef: { name: default }
+  interfaces:
+    - name: app
+      primary: true                  # the guest's primary IP
+      networkRef: { name: ovn-l2 }    # rides the multi-node NAD

--- a/docs/networking/multi-node-l2.md
+++ b/docs/networking/multi-node-l2.md
@@ -1,0 +1,109 @@
+# Multi-node L2 networking (IP-preserving guests)
+
+> **Status (2026-06):** the **control-plane** half is shipped — the
+> `spec.interfaces[].primary` field, the resolver wiring, and the corrected
+> SwiftMigration IP-preservation gate. The **runtime datapath** (attaching the
+> *primary* NIC to a NAD inside the launcher, and discovering its NAD-assigned
+> IP) is landing across follow-up PRs; until then, a `primary: true` + NAD
+> interface is admitted and classified correctly for migration but the in-guest
+> datapath is not yet wired. See
+> [`../design/network-architecture-requirements.md`](../design/network-architecture-requirements.md)
+> for the framework and the chosen approach.
+
+By default a SwiftGuest's primary IP is **node-local** — it comes from a
+per-node dnsmasq on `br0` and is NAT-masqueraded out the pod's `eth0`. That IP
+does **not** survive a move to another node, which is why cross-node migration
+of a default-networking guest requires `spec.allowIPChange=true`.
+
+To give a guest a **portable** primary IP (one that follows it across nodes —
+e.g. for IP-preserving live migration, telco/NFV, or stateful services with
+external clients), put its **primary interface on a multi-node L2 network**: a
+single L2 broadcast domain that spans every candidate node. KubeSwift attaches
+to it through a Multus NetworkAttachmentDefinition (NAD), so the technology is
+the operator's choice — the recommended reference is **OVN-Kubernetes
+layer-2** (portable overlay, no physical-NIC dependency).
+
+## The `primary` field
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: portable-ip-guest
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: default }
+  seedProfileRef: { name: default }
+  interfaces:
+    - name: app
+      primary: true                 # this NIC is the guest's primary IP
+      networkRef: { name: ovn-l2 }   # ...and it rides a multi-node NAD
+```
+
+- At most one interface may set `primary: true`, and only a bridge-type
+  interface (the default) can be primary.
+- When `primary: true` **and** `networkRef` are both set, the primary NIC rides
+  the NAD instead of the node-local bridge — the guest's IP comes from the NAD's
+  IPAM and is portable.
+- This is also the operator's **attestation** that the NAD is a genuine
+  multi-node L2: the SwiftMigration webhook then treats the guest as
+  IP-preserving and does **not** require `allowIPChange` for cross-node moves.
+
+### Migration-gate behavior (shipped)
+
+The IP-preservation gate keys on the **primary** interface, not on "any
+`networkRef`":
+
+| Guest networking | Cross-node migration |
+|---|---|
+| Default (node-local bridge) | requires `spec.allowIPChange=true` (IP changes) |
+| Node-local primary **+** secondary NAD | requires `allowIPChange` — the *primary* IP still changes |
+| **Primary on a NAD** (`primary: true` + `networkRef`) | accepted, IP preserved, no `allowIPChange` |
+| Single NAD interface (de-facto primary) | accepted, IP preserved |
+
+(The middle row is the correctness fix from
+[network-architecture-requirements.md §7.2](../design/network-architecture-requirements.md):
+a secondary NAD no longer makes a node-local-primary guest look IP-preserving.)
+
+## Reference recipe: OVN-Kubernetes layer-2 NAD
+
+> Requires OVN-Kubernetes as the cluster CNI (or secondary-network provider).
+> The dev cluster runs Calico, so this path is **not validated there** — it is
+> documented as the reference for clusters on OVN-K. macvlan is the lightweight
+> alternative on operator-controlled L2 (see the design doc §5.1; note the
+> MAC-filtering caveat on clouds / Hetzner).
+
+A layer-2 NAD defines an overlay L2 segment spanning all nodes:
+
+```yaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ovn-l2
+  namespace: default
+spec:
+  config: |
+    {
+      "cniVersion": "0.4.0",
+      "type": "ovn-k8s-cni-overlay",
+      "name": "ovn-l2",
+      "topology": "layer2",
+      "subnets": "10.20.0.0/16",
+      "netAttachDefName": "default/ovn-l2"
+    }
+```
+
+Then reference it from the guest's primary interface as shown above. OVN-K
+provides DHCP/IPAM on the segment, so the guest receives a `10.20.x.y` address
+that the segment delivers to whichever node the guest runs on — the property
+that makes the IP portable across a migration.
+
+## Limitations / follow-ups
+
+- **Runtime datapath in progress** (see the status banner). The control-plane
+  classification is shipped; the launcher-side attach + IP discovery land next.
+- **A prerequisite multi-NIC fix** (the `network-init` container gaining the
+  RuntimeIntent mount so Multus interfaces are actually bridged) ships ahead of
+  the primary-on-NAD datapath.
+- **SR-IOV** is a hardware-passthrough NIC, not a Tier-C overlay; it is rejected
+  for cross-node migration regardless (Phase 4+).

--- a/internal/controller/swiftmigration/validating.go
+++ b/internal/controller/swiftmigration/validating.go
@@ -264,18 +264,10 @@ func NodeHasCapacity(
 // scheme registration). Keep this textually identical to
 // internal/webhook/swiftmigration/validator.go's copy.
 func isDefaultNodeLocalNetworking(guest *swiftv1alpha1.SwiftGuest) bool {
-	if len(guest.Spec.Interfaces) == 0 {
-		return true
-	}
-	for _, iface := range guest.Spec.Interfaces {
-		if iface.NetworkRef != nil {
-			return false
-		}
-		if iface.Type == swiftv1alpha1.InterfaceTypeSRIOV {
-			return false
-		}
-	}
-	return true
+	// See the webhook copy: the guest's primary IP is node-local unless the
+	// PRIMARY interface rides a multi-node NAD. Both call the shared api helper
+	// (PrimaryIPPreservedCrossNode) so the two paths can no longer drift.
+	return !guest.PrimaryIPPreservedCrossNode()
 }
 
 // nodeReady mirrors the webhook helper.

--- a/internal/resolved/types.go
+++ b/internal/resolved/types.go
@@ -280,6 +280,16 @@ func (r *ResolvedGuest) GetNICs() []runtimeintent.NICIntent {
 	tapIdx := 0
 	bridgeIdx := 0
 	multusIdx := 1 // Multus interfaces start at net1
+	// An operator may mark one interface primary=true. When unset, the legacy
+	// rule applies (every node-local bridge interface is primary) — preserved
+	// exactly for backward compatibility.
+	explicitPrimary := ""
+	for i := range r.Interfaces {
+		if r.Interfaces[i].Primary {
+			explicitPrimary = r.Interfaces[i].Name
+			break
+		}
+	}
 	for _, iface := range r.Interfaces {
 		ifaceType := iface.Type
 		if ifaceType == "" {
@@ -333,11 +343,20 @@ func (r *ResolvedGuest) GetNICs() []runtimeintent.NICIntent {
 			MAC:       mac,
 			Bridge:    fmt.Sprintf("br%d", bridgeIdx),
 		}
-		if iface.NetworkRef == nil {
-			nic.Primary = true
-		} else {
+		// MultusInterface is set whenever the interface rides a NAD —
+		// including when it is ALSO the primary (primary-on-NAD). swiftletd
+		// branches on MultusInterface != "" to choose the node-local bridge
+		// path vs the Multus-attach path.
+		if iface.NetworkRef != nil {
 			nic.MultusInterface = fmt.Sprintf("net%d", multusIdx)
 			multusIdx++
+		}
+		if explicitPrimary != "" {
+			// Operator picked the primary explicitly; it may ride a NAD.
+			nic.Primary = iface.Name == explicitPrimary
+		} else {
+			// Legacy rule (unchanged): node-local bridges are primary.
+			nic.Primary = iface.NetworkRef == nil
 		}
 		nics = append(nics, nic)
 		tapIdx++

--- a/internal/resolved/types_test.go
+++ b/internal/resolved/types_test.go
@@ -406,3 +406,25 @@ func TestGetVhostUserDevices(t *testing.T) {
 		t.Errorf("out[1] = %+v", out[1])
 	}
 }
+
+func TestGetNICs_PrimaryOnNAD(t *testing.T) {
+	rg := &ResolvedGuest{
+		Meta: Meta{Namespace: "ns", Name: "g"},
+		Interfaces: []swiftv1alpha1.GuestInterface{
+			{Name: "app", Primary: true, NetworkRef: &swiftv1alpha1.NetworkReference{Name: "ovn-l2"}},
+			{Name: "extra", NetworkRef: &swiftv1alpha1.NetworkReference{Name: "other"}},
+		},
+	}
+	nics := rg.GetNICs()
+	if len(nics) != 2 {
+		t.Fatalf("len=%d want 2", len(nics))
+	}
+	// Primary rides the NAD: Primary=true AND MultusInterface set.
+	if !nics[0].Primary || nics[0].MultusInterface != "net1" {
+		t.Errorf("nics[0] = %+v, want Primary + MultusInterface=net1", nics[0])
+	}
+	// Secondary: not primary, MultusInterface=net2.
+	if nics[1].Primary || nics[1].MultusInterface != "net2" {
+		t.Errorf("nics[1] = %+v, want non-primary + net2", nics[1])
+	}
+}

--- a/internal/webhook/swiftguest/validator.go
+++ b/internal/webhook/swiftguest/validator.go
@@ -175,6 +175,24 @@ func validateInterfaces(spec *swiftv1alpha1.SwiftGuestSpec) error {
 	if hasVhostUser && spec.GPUProfileRef != nil {
 		return fmt.Errorf("spec.interfaces: vhost-user is not supported with spec.gpuProfileRef (Cloud Hypervisor only in v1)")
 	}
+
+	// At most one interface may be primary, and only a bridge-type interface
+	// (the default) can be primary — SR-IOV and vhost-user are never the
+	// guest's DHCP/management NIC.
+	primaries := 0
+	for i := range spec.Interfaces {
+		iface := &spec.Interfaces[i]
+		if !iface.Primary {
+			continue
+		}
+		primaries++
+		if iface.Type == swiftv1alpha1.InterfaceTypeSRIOV || iface.Type == swiftv1alpha1.InterfaceTypeVhostUser {
+			return fmt.Errorf("spec.interfaces[%d]: primary=true is only valid on a bridge interface, not %q", i, iface.Type)
+		}
+	}
+	if primaries > 1 {
+		return fmt.Errorf("spec.interfaces: at most one interface may set primary=true (got %d)", primaries)
+	}
 	return nil
 }
 

--- a/internal/webhook/swiftmigration/validator.go
+++ b/internal/webhook/swiftmigration/validator.go
@@ -626,23 +626,12 @@ func (v *Validator) checkPerSourceNodeConcurrency(
 // interfaces hits the GPU refusal first; this check would not fire
 // because of the type check.
 func isDefaultNodeLocalNetworking(guest *swiftv1alpha1.SwiftGuest) bool {
-	if len(guest.Spec.Interfaces) == 0 {
-		return true
-	}
-	for _, iface := range guest.Spec.Interfaces {
-		if iface.NetworkRef != nil {
-			return false
-		}
-		// type == sriov is multi-node-capable in principle, but blocked
-		// by the GPU refusal above. We treat type==sriov as "not
-		// default" so this function returns false consistently with
-		// its name even when the migration is going to be rejected
-		// elsewhere.
-		if iface.Type == swiftv1alpha1.InterfaceTypeSRIOV {
-			return false
-		}
-	}
-	return true
+	// The guest's primary IP is node-local (and changes on migration) unless
+	// the PRIMARY interface rides a multi-node NAD. A secondary NAD does not
+	// preserve the primary IP, so it no longer flips this to false (the prior
+	// "any networkRef" heuristic was the §7.2 gap). SR-IOV guests are blocked
+	// by the VFIO refusal before this is consulted.
+	return !guest.PrimaryIPPreservedCrossNode()
 }
 
 func nodeReady(node *corev1.Node) bool {

--- a/internal/webhook/swiftmigration/validator_test.go
+++ b/internal/webhook/swiftmigration/validator_test.go
@@ -704,18 +704,36 @@ func TestValidateClusterState_SourceNotYetScheduled(t *testing.T) {
 }
 
 // TestValidateClusterState_MixedInterfaces_DefaultPlusMultus pins the
-// behavior of isDefaultNodeLocalNetworking on a mixed-interface guest:
-// any non-nil NetworkRef makes the helper return false (treats the
-// guest as multi-node-capable). The default-bridge interface's IP will
-// still change cross-node, but the operator presumably has reasons to
-// run mixed networking — silently accepting the cross-node migration
-// is the architect's call.
+// CORRECTED behavior (network-architecture-requirements.md §7): a guest with a
+// node-local PRIMARY plus a Multus SECONDARY is NOT IP-preserving — its primary
+// IP still changes cross-node — so it must require allowIPChange. (The earlier
+// "any networkRef => multi-node-capable" heuristic was the §7.2 gap; a secondary
+// NAD no longer flips the gate.)
 func TestValidateClusterState_MixedInterfaces_DefaultPlusMultus(t *testing.T) {
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default")
 	guest.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
-		{Name: "mgmt"}, // default bridge
+		{Name: "mgmt"}, // default node-local bridge = the primary IP
 		{Name: "data", NetworkRef: &swiftv1alpha1.NetworkReference{Name: "macvlan", Namespace: "default"}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	v := &Validator{Client: c}
+
+	mig := newSwiftMigration("m", "default") // allowIPChange=false
+	if _, err := v.validate(context.Background(), mig); err == nil {
+		t.Error("mixed default-primary + multus-secondary should REQUIRE allowIPChange (primary IP changes cross-node); got accept")
+	}
+}
+
+// TestValidateClusterState_PrimaryOnNAD: when the PRIMARY interface rides a
+// multi-node NAD (primary=true + networkRef), the primary IP is preserved
+// cross-node, so the migration is accepted without allowIPChange and emits no
+// IP-change warning.
+func TestValidateClusterState_PrimaryOnNAD(t *testing.T) {
+	scheme := migrationScheme(t)
+	guest := newSwiftGuest("guest", "default")
+	guest.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
+		{Name: "mgmt", Primary: true, NetworkRef: &swiftv1alpha1.NetworkReference{Name: "ovn-l2", Namespace: "default"}},
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
 	v := &Validator{Client: c}
@@ -723,13 +741,10 @@ func TestValidateClusterState_MixedInterfaces_DefaultPlusMultus(t *testing.T) {
 	mig := newSwiftMigration("m", "default") // allowIPChange=false
 	warnings, err := v.validate(context.Background(), mig)
 	if err != nil {
-		t.Errorf("validate mixed-interface guest cross-node should accept (multus interface treats as multi-node-capable); got %v", err)
+		t.Errorf("primary-on-NAD guest should accept without allowIPChange; got %v", err)
 	}
-	// No allowIPChange warning because the multus interface marks the
-	// guest as not-default. If a future refactor changes
-	// isDefaultNodeLocalNetworking to be stricter, this will fail.
 	if len(warnings) != 0 {
-		t.Errorf("mixed-interface accepted path should produce no warnings; got %v", warnings)
+		t.Errorf("primary-on-NAD guest should produce no IP-change warning; got %v", warnings)
 	}
 }
 


### PR DESCRIPTION
The **control-plane** half of Multi-node L2 networking (design #176). Lets an operator declare a guest's **primary** interface on a multi-node Multus NAD, and fixes the SwiftMigration IP-preservation gate.

## What's in

- **CRD `GuestInterface.primary`.** At most one primary; bridge-type only (webhook-enforced). `primary: true` + `networkRef` ⇒ the primary rides the NAD (resolver marks the NIC `Primary=true` **and** sets `MultusInterface`), and that doubles as the operator's attestation that the NAD is a genuine multi-node L2.
- **Migration-gate correctness fix (§7.2).** The old `isDefaultNodeLocalNetworking` treated *any* `networkRef` as multi-node-capable, so a node-local-primary + secondary-NAD guest skipped `allowIPChange` even though its primary IP changes cross-node. Replaced the **two textually-duplicated copies** (webhook + controller, which could silently drift) with one shared api helper: `SwiftGuest.PrimaryInterface()` + `PrimaryIPPreservedCrossNode()`.

| Guest networking | Cross-node migration |
|---|---|
| Default node-local bridge | requires `allowIPChange` |
| Node-local primary + secondary NAD | requires `allowIPChange` (primary IP still changes) ← **the fix** |
| Primary on a NAD | accepted, IP preserved |
| Single NAD interface | accepted, IP preserved |

- **Docs + samples:** `docs/networking/multi-node-l2.md` (operator recipe, OVN-K L2 reference, shipped gate-behavior table, honest *runtime-in-progress* banner) + `config/samples/multi-node-l2/`.
- **Tests:** `PrimaryInterface` 3-clause coverage; resolver primary-on-NAD intent; reworked the migration-gate tests that encoded the old "any networkRef" behavior + a new primary-on-NAD accept case. Full Go suite green; `gofmt -s` clean.

## What's deliberately NOT here (and why)

**Runtime datapath only — no launcher-side change.** Putting the *primary* NIC on a NAD in `network-init.sh` is blocked on a latent bug I found while implementing this: **`networkInitContainer()` has no RuntimeIntent volume mount**, so `network-init.sh` can never read the intent and its entire multi-NIC/Multus-bridging path is **unreachable** — meaning **multi-NIC secondary bridging is silently broken today** (the smoke-test multi-nic "flake" may be this). So the sequencing is:

1. **This PR** — control-plane (gate fix + CRD + resolver + webhook + docs). Validated by unit tests.
2. **Next PR** — fix the `network-init` intent mount (un-breaks multi-NIC; validatable with a simple bridge NAD).
3. **Then** — the primary-on-NAD launcher datapath + NAD IP discovery, on top of (2).

This keeps "verified before merged": (2)/(3) build on solid ground instead of guessing an unvalidatable datapath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)