### PR TITLE
fix(chart): set KUBESWIFT_MIGRATION_STUNNEL_IMAGE (mtls sidecar pulled :latest)

### DIFF
--- a/charts/kubeswift/templates/controller-manager/deployment.yaml
+++ b/charts/kubeswift/templates/controller-manager/deployment.yaml
@@ -27,6 +27,8 @@ spec:
               value: {{ .Values.swiftletd.image.registry }}/swiftletd:{{ include "kubeswift.imageTag" (dict "tag" .Values.swiftletd.image.tag "appVersion" .Chart.AppVersion) }}
             - name: KUBESWIFT_SNAPSHOT_S3_IMAGE
               value: {{ .Values.snapshotS3.image.registry }}/snapshot-s3:{{ include "kubeswift.imageTag" (dict "tag" .Values.snapshotS3.image.tag "appVersion" .Chart.AppVersion) }}
+            - name: KUBESWIFT_MIGRATION_STUNNEL_IMAGE
+              value: {{ .Values.migrationStunnel.image.registry }}/migration-stunnel:{{ include "kubeswift.imageTag" (dict "tag" .Values.migrationStunnel.image.tag "appVersion" .Chart.AppVersion) }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -49,6 +49,16 @@ snapshotS3:
     # Same as controllerManager; use tag: latest for local build+load.
     tag: latest
 
+# migration-stunnel: the mTLS sidecar image for cross-node live migration
+# (Phase 3c). The controller injects it into launcher pods when
+# migration.mtls.enabled=true, reading KUBESWIFT_MIGRATION_STUNNEL_IMAGE.
+# No separate workload is deployed; this only sets the image reference.
+migrationStunnel:
+  image:
+    registry: ghcr.io/projectbeskar/kubeswift
+    # Same as controllerManager; use tag: latest for local build+load.
+    tag: latest
+
 # GPU discovery DaemonSet: auto-discovers GPU hardware on nodes labeled kubeswift.io/gpu-node=true.
 # Populates SwiftGPUNode status with GPU inventory, NUMA topology, and Fabric Manager state.
 gpuDiscovery:


### PR DESCRIPTION
Found **dogfooding the released 0.3.0 chart** on the dev cluster — the first helm-path install with `migration.mtls.enabled=true`.

The controller injects the mTLS stunnel sidecar into launcher pods reading `KUBESWIFT_MIGRATION_STUNNEL_IMAGE`, but **the chart never set it** → the code default `:latest` leaked through → **no `:latest` tag exists** → every launcher pod stuck `1/2 ImagePullBackOff`. The VM itself ran (`GuestRunning=True`, IP up) but the pod never went Ready, so `PodScheduled=False` and the guest never reached `phase=Running`.

Same bug family as #72 (`KUBESWIFT_SNAPSHOT_S3_IMAGE`): the kustomize deploy path sets the env via the Makefile, masking the chart gap — the W5 pattern at the chart layer.

**Fix** mirrors the snapshotS3 pattern exactly: `values.migrationStunnel.image` + an env entry via the `kubeswift.imageTag` helper (`latest` → `v<appVersion>`). Render-verified → `migration-stunnel:v0.3.0`.

**Impact:** the published **0.3.0 chart carries this bug** for `migration.mtls.enabled=true` installs only (default-off installs unaffected). Suggest a **v0.3.1 chart-carrying patch release** after merge.

Cluster-validated via env hotfix on the lab: pod `2/2`, guest `Running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)