### PR TITLE
chore(release): v0.3.1 — chart mtls sidecar image fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.3.1] — 2026-06-10
+
+Patch release. Content is identical to v0.3.0 (images rebuilt as `v0.3.1`);
+the fix is in the Helm chart.
+
+### Fixed
+- **Helm chart: `migration.mtls.enabled=true` installs were broken** — the
+  chart never set `KUBESWIFT_MIGRATION_STUNNEL_IMAGE`, so the controller's
+  mTLS sidecar injection fell back to the code default `:latest`, a tag that
+  does not exist in the registry. Every launcher pod stuck `1/2
+  ImagePullBackOff` (the VM ran, but the guest never reached
+  `phase=Running`). The chart now sets the env via a new
+  `migrationStunnel.image` values block, mirroring the `snapshotS3` pattern
+  (tag defaults to `v<appVersion>`). Found dogfooding the released 0.3.0
+  chart — the first helm-path install with mTLS enabled; the kustomize dev
+  deploy sets the env via the Makefile, which masked the gap. Installs with
+  `migration.mtls.enabled=false` (the default) were unaffected.
+
+---
+
 ## [v0.3.0] — 2026-06-09
 
 Consolidates everything since v0.1.0 (the v0.2.0-rc.1 tag from April was never

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-native Kubernetes operator
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"
 keywords:
   - kubeswift
   - cloud-hypervisor


### PR DESCRIPTION
Patch-release prep: CHANGELOG section for v0.3.1 (the #195 chart fix; images content-identical to v0.3.0) + Chart.yaml 0.3.1. Tag `v0.3.1` lands on this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)