### PR TITLE
fix(network): network-init.sh skips vhost-user NICs (no in-pod tap/bridge)

### DIFF
--- a/rust/swiftletd/scripts/network-init.sh
+++ b/rust/swiftletd/scripts/network-init.sh
@@ -145,6 +145,13 @@ for nic in nics:
             echo "Skipping SR-IOV interface $name -- VFIO passthrough handled by swiftletd"
             continue
         fi
+        if [ "$nic_type" = "vhost-user" ]; then
+            # vhost-user-net: the datapath is an operator backend socket; there
+            # is no in-pod tap/bridge to set up (and no multusInterface). Skip,
+            # like SR-IOV -- swiftletd hands CH --net vhost_user=on,socket=.
+            echo "Skipping vhost-user interface $name -- backend datapath handled by swiftletd"
+            continue
+        fi
         if [ "$primary" = "1" ]; then
             setup_primary_nic "$bridge" "$tap"
         else


### PR DESCRIPTION
The multi-NIC loop in `network-init.sh` skipped only **SR-IOV** interfaces. A `type: vhost-user` interface (vhost-user-net, #175) has **no in-pod tap/bridge** and no `multusInterface` — its datapath is the operator backend socket, plumbed by swiftletd via `--net vhost_user=on,socket=`. The loop fell through to `setup_secondary_nic` with an **empty** Multus name, hung 30s, then errored (`Multus interface ` ` not found`), failing network-init and the guest.

Latent until now: network-init couldn't read the intent until #179, so a vhost-user-net guest previously took the legacy `br0/tap0` path. With #179 (intent mount) + #180 (python3), the vhost-user NIC reaches the loop and trips it. **Cluster-observed** on sha-3128639.

**Fix:** skip `type: vhost-user` in the loop, like SR-IOV.

Found during the #179/#180 multi-NIC cluster re-validation (W5 pattern, same pass that validated the vhost-user **device** wiring — CH spawned with `--disk vhost_user=on` + `--generic-vhost-user`). I'll re-validate the vhost-user-**net** wiring (network-init completes → launcher gets `--net vhost_user=on`) after the image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)