### PR TITLE
fix(network): mount runtime-intent + run into the network-init container (un-break multi-NIC)

### DIFF
--- a/internal/controller/swiftguest/pod_test.go
+++ b/internal/controller/swiftguest/pod_test.go
@@ -758,3 +758,56 @@ func TestBuildPod_VhostUserSocketDedup(t *testing.T) {
 		t.Errorf("/run/spdk vol=%d mount=%d, want 1/1", dirs["/run/spdk"], mountPaths["/run/spdk"])
 	}
 }
+
+func TestBuildPod_NetworkInitHasIntentMount(t *testing.T) {
+	// Regression: the network-init init container MUST mount the runtime-intent
+	// ConfigMap, else network-init.sh's has_nics() can't read the intent and
+	// silently falls back to legacy single-NIC br0/tap0 — leaving multi-NIC
+	// Multus interfaces unbridged. Also mounts the shared "run" emptyDir.
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "ni", Namespace: "default"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef:      &corev1.LocalObjectReference{Name: "img"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "class"},
+			Interfaces: []swiftv1alpha1.GuestInterface{
+				{Name: "mgmt"},
+				{Name: "data", NetworkRef: &swiftv1alpha1.NetworkReference{Name: "nad"}},
+			},
+		},
+	}
+	rg := &resolved.ResolvedGuest{
+		Resources:     resolved.Resources{CPU: 2, Memory: 2048},
+		PreparedImage: resolved.PreparedImage{PVCName: "pvc"},
+		Network:       true,
+		Interfaces:    guest.Spec.Interfaces,
+	}
+	pod := BuildPod(guest, rg, "", "test-intent", nil)
+
+	var ni *corev1.Container
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == "network-init" {
+			ni = &pod.Spec.InitContainers[i]
+		}
+	}
+	if ni == nil {
+		t.Fatal("no network-init container")
+	}
+	got := map[string]string{}
+	for _, m := range ni.VolumeMounts {
+		got[m.Name] = m.MountPath
+	}
+	if got["runtime-intent"] != IntentPath {
+		t.Errorf("network-init runtime-intent mount = %q, want %q", got["runtime-intent"], IntentPath)
+	}
+	if got["run"] != RunDirPath {
+		t.Errorf("network-init run mount = %q, want %q", got["run"], RunDirPath)
+	}
+	// The referenced volumes must exist in the pod (else the pod is invalid).
+	vols := map[string]bool{}
+	for _, v := range pod.Spec.Volumes {
+		vols[v.Name] = true
+	}
+	if !vols["runtime-intent"] || !vols["run"] {
+		t.Errorf("pod missing volumes for network-init mounts: %v", vols)
+	}
+}

--- a/internal/controller/swiftguest/security.go
+++ b/internal/controller/swiftguest/security.go
@@ -23,6 +23,18 @@ func privilegedContext() *corev1.SecurityContext {
 }
 
 // networkInitContainer returns the network-init init container.
+//
+// It mounts the runtime-intent ConfigMap and the shared run emptyDir at the
+// SAME paths the launcher uses. Without the intent mount, network-init.sh's
+// has_nics() check fails and the script silently falls back to the legacy
+// single-NIC br0/tap0 path — meaning its multi-NIC / Multus secondary-bridging
+// path was unreachable and secondary NADs were never bridged into the guest.
+// The run mount lets network setup persist state the launcher reads (e.g. a
+// NAD-assigned primary IP for the multi-node-L2 datapath).
+//
+// All pod builders that add this init container (disk-boot, kernel-boot, GPU,
+// restore) define both the "runtime-intent" and "run" volumes, so referencing
+// them here is safe.
 func networkInitContainer() corev1.Container {
 	return corev1.Container{
 		Name:            "network-init",
@@ -30,6 +42,10 @@ func networkInitContainer() corev1.Container {
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "/usr/local/bin/network-init.sh"},
 		SecurityContext: privilegedContext(),
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "runtime-intent", MountPath: IntentPath},
+			{Name: "run", MountPath: RunDirPath},
+		},
 	}
 }
 


### PR DESCRIPTION
**Latent bug fix** found while implementing multi-node L2 (#178). The `network-init` init container had **no volume mounts**, so `network-init.sh` could never read the RuntimeIntent — `has_nics()` always failed and the script silently fell back to the legacy single-NIC `br0/tap0` path. Its entire **multi-NIC / Multus secondary-bridging code path was unreachable**, so a guest's secondary NADs were never bridged into the guest. **Multi-NIC has been silently broken** (this may be the smoke-test multi-nic "flake" attributed to Longhorn).

## Fix

`networkInitContainer()` now mounts:
- `runtime-intent` ConfigMap at `IntentPath` (`/var/lib/kubeswift/intent`) — so the script reads the intent and the multi-NIC path actually runs.
- `run` emptyDir at `RunDirPath` — so network setup can persist state the launcher reads (needed by the upcoming primary-on-NAD IP-discovery).

All four pod builders that add this init container (disk-boot, kernel-boot, GPU, restore) already define both volumes, so the references are safe.

## Backward compatible

Guests with no `spec.interfaces` still have no `"nics"` in the intent → legacy `br0/tap0` path unchanged. Multi-NIC guests now correctly bridge their Multus secondaries (the fix). No regression to single-NIC guests.

## Tests / validation

Regression test asserts the network-init container carries both mounts and the pod defines the referenced volumes. **Cluster-validatable** (unlike the OVN-K datapath): a multi-NIC guest with a simple bridge/macvlan NAD should now actually get its secondary interface — I'll validate on-cluster after merge (controller-side change; needs the rebuilt controller image).

Prerequisite for the multi-node-L2 primary-on-NAD datapath (the #178 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)