### PR TITLE
docs(runtime): clarify runPolicy vs CH v52 reset-in-place reboot semantics [#5]

### DIFF
--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -6,6 +6,21 @@ import (
 )
 
 // RunPolicy defines the desired run state of a guest.
+//
+// RunPolicy governs what the controller does when the launcher POD reaches a
+// terminal state (Succeeded/Failed) — i.e. when Cloud Hypervisor itself exits.
+// A guest *reboot* is NOT such an event: on Cloud Hypervisor v52 a guest reboot
+// RESETS THE VM IN PLACE (the CH process and the launcher pod survive, the
+// guest restarts), so reboots never trigger RunPolicy. CH exits only on guest
+// shutdown/poweroff or a crash; those are what Stopped/RestartOnFailure/Always
+// act on. (v51 exited on reboot too, churning the pod — v52 reset-in-place is
+// the cleaner behavior; KubeSwift passes no --no-reboot, keeping the default.)
+//
+//	Running          run; do not auto-restart if CH exits (guest stops).
+//	Stopped          keep the guest stopped (no pod).
+//	RestartOnFailure recreate the pod if CH exits abnormally (pod Failed).
+//	Always           recreate the pod whenever CH exits (Failed or Succeeded).
+//
 // +kubebuilder:validation:Enum=Running;Stopped;RestartOnFailure;Always
 type RunPolicy string
 

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
@@ -524,8 +524,22 @@ spec:
                         - windows
                         type: string
                       runPolicy:
-                        description: RunPolicy defines the desired run state of a
-                          guest.
+                        description: "RunPolicy defines the desired run state of a
+                          guest.\n\nRunPolicy governs what the controller does when
+                          the launcher POD reaches a\nterminal state (Succeeded/Failed)
+                          — i.e. when Cloud Hypervisor itself exits.\nA guest *reboot*
+                          is NOT such an event: on Cloud Hypervisor v52 a guest reboot\nRESETS
+                          THE VM IN PLACE (the CH process and the launcher pod survive,
+                          the\nguest restarts), so reboots never trigger RunPolicy.
+                          CH exits only on guest\nshutdown/poweroff or a crash; those
+                          are what Stopped/RestartOnFailure/Always\nact on. (v51 exited
+                          on reboot too, churning the pod — v52 reset-in-place is\nthe
+                          cleaner behavior; KubeSwift passes no --no-reboot, keeping
+                          the default.)\n\n\tRunning          run; do not auto-restart
+                          if CH exits (guest stops).\n\tStopped          keep the
+                          guest stopped (no pod).\n\tRestartOnFailure recreate the
+                          pod if CH exits abnormally (pod Failed).\n\tAlways           recreate
+                          the pod whenever CH exits (Failed or Succeeded)."
                         enum:
                         - Running
                         - Stopped

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -456,7 +456,20 @@ spec:
                 - windows
                 type: string
               runPolicy:
-                description: RunPolicy defines the desired run state of a guest.
+                description: "RunPolicy defines the desired run state of a guest.\n\nRunPolicy
+                  governs what the controller does when the launcher POD reaches a\nterminal
+                  state (Succeeded/Failed) — i.e. when Cloud Hypervisor itself exits.\nA
+                  guest *reboot* is NOT such an event: on Cloud Hypervisor v52 a guest
+                  reboot\nRESETS THE VM IN PLACE (the CH process and the launcher
+                  pod survive, the\nguest restarts), so reboots never trigger RunPolicy.
+                  CH exits only on guest\nshutdown/poweroff or a crash; those are
+                  what Stopped/RestartOnFailure/Always\nact on. (v51 exited on reboot
+                  too, churning the pod — v52 reset-in-place is\nthe cleaner behavior;
+                  KubeSwift passes no --no-reboot, keeping the default.)\n\n\tRunning
+                  \         run; do not auto-restart if CH exits (guest stops).\n\tStopped
+                  \         keep the guest stopped (no pod).\n\tRestartOnFailure recreate
+                  the pod if CH exits abnormally (pod Failed).\n\tAlways           recreate
+                  the pod whenever CH exits (Failed or Succeeded)."
                 enum:
                 - Running
                 - Stopped

--- a/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
@@ -524,8 +524,22 @@ spec:
                         - windows
                         type: string
                       runPolicy:
-                        description: RunPolicy defines the desired run state of a
-                          guest.
+                        description: "RunPolicy defines the desired run state of a
+                          guest.\n\nRunPolicy governs what the controller does when
+                          the launcher POD reaches a\nterminal state (Succeeded/Failed)
+                          — i.e. when Cloud Hypervisor itself exits.\nA guest *reboot*
+                          is NOT such an event: on Cloud Hypervisor v52 a guest reboot\nRESETS
+                          THE VM IN PLACE (the CH process and the launcher pod survive,
+                          the\nguest restarts), so reboots never trigger RunPolicy.
+                          CH exits only on guest\nshutdown/poweroff or a crash; those
+                          are what Stopped/RestartOnFailure/Always\nact on. (v51 exited
+                          on reboot too, churning the pod — v52 reset-in-place is\nthe
+                          cleaner behavior; KubeSwift passes no --no-reboot, keeping
+                          the default.)\n\n\tRunning          run; do not auto-restart
+                          if CH exits (guest stops).\n\tStopped          keep the
+                          guest stopped (no pod).\n\tRestartOnFailure recreate the
+                          pod if CH exits abnormally (pod Failed).\n\tAlways           recreate
+                          the pod whenever CH exits (Failed or Succeeded)."
                         enum:
                         - Running
                         - Stopped

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -456,7 +456,20 @@ spec:
                 - windows
                 type: string
               runPolicy:
-                description: RunPolicy defines the desired run state of a guest.
+                description: "RunPolicy defines the desired run state of a guest.\n\nRunPolicy
+                  governs what the controller does when the launcher POD reaches a\nterminal
+                  state (Succeeded/Failed) — i.e. when Cloud Hypervisor itself exits.\nA
+                  guest *reboot* is NOT such an event: on Cloud Hypervisor v52 a guest
+                  reboot\nRESETS THE VM IN PLACE (the CH process and the launcher
+                  pod survive, the\nguest restarts), so reboots never trigger RunPolicy.
+                  CH exits only on guest\nshutdown/poweroff or a crash; those are
+                  what Stopped/RestartOnFailure/Always\nact on. (v51 exited on reboot
+                  too, churning the pod — v52 reset-in-place is\nthe cleaner behavior;
+                  KubeSwift passes no --no-reboot, keeping the default.)\n\n\tRunning
+                  \         run; do not auto-restart if CH exits (guest stops).\n\tStopped
+                  \         keep the guest stopped (no pod).\n\tRestartOnFailure recreate
+                  the pod if CH exits abnormally (pod Failed).\n\tAlways           recreate
+                  the pod whenever CH exits (Failed or Succeeded)."
                 enum:
                 - Running
                 - Stopped

--- a/docs/swiftguest-reconcile.md
+++ b/docs/swiftguest-reconcile.md
@@ -36,6 +36,15 @@ and the pod has failed (or succeeded for Always), the controller:
    sets `status.lastRestartTime`, and returns — the next reconcile
    creates a fresh pod
 
+Both guards key on the launcher **pod's terminal state** (Succeeded/Failed),
+which means Cloud Hypervisor exited. A guest **reboot is not such an event on
+CH v52**: the VM resets in place, so the CH process and the pod survive and the
+guest restarts without any controller action (validated 2026-06-09 — the pod
+stayed Running with the same CH PID across an in-guest `reboot`, only the
+guest's `boot_id` changed). CH exits — and these guards fire — only on guest
+shutdown/poweroff or a crash. (KubeSwift passes no `--no-reboot` to keep this
+reset-in-place default; CH v51 exited on reboot, churning the pod.)
+
 ## Conditions
 
 - **Resolved** – True when resolution succeeded; False with reason when resolution failed.

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -313,6 +313,12 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
+	// This block fires on launcher-pod TERMINAL states (Failed/Succeeded), i.e.
+	// when Cloud Hypervisor exits. A guest reboot is NOT terminal on CH v52 (it
+	// resets the VM in place — the pod stays Running, validated 2026-06-09), so
+	// reboots never reach here. CH exits only on guest shutdown/poweroff (pod
+	// Succeeded) or a crash (pod Failed); those are what RestartOnFailure/Always
+	// act on.
 	if guest.Spec.RunPolicy == swiftv1alpha1.RunPolicyRestartOnFailure ||
 		guest.Spec.RunPolicy == swiftv1alpha1.RunPolicyAlways {
 


### PR DESCRIPTION
#5 (CH v52 reset-in-place / `--no-shutdown`). **Validated + clarified — no behavior change needed.**

CH v52 **resets a guest in place on reboot** (v51 exited, churning the launcher pod). KubeSwift passes no `--no-reboot`, so reset-in-place is already the active default. So a guest reboot is **not** a pod-terminal event and never triggers the RunPolicy restart/stopped guards — those fire only when Cloud Hypervisor exits (guest shutdown/poweroff or a crash).

The runPolicy handling already keys on launcher-pod `Succeeded`/`Failed`, so this is a **clarification**:
- `RunPolicy` CRD doc comment now spells out reboot-in-place vs CH-exit and what each policy acts on (flows into the CRD `kubectl explain` description).
- A comment at the controller's restart guard.
- `docs/swiftguest-reconcile.md` restart-guard section.

**No `--no-shutdown`:** the current flow (CH exits on guest shutdown → pod Succeeded → controller marks Stopped, or restarts for Always) is correct and simpler; `--no-shutdown` would make the controller own VMM teardown for no benefit.

## Cluster validation (2026-06-09, sha-3128639, Rocky 9 on boba)

An in-guest `reboot`:
```
BEFORE: pod Running, restarts=0, CH pid=44, boot_id=9fc9040d-…
AFTER:  pod Running, restarts=0, CH pid=44, boot_id=949cca87-…   (guest really rebooted; pod + CH survived)
```
Under v51 this would have exited CH and churned the pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)