### PR TITLE
fix(grafana): provisioning-native dashboards + CI lint (observability O1 PR 1)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ on:
       - 'go.sum'
       - 'test/**'
       - 'Makefile'
+      - 'config/grafana/**'
+      - 'tools/lint-dashboards.sh'
       - '.github/workflows/**'
   pull_request:
     branches: [main]
@@ -34,6 +36,8 @@ on:
       - 'go.sum'
       - 'test/**'
       - 'Makefile'
+      - 'config/grafana/**'
+      - 'tools/lint-dashboards.sh'
       - '.github/workflows/**'
 
 jobs:
@@ -120,6 +124,21 @@ jobs:
       # bash -n on every PR keeps the suite from rotting silently.
       - name: bash -n every test script
         run: make verify-e2e-scripts
+
+  dashboards:
+    name: Dashboard lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Provisioning-native hygiene for config/grafana/*.json: no
+      # __inputs blocks, no ${DS_*} import placeholders, stable uids,
+      # a defaulted `datasource` templating variable. Import-style JSON
+      # renders on manual import but silently shows "no data" under
+      # sidecar/ConfigMap provisioning (the Helm monitoring.dashboards
+      # path) — see docs/design/observability.md D6.
+      - name: Lint Grafana dashboards
+        run: make verify-dashboards
 
   swiftletd-image:
     name: swiftletd image

--- a/Makefile
+++ b/Makefile
@@ -338,5 +338,12 @@ verify-e2e-scripts:
 	done; \
 	echo "  all e2e scripts parse"
 
+# Provisioning-native hygiene checks for the Grafana dashboards under
+# config/grafana/ (no __inputs, no ${DS_*} placeholders, stable uids).
+# Import-style JSON silently breaks sidecar/ConfigMap provisioning —
+# see docs/design/observability.md D6. Designed to run on every PR.
+verify-dashboards:
+	@./tools/lint-dashboards.sh
+
 preflight:
 	@./scripts/kubeswift-preflight.sh

--- a/config/grafana/kubeswift-migrations.json
+++ b/config/grafana/kubeswift-migrations.json
@@ -1,30 +1,34 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "Prometheus data source scraping the KubeSwift controller-manager /metrics endpoint",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "graphTooltip": 1,
   "schemaVersion": 39,
-  "tags": ["kubeswift", "migration"],
-  "title": "KubeSwift — Live Migration",
+  "tags": [
+    "kubeswift",
+    "migration"
+  ],
+  "title": "KubeSwift \u2014 Live Migration",
   "uid": "kubeswift-migrations",
-  "time": { "from": "now-24h", "to": "now" },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "templating": {
     "list": [
       {
-        "name": "DS_PROMETHEUS",
-        "type": "datasource",
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
         "query": "prometheus",
-        "current": {},
-        "hide": 0
+        "regex": "",
+        "type": "datasource"
       }
     ]
   },
@@ -32,13 +36,31 @@
     {
       "title": "Migrations by result (range)",
       "type": "stat",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (result) (increase(kubeswift_migration_total[$__range]))",
           "legendFormat": "{{result}}"
         }
@@ -47,13 +69,30 @@
     {
       "title": "Migration success ratio (range)",
       "type": "gauge",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
-      "fieldConfig": { "defaults": { "min": 0, "max": 1, "unit": "percentunit" } },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit"
+        }
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum(increase(kubeswift_migration_total{result=\"completed\"}[$__range])) / clamp_min(sum(increase(kubeswift_migration_total[$__range])), 1)",
           "legendFormat": "success"
         }
@@ -62,12 +101,23 @@
     {
       "title": "Migrations by mode + result (total)",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (mode, result) (kubeswift_migration_total)",
           "legendFormat": "{{mode}}/{{result}}"
         }
@@ -76,25 +126,46 @@
     {
       "title": "Observed downtime quantiles by mode",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
-      "fieldConfig": { "defaults": { "unit": "s" } },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.50, sum by (le, mode) (rate(kubeswift_migration_downtime_seconds_bucket[1h])))",
           "legendFormat": "p50 {{mode}}"
         },
         {
           "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, sum by (le, mode) (rate(kubeswift_migration_downtime_seconds_bucket[1h])))",
           "legendFormat": "p95 {{mode}}"
         },
         {
           "refId": "C",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.99, sum by (le, mode) (rate(kubeswift_migration_downtime_seconds_bucket[1h])))",
           "legendFormat": "p99 {{mode}}"
         }
@@ -103,13 +174,29 @@
     {
       "title": "Downtime distribution (heatmap)",
       "type": "heatmap",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
-      "options": { "calculate": false, "yAxis": { "unit": "s" } },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "options": {
+        "calculate": false,
+        "yAxis": {
+          "unit": "s"
+        }
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (le) (increase(kubeswift_migration_downtime_seconds_bucket[$__interval]))",
           "legendFormat": "{{le}}",
           "format": "heatmap"
@@ -119,19 +206,37 @@
     {
       "title": "State-transfer duration quantiles by mode",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
-      "fieldConfig": { "defaults": { "unit": "s" } },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.50, sum by (le, mode) (rate(kubeswift_migration_transfer_seconds_bucket[1h])))",
           "legendFormat": "p50 {{mode}}"
         },
         {
           "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, sum by (le, mode) (rate(kubeswift_migration_transfer_seconds_bucket[1h])))",
           "legendFormat": "p95 {{mode}}"
         }

--- a/config/grafana/kubeswift-snapshots.json
+++ b/config/grafana/kubeswift-snapshots.json
@@ -1,30 +1,35 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "Prometheus data source scraping the KubeSwift controller-manager /metrics endpoint",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "graphTooltip": 1,
   "schemaVersion": 39,
-  "tags": ["kubeswift", "snapshot", "restore"],
-  "title": "KubeSwift — Snapshots & Restore",
+  "tags": [
+    "kubeswift",
+    "snapshot",
+    "restore"
+  ],
+  "title": "KubeSwift \u2014 Snapshots & Restore",
   "uid": "kubeswift-snapshots",
-  "time": { "from": "now-24h", "to": "now" },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "templating": {
     "list": [
       {
-        "name": "DS_PROMETHEUS",
-        "type": "datasource",
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
         "query": "prometheus",
-        "current": {},
-        "hide": 0
+        "regex": "",
+        "type": "datasource"
       }
     ]
   },
@@ -32,13 +37,31 @@
     {
       "title": "Snapshots by result (range)",
       "type": "stat",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (result) (increase(kubeswift_snapshot_total[$__range]))",
           "legendFormat": "{{result}}"
         }
@@ -47,13 +70,30 @@
     {
       "title": "Snapshot success ratio (range)",
       "type": "gauge",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
-      "fieldConfig": { "defaults": { "min": 0, "max": 1, "unit": "percentunit" } },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit"
+        }
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum(increase(kubeswift_snapshot_total{result=\"ready\"}[$__range])) / clamp_min(sum(increase(kubeswift_snapshot_total[$__range])), 1)",
           "legendFormat": "success"
         }
@@ -62,13 +102,31 @@
     {
       "title": "Restores by result (range)",
       "type": "stat",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 0 },
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (result) (increase(kubeswift_restore_total[$__range]))",
           "legendFormat": "{{result}}"
         }
@@ -77,12 +135,23 @@
     {
       "title": "Snapshots by backend + result (total)",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 6 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (backend, result) (kubeswift_snapshot_total)",
           "legendFormat": "{{backend}}/{{result}}"
         }
@@ -91,12 +160,23 @@
     {
       "title": "cloneFromSnapshot guests by result (total)",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 6 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (result) (kubeswift_clone_total)",
           "legendFormat": "{{result}}"
         }
@@ -105,19 +185,37 @@
     {
       "title": "Capture latency quantiles by backend",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
-      "fieldConfig": { "defaults": { "unit": "s" } },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.50, sum by (le, backend) (rate(kubeswift_snapshot_capture_seconds_bucket[1h])))",
           "legendFormat": "p50 {{backend}}"
         },
         {
           "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, sum by (le, backend) (rate(kubeswift_snapshot_capture_seconds_bucket[1h])))",
           "legendFormat": "p95 {{backend}}"
         }
@@ -126,25 +224,46 @@
     {
       "title": "Restore latency quantiles",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
-      "fieldConfig": { "defaults": { "unit": "s" } },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.50, sum by (le) (rate(kubeswift_restore_seconds_bucket[1h])))",
           "legendFormat": "p50"
         },
         {
           "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, sum by (le) (rate(kubeswift_restore_seconds_bucket[1h])))",
           "legendFormat": "p95"
         },
         {
           "refId": "C",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.99, sum by (le) (rate(kubeswift_restore_seconds_bucket[1h])))",
           "legendFormat": "p99"
         }
@@ -153,13 +272,28 @@
     {
       "title": "Memory pause window p95 by backend",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
-      "fieldConfig": { "defaults": { "unit": "s" } },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, sum by (le, backend) (rate(kubeswift_snapshot_pause_window_seconds_bucket[1h])))",
           "legendFormat": "p95 {{backend}}"
         }
@@ -168,19 +302,37 @@
     {
       "title": "Tier C upload latency quantiles",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
-      "fieldConfig": { "defaults": { "unit": "s" } },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.50, sum by (le) (rate(kubeswift_snapshot_upload_seconds_bucket[1h])))",
           "legendFormat": "p50"
         },
         {
           "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, sum by (le) (rate(kubeswift_snapshot_upload_seconds_bucket[1h])))",
           "legendFormat": "p95"
         }
@@ -189,19 +341,37 @@
     {
       "title": "Tier C bytes moved (rate)",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
-      "fieldConfig": { "defaults": { "unit": "Bps" } },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        }
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "rate(kubeswift_snapshot_upload_bytes_total[5m])",
           "legendFormat": "upload"
         },
         {
           "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "rate(kubeswift_restore_download_bytes_total[5m])",
           "legendFormat": "download"
         }
@@ -210,13 +380,29 @@
     {
       "title": "Snapshot size distribution (heatmap)",
       "type": "heatmap",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
-      "options": { "calculate": false, "yAxis": { "unit": "bytes" } },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "options": {
+        "calculate": false,
+        "yAxis": {
+          "unit": "bytes"
+        }
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (le) (increase(kubeswift_snapshot_size_bytes_bucket[$__interval]))",
           "legendFormat": "{{le}}",
           "format": "heatmap"

--- a/tools/lint-dashboards.sh
+++ b/tools/lint-dashboards.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# lint-dashboards.sh — provisioning-native hygiene checks for the Grafana
+# dashboards under config/grafana/.
+#
+# Dashboards ship to operators as sidecar-provisioned ConfigMaps (Helm
+# monitoring.dashboards). Import-style JSON (__inputs blocks, ${DS_*}
+# placeholder variables) renders fine on manual import but silently breaks
+# under provisioning: the inputs are never bound, panels resolve no
+# datasource, and every panel shows "no data" (observability design doc
+# D6; confirmed live 2026-06-10). These checks keep the JSONs in the form
+# that works in BOTH paths: a `datasource` templating variable defaulting
+# to the instance default, referenced as ${datasource}.
+#
+# Rules:
+#   1. valid JSON
+#   2. no __inputs / __requires blocks
+#   3. no ${DS_*} import-time placeholders
+#   4. uid present and equal to the filename stem (stable cross-version)
+#   5. tags include "kubeswift"; editable: true; title present
+#   6. every ${datasource} reference is backed by a templating variable
+#      named "datasource" of type "datasource" with a current value
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+for f in config/grafana/*.json; do
+    python3 - "$f" <<'PY' || fail=1
+import json
+import os
+import sys
+
+path = sys.argv[1]
+stem = os.path.splitext(os.path.basename(path))[0]
+raw = open(path).read()
+
+errs = []
+try:
+    d = json.loads(raw)
+except ValueError as e:
+    print(f"FAIL {path}: invalid JSON: {e}")
+    sys.exit(1)
+
+for key in ("__inputs", "__requires"):
+    if key in d:
+        errs.append(f"has import-style '{key}' block (breaks sidecar provisioning)")
+
+if "${DS_" in raw:
+    errs.append("references a ${DS_*} import placeholder (use ${datasource})")
+
+if d.get("uid") != stem:
+    errs.append(f"uid {d.get('uid')!r} != filename stem {stem!r}")
+if "kubeswift" not in (d.get("tags") or []):
+    errs.append("tags missing 'kubeswift'")
+if d.get("editable") is not True:
+    errs.append("editable must be true")
+if not d.get("title"):
+    errs.append("title missing")
+
+if "${datasource}" in raw:
+    tvars = {v.get("name"): v for v in d.get("templating", {}).get("list", [])}
+    ds = tvars.get("datasource")
+    if ds is None:
+        errs.append("${datasource} referenced but no 'datasource' templating variable")
+    elif ds.get("type") != "datasource":
+        errs.append("'datasource' templating variable must have type 'datasource'")
+    elif not (ds.get("current") or {}).get("value"):
+        errs.append("'datasource' templating variable needs a current default value")
+
+if errs:
+    for e in errs:
+        print(f"FAIL {path}: {e}")
+    sys.exit(1)
+print(f"  ok {path}")
+PY
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo "dashboard lint FAILED"
+    exit 1
+fi
+echo "  all dashboards provisioning-native"


### PR DESCRIPTION
## Summary

Phase O1 PR 1 of the observability program ([design doc](https://github.com/projectbeskar/kubeswift/blob/main/docs/design/observability.md), D6).

Both shipped dashboards were import-style JSON (`__inputs` + `${DS_PROMETHEUS}` placeholders) — fine on manual import, **silently broken under sidecar/ConfigMap provisioning** (the form the Helm `monitoring.dashboards` packaging in PR 2 will use): the input never binds, panels resolve no datasource, everything shows "no data". Confirmed live on the lab.

## Changes
- Convert both dashboards to the kube-prometheus-stack pattern: a `datasource` templating variable (type `datasource`, current=default) referenced as `${datasource}` — works under provisioning AND manual import.
- `tools/lint-dashboards.sh` + `make verify-dashboards` + CI job `dashboards`: no `__inputs`/`__requires`, no `${DS_*}`, uid == filename stem, kubeswift tag, defaulted datasource var. Lint negative-tested (catches a re-introduced `__inputs` block).
- CI path triggers extended with `config/grafana/**` + the lint script.

## Validation
- `make verify-dashboards` green; load-bearing check: corrupted file fails the lint.
- Cluster: repo JSONs applied as `grafana_dashboard=1` ConfigMaps on the lab kube-prometheus-stack → sidecar re-synced, datasource variable resolves to default, panels render the demo migration (2.70s downtime) + snapshot data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)