### PR TITLE
feat(chart): monitoring.* gate — ServiceMonitor + Grafana dashboards (observability O1 PR 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,11 +339,20 @@ verify-e2e-scripts:
 	echo "  all e2e scripts parse"
 
 # Provisioning-native hygiene checks for the Grafana dashboards under
-# config/grafana/ (no __inputs, no ${DS_*} placeholders, stable uids).
-# Import-style JSON silently breaks sidecar/ConfigMap provisioning —
-# see docs/design/observability.md D6. Designed to run on every PR.
+# config/grafana/ (no __inputs, no ${DS_*} placeholders, stable uids),
+# plus a drift check against the Helm chart copies. Import-style JSON
+# silently breaks sidecar/ConfigMap provisioning — see
+# docs/design/observability.md D6. Designed to run on every PR.
 verify-dashboards:
 	@./tools/lint-dashboards.sh
+
+# Sync the canonical dashboards (config/grafana/) into the Helm chart
+# (charts/kubeswift/dashboards/), where templates/monitoring/dashboards.yaml
+# embeds them via .Files.Get. Same pattern as the CRD copy step — the
+# chart copies are build artifacts, never edited directly.
+dashboards-sync:
+	@cp config/grafana/*.json charts/kubeswift/dashboards/
+	@echo "  dashboards synced to charts/kubeswift/dashboards/"
 
 preflight:
 	@./scripts/kubeswift-preflight.sh

--- a/charts/kubeswift/dashboards/kubeswift-migrations.json
+++ b/charts/kubeswift/dashboards/kubeswift-migrations.json
@@ -1,0 +1,246 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "kubeswift",
+    "migration"
+  ],
+  "title": "KubeSwift \u2014 Live Migration",
+  "uid": "kubeswift-migrations",
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "query": "prometheus",
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Migrations by result (range)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (increase(kubeswift_migration_total[$__range]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Migration success ratio (range)",
+      "type": "gauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(kubeswift_migration_total{result=\"completed\"}[$__range])) / clamp_min(sum(increase(kubeswift_migration_total[$__range])), 1)",
+          "legendFormat": "success"
+        }
+      ]
+    },
+    {
+      "title": "Migrations by mode + result (total)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (mode, result) (kubeswift_migration_total)",
+          "legendFormat": "{{mode}}/{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Observed downtime quantiles by mode",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, mode) (rate(kubeswift_migration_downtime_seconds_bucket[1h])))",
+          "legendFormat": "p50 {{mode}}"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, mode) (rate(kubeswift_migration_downtime_seconds_bucket[1h])))",
+          "legendFormat": "p95 {{mode}}"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, mode) (rate(kubeswift_migration_downtime_seconds_bucket[1h])))",
+          "legendFormat": "p99 {{mode}}"
+        }
+      ]
+    },
+    {
+      "title": "Downtime distribution (heatmap)",
+      "type": "heatmap",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "options": {
+        "calculate": false,
+        "yAxis": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (le) (increase(kubeswift_migration_downtime_seconds_bucket[$__interval]))",
+          "legendFormat": "{{le}}",
+          "format": "heatmap"
+        }
+      ]
+    },
+    {
+      "title": "State-transfer duration quantiles by mode",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, mode) (rate(kubeswift_migration_transfer_seconds_bucket[1h])))",
+          "legendFormat": "p50 {{mode}}"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, mode) (rate(kubeswift_migration_transfer_seconds_bucket[1h])))",
+          "legendFormat": "p95 {{mode}}"
+        }
+      ]
+    }
+  ]
+}

--- a/charts/kubeswift/dashboards/kubeswift-snapshots.json
+++ b/charts/kubeswift/dashboards/kubeswift-snapshots.json
@@ -1,0 +1,413 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "kubeswift",
+    "snapshot",
+    "restore"
+  ],
+  "title": "KubeSwift \u2014 Snapshots & Restore",
+  "uid": "kubeswift-snapshots",
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "query": "prometheus",
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Snapshots by result (range)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (increase(kubeswift_snapshot_total[$__range]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Snapshot success ratio (range)",
+      "type": "gauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(kubeswift_snapshot_total{result=\"ready\"}[$__range])) / clamp_min(sum(increase(kubeswift_snapshot_total[$__range])), 1)",
+          "legendFormat": "success"
+        }
+      ]
+    },
+    {
+      "title": "Restores by result (range)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (increase(kubeswift_restore_total[$__range]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Snapshots by backend + result (total)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (backend, result) (kubeswift_snapshot_total)",
+          "legendFormat": "{{backend}}/{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "cloneFromSnapshot guests by result (total)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (kubeswift_clone_total)",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Capture latency quantiles by backend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, backend) (rate(kubeswift_snapshot_capture_seconds_bucket[1h])))",
+          "legendFormat": "p50 {{backend}}"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, backend) (rate(kubeswift_snapshot_capture_seconds_bucket[1h])))",
+          "legendFormat": "p95 {{backend}}"
+        }
+      ]
+    },
+    {
+      "title": "Restore latency quantiles",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(kubeswift_restore_seconds_bucket[1h])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(kubeswift_restore_seconds_bucket[1h])))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(kubeswift_restore_seconds_bucket[1h])))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "title": "Memory pause window p95 by backend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, backend) (rate(kubeswift_snapshot_pause_window_seconds_bucket[1h])))",
+          "legendFormat": "p95 {{backend}}"
+        }
+      ]
+    },
+    {
+      "title": "Tier C upload latency quantiles",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(kubeswift_snapshot_upload_seconds_bucket[1h])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(kubeswift_snapshot_upload_seconds_bucket[1h])))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "title": "Tier C bytes moved (rate)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(kubeswift_snapshot_upload_bytes_total[5m])",
+          "legendFormat": "upload"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(kubeswift_restore_download_bytes_total[5m])",
+          "legendFormat": "download"
+        }
+      ]
+    },
+    {
+      "title": "Snapshot size distribution (heatmap)",
+      "type": "heatmap",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "options": {
+        "calculate": false,
+        "yAxis": {
+          "unit": "bytes"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (le) (increase(kubeswift_snapshot_size_bytes_bucket[$__interval]))",
+          "legendFormat": "{{le}}",
+          "format": "heatmap"
+        }
+      ]
+    }
+  ]
+}

--- a/charts/kubeswift/templates/monitoring/dashboards.yaml
+++ b/charts/kubeswift/templates/monitoring/dashboards.yaml
@@ -1,0 +1,37 @@
+{{- /*
+Nil-safe access (see servicemonitor.yaml): every nested key may be absent
+under `--reuse-values --set monitoring.enabled=true`; explicit
+`enabled: false` must still win (hence ternary/hasKey, not `default`).
+*/ -}}
+{{- $mon := .Values.monitoring | default dict }}
+{{- $db := $mon.dashboards | default dict }}
+{{- if and $mon.enabled (ternary $db.enabled true (hasKey $db "enabled")) }}
+{{- $ns := $db.namespace | default .Values.namespace }}
+{{- $label := $db.label | default "grafana_dashboard" }}
+{{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
+{{- $name := base $path | trimSuffix ".json" }}
+---
+# Grafana dashboard, discovered by the grafana sidecar via the
+# {{ $label }} label. The JSONs under dashboards/ are synced verbatim
+# from config/grafana/ by `make dashboards-sync` (drift fails
+# `make verify-dashboards` in CI). Set monitoring.dashboards.namespace
+# to your Grafana namespace if the sidecar does not watch all
+# namespaces (its default is its own).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: dashboards
+    {{ $label }}: "1"
+  {{- with $db.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  {{ base $path }}: |-
+{{ $.Files.Get $path | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/kubeswift/templates/monitoring/servicemonitor.yaml
+++ b/charts/kubeswift/templates/monitoring/servicemonitor.yaml
@@ -1,0 +1,37 @@
+{{- /*
+Nil-safe access: with `helm upgrade --reuse-values --set monitoring.enabled=true`
+the monitoring subtree from values.yaml is NOT merged, so every nested key may
+be absent. `ternary ... (hasKey ...)` keeps an explicit `enabled: false`
+working (sprig's `default` would swallow false).
+*/ -}}
+{{- $mon := .Values.monitoring | default dict }}
+{{- $sm := $mon.serviceMonitor | default dict }}
+{{- if and $mon.enabled (ternary $sm.enabled true (hasKey $sm "enabled")) }}
+# Scrapes the controller-manager /metrics endpoint (kubeswift_* feature
+# metrics + the controller-runtime reconcile/workqueue/webhook series).
+# Requires the Prometheus Operator CRDs (monitoring.coreos.com) — the
+# monitoring.enabled gate keeps default installs free of that dependency.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubeswift-controller-manager
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: controller-manager
+    {{- with $sm.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubeswift
+      app.kubernetes.io/component: controller-manager
+  endpoints:
+    - port: metrics
+      interval: {{ $sm.interval | default "30s" }}
+      path: /metrics
+{{- end }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -79,6 +79,32 @@ gpuDiscovery:
 webhook:
   enabled: false
 
+# Observability (optional). Requires the Prometheus Operator CRDs
+# (monitoring.coreos.com — e.g. kube-prometheus-stack) when enabled; the
+# dashboards additionally need a Grafana with the dashboard sidecar (the
+# kube-prometheus-stack default). Off by default — default installs incur
+# no monitoring CRD dependency. See docs/design/observability.md.
+monitoring:
+  enabled: false
+  # ServiceMonitor scraping the controller-manager /metrics endpoint.
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    # Extra labels for Prometheus instances that select ServiceMonitors by
+    # label (e.g. release: kube-prometheus-stack).
+    additionalLabels: {}
+  # Grafana dashboards as sidecar-discovered ConfigMaps.
+  dashboards:
+    enabled: true
+    # The sidecar discovery label (kube-prometheus-stack default shown).
+    label: grafana_dashboard
+    # Namespace for the dashboard ConfigMaps. Empty = the KubeSwift
+    # namespace; set this to your Grafana namespace if the sidecar only
+    # watches its own namespace (its default).
+    namespace: ""
+    # Extra annotations, e.g. grafana_folder: KubeSwift
+    annotations: {}
+
 # Live migration settings.
 migration:
   # mTLS transport for cross-node live migration (Phase 3c, Option B per-node

--- a/config/grafana/servicemonitor.yaml
+++ b/config/grafana/servicemonitor.yaml
@@ -1,8 +1,10 @@
 # Prometheus Operator ServiceMonitor for the KubeSwift controller-manager
 # /metrics endpoint. Apply ONLY if your cluster runs the Prometheus Operator
-# (the monitoring.coreos.com CRDs must exist) — it is intentionally NOT part of
-# `make deploy` / the Helm chart, since most clusters scrape via their own
-# Prometheus config instead.
+# (the monitoring.coreos.com CRDs must exist). It is intentionally NOT part
+# of `make deploy` (kustomize installs stay monitoring-CRD-free). Helm users
+# should prefer `--set monitoring.enabled=true`, which renders the chart's
+# equivalent (templates/monitoring/servicemonitor.yaml) plus the dashboard
+# ConfigMaps — this sample exists for non-Helm installs.
 #
 #   kubectl apply -f config/grafana/servicemonitor.yaml
 #

--- a/tools/lint-dashboards.sh
+++ b/tools/lint-dashboards.sh
@@ -75,8 +75,22 @@ print(f"  ok {path}")
 PY
 done
 
+# Drift check: the Helm chart embeds verbatim copies under
+# charts/kubeswift/dashboards/ (via .Files.Get). The canonical source is
+# config/grafana/; `make dashboards-sync` copies. Same lesson as the CRD
+# copy step — drift between the two ships stale dashboards silently.
+if [ -d charts/kubeswift/dashboards ]; then
+    for f in config/grafana/*.json; do
+        chart="charts/kubeswift/dashboards/$(basename "$f")"
+        if ! cmp -s "$f" "$chart"; then
+            echo "FAIL $chart: out of sync with $f — run 'make dashboards-sync'"
+            fail=1
+        fi
+    done
+fi
+
 if [ "$fail" -ne 0 ]; then
     echo "dashboard lint FAILED"
     exit 1
 fi
-echo "  all dashboards provisioning-native"
+echo "  all dashboards provisioning-native and chart-synced"


### PR DESCRIPTION
## Summary

Phase O1 PR 2 of the observability program ([design doc](https://github.com/projectbeskar/kubeswift/blob/main/docs/design/observability.md), D5): the chart can now ship the complete scrape+dashboards experience behind one flag.

```bash
helm upgrade kubeswift oci://ghcr.io/projectbeskar/charts/kubeswift \
  --set monitoring.enabled=true \
  --set monitoring.dashboards.namespace=<your-grafana-namespace>
```

## Changes
- **values: `monitoring.*`** (default **off** — no monitoring.coreos.com CRD dependency, consistent with `webhook.enabled`): `serviceMonitor.{enabled,interval,additionalLabels}` + `dashboards.{enabled,label,namespace,annotations}`.
- **templates/monitoring/servicemonitor.yaml** — scrapes controller-manager `/metrics`.
- **templates/monitoring/dashboards.yaml** — dashboards as sidecar-discovered ConfigMaps via `.Files.Get`.
- **`charts/kubeswift/dashboards/`** — verbatim copies of `config/grafana/*.json`, synced by `make dashboards-sync`; `make verify-dashboards` (CI) fails on drift — the CRD-copy lesson applied to dashboards.
- Templates are **nil-safe for `--reuse-values`** (first lab upgrade hit the nil-pointer; `ternary`/`hasKey` keeps explicit `enabled: false` working where sprig `default` would swallow it).
- Stale comment fix in `config/grafana/servicemonitor.yaml` (kept for non-Helm installs).

## Validation
- Render matrix: default → zero monitoring resources; `enabled=true` alone → SM + 2 ConfigMaps; explicit-false subkeys → clean. `helm lint` green.
- **Lab (rev 46):** one-flag `--reuse-values` upgrade → Helm-owned ServiceMonitor with Prometheus target `up`, both dashboard ConfigMaps in `monitoring` ns, Grafana sidecar imported both, demo data renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)