### PR TITLE
fix(network): add python3 to launcher image — multi-NIC network-init needs it

### DIFF
--- a/images/swiftletd/Containerfile
+++ b/images/swiftletd/Containerfile
@@ -69,6 +69,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dnsutils \
     qemu-system-x86 \
     ovmf \
+    python3 \
     libseccomp2 \
     libcap-ng0 \
     && rm -rf /var/lib/apt/lists/*

--- a/rust/swiftletd/scripts/network-init.sh
+++ b/rust/swiftletd/scripts/network-init.sh
@@ -107,8 +107,15 @@ has_nics() {
 }
 
 if has_nics; then
-    # Multi-NIC mode: parse NIC list from intent JSON
-    # Uses lightweight JSON parsing with grep/sed -- no jq dependency
+    # Multi-NIC mode: parse NIC list from intent JSON with python3.
+    # FAIL LOUD if python3 is missing — otherwise the python3 pipe below
+    # produces no output, the per-NIC loop runs zero times, and the script
+    # would falsely report success while configuring NO interfaces (the guest
+    # then fails later at "No IP on br0"). python3 ships in the launcher image.
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "ERROR: python3 not found but multi-NIC intent present; cannot configure interfaces" >&2
+        exit 1
+    fi
     # Extract the nics array content
     NIC_COUNT=$(grep -o '"tapDevice"' "$INTENT_PATH" | wc -l)
 


### PR DESCRIPTION
**Regression exposed by #179** (cluster-validated, W5 pattern). `network-init.sh` parses the multi-NIC intent with `python3 -c "import json…"`, but **`python3` is not in the launcher image**.

- **Before #179:** network-init couldn't read the intent → legacy `br0/tap0` path (python3-free) → a multi-NIC guest's *primary* NIC worked (secondaries silently missing).
- **After #179:** the multi-NIC code path is reached → dies at `python3: not found` → the per-NIC loop runs zero times → the guest gets **no network at all** (launcher fails `No IP on br0`).

Cluster-observed (sha-edf1a17, boba, multi-NIC guest):
```
network-init: "/usr/local/bin/network-init.sh: 124: python3: not found"
              "Network init done: 2 NIC(s) configured"   ← false success
launcher:     Error(1) "No IP on br0"
```

## Fix

- **Add `python3` to the launcher image** (verified `apt-get install python3` provides the `json` stdlib module; both `network-init.sh` and `launcher-entrypoint.sh` use python3).
- **`network-init.sh` fails loud** (`exit 1`) when python3 is absent but a multi-NIC intent is present — instead of silently configuring nothing and reporting success (no-silent-failures).

Completes the multi-NIC un-breaking begun in #179. I'll **re-validate on cluster** after the image builds (multi-NIC guest secondary bridging + the blocked vhost-user wiring-check both ride on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)