### PR TITLE
fix(webhook): vswiftimage immutability uses content equality, not pointer (TFU #23)

### DIFF
--- a/internal/webhook/swiftimage/validator.go
+++ b/internal/webhook/swiftimage/validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -124,10 +125,15 @@ func validateSwiftImageUpdate(oldImg, img *imagev1alpha1.SwiftImage) error {
 		return err
 	}
 	if oldImg.Status.Phase == imagev1alpha1.SwiftImagePhaseReady {
-		// osType is a value (string) compare, so unlike Spec.Source it does not
-		// have the pointer-identity foot-gun (TFU-17/23) — a Ready image's OS is
-		// fixed by what was imported, so it is immutable.
-		if oldImg.Spec.Source != img.Spec.Source || oldImg.Spec.Format != img.Spec.Format ||
+		// Source is compared by CONTENT, not pointer identity (TFU #23). The old
+		// (etcd) and new (admission request) objects are independent decodes, so
+		// their Source pointers always differ; a `!=` pointer compare fired on
+		// EVERY update of a Ready image — including innocuous metadata edits
+		// (label/annotation) where the spec content is unchanged. DeepEqual
+		// compares the dereferenced HTTP/Upload/PVCClone content. Format/OSType
+		// are strings (value compare, no foot-gun).
+		if !apiequality.Semantic.DeepEqual(oldImg.Spec.Source, img.Spec.Source) ||
+			oldImg.Spec.Format != img.Spec.Format ||
 			oldImg.Spec.OSType != img.Spec.OSType {
 			return fmt.Errorf("SwiftImage spec is immutable when status.phase is Ready")
 		}

--- a/internal/webhook/swiftimage/validator_test.go
+++ b/internal/webhook/swiftimage/validator_test.go
@@ -142,3 +142,22 @@ func TestValidateUpdate_SpecMutationOnReadyImage_StillRejected(t *testing.T) {
 		t.Errorf("spec mutation on a Ready image (not being deleted) must still be rejected, got: %v", err)
 	}
 }
+
+// TestValidateUpdate_MetadataEditOnReadyImage_Allowed is the TFU #23 contract:
+// a metadata-only edit (e.g. adding a label) on a Ready image that is NOT being
+// deleted must be ALLOWED. old and new come from separate makeImage calls, so
+// their Spec.Source pointers differ while the content is identical — the old
+// `!=` pointer compare falsely rejected this; the DeepEqual fix allows it.
+func TestValidateUpdate_MetadataEditOnReadyImage_Allowed(t *testing.T) {
+	old := makeImage("img", imagev1alpha1.CloneStrategyCopy, "")
+	old.Status.Phase = imagev1alpha1.SwiftImagePhaseReady
+
+	new := makeImage("img", imagev1alpha1.CloneStrategyCopy, "")
+	new.Status.Phase = imagev1alpha1.SwiftImagePhaseReady
+	new.Labels = map[string]string{"team": "platform"} // metadata-only change
+
+	v := &Validator{}
+	if _, err := v.ValidateUpdate(context.Background(), old, new); err != nil {
+		t.Errorf("metadata-only edit on a Ready image must be allowed (TFU #23); got: %v", err)
+	}
+}


### PR DESCRIPTION
`validateSwiftImageUpdate` compared `oldImg.Spec.Source != img.Spec.Source` — a **pointer-identity** comparison over `ImageSource`'s pointer fields (HTTP/Upload/PVCClone). The old (etcd) and new (admission request) objects are independent decodes, so their `Source` pointers **always differ**; the immutability rule fired on every UPDATE of a Ready image, including innocuous **metadata-only edits** (a label/annotation change) where the spec content is unchanged.

TFU #17's `deletionTimestamp` carve-out fixed the namespace-deletion trap but left this metadata-edit false-rejection — that's TFU #23.

## Fix

Compare `Source` by **content** via `apiequality.Semantic.DeepEqual` (dereferences the HTTP/Upload/PVCClone sub-pointers). `Format`/`OSType` stay string value compares. The `deletionTimestamp` carve-out is kept (defense-in-depth; now also redundant for the content-equal finalizer-removal path).

## Test

A metadata-only label edit on a Ready (non-deleting) image is now **allowed** (load-bearing — the old `!=` rejected it), while a genuine `Source` change is **still rejected**. (Webhook-only — no CRD/image change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)