### PR TITLE
docs(context): fix stale CRD examples (guestRef/snapshotRef, not source.*)

### DIFF
--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -196,10 +196,9 @@ status:
 ```yaml
 apiVersion: snapshot.kubeswift.io/v1alpha1
 spec:
-  source:
-    swiftGuestRef: {name: my-guest}
+  guestRef: {name: my-guest}
   backend:
-    type: csi-volume-snapshot | local
+    type: csi-volume-snapshot | local | s3
     csiVolumeSnapshot:
       volumeSnapshotClassName: longhorn-snapshot
     local:
@@ -216,8 +215,7 @@ status:
 ```yaml
 apiVersion: snapshot.kubeswift.io/v1alpha1
 spec:
-  source:
-    swiftSnapshotRef: {name: my-snapshot}
+  snapshotRef: {name: my-snapshot}
   targetGuest:
     name: my-guest                  # same as source = in-place; different = clone
     overwriteExisting: true         # required for in-place
@@ -231,8 +229,7 @@ status:
 ```yaml
 apiVersion: migration.kubeswift.io/v1alpha1
 spec:
-  source:
-    swiftGuestRef: {name: my-guest}
+  guestRef: {name: my-guest}
   target:
     nodeName: target-node           # exclusive with nodeSelector (Phase 4+)
   mode: auto | live | offline       # Phase 1: auto picks offline; live is webhook-rejected


### PR DESCRIPTION
The SwiftSnapshot/SwiftRestore/SwiftMigration examples in `kubeswift_context.md` wrapped refs in a `source:` block that doesn't exist in the CRDs — the real fields are top-level `spec.guestRef` / `spec.snapshotRef`. Caught when the stale snapshot example was copy-pasted during the observability demo and rejected by strict decoding. Fixed shapes **server-dry-run-validated** against the live v0.3.1 CRDs; the snapshot backend enum now also lists `s3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)