### PR TITLE
feat(network): primary-on-NAD launcher runtime (EXPERIMENTAL, multi-node L2) [#1 PR3]

### DIFF
--- a/docs/networking/multi-node-l2.md
+++ b/docs/networking/multi-node-l2.md
@@ -1,14 +1,24 @@
 # Multi-node L2 networking (IP-preserving guests)
 
-> **Status (2026-06):** the **control-plane** half is shipped — the
-> `spec.interfaces[].primary` field, the resolver wiring, and the corrected
-> SwiftMigration IP-preservation gate. The **runtime datapath** (attaching the
-> *primary* NIC to a NAD inside the launcher, and discovering its NAD-assigned
-> IP) is landing across follow-up PRs; until then, a `primary: true` + NAD
-> interface is admitted and classified correctly for migration but the in-guest
-> datapath is not yet wired. See
+> **Status (2026-06): control-plane shipped + runtime EXPERIMENTAL.** The
+> control-plane (the `spec.interfaces[].primary` field, the resolver wiring, and
+> the corrected SwiftMigration IP-preservation gate) is shipped and tested. The
+> launcher **runtime datapath** (attaching the *primary* NIC to a NAD and giving
+> the guest the NAD's IP) is now implemented but the **datapath is UNVALIDATED**
+> — the dev cluster has no working multi-node L2 (Multus secondary attach does
+> not produce an interface there). It will be validated and tuned on an
+> OVN-Kubernetes cluster. Treat primary-on-NAD as experimental until then. See
 > [`../design/network-architecture-requirements.md`](../design/network-architecture-requirements.md)
-> for the framework and the chosen approach.
+> for the framework.
+>
+> **Runtime model (KubeVirt-style bridge binding):** network-init reads the IP
+> the NAD's CNI assigned to the pod's Multus interface, flushes it off that
+> interface, bridges the interface to the guest's tap, and the launcher's
+> in-pod dnsmasq hands that exact IP to the guest (matched by MAC) — so the
+> guest's primary IP is the NAD's portable IP, and the existing lease-file IP
+> discovery works unchanged. The in-pod dnsmasq binds via a best-effort helper
+> IP (`<subnet>.254`) in the NAD subnet — a heuristic with a documented
+> collision risk, expected to be refined during real-cluster validation.
 
 By default a SwiftGuest's primary IP is **node-local** — it comes from a
 per-node dnsmasq on `br0` and is NAT-masqueraded out the pod's `eth0`. That IP
@@ -100,10 +110,14 @@ that makes the IP portable across a migration.
 
 ## Limitations / follow-ups
 
-- **Runtime datapath in progress** (see the status banner). The control-plane
-  classification is shipped; the launcher-side attach + IP discovery land next.
-- **A prerequisite multi-NIC fix** (the `network-init` container gaining the
-  RuntimeIntent mount so Multus interfaces are actually bridged) ships ahead of
-  the primary-on-NAD datapath.
+- **Runtime datapath is EXPERIMENTAL and unvalidated** (see the status banner) —
+  it needs an OVN-K / working-NAD cluster to validate and tune (the helper-IP /
+  dnsmasq binding in particular).
+- **Prerequisite multi-NIC fixes — shipped.** The `network-init` container now
+  mounts the RuntimeIntent + run dir, the launcher image carries `python3`, and
+  network-init skips vhost-user NICs, so multi-NIC bridging actually runs. (These
+  were latent bugs that meant multi-NIC never worked end-to-end before.)
+- **Helper-IP heuristic.** The in-pod dnsmasq binds to `<NAD-subnet>.254`; if
+  that host is taken on the segment it will collide. Refine during validation.
 - **SR-IOV** is a hardware-passthrough NIC, not a Tier-C overlay; it is rejected
   for cross-node migration regardless (Phase 4+).

--- a/rust/swiftletd/scripts/launcher-entrypoint.sh
+++ b/rust/swiftletd/scripts/launcher-entrypoint.sh
@@ -51,6 +51,29 @@ if network_enabled; then
     lease_dir="$RUN_DIR/$safe_id"
     mkdir -p "$lease_dir"
 
+    # Primary-on-NAD (multi-node L2, EXPERIMENTAL): network-init persisted the
+    # NAD-assigned primary IP. Hand exactly that IP to the guest (matched by
+    # MAC) via a fixed dnsmasq lease, so the guest's primary IP is the NAD's
+    # portable IP. lease.rs then discovers it from the same lease file (no code
+    # change). DATAPATH UNVALIDATED -- see docs/networking/multi-node-l2.md.
+    nad_env="$lease_dir/primary-nad.env"
+    if [ -f "$nad_env" ]; then
+        # shellcheck disable=SC1090
+        . "$nad_env"   # NAD_IP, NAD_PREFIX, NAD_GW, NAD_MAC, NAD_BRIDGE
+        dns=$(grep '^nameserver ' /etc/resolv.conf 2>/dev/null | head -1 | awk '{print $2}')
+        [ -z "$dns" ] && dns="10.96.0.10"
+        echo "Primary-on-NAD dnsmasq: handing $NAD_IP to $NAD_MAC on $NAD_BRIDGE (gw $NAD_GW)"
+        dnsmasq --no-daemon --bind-interfaces --interface="$NAD_BRIDGE" \
+            --dhcp-range="$NAD_IP,$NAD_IP" \
+            ${NAD_MAC:+--dhcp-host="$NAD_MAC,$NAD_IP"} \
+            ${NAD_GW:+--dhcp-option=option:router,"$NAD_GW"} \
+            --dhcp-option=option:dns-server,"$dns" \
+            --dhcp-leasefile="$lease_dir/dnsmasq.leases" \
+            --dhcp-authoritative &
+        sleep 1
+        exec /usr/local/bin/swiftletd "$@"
+    fi
+
     # Derive subnet from bridge (e.g. 10.244.125.1/24 -> 10.244.125.0/24)
     br_addr=$(ip -4 addr show "$BRIDGE" 2>/dev/null | grep 'inet ' | awk '{print $2}' | head -1)
     [ -z "$br_addr" ] && { echo "No IP on $BRIDGE"; exit 1; }

--- a/rust/swiftletd/scripts/network-init.sh
+++ b/rust/swiftletd/scripts/network-init.sh
@@ -11,8 +11,17 @@
 set -e
 
 INTENT_PATH="${KUBESWIFT_INTENT_PATH:-/var/lib/kubeswift/intent/runtime-intent.json}"
+RUN_DIR="${KUBESWIFT_RUN_DIR:-/var/lib/kubeswift/run}"
 
 # --- Helper functions ---
+
+# guest_run_dir prints the per-guest run directory (shared with the launcher
+# via the "run" emptyDir, mounted in this init container). Used to hand the
+# launcher entrypoint the NAD-assigned primary IP (primary-on-NAD path).
+guest_run_dir() {
+    gid=$(grep -o '"guestId"[[:space:]]*:[[:space:]]*"[^"]*"' "$INTENT_PATH" 2>/dev/null | cut -d'"' -f4)
+    echo "$RUN_DIR/$(echo "$gid" | tr '/' '-')"
+}
 
 setup_primary_nic() {
     local bridge="$1" tap="$2"
@@ -20,7 +29,7 @@ setup_primary_nic() {
     # VM-internal subnet (per launcher-pod network namespace; must NOT
     # collide with the cluster pod-CIDR pool or any per-node Calico
     # allocation, otherwise SYN-ACK replies to cross-node traffic
-    # routed via this br0 (linkdown) instead of eth0 — see
+    # routed via this br0 (linkdown) instead of eth0 -- see
     # docs/design/live-migration-phase-3a-spike.md B0 finding.
     local bridge_ip="${BRIDGE_IP:-192.168.99.1/24}"
 
@@ -97,6 +106,81 @@ setup_secondary_nic() {
     echo "Secondary NIC: $bridge with $tap, bridged to $multus_iface"
 }
 
+# setup_primary_nad_nic -- EXPERIMENTAL (multi-node L2, primary-on-NAD).
+#
+# DATAPATH IS UNVALIDATED on the dev cluster (no working multi-node L2). It
+# implements the KubeVirt-style "bridge binding": the NAD's CNI assigns the
+# pod's Multus interface an IP; we hand that exact IP to the GUEST so the
+# guest's primary IP is the NAD's portable IP (survives a move between nodes).
+#
+#   1. wait for the Multus interface, read its CNI-assigned IP + gateway
+#   2. persist them (+ the guest MAC) to the per-guest run dir, for the
+#      launcher entrypoint to drive a fixed-lease dnsmasq
+#   3. flush the IP off the Multus interface (the GUEST will own it; avoids a
+#      duplicate-address ARP conflict on the L2)
+#   4. bridge the Multus interface to the guest's tap (br has NO node-local IP,
+#      no NAT -- this is a flat L2 bridge, not the node-local masqueraded one)
+#   5. give the bridge a best-effort helper IP in the NAD subnet so the
+#      entrypoint's dnsmasq can bind and serve the fixed lease
+#
+# Tuning of the helper IP / dnsmasq binding is expected during real-cluster
+# validation; the structure (read->flush->bridge->serve->lease.rs discovers) is the
+# contract.
+setup_primary_nad_nic() {
+    bridge="$1"; tap="$2"; multus_iface="$3"; guest_mac="$4"
+
+    attempts=0
+    while [ $attempts -lt 30 ]; do
+        ip link show "$multus_iface" >/dev/null 2>&1 && break
+        sleep 1; attempts=$((attempts + 1))
+    done
+    if ! ip link show "$multus_iface" >/dev/null 2>&1; then
+        echo "ERROR: primary NAD interface $multus_iface not found after 30s" >&2
+        exit 1
+    fi
+
+    nad_cidr=$(ip -4 addr show "$multus_iface" 2>/dev/null | awk '/inet /{print $2; exit}')
+    if [ -z "$nad_cidr" ]; then
+        echo "ERROR: primary NAD interface $multus_iface has no IPv4 address (NAD IPAM did not assign one)" >&2
+        exit 1
+    fi
+    nad_ip="${nad_cidr%/*}"
+    nad_prefix="${nad_cidr#*/}"
+    nad_gw=$(ip route show default 2>/dev/null | awk -v d="$multus_iface" '$0 ~ ("dev "d){print $3; exit}')
+    [ -z "$nad_gw" ] && nad_gw=$(ip route show dev "$multus_iface" 2>/dev/null | awk '/default/{print $3; exit}')
+
+    # Persist for the launcher entrypoint (shared run dir).
+    rd=$(guest_run_dir); mkdir -p "$rd"
+    {
+        echo "NAD_IP=$nad_ip"
+        echo "NAD_PREFIX=$nad_prefix"
+        echo "NAD_GW=$nad_gw"
+        echo "NAD_MAC=$guest_mac"
+        echo "NAD_BRIDGE=$bridge"
+    } > "$rd/primary-nad.env"
+
+    # The guest claims nad_ip; the host must not also hold it on the L2.
+    ip addr flush dev "$multus_iface" 2>/dev/null || true
+
+    ip link add "$bridge" type bridge stp_state 0 2>/dev/null || true
+    ip link set "$bridge" up
+    ip tuntap add dev "$tap" mode tap 2>/dev/null || true
+    ip link set "$tap" up
+    ip link set "$tap" master "$bridge"
+    ip link set "$multus_iface" master "$bridge"
+    ip link set "$multus_iface" up
+
+    # Best-effort helper IP in the NAD subnet for dnsmasq to bind. Heuristic
+    # (.254 host) -- refine during real-cluster validation; documented collision
+    # risk in docs/networking/multi-node-l2.md.
+    net_base=$(echo "$nad_ip" | sed 's/\.[0-9]*$//')
+    helper="${net_base}.254"
+    [ "$helper" = "$nad_ip" ] && helper="${net_base}.253"
+    ip addr add "$helper/$nad_prefix" dev "$bridge" 2>/dev/null || true
+
+    echo "Primary NIC on NAD (EXPERIMENTAL): $bridge bridges $multus_iface to $tap; guest IP=$nad_ip/$nad_prefix gw=$nad_gw (helper $helper)"
+}
+
 # --- Main ---
 
 # Check if intent has "nics" array (multi-NIC mode)
@@ -108,7 +192,7 @@ has_nics() {
 
 if has_nics; then
     # Multi-NIC mode: parse NIC list from intent JSON with python3.
-    # FAIL LOUD if python3 is missing — otherwise the python3 pipe below
+    # FAIL LOUD if python3 is missing -- otherwise the python3 pipe below
     # produces no output, the per-NIC loop runs zero times, and the script
     # would falsely report success while configuring NO interfaces (the guest
     # then fails later at "No IP on br0"). python3 ships in the launcher image.
@@ -139,8 +223,9 @@ for nic in nics:
     multus = nic.get('multusInterface', '')
     tap = nic.get('tapDevice', '')
     bridge = nic.get('bridge', '')
-    print(f\"{nic_type}|{tap}|{bridge}|{primary}|{multus}|{nic['name']}\")
-" | while IFS='|' read -r nic_type tap bridge primary multus name; do
+    mac = nic.get('mac', '')
+    print(f\"{nic_type}|{tap}|{bridge}|{primary}|{multus}|{mac}|{nic['name']}\")
+" | while IFS='|' read -r nic_type tap bridge primary multus mac name; do
         if [ "$nic_type" = "sriov" ]; then
             echo "Skipping SR-IOV interface $name -- VFIO passthrough handled by swiftletd"
             continue
@@ -152,7 +237,11 @@ for nic in nics:
             echo "Skipping vhost-user interface $name -- backend datapath handled by swiftletd"
             continue
         fi
-        if [ "$primary" = "1" ]; then
+        if [ "$primary" = "1" ] && [ -n "$multus" ]; then
+            # Primary-on-NAD (multi-node L2, EXPERIMENTAL): the primary rides a
+            # Multus NAD instead of the node-local bridge.
+            setup_primary_nad_nic "$bridge" "$tap" "$multus" "$mac"
+        elif [ "$primary" = "1" ]; then
             setup_primary_nic "$bridge" "$tap"
         else
             setup_secondary_nic "$bridge" "$tap" "$multus"


### PR DESCRIPTION
Implements the launcher-side datapath for the multi-node-L2 **primary-on-NAD** control-plane shipped in #178 — completing the #1 (Multi-node L2) arc.

> ⚠️ **DATAPATH UNVALIDATED.** The dev cluster has no working multi-node L2 (Multus secondary attach produces no interface there), so this **cannot be verified on-cluster yet**. It's implemented to be validated + tuned on an OVN-Kubernetes cluster, and is marked **EXPERIMENTAL** throughout. Shipping per explicit direction to push despite the validation gap.

## Model — KubeVirt-style bridge binding

`network-init.sh::setup_primary_nad_nic` (for a NIC that is `primary` **and** has a `multusInterface`):
1. wait for the Multus interface; read its **CNI-assigned IP + gateway**
2. persist IP/prefix/gw/guest-MAC/bridge to the per-guest run dir (shared with the launcher via the `run` emptyDir mounted in network-init since #179)
3. **flush** the IP off the Multus interface (the guest will own it — avoids a duplicate-address ARP conflict)
4. **bridge** the Multus interface to the guest's tap (flat L2, no node-local IP/NAT)
5. give the bridge a best-effort helper IP (`<subnet>.254`) so dnsmasq can bind

`launcher-entrypoint.sh`: when `primary-nad.env` is present, run dnsmasq with a **fixed lease** (`--dhcp-range=IP,IP`, `--dhcp-host=MAC,IP`, `router=gw`) so the guest gets **exactly the NAD's IP**. The existing `lease.rs` IP discovery then works unchanged (same lease file). **No Rust change.**

## Honest caveats (in the doc)

- The helper-IP `.254` heuristic can collide on the segment.
- dnsmasq binding + the gateway model need real-cluster tuning.
- The **structure** (`read → flush → bridge → serve → lease.rs discovers`) is the contract; the exact dnsmasq/helper tuning is expected to change during validation.

Scripts kept pure-ASCII (project rule); `sh -n` clean. Docs: `docs/networking/multi-node-l2.md` updated (status banner + runtime model + limitations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)