### PR TITLE
refactor(migration): typed FailureReasonCode enum + fix stale cycle comment [TFU #21/#20]

### DIFF
--- a/api/migration/v1alpha1/swiftmigration_types.go
+++ b/api/migration/v1alpha1/swiftmigration_types.go
@@ -105,27 +105,32 @@ const (
 // Phase 3b PR 2 extends the taxonomy with seven additional codes that
 // classify live-mode failures more precisely; see the per-code docstrings
 // for fire conditions and the swiftletd-side / controller-side origin.
+// FailureReasonCode is the typed code stored in status.failureReason.
+// Typing it (vs a bare string) makes typos compile-fail. The string VALUES are
+// unchanged, so this is wire/CRD-compatible. (TFU #21.)
+type FailureReasonCode string
+
 const (
 	// FailureReasonCancelled — set when the operator cancels the
 	// migration via spec.cancelRequested in a pre-cutover phase (the W21
 	// CancelIgnored gate suppresses this for post-cutover cancels). Also
 	// set when swiftletd reports cancellation propagating from the dst
 	// pod's cancel handshake.
-	FailureReasonCancelled = "Cancelled"
+	FailureReasonCancelled FailureReasonCode = "Cancelled"
 	// FailureReasonPodTerminated — set when the dst pod terminates
 	// mid-migration (drain, graceful delete, OOM, etc.) or when the
 	// PreparingLive budget expires without the dst pod reaching Running.
-	FailureReasonPodTerminated = "PodTerminated"
+	FailureReasonPodTerminated FailureReasonCode = "PodTerminated"
 	// FailureReasonSourcePodReplaced — set when the src pod's UID
 	// changes mid-migration (K8s-terminated and recreated). Detected via
 	// status.sourcePodUID lock-in per F4.2.
-	FailureReasonSourcePodReplaced = "SourcePodReplaced"
+	FailureReasonSourcePodReplaced FailureReasonCode = "SourcePodReplaced"
 	// FailureReasonTimeout — set when spec.timeout (default 30m,
 	// minimum 60s for live mode) expires.
-	FailureReasonTimeout = "Timeout"
+	FailureReasonTimeout FailureReasonCode = "Timeout"
 	// FailureReasonOther — catch-all for migration-internal errors
 	// that don't fit any specific code. Detail in FailureMessage.
-	FailureReasonOther = "Other"
+	FailureReasonOther FailureReasonCode = "Other"
 
 	// Phase 3b PR 2 additions — see Phase 3b design doc §4.7.
 
@@ -135,11 +140,11 @@ const (
 	// Defensive twin of the webhook's admission-time gate; fires for the
 	// rare case where eligibility changed after admission (e.g., guest's
 	// storage spec mutated between SwiftMigration creation and reconcile).
-	FailureReasonEligibilityMismatch = "EligibilityMismatch"
+	FailureReasonEligibilityMismatch FailureReasonCode = "EligibilityMismatch"
 	// FailureReasonDstScheduleFailed — set when the dst pod cannot be
 	// scheduled onto the target node (insufficient capacity, taints,
 	// affinity rules, etc.) within the PreparingLive budget.
-	FailureReasonDstScheduleFailed = "DstScheduleFailed"
+	FailureReasonDstScheduleFailed FailureReasonCode = "DstScheduleFailed"
 	// FailureReasonDstNeverReady — set when the dst pod is created but
 	// does not reach Ready within the PreparingLive budget (default
 	// 60s). Distinguishes a stuck-but-alive dst pod from one that
@@ -157,7 +162,7 @@ const (
 	// the "could not be scheduled onto target node" case from
 	// DstNeverReady. Until then, scheduling-failure scenarios fall into
 	// DstNeverReady (the budget-timeout site catches both).
-	FailureReasonDstNeverReady = "DstNeverReady"
+	FailureReasonDstNeverReady FailureReasonCode = "DstNeverReady"
 	// FailureReasonReceiveDisconnect — set when CH's migration RPC
 	// reports a peer/network disconnect (transport_error or
 	// connection_refused category from sanitize_ch_error). The name
@@ -167,13 +172,13 @@ const (
 	// peer drop) detail strings classify to this code. Operator-
 	// visible naming asymmetry intentional: the underlying failure is
 	// the same network event regardless of which end reported it.
-	FailureReasonReceiveDisconnect = "ReceiveDisconnect"
+	FailureReasonReceiveDisconnect FailureReasonCode = "ReceiveDisconnect"
 	// FailureReasonRpcError — set when CH's vm.send-migration or
 	// vm.receive-migration HTTP RPC returns an error that doesn't map to
 	// a more specific code (CPU incompatibility, version skew at the
 	// wire level, protocol error). Classified from swiftletd's
 	// failure-reason-code annotation; detail in FailureMessage.
-	FailureReasonRpcError = "RpcError"
+	FailureReasonRpcError FailureReasonCode = "RpcError"
 	// FailureReasonImageTagMismatch — set when the Validating phase's
 	// defensive image-tag-match check (LBA-1 trip-wire) detects that the
 	// destination pod would not inherit the source pod's launcher
@@ -181,14 +186,14 @@ const (
 	// srcPod.DeepCopy() which clones the source image atomically; if
 	// this code surfaces, a refactor has regressed the clone-src
 	// guarantee. See docs/design/live-migration-phase-3b.md LBA-1.
-	FailureReasonImageTagMismatch = "ImageTagMismatch"
+	FailureReasonImageTagMismatch FailureReasonCode = "ImageTagMismatch"
 	// FailureReasonDstPodConflict — set when the controller observes a
 	// dst pod with the deterministic dst-pod name already present at
 	// PreparingLive entry but its shape does not match what newDstPod
 	// would produce (wrong nodeName, wrong receiver-mode env, wrong
 	// owner ref, etc.). Distinguishes a clean leader-handover idempotent
 	// re-entry from a name collision with foreign state.
-	FailureReasonDstPodConflict = "DstPodConflict"
+	FailureReasonDstPodConflict FailureReasonCode = "DstPodConflict"
 	// FailureReasonMigrationIdentityNotReady — set by the Validating-live
 	// precondition (Phase 3c, Option B) when live-migration mTLS is
 	// enabled but a participating node's per-node identity Secret is not
@@ -198,7 +203,7 @@ const (
 	// a missing/expired node identity from ever reaching the cutover
 	// window. Untyped string (TFU #21) for consistency with the rest of
 	// this enum.
-	FailureReasonMigrationIdentityNotReady = "MigrationIdentityNotReady"
+	FailureReasonMigrationIdentityNotReady FailureReasonCode = "MigrationIdentityNotReady"
 	// FailureReasonSourceSidecarNotReady — set by Validating-live (Phase
 	// 3c, Option B) when live-migration mTLS is enabled but the source pod
 	// lacks a client-role migration-stunnel sidecar. Happens when the
@@ -207,7 +212,7 @@ const (
 	// from a prior migration (server-role sidecar; chain migrations under
 	// mTLS need a pod recycle). Operators recycle the guest's pod and
 	// retry. Untyped string (TFU #21).
-	FailureReasonSourceSidecarNotReady = "SourceSidecarNotReady"
+	FailureReasonSourceSidecarNotReady FailureReasonCode = "SourceSidecarNotReady"
 )
 
 // Phase 3a phaseDetail vocabulary additions (live mode only). These
@@ -516,7 +521,7 @@ type SwiftMigrationStatus struct {
 	// for `kubectl get swiftmigration` output and dashboard alerting.
 	// +kubebuilder:validation:Enum=Cancelled;PodTerminated;SourcePodReplaced;Timeout;Other;EligibilityMismatch;DstScheduleFailed;DstNeverReady;ReceiveDisconnect;RpcError;ImageTagMismatch;DstPodConflict;MigrationIdentityNotReady;SourceSidecarNotReady
 	// +optional
-	FailureReason string `json:"failureReason,omitempty"`
+	FailureReason FailureReasonCode `json:"failureReason,omitempty"`
 	// SourcePodUID is the source launcher pod's UID at Validating-phase
 	// entry. Used by F4.2's UID-change failure detection: at every
 	// reconcile in pre-cutover phases, the controller compares the

--- a/internal/controller/swiftdrain/controller.go
+++ b/internal/controller/swiftdrain/controller.go
@@ -210,7 +210,7 @@ func failureDetail(mig *migrationv1alpha1.SwiftMigration) string {
 		return mig.Status.FailureMessage
 	}
 	if mig.Status.FailureReason != "" {
-		return mig.Status.FailureReason
+		return string(mig.Status.FailureReason)
 	}
 	return "no detail reported"
 }

--- a/internal/controller/swiftmigration/controller.go
+++ b/internal/controller/swiftmigration/controller.go
@@ -152,7 +152,7 @@ type phaseResult struct {
 	// Timeout, Other). Empty for offline-mode failures and for
 	// non-failure paths. See api/migration/v1alpha1's
 	// FailureReason* constants.
-	FailureReason string
+	FailureReason migrationv1alpha1.FailureReasonCode
 }
 
 // phaseAdvance returns a phaseResult that signals "phase advanced;
@@ -172,7 +172,7 @@ func phaseRequeue(d time.Duration) *phaseResult {
 // phase. The msg is human-readable; reason is the §6 enum (use one of
 // the FailureReason* constants in api/migration/v1alpha1; pass "" for
 // offline-mode where the enum is not populated).
-func phaseFailure(msg, reason string) *phaseResult {
+func phaseFailure(msg string, reason migrationv1alpha1.FailureReasonCode) *phaseResult {
 	return &phaseResult{FailureMsg: msg, FailureReason: reason}
 }
 

--- a/internal/controller/swiftmigration/stopandcopy_failure.go
+++ b/internal/controller/swiftmigration/stopandcopy_failure.go
@@ -61,7 +61,7 @@ import (
 // EligibilityMismatch / ImageTagMismatch / DstPodConflict outside
 // this classifier — they are controller-side stamps, not swiftletd-
 // reported failures.
-func classifyFailureFromDetail(detail string) string {
+func classifyFailureFromDetail(detail string) migrationv1alpha1.FailureReasonCode {
 	d := strings.ToLower(strings.TrimSpace(detail))
 	if d == "" {
 		return migrationv1alpha1.FailureReasonOther

--- a/internal/controller/swiftmigration/stopandcopy_failure_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_failure_test.go
@@ -24,7 +24,7 @@ func TestClassifyFailureFromDetail_Table(t *testing.T) {
 	cases := []struct {
 		name   string
 		detail string
-		want   string
+		want   migrationv1alpha1.FailureReasonCode
 	}{
 		// Empty / unrecognised → Other.
 		{"empty", "", migrationv1alpha1.FailureReasonOther},

--- a/internal/controller/swiftmigration/validating_live.go
+++ b/internal/controller/swiftmigration/validating_live.go
@@ -258,11 +258,13 @@ func (r *SwiftMigrationReconciler) handleValidatingLive(
 // have been set to the destination pod name; this helper returns
 // that value.
 //
-// Mirrors the swiftguest controller's canonicalPodName helper. The
-// controller package is the canonical source; this duplicate exists
-// because importing the swiftguest package from swiftmigration would
-// create a cycle (swiftguest already imports swiftmigration types).
-// PR 2 will consolidate via a shared helper package.
+// Mirrors the swiftguest controller's canonicalPodName helper. This
+// duplicate exists because that helper is package-private (unexported),
+// NOT because of an import cycle (TFU #20): this package already imports
+// internal/controller/swiftguest (see the import block above), and the
+// swiftguest controller does not import the swiftmigration controller.
+// A future cleanup could export the swiftguest helper (or move it to a
+// shared package) and drop this copy.
 func canonicalPodNameForGuest(guest *swiftv1alpha1.SwiftGuest) string {
 	if guest.Status.PodRef != nil && guest.Status.PodRef.Name != "" {
 		return guest.Status.PodRef.Name


### PR DESCRIPTION
Two LOW-severity hygiene items.

## TFU #21 — typed `FailureReasonCode` enum

`status.failureReason` codes were **untyped string constants**, so a typo reached the cluster. Introduce `type FailureReasonCode string` and type:
- all 14 `FailureReason*` constants,
- the `SwiftMigrationStatus.FailureReason` field,
- the controller's internal `phaseResult.FailureReason`, `phaseFailure(reason)`, and `classifyFailureFromDetail`'s return.

Now a typo'd reason **compile-fails**. The string **values are unchanged**, so it's wire/CRD-compatible — controller-gen still emits `type: string` + the existing enum marker (**no CRD diff, no cluster-state migration**). `swiftdrain`'s `failureDetail()` converts with `string()` (it builds a human-readable message).

## TFU #20 — fix stale import-cycle comment

`validating_live.go`'s `canonicalPodNameForGuest` comment claimed importing the swiftguest package "would create a cycle" — but **that same file already imports `internal/controller/swiftguest`** (line 15), and swiftguest does **not** import the swiftmigration controller. Corrected: the duplicate exists because swiftguest's `canonicalPodName` is **package-private (unexported)**, not because of a cycle.

Go-only; full suite green; `gofmt -s` clean; no CRD change.