### PR TITLE
fix(migration): gate virtiofs/vhost-user guests to offline migration

### DIFF
--- a/api/swift/v1alpha1/networking_helpers_test.go
+++ b/api/swift/v1alpha1/networking_helpers_test.go
@@ -46,3 +46,26 @@ func TestPrimaryInterface_SkipsNonBridge(t *testing.T) {
 		t.Errorf("PrimaryInterface = %q, want nil (no bridge interface)", p.Name)
 	}
 }
+
+func TestHasNodeLocalVirtioBackends(t *testing.T) {
+	hp := "/srv/x"
+	cases := []struct {
+		name string
+		spec SwiftGuestSpec
+		want bool
+	}{
+		{"none", SwiftGuestSpec{}, false},
+		{"bridge-only interfaces", SwiftGuestSpec{Interfaces: []GuestInterface{{Name: "mgmt"}}}, false},
+		{"virtiofs", SwiftGuestSpec{Filesystems: []Filesystem{{Name: "d", Source: FilesystemSource{HostPath: &hp}}}}, true},
+		{"vhost-user device", SwiftGuestSpec{VhostUserDevices: []VhostUserDevice{{Name: "b", Type: VhostUserDeviceTypeBlk, Socket: "/s"}}}, true},
+		{"vhost-user NIC", SwiftGuestSpec{Interfaces: []GuestInterface{{Name: "f", Type: InterfaceTypeVhostUser, Socket: "/s"}}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &SwiftGuest{Spec: tc.spec}
+			if got := g.HasNodeLocalVirtioBackends(); got != tc.want {
+				t.Errorf("HasNodeLocalVirtioBackends = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -249,6 +249,31 @@ func (g *SwiftGuest) HasVFIODevices() bool {
 	return g.HasSRIOVInterface()
 }
 
+// HasNodeLocalVirtioBackends reports whether the guest uses virtio devices
+// whose backend is a node-local process or socket that cannot follow a live
+// migration: virtiofs shares (spec.filesystems — the virtiofsd backend and its
+// hostPath/PVC source mount live in the source launcher pod) and vhost-user
+// devices (spec.vhostUserDevices and vhost-user NICs — the operator's
+// DPDK/SPDK backend socket is node-local). Live migration would resume the
+// guest on a destination with no equivalent backend, breaking the device
+// mid-flight — so such guests are OFFLINE-only, like VFIO: the offline path
+// recreates the launcher pod on the target, where the pod builder re-mounts
+// the sources and swiftletd respawns/reconnects the backends (for hostPath
+// sources and operator sockets, provisioning equivalent content on the target
+// is the operator's documented responsibility).
+// See docs/design/vhost-user-devices.md §7.
+func (g *SwiftGuest) HasNodeLocalVirtioBackends() bool {
+	if len(g.Spec.Filesystems) > 0 || len(g.Spec.VhostUserDevices) > 0 {
+		return true
+	}
+	for i := range g.Spec.Interfaces {
+		if g.Spec.Interfaces[i].Type == InterfaceTypeVhostUser {
+			return true
+		}
+	}
+	return false
+}
+
 // HasSRIOVInterface reports whether the guest has any SR-IOV (VFIO NIC)
 // interface. SR-IOV NIC passthrough cannot be migrated off a node by the GPU
 // release-and-reallocate path (that handles GPUs only; NIC reattach on the

--- a/cmd/swiftctl/migration_check.go
+++ b/cmd/swiftctl/migration_check.go
@@ -104,13 +104,21 @@ func runMigratePreflight(cmd *cobra.Command, c client.Client, guestName, ns stri
 
 	// 4. Mode / VFIO.
 	vfio := guest.HasVFIODevices() || guest.HasSRIOVInterface()
-	nodeLocalBackend := len(guest.Spec.Filesystems) > 0 || len(guest.Spec.VhostUserDevices) > 0
+	nodeLocalBackend := guest.HasNodeLocalVirtioBackends()
 	switch {
 	case mode == migrationv1alpha1.SwiftMigrationModeLive && vfio:
 		line(fail, "live migration requested but the guest has VFIO/SR-IOV devices — not supported; use --preferred-mode offline")
 		blockers++
+	case mode == migrationv1alpha1.SwiftMigrationModeLive && nodeLocalBackend:
+		// Mirrors the webhook's node-local virtio backend gate: virtiofs /
+		// vhost-user backends live on the source node and cannot follow a
+		// live migration.
+		line(fail, "live migration requested but the guest has virtiofs/vhost-user devices (node-local backends) — not supported; use --preferred-mode offline")
+		blockers++
 	case vfio:
 		line(info, "guest has VFIO/SR-IOV devices — only offline migration is possible (mode will resolve to offline)")
+	case nodeLocalBackend:
+		line(info, "guest has virtiofs/vhost-user devices — only offline migration is possible (mode will resolve to offline)")
 	case mode == migrationv1alpha1.SwiftMigrationModeLive:
 		line(info, "mode: live (requested)")
 	case mode == migrationv1alpha1.SwiftMigrationModeOffline:
@@ -119,7 +127,7 @@ func runMigratePreflight(cmd *cobra.Command, c client.Client, guestName, ns stri
 		line(info, "mode: auto — the controller live-migrates when eligible, else offline")
 	}
 	if nodeLocalBackend {
-		line(warn, "guest has virtiofs/vhost-user devices backed by node-local state — the target node must provide the same backends (sockets/shares); these do not move with the guest")
+		line(warn, "virtiofs/vhost-user backends are node-local state — the target node must provide the same backends (sockets/shares); these do not move with the guest")
 	}
 
 	// 5. Architecture + CPU features (source vs target).

--- a/docs/design/live-migration.md
+++ b/docs/design/live-migration.md
@@ -113,11 +113,24 @@ hard-stops the VM. Once live migration ships, the upgrade workflow needs
 documentation that says "drain first, then upgrade" — or eventually,
 controller-driven automation that handles it.
 
-### Constraint 3 — virtio-fs is incompatible with live migration
+### Constraint 3 — virtio-fs / vhost-user devices are incompatible with live migration
 
-If KubeSwift adds virtio-fs file sharing in the future (it doesn't today),
-those VMs become non-live-migratable. This isn't a present blocker, just
-something to flag in the doc so it doesn't sneak in unnoticed.
+KubeSwift now ships virtiofs shares (`spec.filesystems`, 2026-06) and
+operator-backed vhost-user devices (`spec.vhostUserDevices` + `type:
+vhost-user` interfaces) — see
+[`vhost-user-devices.md`](vhost-user-devices.md). Their backends (the
+virtiofsd processes and their source mounts, the operator's DPDK/SPDK
+sockets) live in/on the **source** pod and node; CH live migration does
+not transfer them, so a live-migrated guest's devices would break
+mid-flight.
+
+**Enforced:** such guests are **offline-only**, exactly like VFIO — the
+SwiftMigration webhook rejects explicit `mode: live`
+(`SwiftGuest.HasNodeLocalVirtioBackends()`), and `mode: auto` resolves
+to offline. Offline recreates the launcher pod on the target, where the
+pod builder re-mounts the sources and swiftletd re-establishes the
+backends (provisioning equivalent hostPath content / operator sockets on
+the target is the operator's documented responsibility).
 
 ### Constraint 4 — Storage paths must match on both nodes
 

--- a/internal/controller/swiftmigration/auto_mode.go
+++ b/internal/controller/swiftmigration/auto_mode.go
@@ -77,6 +77,17 @@ func (r *SwiftMigrationReconciler) resolveAutoMode(
 		return nil
 	}
 
+	if guest.HasNodeLocalVirtioBackends() {
+		// virtiofs / vhost-user backends (virtiofsd processes, source
+		// mounts, operator backend sockets) live in/on the SOURCE pod
+		// and node; CH live migration does not transfer them, so the
+		// resumed guest's devices would break. Offline recreates the
+		// launcher pod on the target where the backends are
+		// re-established — mirror the VFIO rule. The webhook rejects
+		// explicit mode=live for these guests.
+		return nil
+	}
+
 	if isDefaultNodeLocalNetworking(&guest) && !mig.Spec.AllowIPChange {
 		// Default node-local networking produces a fresh IP on the
 		// destination. Without operator opt-in (allowIPChange=true),

--- a/internal/controller/swiftmigration/auto_mode_test.go
+++ b/internal/controller/swiftmigration/auto_mode_test.go
@@ -115,3 +115,31 @@ func TestHasVFIODevices_None_False(t *testing.T) {
 		t.Errorf("no VFIO devices must yield false")
 	}
 }
+
+func TestResolveAutoMode_NodeLocalVirtioBackends_ResolvesToOffline(t *testing.T) {
+	// virtiofs / vhost-user backends are node-local; auto must resolve to
+	// offline (mirrors the VFIO rule). AllowIPChange=true so the networking
+	// branch cannot be what forces offline — the backend rule must.
+	scheme := testScheme(t)
+	hp := "/srv/share"
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			Filesystems: []swiftv1alpha1.Filesystem{
+				{Name: "data", Source: swiftv1alpha1.FilesystemSource{HostPath: &hp}},
+			},
+		},
+	}
+	mig := newMigration("m", "default")
+	mig.Spec.AllowIPChange = true
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme}
+
+	if res := r.resolveAutoMode(context.Background(), mig, &mig.Status); res != nil {
+		t.Fatalf("expected nil result; got %+v", res)
+	}
+	if mig.Status.Mode != migrationv1alpha1.SwiftMigrationModeOffline {
+		t.Errorf("virtiofs guest must resolve auto→offline; got %q", mig.Status.Mode)
+	}
+}

--- a/internal/webhook/swiftmigration/validator.go
+++ b/internal/webhook/swiftmigration/validator.go
@@ -440,6 +440,18 @@ func (v *Validator) validateClusterState(ctx context.Context, mig *migrationv1al
 		return nil, fmt.Errorf("SwiftGuest %q has an SR-IOV interface; cross-node migration of SR-IOV NIC passthrough is not supported",
 			guest.Name)
 	}
+	// Node-local virtio backend gate (virtiofs / vhost-user — design doc
+	// vhost-user-devices.md §7). The virtiofsd processes, their source mounts,
+	// and the operator's vhost-user backend sockets live in/on the SOURCE pod
+	// and node; CH live migration does not transfer them, so the resumed guest's
+	// virtiofs mounts / vhost-user devices would break mid-flight. Offline
+	// migration is fine: the launcher pod is recreated on the target, where the
+	// backends are re-established (auto mode resolves these guests to offline,
+	// mirroring VFIO).
+	if guest.HasNodeLocalVirtioBackends() && mig.Spec.Mode == migrationv1alpha1.SwiftMigrationModeLive {
+		return nil, fmt.Errorf("SwiftGuest %q has node-local virtio backends (spec.filesystems, spec.vhostUserDevices, or a vhost-user interface); they cannot live-migrate — use mode=offline (or auto, which resolves to offline for such guests)",
+			guest.Name)
+	}
 
 	// Live-mode storage gate (W6 follow-up; Phase 3a kernel-boot
 	// adjustment).

--- a/internal/webhook/swiftmigration/validator_test.go
+++ b/internal/webhook/swiftmigration/validator_test.go
@@ -1298,3 +1298,82 @@ func TestValidate_ModeLivePerSourceNodeConcurrency_OfflinePeerOk(t *testing.T) {
 		t.Errorf("offline peer must not block live; got %v", err)
 	}
 }
+
+// Node-local virtio backend gate (virtiofs / vhost-user → offline-only, like
+// VFIO). See docs/design/vhost-user-devices.md §7 and live-migration.md
+// Constraint 3.
+
+func TestValidateClusterState_VirtiofsLiveRejected(t *testing.T) {
+	scheme := migrationScheme(t)
+	guest := newSwiftGuest("guest", "default")
+	hp := "/srv/share"
+	guest.Spec.Filesystems = []swiftv1alpha1.Filesystem{
+		{Name: "data", Source: swiftv1alpha1.FilesystemSource{HostPath: &hp}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	v := &Validator{Client: c}
+
+	mig := newSwiftMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
+	_, err := v.validate(context.Background(), mig)
+	if err == nil || !strings.Contains(err.Error(), "node-local virtio backends") {
+		t.Errorf("live + virtiofs must be rejected by the node-local-backend gate; got %v", err)
+	}
+}
+
+func TestValidateClusterState_VhostUserDeviceLiveRejected(t *testing.T) {
+	scheme := migrationScheme(t)
+	guest := newSwiftGuest("guest", "default")
+	guest.Spec.VhostUserDevices = []swiftv1alpha1.VhostUserDevice{
+		{Name: "blk0", Type: swiftv1alpha1.VhostUserDeviceTypeBlk, Socket: "/run/spdk/0"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	v := &Validator{Client: c}
+
+	mig := newSwiftMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
+	_, err := v.validate(context.Background(), mig)
+	if err == nil || !strings.Contains(err.Error(), "node-local virtio backends") {
+		t.Errorf("live + vhost-user device must be rejected; got %v", err)
+	}
+}
+
+func TestValidateClusterState_VhostUserNICLiveRejected(t *testing.T) {
+	scheme := migrationScheme(t)
+	guest := newSwiftGuest("guest", "default")
+	guest.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
+		{Name: "mgmt"},
+		{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser, Socket: "/var/run/vhost/fast0.sock"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	v := &Validator{Client: c}
+
+	mig := newSwiftMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
+	_, err := v.validate(context.Background(), mig)
+	if err == nil || !strings.Contains(err.Error(), "node-local virtio backends") {
+		t.Errorf("live + vhost-user NIC must be rejected; got %v", err)
+	}
+}
+
+func TestValidateClusterState_VirtiofsOfflineNotRejected(t *testing.T) {
+	// Offline migration of a virtiofs guest must NOT hit the node-local-backend
+	// gate (offline recreates the launcher pod on the target where the backends
+	// are re-established).
+	scheme := migrationScheme(t)
+	guest := newSwiftGuest("guest", "default")
+	hp := "/srv/share"
+	guest.Spec.Filesystems = []swiftv1alpha1.Filesystem{
+		{Name: "data", Source: swiftv1alpha1.FilesystemSource{HostPath: &hp}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	v := &Validator{Client: c}
+
+	mig := newSwiftMigration("m", "default")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeOffline
+	mig.Spec.AllowIPChange = true
+	_, err := v.validate(context.Background(), mig)
+	if err != nil && strings.Contains(err.Error(), "node-local virtio backends") {
+		t.Errorf("offline virtiofs migration must not hit the node-local-backend gate; got %v", err)
+	}
+}


### PR DESCRIPTION
Closes the correctness gap flagged during the vhost-user arc: **virtiofs/vhost-user guests could be live-migrated**, but their backends are node-local — the virtiofsd processes + source mounts and the operator's DPDK/SPDK sockets live in/on the **source** launcher pod and node. CH live migration does not transfer them, so a live-migrated guest's virtiofs mounts / vhost-user devices would break mid-flight. Only VFIO was gated until now.

## Fix — treat them exactly like VFIO (offline-only)

- New **`SwiftGuest.HasNodeLocalVirtioBackends()`** predicate (`spec.filesystems`, `spec.vhostUserDevices`, or any `type: vhost-user` interface).
- **Webhook:** explicit `mode: live` rejected with a clear message (placed with the VFIO/SR-IOV gates, before the storage gate; per-operation discipline preserved).
- **`resolveAutoMode`:** `auto` resolves to **offline** (mirrors the VFIO branch).
- **`swiftctl migrate --check`:** live + node-local backends is a FAIL blocker (mirrors the webhook); auto/offline get the resolves-to-offline info + the target-must-provide-backends warning.
- **`live-migration.md` Constraint 3 de-staled** — it still said "if KubeSwift adds virtio-fs in the future (it doesn't today)"; virtiofs shipped in #174. Now states the enforced rule, cross-referencing `vhost-user-devices.md` §7 (which already specified filesystems-are-offline-like-VFIO).

Offline is genuinely fine: the offline path recreates the launcher pod on the target, where the pod builder re-mounts the sources and swiftletd respawns/reconnects the backends (equivalent hostPath content / operator sockets on the target are the operator's documented responsibility).

## Tests

Predicate table; webhook live-rejection for all three shapes + offline-not-gated; `resolveAutoMode` virtiofs→offline. Full Go suite green; **CRD unchanged** (the predicate is a method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)