### PR TITLE
chore(release): promote CHANGELOG section to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
-## [v0.3.0-rc.1] — 2026-06-09
+## [v0.3.0] — 2026-06-09
 
 Consolidates everything since v0.1.0 (the v0.2.0-rc.1 tag from April was never
 promoted and is superseded by this release). Roughly 500 commits across six


### PR DESCRIPTION
Final release hygiene: the consolidated section heading becomes `v0.3.0` (it covers rc.1, rc.2, and the stable release). Tag `v0.3.0` lands on this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)