### PR TITLE
feat(security): vCPU core-scheduling (SMT side-channel mitigation) [#6]

### DIFF
--- a/api/swift/v1alpha1/swiftguestclass_types.go
+++ b/api/swift/v1alpha1/swiftguestclass_types.go
@@ -20,6 +20,26 @@ type RootDiskSpec struct {
 	Format DiskFormat        `json:"format"`
 }
 
+// CoreScheduling selects the Cloud Hypervisor vCPU core-scheduling policy
+// (CH v52 `--cpus core_scheduling=`), a defense against cross-thread SMT
+// (hyper-threading) side channels without disabling SMT host-wide.
+//
+//	off  (default) no core-scheduling.
+//	vm   all of the guest's vCPUs share one core-scheduling group, so a
+//	     physical core's sibling threads run only this guest's vCPUs (never
+//	     another tenant's) — the multi-tenant isolation setting.
+//	vcpu each vCPU is its own group (strongest; siblings never co-run even
+//	     within the guest).
+//
+// +kubebuilder:validation:Enum=off;vm;vcpu
+type CoreScheduling string
+
+const (
+	CoreSchedulingOff  CoreScheduling = "off"
+	CoreSchedulingVM   CoreScheduling = "vm"
+	CoreSchedulingVCPU CoreScheduling = "vcpu"
+)
+
 // SwiftGuestClassSpec defines the desired state of SwiftGuestClass.
 type SwiftGuestClassSpec struct {
 	CPU      resource.Quantity `json:"cpu"`
@@ -32,6 +52,12 @@ type SwiftGuestClassSpec struct {
 	// StorageClassName inherited from the source SwiftImage's PVC.
 	// +optional
 	Storage *StorageSpec `json:"storage,omitempty"`
+	// CoreScheduling sets the vCPU core-scheduling policy for guests of this
+	// class (SMT side-channel mitigation). Default off; use vm for multi-tenant
+	// isolation. Empty is treated as off (no change to the CH --cpus args).
+	// +kubebuilder:default=off
+	// +optional
+	CoreScheduling CoreScheduling `json:"coreScheduling,omitempty"`
 }
 
 // SwiftGuestClass is the Schema for the swiftguestclasses API.

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestclasses.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestclasses.yaml
@@ -54,6 +54,17 @@ spec:
           spec:
             description: SwiftGuestClassSpec defines the desired state of SwiftGuestClass.
             properties:
+              coreScheduling:
+                default: "off"
+                description: |-
+                  CoreScheduling sets the vCPU core-scheduling policy for guests of this
+                  class (SMT side-channel mitigation). Default off; use vm for multi-tenant
+                  isolation. Empty is treated as off (no change to the CH --cpus args).
+                enum:
+                - "off"
+                - vm
+                - vcpu
+                type: string
               cpu:
                 anyOf:
                 - type: integer

--- a/config/crd/bases/swift.kubeswift.io_swiftguestclasses.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestclasses.yaml
@@ -54,6 +54,17 @@ spec:
           spec:
             description: SwiftGuestClassSpec defines the desired state of SwiftGuestClass.
             properties:
+              coreScheduling:
+                default: "off"
+                description: |-
+                  CoreScheduling sets the vCPU core-scheduling policy for guests of this
+                  class (SMT side-channel mitigation). Default off; use vm for multi-tenant
+                  isolation. Empty is treated as off (no change to the CH --cpus args).
+                enum:
+                - "off"
+                - vm
+                - vcpu
+                type: string
               cpu:
                 anyOf:
                 - type: integer

--- a/config/samples/security/swiftguestclass-core-scheduling.yaml
+++ b/config/samples/security/swiftguestclass-core-scheduling.yaml
@@ -1,0 +1,13 @@
+# A guest class that enables vCPU core-scheduling (SMT side-channel mitigation).
+# `vm` keeps a physical core's sibling threads running only THIS guest's vCPUs,
+# never another tenant's — the multi-tenant isolation setting. Use `vcpu` for the
+# strongest isolation, or omit/off for none (the default).
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestClass
+metadata:
+  name: secure-multitenant
+spec:
+  cpu: 2
+  memory: 4Gi
+  rootDisk: { format: raw, size: 20Gi }
+  coreScheduling: vm

--- a/docs/security-hardening-notes.md
+++ b/docs/security-hardening-notes.md
@@ -137,3 +137,20 @@ setting. Test empirically on HGX hardware before implementing.
 | 33 | `/dev/net/tun` not mounted — `ip tuntap add` fails | Add dev-net-tun hostPath CharDevice volume |
 | 34 | `/proc/sys` read-only in non-privileged containers | Pod-level sysctl `net.ipv4.ip_forward=1` |
 | — | Helm chart missing `gpu.kubeswift.io` RBAC rules | Added to chart ClusterRole |
+
+## vCPU core-scheduling (SMT side-channel mitigation)
+
+`SwiftGuestClass.spec.coreScheduling` enables Cloud Hypervisor's vCPU
+core-scheduling (CH v52, `--cpus core_scheduling=`), which mitigates
+cross-thread SMT (hyper-threading) side channels **without disabling SMT
+host-wide**:
+
+- `off` (default) — no core-scheduling.
+- `vm` — all of the guest's vCPUs share one core-scheduling group, so a
+  physical core's sibling threads only ever run **this guest's** vCPUs, never
+  another tenant's. This is the multi-tenant isolation setting.
+- `vcpu` — each vCPU is its own group (strongest; siblings never co-run even
+  within the guest, at a throughput cost).
+
+Set it on the class so a "secure" tier opts whole fleets in. Sample:
+[`config/samples/security/swiftguestclass-core-scheduling.yaml`](../config/samples/security/swiftguestclass-core-scheduling.yaml).

--- a/internal/resolved/merge.go
+++ b/internal/resolved/merge.go
@@ -30,6 +30,12 @@ func Merge(
 	// Resources: from GuestClass (guest has no override in MVP)
 	rg.Resources = mergeResources(guestClass)
 
+	// CoreScheduling: from GuestClass (SMT side-channel mitigation). Empty/off
+	// means no core_scheduling on the CH --cpus args.
+	if guestClass != nil {
+		rg.CoreScheduling = string(guestClass.Spec.CoreScheduling)
+	}
+
 	// RootDisk: from GuestClass
 	rg.RootDisk = mergeRootDisk(guestClass)
 

--- a/internal/resolved/types.go
+++ b/internal/resolved/types.go
@@ -58,6 +58,9 @@ type ResolvedGuest struct {
 	// Consumed by the runtime layer (PR 4: windows adds kvm_hyperv on the CH
 	// disk-boot path) and provisioning (PR 5: cloudbase-init vs cloud-init).
 	OSType string `json:"osType,omitempty"`
+	// CoreScheduling is the vCPU core-scheduling policy from the SwiftGuestClass
+	// ("off"/"vm"/"vcpu"). Empty/"off" omits the CH --cpus core_scheduling param.
+	CoreScheduling string `json:"coreScheduling,omitempty"`
 }
 
 // GuestSettings holds architecture, firmware, bus, interface model, shutdown method.
@@ -255,6 +258,15 @@ func (r *ResolvedGuest) GetOSType() string {
 		return "linux"
 	}
 	return r.OSType
+}
+
+// GetCoreScheduling returns the vCPU core-scheduling policy ("vm"/"vcpu"), or
+// "" when off/unset (no CH core_scheduling param).
+func (r *ResolvedGuest) GetCoreScheduling() string {
+	if r.CoreScheduling == "" || r.CoreScheduling == string(swiftv1alpha1.CoreSchedulingOff) {
+		return ""
+	}
+	return r.CoreScheduling
 }
 
 // IsWindows reports whether the resolved guest is a Windows guest.

--- a/internal/resolved/types_test.go
+++ b/internal/resolved/types_test.go
@@ -428,3 +428,17 @@ func TestGetNICs_PrimaryOnNAD(t *testing.T) {
 		t.Errorf("nics[1] = %+v, want non-primary + net2", nics[1])
 	}
 }
+
+func TestGetCoreScheduling(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"", ""},
+		{"off", ""},
+		{"vm", "vm"},
+		{"vcpu", "vcpu"},
+	} {
+		rg := &ResolvedGuest{CoreScheduling: tc.in}
+		if got := rg.GetCoreScheduling(); got != tc.want {
+			t.Errorf("GetCoreScheduling(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/runtimeintent/build.go
+++ b/internal/runtimeintent/build.go
@@ -27,6 +27,7 @@ type ResolvedGuest interface {
 	GetNICs() []NICIntent
 	GetFilesystems() []FilesystemIntent
 	GetVhostUserDevices() []VhostUserDeviceIntent
+	GetCoreScheduling() string
 }
 
 // Build creates a RuntimeIntent from ResolvedGuest using canonical paths.
@@ -42,6 +43,7 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 	nics := rg.GetNICs()
 	filesystems := rg.GetFilesystems()
 	vhostUserDevices := rg.GetVhostUserDevices()
+	coreScheduling := rg.GetCoreScheduling()
 
 	if rg.HasKernel() {
 		lifecycle := rg.GetLifecycle()
@@ -62,6 +64,7 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 			NICs:             nics,
 			Filesystems:      filesystems,
 			VhostUserDevices: vhostUserDevices,
+			CoreScheduling:   coreScheduling,
 			KernelBoot: &KernelBootSpec{
 				KernelPath:    rg.GetKernelPath(),
 				InitramfsPath: rg.GetInitramfsPath(),
@@ -104,5 +107,6 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 		NICs:             nics,
 		Filesystems:      filesystems,
 		VhostUserDevices: vhostUserDevices,
+		CoreScheduling:   coreScheduling,
 	}
 }

--- a/internal/runtimeintent/build_test.go
+++ b/internal/runtimeintent/build_test.go
@@ -23,6 +23,7 @@ type mockResolvedGuest struct {
 	osType           string
 	filesystems      []FilesystemIntent
 	vhostUserDevices []VhostUserDeviceIntent
+	coreScheduling   string
 }
 
 func (m *mockResolvedGuest) HasSeed() bool                 { return m.hasSeed }
@@ -50,6 +51,7 @@ func (m *mockResolvedGuest) GetFilesystems() []FilesystemIntent { return m.files
 func (m *mockResolvedGuest) GetVhostUserDevices() []VhostUserDeviceIntent {
 	return m.vhostUserDevices
 }
+func (m *mockResolvedGuest) GetCoreScheduling() string { return m.coreScheduling }
 
 // TestBuild_DiskBootBlockMode is the W9 contract test for the
 // runtimeintent producer side: a guest with Block-mode root storage
@@ -383,5 +385,26 @@ func TestBuild_VhostUserDevices(t *testing.T) {
 	none := Build(&mockResolvedGuest{hasSeed: true, format: "raw", guestID: "x"})
 	if none.VhostUserDevices != nil {
 		t.Errorf("want nil when none set")
+	}
+}
+
+func TestBuild_CoreScheduling(t *testing.T) {
+	disk := Build(&mockResolvedGuest{
+		hasSeed: true, format: "raw", cpu: 2, memory: 2048, lifecycle: "start",
+		guestID: "default/cs", coreScheduling: "vm",
+	})
+	if disk.CoreScheduling != "vm" {
+		t.Errorf("disk-boot CoreScheduling = %q, want vm", disk.CoreScheduling)
+	}
+	kern := Build(&mockResolvedGuest{
+		hasKernel: true, cpu: 1, memory: 1024, lifecycle: "start",
+		guestID: "default/cs-k", coreScheduling: "vcpu",
+	})
+	if kern.CoreScheduling != "vcpu" {
+		t.Errorf("kernel-boot CoreScheduling = %q, want vcpu", kern.CoreScheduling)
+	}
+	none := Build(&mockResolvedGuest{hasSeed: true, format: "raw", guestID: "x"})
+	if none.CoreScheduling != "" {
+		t.Errorf("CoreScheduling = %q, want empty", none.CoreScheduling)
 	}
 }

--- a/internal/runtimeintent/types.go
+++ b/internal/runtimeintent/types.go
@@ -13,8 +13,11 @@ type RuntimeIntent struct {
 	KernelBoot *KernelBootSpec `json:"kernelBoot,omitempty"` // when set, boot via --kernel + --initramfs
 	Hypervisor string          `json:"hypervisor,omitempty"` // "cloud-hypervisor" (default) or "qemu"
 	OSType     string          `json:"osType,omitempty"`     // "linux" (default) or "windows" — windows adds kvm_hyperv on the CH --cpus arg
-	GPU        *GPUIntent      `json:"gpu,omitempty"`        // populated when gpuProfileRef is set
-	DataDisk   *RootDiskSpec   `json:"dataDisk,omitempty"`   // secondary data disk (appears as /dev/vdb)
+	// CoreScheduling is the CH vCPU core-scheduling policy ("vm"/"vcpu"), empty
+	// when off. When set, swiftletd appends core_scheduling=<v> to --cpus.
+	CoreScheduling string        `json:"coreScheduling,omitempty"`
+	GPU            *GPUIntent    `json:"gpu,omitempty"`      // populated when gpuProfileRef is set
+	DataDisk       *RootDiskSpec `json:"dataDisk,omitempty"` // secondary data disk (appears as /dev/vdb)
 	// NICs is the list of network interfaces for the VM.
 	// If empty and Network is true, a single default NIC is created (backward compat).
 	NICs []NICIntent `json:"nics,omitempty"`

--- a/rust/swift-ch-client/src/config.rs
+++ b/rust/swift-ch-client/src/config.rs
@@ -50,6 +50,9 @@ pub struct VmConfig {
     /// KVM Hyper-V enlightenments (docs/design/windows-guest-support-spike.md).
     /// Harmless/unused for Linux guests (default false).
     pub kvm_hyperv: bool,
+    /// vCPU core-scheduling policy ("vm"/"vcpu"), appended to --cpus as
+    /// core_scheduling=<v>. None = off (param omitted). SMT side-channel mitigation.
+    pub core_scheduling: Option<String>,
     /// Path for Cloud Hypervisor API socket.
     pub api_socket: String,
     /// Optional path to seed media (NoCloud dir or ISO). Empty = no seed.
@@ -145,6 +148,11 @@ impl VmConfig {
                 if self.kvm_hyperv {
                     // Windows: KVM Hyper-V enlightenments (required on CH).
                     cpus.push_str(",kvm_hyperv=on");
+                }
+                if let Some(ref cs) = self.core_scheduling {
+                    // vCPU core-scheduling (SMT side-channel mitigation): "vm"
+                    // or "vcpu". Omitted when off.
+                    cpus.push_str(&format!(",core_scheduling={}", cs));
                 }
                 cpus
             },
@@ -315,6 +323,7 @@ mod tests {
             memory_mib: 2048,
             cpus: 2,
             kvm_hyperv: false,
+            core_scheduling: None,
             api_socket: "/tmp/ch.sock".to_string(),
             seed_path: "/data/seed".to_string(),
             serial_socket_path: Some("/tmp/serial.sock".to_string()),
@@ -434,6 +443,25 @@ mod tests {
         assert!(
             !none.contains("--generic-vhost-user"),
             "unexpected generic: {}",
+            none
+        );
+    }
+
+    #[test]
+    fn test_core_scheduling_emits_on_cpus() {
+        let mut cfg = make_disk_boot_config();
+        cfg.core_scheduling = Some("vm".to_string());
+        let joined = cfg.to_args().join(" ");
+        assert!(
+            joined.contains("--cpus boot=") && joined.contains(",core_scheduling=vm"),
+            "missing core_scheduling on --cpus: {}",
+            joined
+        );
+        // None -> no core_scheduling param.
+        let none = make_disk_boot_config().to_args().join(" ");
+        assert!(
+            !none.contains("core_scheduling"),
+            "unexpected core_scheduling: {}",
             none
         );
     }

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -35,6 +35,10 @@ pub struct RuntimeIntent {
     /// early MP/HAL init). See docs/design/windows-guest-support-spike.md.
     #[serde(default)]
     pub os_type: Option<String>,
+    /// vCPU core-scheduling policy ("vm"/"vcpu"); absent/empty = off. When set,
+    /// swiftletd appends core_scheduling=<v> to the CH --cpus arg.
+    #[serde(default)]
+    pub core_scheduling: Option<String>,
     /// Optional secondary data disk (appears as /dev/vdb in guest).
     #[serde(default)]
     pub data_disk: Option<RootDisk>,

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -375,6 +375,10 @@ where
             memory_mib: intent.memory.max(128),
             cpus: intent.cpu.max(1),
             kvm_hyperv: intent.is_windows(),
+            core_scheduling: intent
+                .core_scheduling
+                .clone()
+                .filter(|s| !s.is_empty() && s != "off"),
             api_socket: runtime_dir.api_socket().to_string_lossy().to_string(),
             seed_path: String::new(),
             serial_socket_path: Some(serial_socket_path.clone()),
@@ -396,6 +400,10 @@ where
             memory_mib: intent.memory.max(128),
             cpus: intent.cpu.max(1),
             kvm_hyperv: intent.is_windows(),
+            core_scheduling: intent
+                .core_scheduling
+                .clone()
+                .filter(|s| !s.is_empty() && s != "off"),
             api_socket: runtime_dir.api_socket().to_string_lossy().to_string(),
             seed_path,
             serial_socket_path: Some(serial_socket_path.clone()),


### PR DESCRIPTION
`SwiftGuestClass.spec.coreScheduling` (`off`|`vm`|`vcpu`, default `off`) enables Cloud Hypervisor v52's **vCPU core-scheduling** (`--cpus core_scheduling=`), mitigating cross-thread **SMT** (hyper-threading) side channels **without disabling SMT host-wide**:

- **`vm`** — the guest's vCPUs share one core-scheduling group, so a physical core's sibling threads run only **this guest's** vCPUs, never another tenant's. The multi-tenant isolation setting.
- **`vcpu`** — each vCPU isolated (strongest; throughput cost).
- **`off`** — none (default; existing classes' `--cpus` args unchanged).

## Plumbing

SwiftGuestClass CRD enum (apiserver-enforced) → `resolved.CoreScheduling` → `RuntimeIntent.CoreScheduling` → swiftletd intent → `swift-ch-client` appends `,core_scheduling=<v>` to `--cpus` (omitted when off, so no change for existing guests).

## Tests / validation

Unit: `resolved.GetCoreScheduling` (off/empty → none), `Build` passthrough (both boot paths), `swift-ch-client` `to_args` (emit + absent). Full Go + Rust suites green; `gofmt -s` + Generate idempotent. Sample (`config/samples/security/`) + security-hardening note.

**Cluster validation** (the CH `--cpus` carries `core_scheduling=vm` and the guest boots) **after the image builds** — it's a fully validatable feature (real CH v52 flag).

(Per-class, per the security option's intent. A per-guest override is a possible follow-up. security-engineer review welcome on the default/`vm` recommendation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)