### PR TITLE
feat(swiftctl): migrate --check preflight (TFU #10)

### DIFF
--- a/cmd/swiftctl/migration.go
+++ b/cmd/swiftctl/migration.go
@@ -32,6 +32,7 @@ var (
 	migratePreferredMode string
 	migrateTimeout       time.Duration
 	migrateTTL           time.Duration
+	migrateCheck         bool
 	migrationListAllNS   bool
 )
 
@@ -68,6 +69,7 @@ across nodes. Pass --allow-ip-change to acknowledge and proceed,
 or attach the guest to a multi-node network (Multus + macvlan or
 OVN-K layer-2) for IP preservation.`,
 	Example: `  swiftctl migrate db --to worker-3
+  swiftctl migrate db --to worker-3 --check   # preflight only, creates nothing
   swiftctl migrate web --to worker-3 --preferred-mode live --allow-ip-change
   swiftctl migrate db --to worker-3 --preferred-mode offline
   swiftctl migrate db --to worker-3 --name db-rebalance-2026-04-28`,
@@ -112,6 +114,8 @@ var migrationCancelCmd = &cobra.Command{
 
 func init() {
 	migrateCmd.Flags().StringVar(&migrateTargetNode, "to", "", "Target node name (required)")
+	migrateCmd.Flags().BoolVar(&migrateCheck, "check", false,
+		"Preflight only: report node readiness/capacity, IP-preservation, mode, and CPU compatibility without creating the migration")
 	migrateCmd.Flags().BoolVar(&migrateAllowIPChange, "allow-ip-change", false,
 		"Acknowledge that the guest IP will change cross-node on default node-local networking")
 	migrateCmd.Flags().StringVar(&migrateName, "name", "",
@@ -164,6 +168,9 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 	c, err := newMigrationClient()
 	if err != nil {
 		return err
+	}
+	if migrateCheck {
+		return runMigratePreflight(cmd, c, guestName, ns, mode)
 	}
 	name := migrateName
 	if name == "" {

--- a/cmd/swiftctl/migration_check.go
+++ b/cmd/swiftctl/migration_check.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	swiftmigration "github.com/projectbeskar/kubeswift/internal/controller/swiftmigration"
+)
+
+// nfdCPUIDLabelPrefix is the node-feature-discovery label prefix for CPUID
+// feature flags (e.g. feature.node.kubernetes.io/cpu-cpuid.AVX512F=true). When
+// present on both nodes we can diff the flag sets; otherwise CPU-feature
+// uniformity is an operator runbook concern (compare `lscpu` by hand).
+const nfdCPUIDLabelPrefix = "feature.node.kubernetes.io/cpu-cpuid."
+
+// runMigratePreflight reports, without creating anything, whether a
+// `swiftctl migrate <guest> --to <node>` is likely to succeed: target node
+// readiness + capacity, IP preservation, the mode that would be picked, and
+// CPU/architecture compatibility. Mirrors the Phase-1 target-node-Ready
+// ergonomic — warnings, not hard rejections, except for outright blockers
+// (guest/target missing, live requested for a VFIO guest). Returns a non-nil
+// error (exit 1) only when a hard blocker is present.
+func runMigratePreflight(cmd *cobra.Command, c client.Client, guestName, ns string, mode migrationv1alpha1.SwiftMigrationMode) error {
+	ctx := context.Background()
+	out := cmd.OutOrStdout()
+	target := migrateTargetNode
+
+	const (
+		ok   = "[ OK ]"
+		warn = "[WARN]"
+		info = "[INFO]"
+		fail = "[FAIL]"
+	)
+	blockers := 0
+	line := func(status, format string, a ...interface{}) {
+		fmt.Fprintf(out, "%s %s\n", status, fmt.Sprintf(format, a...))
+	}
+
+	fmt.Fprintf(out, "Preflight: migrate %s/%s --to %q\n\n", ns, guestName, target)
+
+	// 1. Guest exists.
+	var guest swiftv1alpha1.SwiftGuest
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: guestName}, &guest); err != nil {
+		line(fail, "SwiftGuest %s/%s not found: %v", ns, guestName, err)
+		return fmt.Errorf("preflight failed: guest not found")
+	}
+	line(ok, "SwiftGuest %s/%s found (phase=%s)", ns, guestName, guest.Status.Phase)
+
+	srcNode := guest.Status.NodeName
+	switch {
+	case srcNode == "":
+		line(warn, "source node unknown (guest not scheduled / not Running)")
+	case srcNode == target:
+		line(warn, "target node %q is the guest's current node — nothing to migrate", target)
+	default:
+		line(info, "source node: %s", srcNode)
+	}
+
+	// 2. Target node: exists, Ready, capacity.
+	var tnode corev1.Node
+	if err := c.Get(ctx, client.ObjectKey{Name: target}, &tnode); err != nil {
+		if apierrors.IsNotFound(err) {
+			line(fail, "target node %q not found", target)
+		} else {
+			line(fail, "target node %q lookup error: %v", target, err)
+		}
+		blockers++
+	} else {
+		if isNodeReady(&tnode) {
+			line(ok, "target node %q is Ready", target)
+		} else {
+			line(warn, "target node %q is NOT Ready (cordoned/NotReady) — scheduling may not succeed", target)
+		}
+		// Capacity (reuses the controller's check against the guest's class).
+		if class, err := guestClass(ctx, c, &guest); err != nil {
+			line(info, "capacity not checked: %v", err)
+		} else if err := swiftmigration.NodeHasCapacity(ctx, c, &tnode, class); err != nil {
+			line(warn, "target node capacity: %v", err)
+		} else {
+			line(ok, "target node %q has capacity for the guest (%s CPU / %s memory)",
+				target, class.Spec.CPU.String(), class.Spec.Memory.String())
+		}
+	}
+
+	// 3. IP preservation.
+	switch {
+	case guest.PrimaryIPPreservedCrossNode():
+		line(ok, "primary IP rides a multi-node NAD — preserved across the move")
+	case migrateAllowIPChange:
+		line(warn, "primary IP will change on the target (you passed --allow-ip-change)")
+	default:
+		line(warn, "primary IP will change cross-node (default node-local networking); "+
+			"pass --allow-ip-change, or put the primary on a multi-node NAD (primary: true + networkRef)")
+	}
+
+	// 4. Mode / VFIO.
+	vfio := guest.HasVFIODevices() || guest.HasSRIOVInterface()
+	nodeLocalBackend := len(guest.Spec.Filesystems) > 0 || len(guest.Spec.VhostUserDevices) > 0
+	switch {
+	case mode == migrationv1alpha1.SwiftMigrationModeLive && vfio:
+		line(fail, "live migration requested but the guest has VFIO/SR-IOV devices — not supported; use --preferred-mode offline")
+		blockers++
+	case vfio:
+		line(info, "guest has VFIO/SR-IOV devices — only offline migration is possible (mode will resolve to offline)")
+	case mode == migrationv1alpha1.SwiftMigrationModeLive:
+		line(info, "mode: live (requested)")
+	case mode == migrationv1alpha1.SwiftMigrationModeOffline:
+		line(info, "mode: offline (requested)")
+	default:
+		line(info, "mode: auto — the controller live-migrates when eligible, else offline")
+	}
+	if nodeLocalBackend {
+		line(warn, "guest has virtiofs/vhost-user devices backed by node-local state — the target node must provide the same backends (sockets/shares); these do not move with the guest")
+	}
+
+	// 5. Architecture + CPU features (source vs target).
+	if srcNode != "" && srcNode != target {
+		var snode corev1.Node
+		if err := c.Get(ctx, client.ObjectKey{Name: srcNode}, &snode); err != nil {
+			line(info, "source node %q not readable for CPU comparison: %v", srcNode, err)
+		} else {
+			checkCPUCompat(line, ok, warn, info, &snode, &tnode)
+		}
+	} else {
+		line(info, "CPU/arch comparison skipped (no distinct source node); verify source and target expose identical `lscpu` flags")
+	}
+
+	fmt.Fprintln(out)
+	if blockers > 0 {
+		fmt.Fprintf(out, "Preflight: %d blocker(s) — this migration would be rejected.\n", blockers)
+		return fmt.Errorf("preflight failed: %d blocker(s)", blockers)
+	}
+	fmt.Fprintln(out, "Preflight: no blockers. Re-run without --check to create the migration.")
+	return nil
+}
+
+// checkCPUCompat compares architecture and (when NFD labels are present) the
+// CPUID feature-flag sets of the source and target nodes. CPU flags are not in
+// the Node API, so without NFD this is an advisory.
+func checkCPUCompat(line func(string, string, ...interface{}), ok, warn, info string, src, dst *corev1.Node) {
+	if a, b := src.Status.NodeInfo.Architecture, dst.Status.NodeInfo.Architecture; a != "" && a != b {
+		line(warn, "architecture mismatch: source=%s target=%s — migration will fail", a, b)
+	} else if a != "" {
+		line(ok, "architecture matches (%s)", a)
+	}
+
+	srcFlags := nfdCPUFlags(src)
+	dstFlags := nfdCPUFlags(dst)
+	if len(srcFlags) == 0 || len(dstFlags) == 0 {
+		line(info, "CPU-feature uniformity not auto-verifiable (node-feature-discovery labels absent); "+
+			"compare `lscpu` flags across the nodes — CPU-feature mismatch is the realistic live-migration failure mode")
+		return
+	}
+	var missing []string
+	for f := range srcFlags {
+		if !dstFlags[f] {
+			missing = append(missing, f)
+		}
+	}
+	if len(missing) == 0 {
+		line(ok, "target CPU exposes all %d source CPUID features (NFD)", len(srcFlags))
+	} else {
+		sort.Strings(missing)
+		line(warn, "target is MISSING %d source CPU feature(s): %s — the guest may fault on resume",
+			len(missing), strings.Join(missing, ","))
+	}
+}
+
+// nfdCPUFlags returns the set of CPUID feature flags a node advertises via
+// node-feature-discovery labels.
+func nfdCPUFlags(n *corev1.Node) map[string]bool {
+	out := map[string]bool{}
+	for k, v := range n.Labels {
+		if v == "true" && strings.HasPrefix(k, nfdCPUIDLabelPrefix) {
+			out[strings.TrimPrefix(k, nfdCPUIDLabelPrefix)] = true
+		}
+	}
+	return out
+}
+
+// guestClass fetches the SwiftGuestClass referenced by the guest (cluster-scoped).
+func guestClass(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest) (*swiftv1alpha1.SwiftGuestClass, error) {
+	if guest.Spec.GuestClassRef.Name == "" {
+		return nil, fmt.Errorf("guest has no guestClassRef")
+	}
+	var class swiftv1alpha1.SwiftGuestClass
+	if err := c.Get(ctx, client.ObjectKey{Name: guest.Spec.GuestClassRef.Name}, &class); err != nil {
+		return nil, fmt.Errorf("SwiftGuestClass %q: %w", guest.Spec.GuestClassRef.Name, err)
+	}
+	return &class, nil
+}
+
+// isNodeReady reports whether the node's Ready condition is True.
+func isNodeReady(n *corev1.Node) bool {
+	for _, cond := range n.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/cmd/swiftctl/migration_check_test.go
+++ b/cmd/swiftctl/migration_check_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/scheme"
+)
+
+func readyNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Conditions:  []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			NodeInfo:    corev1.NodeSystemInfo{Architecture: "amd64"},
+			Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8"), corev1.ResourceMemory: resource.MustParse("32Gi")},
+		},
+	}
+}
+
+func TestMigratePreflight_PrimaryOnNAD_NoBlockers(t *testing.T) {
+	migrateTargetNode = "miles"
+	migrateAllowIPChange = false
+	defer func() { migrateTargetNode = ""; migrateAllowIPChange = false }()
+
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "default"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			GuestClassRef: corev1.LocalObjectReference{Name: "cls"},
+			Interfaces: []swiftv1alpha1.GuestInterface{
+				{Name: "app", Primary: true, NetworkRef: &swiftv1alpha1.NetworkReference{Name: "ovn-l2"}},
+			},
+		},
+		Status: swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning, NodeName: "boba"},
+	}
+	class := &swiftv1alpha1.SwiftGuestClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cls"},
+		Spec:       swiftv1alpha1.SwiftGuestClassSpec{CPU: resource.MustParse("2"), Memory: resource.MustParse("4Gi")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(guest, class, readyNode("miles"), readyNode("boba")).Build()
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := runMigratePreflight(cmd, c, "g", "default", migrationv1alpha1.SwiftMigrationModeAuto)
+	if err != nil {
+		t.Fatalf("expected no blockers, got %v\n%s", err, buf.String())
+	}
+	s := buf.String()
+	for _, want := range []string{"SwiftGuest default/g found", "is Ready", "primary IP rides a multi-node NAD", "no blockers"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q:\n%s", want, s)
+		}
+	}
+}
+
+func TestMigratePreflight_LiveWithSRIOV_IsBlocker(t *testing.T) {
+	migrateTargetNode = "miles"
+	defer func() { migrateTargetNode = "" }()
+
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "default"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			GuestClassRef: corev1.LocalObjectReference{Name: "cls"},
+			Interfaces:    []swiftv1alpha1.GuestInterface{{Name: "rdma", Type: swiftv1alpha1.InterfaceTypeSRIOV}},
+		},
+		Status: swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning, NodeName: "boba"},
+	}
+	class := &swiftv1alpha1.SwiftGuestClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cls"},
+		Spec:       swiftv1alpha1.SwiftGuestClassSpec{CPU: resource.MustParse("2"), Memory: resource.MustParse("4Gi")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(guest, class, readyNode("miles"), readyNode("boba")).Build()
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := runMigratePreflight(cmd, c, "g", "default", migrationv1alpha1.SwiftMigrationModeLive)
+	if err == nil {
+		t.Fatalf("expected a blocker for live+SR-IOV; output:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "not supported; use --preferred-mode offline") {
+		t.Errorf("missing SR-IOV blocker message:\n%s", buf.String())
+	}
+}
+
+func TestMigratePreflight_GuestNotFound(t *testing.T) {
+	migrateTargetNode = "miles"
+	defer func() { migrateTargetNode = "" }()
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	if err := runMigratePreflight(cmd, c, "nope", "default", migrationv1alpha1.SwiftMigrationModeAuto); err == nil {
+		t.Fatal("expected error for missing guest")
+	}
+}

--- a/docs/migration/overview.md
+++ b/docs/migration/overview.md
@@ -89,5 +89,24 @@ For a guest on default networking:
 swiftctl migrate web --to worker-3 --allow-ip-change
 ```
 
+### Preflight check
+
+`--check` runs a read-only preflight and creates nothing — handy before a
+real move:
+
+```bash
+swiftctl migrate db --to worker-3 --check
+```
+
+It reports the target node's readiness and capacity, whether the guest's
+primary IP is preserved (multi-node NAD) or will change, the mode the
+controller would pick (and whether VFIO/SR-IOV forces offline), any
+node-local virtiofs/vhost-user backends the target must also provide, and
+source-vs-target CPU/architecture compatibility (CPU-feature flags when
+node-feature-discovery labels are present, otherwise an advisory to compare
+`lscpu` — CPU-feature mismatch is the realistic live-migration failure mode).
+Hard blockers (missing guest/target, `--preferred-mode live` for a VFIO
+guest) exit non-zero; everything else is a warning.
+
 For full operational details and timing characteristics, see
 [offline-migration.md](offline-migration.md).


### PR DESCRIPTION
`swiftctl migrate <guest> --to <node> --check` runs a **read-only preflight** and creates nothing — the CLI analogue of the Phase-1 target-node-Ready check (TFU #10).

## Reports

- guest exists; source node (or "not scheduled")
- **target node Ready + capacity** (reuses the exported `swiftmigration.NodeHasCapacity`)
- **IP preservation** via `guest.PrimaryIPPreservedCrossNode()` — "preserved" for a primary-on-NAD guest, else "IP will change; `--allow-ip-change` or use a NAD"
- **mode** the controller would pick; VFIO/SR-IOV forces offline (**live+VFIO is a hard blocker → exit 1**)
- node-local **virtiofs/vhost-user** backends the target must also provide
- **CPU/architecture compatibility**: arch match; CPUID feature diff when node-feature-discovery labels are present, else an advisory to compare `lscpu` (CPU-feature mismatch is the realistic live-migration failure mode). CPU flags aren't in the Node API, so without NFD this is advisory.

Warnings, not hard rejections, except outright blockers (missing guest/target, live+VFIO) which exit non-zero.

## Validation

Unit tests (primary-on-NAD no-blockers / live+SR-IOV blocker / guest-not-found) **and cluster-smoked** against the dev cluster:

```
[ OK ] SwiftGuest default/chk-guest found (phase=Scheduling)
[ OK ] target node "miles" is Ready
[ OK ] target node "miles" has capacity for the guest (2 CPU / 2Gi memory)
[ OK ] primary IP rides a multi-node NAD — preserved across the move
[INFO] mode: auto — the controller live-migrates when eligible, else offline
Preflight: no blockers.
```

(CLI-only — no controller/image change.) Re-confirms the #178 primary-on-NAD IP-preservation classification along the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)