### PR TITLE
feat(metrics): cache-backed CR-state collector + metric defect fixes (observability O2)

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftrestore"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftsnapshot"
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftsnapshotschedule"
+	kubeswiftmetrics "github.com/projectbeskar/kubeswift/internal/metrics"
 	"github.com/projectbeskar/kubeswift/internal/scheme"
 	"github.com/projectbeskar/kubeswift/internal/version"
 	evictionwebhook "github.com/projectbeskar/kubeswift/internal/webhook/eviction"
@@ -128,6 +129,11 @@ func main() {
 		klog.ErrorS(err, "unable to create kubernetes clientset")
 		os.Exit(1)
 	}
+
+	// CR-state gauges (kubeswift_guests, kubeswift_pool_replicas, ...) are
+	// computed from the informer cache at scrape time — every listed type
+	// already has a controller-driven informer, so scrapes are in-memory.
+	kubeswiftmetrics.RegisterStateCollector(mgr.GetClient())
 
 	if err = (&swiftimage.SwiftImageReconciler{
 		Client:    mgr.GetClient(),

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -515,12 +515,11 @@ func recordGuestMetrics(guest *swiftv1alpha1.SwiftGuest, oldStatus, newStatus *s
 		newPhase = newStatus.Phase
 	}
 
-	// GuestRunningTotal: increment on transition to Running, decrement on transition away
-	if newPhase == swiftv1alpha1.SwiftGuestPhaseRunning && oldPhase != swiftv1alpha1.SwiftGuestPhaseRunning {
-		metrics.GuestRunningTotal.WithLabelValues(ns).Inc()
-	}
+	// Running-count gauges live in metrics.StateCollector (computed from
+	// cluster state at scrape time). Never re-add an Inc/Dec transition
+	// gauge here: it silently drifts to 0/negative across controller
+	// restarts (already-Running guests produce no transition to re-count).
 	if oldPhase == swiftv1alpha1.SwiftGuestPhaseRunning && newPhase != swiftv1alpha1.SwiftGuestPhaseRunning {
-		metrics.GuestRunningTotal.WithLabelValues(ns).Dec()
 		metrics.UnmarkVMBootObserved(ns + "/" + guest.Name)
 	}
 
@@ -536,15 +535,20 @@ func recordGuestMetrics(guest *swiftv1alpha1.SwiftGuest, oldStatus, newStatus *s
 		}
 	}
 
-	// VMFailuresTotal: increment on transition to Failed
+	// VMFailuresTotal: increment on transition to Failed. The label carries
+	// the bounded condition .Reason token, NOT the free-text .Message —
+	// messages embed pod/node names and error strings, i.e. unbounded
+	// series cardinality (observability design doc §1.5). Prefer the first
+	// non-True condition so a healthy condition's Reason can't shadow the
+	// failing one.
 	if newPhase == swiftv1alpha1.SwiftGuestPhaseFailed && oldPhase != swiftv1alpha1.SwiftGuestPhaseFailed {
-		reason := "unknown"
-		if c := findCondition(newStatus, "PodScheduled"); c != nil && c.Message != "" {
-			reason = c.Message
-		} else if c := findCondition(newStatus, "GuestRunning"); c != nil && c.Message != "" {
-			reason = c.Message
-		} else if c := findCondition(newStatus, "Resolved"); c != nil && c.Message != "" {
-			reason = c.Message
+		reason := "Unknown"
+		if c := findCondition(newStatus, "PodScheduled"); c != nil && c.Status != metav1.ConditionTrue && c.Reason != "" {
+			reason = c.Reason
+		} else if c := findCondition(newStatus, "GuestRunning"); c != nil && c.Status != metav1.ConditionTrue && c.Reason != "" {
+			reason = c.Reason
+		} else if c := findCondition(newStatus, "Resolved"); c != nil && c.Status != metav1.ConditionTrue && c.Reason != "" {
+			reason = c.Reason
 		}
 		metrics.VMFailuresTotal.WithLabelValues(ns, reason).Inc()
 	}

--- a/internal/controller/swiftguest/failure_reason_metrics_test.go
+++ b/internal/controller/swiftguest/failure_reason_metrics_test.go
@@ -1,0 +1,76 @@
+package swiftguest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
+)
+
+// TestRecordGuestMetrics_FailureReasonIsBoundedToken guards the O2
+// cardinality fix: the vm_failures_total reason label must carry the
+// condition's machine Reason token, never its free-text Message (messages
+// embed pod/node names — unbounded series cardinality, observability
+// design doc §1.5).
+func TestRecordGuestMetrics_FailureReasonIsBoundedToken(t *testing.T) {
+	g := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "reasonns"},
+		Spec:       swiftv1alpha1.SwiftGuestSpec{ImageRef: &corev1.LocalObjectReference{Name: "img"}},
+	}
+	pending := &swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhasePending}
+	failed := &swiftv1alpha1.SwiftGuestStatus{
+		Phase: swiftv1alpha1.SwiftGuestPhaseFailed,
+		Conditions: []metav1.Condition{
+			// A healthy True condition whose Reason must NOT be picked.
+			{Type: "PodScheduled", Status: metav1.ConditionTrue, Reason: "PodScheduled",
+				Message: "pod scheduled to node miles"},
+			// The failing condition: Reason is the bounded token, Message the
+			// free text that previously leaked into the label.
+			{Type: "GuestRunning", Status: metav1.ConditionFalse, Reason: "PodFailed",
+				Message: "launcher pod g-mig-abc123 failed on node miles: init container gpu-init exited 1"},
+		},
+	}
+
+	before := testutil.ToFloat64(metrics.VMFailuresTotal.WithLabelValues("reasonns", "PodFailed"))
+	recordGuestMetrics(g, pending, failed, nil)
+	if got := testutil.ToFloat64(metrics.VMFailuresTotal.WithLabelValues("reasonns", "PodFailed")); got != before+1 {
+		t.Errorf("vm_failures_total{reason=\"PodFailed\"} = %v, want %v", got, before+1)
+	}
+
+	// The free-text message must not appear as any label value.
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range families {
+		if f.GetName() != "kubeswift_vm_failures_total" {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if strings.Contains(l.GetValue(), "g-mig-abc123") || strings.Contains(l.GetValue(), "exited 1") {
+					t.Errorf("free-text message leaked into label %s=%q", l.GetName(), l.GetValue())
+				}
+			}
+		}
+	}
+
+	// No usable Reason on any failing condition -> "Unknown", never "".
+	failedNoReason := &swiftv1alpha1.SwiftGuestStatus{
+		Phase: swiftv1alpha1.SwiftGuestPhaseFailed,
+		Conditions: []metav1.Condition{
+			{Type: "GuestRunning", Status: metav1.ConditionFalse, Message: "free text only"},
+		},
+	}
+	ub := testutil.ToFloat64(metrics.VMFailuresTotal.WithLabelValues("reasonns", "Unknown"))
+	recordGuestMetrics(g, pending, failedNoReason, nil)
+	if got := testutil.ToFloat64(metrics.VMFailuresTotal.WithLabelValues("reasonns", "Unknown")); got != ub+1 {
+		t.Errorf("vm_failures_total{reason=\"Unknown\"} = %v, want %v", got, ub+1)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -21,15 +21,13 @@ func UnmarkVMBootObserved(key string) {
 	vmBootObserved.Delete(key)
 }
 
-var (
-	GuestRunningTotal = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "kubeswift_guest_running_total",
-			Help: "Number of SwiftGuest instances currently in Running phase",
-		},
-		[]string{"namespace"},
-	)
+// kubeswift_guest_running_total moved to the StateCollector
+// (state_collector.go): as an event-accumulated Inc/Dec gauge it silently
+// drifted to 0 (or negative) across controller restarts. It is now emitted
+// from cluster state at scrape time, DEPRECATED in favor of
+// kubeswift_guests{phase="Running"}, and removed after one release.
 
+var (
 	VMBootSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "kubeswift_vm_boot_seconds",
@@ -39,10 +37,14 @@ var (
 		[]string{"namespace"},
 	)
 
+	// VMFailuresTotal counts transitions into Failed by condition Reason.
+	// The reason label MUST carry the bounded machine token (condition
+	// .Reason), never the free-text .Message — messages embed pod/node
+	// names and error strings, which is unbounded series cardinality.
 	VMFailuresTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "kubeswift_vm_failures_total",
-			Help: "Total number of SwiftGuest VM failures",
+			Help: "Total number of SwiftGuest VM failures, by condition reason",
 		},
 		[]string{"namespace", "reason"},
 	)
@@ -232,7 +234,6 @@ func MarkCloneDownloadObserved(key string) bool {
 
 func init() {
 	metrics.Registry.MustRegister(
-		GuestRunningTotal,
 		VMBootSeconds,
 		VMFailuresTotal,
 		ImageImportSeconds,

--- a/internal/metrics/state_collector.go
+++ b/internal/metrics/state_collector.go
@@ -1,0 +1,367 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
+	imagev1alpha1 "github.com/projectbeskar/kubeswift/api/image/v1alpha1"
+	kernelv1alpha1 "github.com/projectbeskar/kubeswift/api/kernel/v1alpha1"
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// StateCollector exports CR-state gauges computed from the informer cache at
+// scrape time (observability design doc D1). State gauges must NEVER be
+// event-accumulated (Inc/Dec on phase transitions): after a controller
+// restart the accumulator resets to zero while the cluster state does not,
+// so the gauge silently drifts to 0 — or negative once a pre-restart guest
+// stops. Computing from a List at scrape time is immune by construction.
+//
+// All series are aggregates with bounded labels (namespace/phase/node/...).
+// Per-CR-name series are deliberately NOT exported (cardinality); operators
+// who want them can layer kube-state-metrics CustomResourceStateMetrics on
+// top (see config/samples/monitoring/).
+//
+// The reader is the manager's cached client: every listed type already has
+// a running informer (each has a controller watching it), so Collect is an
+// in-memory scan — no apiserver round-trips on the scrape path.
+type StateCollector struct {
+	reader client.Reader
+}
+
+// NewStateCollector builds a collector reading from the given cache-backed
+// reader.
+func NewStateCollector(reader client.Reader) *StateCollector {
+	return &StateCollector{reader: reader}
+}
+
+// RegisterStateCollector registers the collector on the controller-runtime
+// metrics registry. Call once from main after the manager is constructed.
+func RegisterStateCollector(reader client.Reader) {
+	metrics.Registry.MustRegister(NewStateCollector(reader))
+}
+
+// collectTimeout bounds the scrape-side cache scan. Cache reads are
+// in-memory; this only guards the not-yet-synced window during startup.
+const collectTimeout = 5 * time.Second
+
+var (
+	guestsDesc = prometheus.NewDesc(
+		"kubeswift_guests",
+		"SwiftGuests by namespace and phase, computed from cluster state at scrape time",
+		[]string{"namespace", "phase"}, nil)
+	guestsByNodeDesc = prometheus.NewDesc(
+		"kubeswift_guests_by_node",
+		"Scheduled SwiftGuests by node and hypervisor",
+		[]string{"node", "hypervisor"}, nil)
+	guestsByBootSourceDesc = prometheus.NewDesc(
+		"kubeswift_guests_by_boot_source",
+		"SwiftGuests by boot source (image|kernel|clone)",
+		[]string{"source"}, nil)
+	// Deprecated alias of sum(kubeswift_guests{phase="Running"}) by namespace.
+	// Pre-O2 this was an event-accumulated gauge that drifted across
+	// controller restarts; it is now emitted from cluster state with correct
+	// semantics. Kept one release for dashboard compatibility — prefer
+	// kubeswift_guests.
+	guestRunningDesc = prometheus.NewDesc(
+		"kubeswift_guest_running_total",
+		"DEPRECATED (use kubeswift_guests{phase=\"Running\"}): Running SwiftGuests by namespace",
+		[]string{"namespace"}, nil)
+	poolReplicasDesc = prometheus.NewDesc(
+		"kubeswift_pool_replicas",
+		"SwiftGuestPool replica counts by state (desired|ready|available|failed|updated)",
+		[]string{"namespace", "pool", "state"}, nil)
+	imagesDesc = prometheus.NewDesc(
+		"kubeswift_images",
+		"SwiftImages by namespace and phase",
+		[]string{"namespace", "phase"}, nil)
+	kernelsDesc = prometheus.NewDesc(
+		"kubeswift_kernels",
+		"SwiftKernels by phase (cluster-wide)",
+		[]string{"phase"}, nil)
+	snapshotsDesc = prometheus.NewDesc(
+		"kubeswift_snapshots",
+		"SwiftSnapshots by namespace and phase",
+		[]string{"namespace", "phase"}, nil)
+	migrationsActiveDesc = prometheus.NewDesc(
+		"kubeswift_migrations_active",
+		"In-flight (non-terminal) SwiftMigrations by mode",
+		[]string{"mode"}, nil)
+	gpuNodeGPUsDesc = prometheus.NewDesc(
+		"kubeswift_gpu_node_gpus",
+		"GPUs per SwiftGPUNode by state (total|free)",
+		[]string{"node", "state"}, nil)
+	gpuNodeInfoDesc = prometheus.NewDesc(
+		"kubeswift_gpu_node_info",
+		"SwiftGPUNode inventory info (value is always 1)",
+		[]string{"node", "model", "vfio_ready"}, nil)
+	gpuNodeLastDiscoveryDesc = prometheus.NewDesc(
+		"kubeswift_gpu_node_last_discovery_timestamp_seconds",
+		"Unix time of the last successful GPU discovery per node",
+		[]string{"node"}, nil)
+	scheduleLastSuccessDesc = prometheus.NewDesc(
+		"kubeswift_snapshot_schedule_last_success_timestamp_seconds",
+		"Unix time a SwiftSnapshotSchedule's snapshot last reached Ready",
+		[]string{"namespace", "schedule"}, nil)
+)
+
+var (
+	guestPhases = []swiftv1alpha1.SwiftGuestPhase{
+		swiftv1alpha1.SwiftGuestPhasePending,
+		swiftv1alpha1.SwiftGuestPhaseScheduling,
+		swiftv1alpha1.SwiftGuestPhaseRunning,
+		swiftv1alpha1.SwiftGuestPhaseStopped,
+		swiftv1alpha1.SwiftGuestPhaseFailed,
+	}
+	imagePhases = []imagev1alpha1.SwiftImagePhase{
+		imagev1alpha1.SwiftImagePhasePending,
+		imagev1alpha1.SwiftImagePhaseImporting,
+		imagev1alpha1.SwiftImagePhaseValidating,
+		imagev1alpha1.SwiftImagePhasePreparing,
+		imagev1alpha1.SwiftImagePhaseSnapshotting,
+		imagev1alpha1.SwiftImagePhaseReady,
+		imagev1alpha1.SwiftImagePhaseFailed,
+	}
+	kernelPhases = []kernelv1alpha1.SwiftKernelPhase{
+		kernelv1alpha1.SwiftKernelPhasePending,
+		kernelv1alpha1.SwiftKernelPhasePulling,
+		kernelv1alpha1.SwiftKernelPhaseReady,
+		kernelv1alpha1.SwiftKernelPhaseFailed,
+	}
+	snapshotPhases = []snapshotv1alpha1.SwiftSnapshotPhase{
+		snapshotv1alpha1.SwiftSnapshotPhasePending,
+		snapshotv1alpha1.SwiftSnapshotPhaseCapturing,
+		snapshotv1alpha1.SwiftSnapshotPhaseUploading,
+		snapshotv1alpha1.SwiftSnapshotPhaseReady,
+		snapshotv1alpha1.SwiftSnapshotPhaseFailed,
+	}
+)
+
+// Describe implements prometheus.Collector.
+func (c *StateCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- guestsDesc
+	ch <- guestsByNodeDesc
+	ch <- guestsByBootSourceDesc
+	ch <- guestRunningDesc
+	ch <- poolReplicasDesc
+	ch <- imagesDesc
+	ch <- kernelsDesc
+	ch <- snapshotsDesc
+	ch <- migrationsActiveDesc
+	ch <- gpuNodeGPUsDesc
+	ch <- gpuNodeInfoDesc
+	ch <- gpuNodeLastDiscoveryDesc
+	ch <- scheduleLastSuccessDesc
+}
+
+// Collect implements prometheus.Collector. Each type is collected
+// independently: a List error (cache not synced yet during startup) skips
+// that type's series for this scrape rather than failing the whole scrape.
+func (c *StateCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), collectTimeout)
+	defer cancel()
+
+	c.collectGuests(ctx, ch)
+	c.collectPools(ctx, ch)
+	c.collectImages(ctx, ch)
+	c.collectKernels(ctx, ch)
+	c.collectSnapshots(ctx, ch)
+	c.collectMigrations(ctx, ch)
+	c.collectGPUNodes(ctx, ch)
+	c.collectSchedules(ctx, ch)
+}
+
+func gauge(ch chan<- prometheus.Metric, desc *prometheus.Desc, v float64, labels ...string) {
+	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, labels...)
+}
+
+func (c *StateCollector) collectGuests(ctx context.Context, ch chan<- prometheus.Metric) {
+	var list swiftv1alpha1.SwiftGuestList
+	if err := c.reader.List(ctx, &list); err != nil {
+		return
+	}
+	// Zero-fill every phase for every namespace that has at least one guest,
+	// so `kubeswift_guests{phase="Failed"} > 0`-style alerts see an explicit
+	// 0 instead of an absent series.
+	byNSPhase := map[string]map[swiftv1alpha1.SwiftGuestPhase]int{}
+	byNode := map[[2]string]int{}
+	bySource := map[string]int{"image": 0, "kernel": 0, "clone": 0}
+	for i := range list.Items {
+		g := &list.Items[i]
+		if byNSPhase[g.Namespace] == nil {
+			byNSPhase[g.Namespace] = map[swiftv1alpha1.SwiftGuestPhase]int{}
+		}
+		byNSPhase[g.Namespace][g.Status.Phase]++
+
+		if g.Status.NodeName != "" {
+			hv := "unknown"
+			if g.Status.Runtime != nil && g.Status.Runtime.Hypervisor != "" {
+				hv = g.Status.Runtime.Hypervisor
+			}
+			byNode[[2]string{g.Status.NodeName, hv}]++
+		}
+
+		switch {
+		case g.UsesCloneFromSnapshot():
+			bySource["clone"]++
+		case g.Spec.KernelRef != nil:
+			bySource["kernel"]++
+		case g.Spec.ImageRef != nil:
+			bySource["image"]++
+		}
+	}
+	for ns, phases := range byNSPhase {
+		for _, p := range guestPhases {
+			gauge(ch, guestsDesc, float64(phases[p]), ns, string(p))
+		}
+		gauge(ch, guestRunningDesc, float64(phases[swiftv1alpha1.SwiftGuestPhaseRunning]), ns)
+	}
+	for k, n := range byNode {
+		gauge(ch, guestsByNodeDesc, float64(n), k[0], k[1])
+	}
+	for src, n := range bySource {
+		gauge(ch, guestsByBootSourceDesc, float64(n), src)
+	}
+}
+
+func (c *StateCollector) collectPools(ctx context.Context, ch chan<- prometheus.Metric) {
+	var list swiftv1alpha1.SwiftGuestPoolList
+	if err := c.reader.List(ctx, &list); err != nil {
+		return
+	}
+	for i := range list.Items {
+		p := &list.Items[i]
+		for state, v := range map[string]int32{
+			"desired":   p.Spec.Replicas,
+			"ready":     p.Status.ReadyReplicas,
+			"available": p.Status.AvailableReplicas,
+			"failed":    p.Status.FailedReplicas,
+			"updated":   p.Status.UpdatedReplicas,
+		} {
+			gauge(ch, poolReplicasDesc, float64(v), p.Namespace, p.Name, state)
+		}
+	}
+}
+
+func (c *StateCollector) collectImages(ctx context.Context, ch chan<- prometheus.Metric) {
+	var list imagev1alpha1.SwiftImageList
+	if err := c.reader.List(ctx, &list); err != nil {
+		return
+	}
+	byNSPhase := map[string]map[imagev1alpha1.SwiftImagePhase]int{}
+	for i := range list.Items {
+		img := &list.Items[i]
+		if byNSPhase[img.Namespace] == nil {
+			byNSPhase[img.Namespace] = map[imagev1alpha1.SwiftImagePhase]int{}
+		}
+		byNSPhase[img.Namespace][img.Status.Phase]++
+	}
+	for ns, phases := range byNSPhase {
+		for _, p := range imagePhases {
+			gauge(ch, imagesDesc, float64(phases[p]), ns, string(p))
+		}
+	}
+}
+
+func (c *StateCollector) collectKernels(ctx context.Context, ch chan<- prometheus.Metric) {
+	var list kernelv1alpha1.SwiftKernelList
+	if err := c.reader.List(ctx, &list); err != nil {
+		return
+	}
+	byPhase := map[kernelv1alpha1.SwiftKernelPhase]int{}
+	for i := range list.Items {
+		byPhase[list.Items[i].Status.Phase]++
+	}
+	for _, p := range kernelPhases {
+		gauge(ch, kernelsDesc, float64(byPhase[p]), string(p))
+	}
+}
+
+func (c *StateCollector) collectSnapshots(ctx context.Context, ch chan<- prometheus.Metric) {
+	var list snapshotv1alpha1.SwiftSnapshotList
+	if err := c.reader.List(ctx, &list); err != nil {
+		return
+	}
+	byNSPhase := map[string]map[snapshotv1alpha1.SwiftSnapshotPhase]int{}
+	for i := range list.Items {
+		s := &list.Items[i]
+		if byNSPhase[s.Namespace] == nil {
+			byNSPhase[s.Namespace] = map[snapshotv1alpha1.SwiftSnapshotPhase]int{}
+		}
+		byNSPhase[s.Namespace][s.Status.Phase]++
+	}
+	for ns, phases := range byNSPhase {
+		for _, p := range snapshotPhases {
+			gauge(ch, snapshotsDesc, float64(phases[p]), ns, string(p))
+		}
+	}
+}
+
+func (c *StateCollector) collectMigrations(ctx context.Context, ch chan<- prometheus.Metric) {
+	var list migrationv1alpha1.SwiftMigrationList
+	if err := c.reader.List(ctx, &list); err != nil {
+		return
+	}
+	// live/offline are always emitted (0 when idle); "auto" appears only for
+	// migrations the controller has not yet resolved (status.Mode empty).
+	byMode := map[string]int{"live": 0, "offline": 0}
+	for i := range list.Items {
+		m := &list.Items[i]
+		switch m.Status.Phase {
+		case migrationv1alpha1.SwiftMigrationPhaseCompleted,
+			migrationv1alpha1.SwiftMigrationPhaseFailed,
+			migrationv1alpha1.SwiftMigrationPhaseCancelled:
+			continue
+		}
+		mode := string(m.Status.Mode)
+		if mode == "" {
+			mode = string(m.Spec.Mode)
+		}
+		if mode == "" {
+			mode = string(migrationv1alpha1.SwiftMigrationModeAuto)
+		}
+		byMode[mode]++
+	}
+	for mode, n := range byMode {
+		gauge(ch, migrationsActiveDesc, float64(n), mode)
+	}
+}
+
+func (c *StateCollector) collectGPUNodes(ctx context.Context, ch chan<- prometheus.Metric) {
+	var list gpuv1alpha1.SwiftGPUNodeList
+	if err := c.reader.List(ctx, &list); err != nil {
+		return
+	}
+	for i := range list.Items {
+		n := &list.Items[i]
+		gauge(ch, gpuNodeGPUsDesc, float64(n.Status.GPUCount), n.Name, "total")
+		gauge(ch, gpuNodeGPUsDesc, float64(n.Status.FreeGPUs), n.Name, "free")
+		vfio := "false"
+		if n.Status.VfioReady {
+			vfio = "true"
+		}
+		gauge(ch, gpuNodeInfoDesc, 1, n.Name, n.Status.GPUModel, vfio)
+		if n.Status.LastDiscovery != nil {
+			gauge(ch, gpuNodeLastDiscoveryDesc, float64(n.Status.LastDiscovery.Unix()), n.Name)
+		}
+	}
+}
+
+func (c *StateCollector) collectSchedules(ctx context.Context, ch chan<- prometheus.Metric) {
+	var list snapshotv1alpha1.SwiftSnapshotScheduleList
+	if err := c.reader.List(ctx, &list); err != nil {
+		return
+	}
+	for i := range list.Items {
+		s := &list.Items[i]
+		if s.Status.LastSuccessfulTime != nil {
+			gauge(ch, scheduleLastSuccessDesc, float64(s.Status.LastSuccessfulTime.Unix()), s.Namespace, s.Name)
+		}
+	}
+}

--- a/internal/metrics/state_collector_test.go
+++ b/internal/metrics/state_collector_test.go
@@ -1,0 +1,208 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
+	imagev1alpha1 "github.com/projectbeskar/kubeswift/api/image/v1alpha1"
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	snapshotv1alpha1 "github.com/projectbeskar/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/scheme"
+)
+
+func guest(ns, name string, phase swiftv1alpha1.SwiftGuestPhase, node, hypervisor string) *swiftv1alpha1.SwiftGuest {
+	g := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef: &corev1.LocalObjectReference{Name: "img"},
+		},
+		Status: swiftv1alpha1.SwiftGuestStatus{Phase: phase, NodeName: node},
+	}
+	if hypervisor != "" {
+		g.Status.Runtime = &swiftv1alpha1.GuestRuntimeStatus{Hypervisor: hypervisor}
+	}
+	return g
+}
+
+func newStateReader(t *testing.T, objs ...client.Object) client.Reader {
+	t.Helper()
+	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).Build()
+}
+
+// TestStateCollector_GuestGauges proves the collector computes guest counts
+// from cluster state at scrape time — including the deprecated
+// kubeswift_guest_running_total alias — with per-namespace zero-fill for
+// every phase.
+func TestStateCollector_GuestGauges(t *testing.T) {
+	c := NewStateCollector(newStateReader(t,
+		guest("a", "g1", swiftv1alpha1.SwiftGuestPhaseRunning, "miles", "cloud-hypervisor"),
+		guest("a", "g2", swiftv1alpha1.SwiftGuestPhaseRunning, "boba", "qemu"),
+		guest("a", "g3", swiftv1alpha1.SwiftGuestPhaseFailed, "", ""),
+		guest("b", "g4", swiftv1alpha1.SwiftGuestPhasePending, "", ""),
+	))
+
+	expected := `
+# HELP kubeswift_guest_running_total DEPRECATED (use kubeswift_guests{phase="Running"}): Running SwiftGuests by namespace
+# TYPE kubeswift_guest_running_total gauge
+kubeswift_guest_running_total{namespace="a"} 2
+kubeswift_guest_running_total{namespace="b"} 0
+# HELP kubeswift_guests SwiftGuests by namespace and phase, computed from cluster state at scrape time
+# TYPE kubeswift_guests gauge
+kubeswift_guests{namespace="a",phase="Failed"} 1
+kubeswift_guests{namespace="a",phase="Pending"} 0
+kubeswift_guests{namespace="a",phase="Running"} 2
+kubeswift_guests{namespace="a",phase="Scheduling"} 0
+kubeswift_guests{namespace="a",phase="Stopped"} 0
+kubeswift_guests{namespace="b",phase="Failed"} 0
+kubeswift_guests{namespace="b",phase="Pending"} 1
+kubeswift_guests{namespace="b",phase="Running"} 0
+kubeswift_guests{namespace="b",phase="Scheduling"} 0
+kubeswift_guests{namespace="b",phase="Stopped"} 0
+# HELP kubeswift_guests_by_node Scheduled SwiftGuests by node and hypervisor
+# TYPE kubeswift_guests_by_node gauge
+kubeswift_guests_by_node{hypervisor="cloud-hypervisor",node="miles"} 1
+kubeswift_guests_by_node{hypervisor="qemu",node="boba"} 1
+`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected),
+		"kubeswift_guests", "kubeswift_guests_by_node", "kubeswift_guest_running_total"); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestStateCollector_SurvivesRestart is the restart-drift contract test. The
+// pre-O2 implementation accumulated kubeswift_guest_running_total with
+// Inc/Dec on phase transitions; a controller restart reset the accumulator
+// to 0 while the cluster still had Running guests — the gauge silently
+// reported 0 (Design Principle #6 violation). The collector computes from
+// state, so a brand-new instance (= restarted controller) over the same
+// cluster reports identical values with NO transitions ever observed.
+func TestStateCollector_SurvivesRestart(t *testing.T) {
+	reader := newStateReader(t,
+		guest("prod", "g1", swiftv1alpha1.SwiftGuestPhaseRunning, "miles", "cloud-hypervisor"),
+		guest("prod", "g2", swiftv1alpha1.SwiftGuestPhaseRunning, "boba", "cloud-hypervisor"),
+	)
+
+	first := NewStateCollector(reader)
+	if got := testutil.CollectAndCount(first, "kubeswift_guest_running_total"); got != 1 {
+		t.Fatalf("first collector: %d running_total series, want 1", got)
+	}
+
+	// "Restart": a fresh collector with zero observed history.
+	restarted := NewStateCollector(reader)
+	expected := `
+# HELP kubeswift_guest_running_total DEPRECATED (use kubeswift_guests{phase="Running"}): Running SwiftGuests by namespace
+# TYPE kubeswift_guest_running_total gauge
+kubeswift_guest_running_total{namespace="prod"} 2
+`
+	if err := testutil.CollectAndCompare(restarted, strings.NewReader(expected),
+		"kubeswift_guest_running_total"); err != nil {
+		t.Errorf("post-restart collector must report cluster state, not accumulated transitions: %v", err)
+	}
+}
+
+func TestStateCollector_PoolsImagesMigrationsGPU(t *testing.T) {
+	lastDiscovery := metav1.Unix(1700000000, 0)
+	lastSuccess := metav1.Unix(1700000100, 0)
+	c := NewStateCollector(newStateReader(t,
+		&swiftv1alpha1.SwiftGuestPool{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "a", Name: "pool1"},
+			Spec:       swiftv1alpha1.SwiftGuestPoolSpec{Replicas: 3},
+			Status:     swiftv1alpha1.SwiftGuestPoolStatus{ReadyReplicas: 2, AvailableReplicas: 2, FailedReplicas: 1, UpdatedReplicas: 3},
+		},
+		&imagev1alpha1.SwiftImage{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "a", Name: "img1"},
+			Status:     imagev1alpha1.SwiftImageStatus{Phase: imagev1alpha1.SwiftImagePhaseImporting},
+		},
+		&migrationv1alpha1.SwiftMigration{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "a", Name: "m-live"},
+			Status:     migrationv1alpha1.SwiftMigrationStatus{Phase: migrationv1alpha1.SwiftMigrationPhaseStopAndCopy, Mode: migrationv1alpha1.SwiftMigrationModeLive},
+		},
+		&migrationv1alpha1.SwiftMigration{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "a", Name: "m-done"},
+			Status:     migrationv1alpha1.SwiftMigrationStatus{Phase: migrationv1alpha1.SwiftMigrationPhaseCompleted, Mode: migrationv1alpha1.SwiftMigrationModeLive},
+		},
+		&gpuv1alpha1.SwiftGPUNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "boba"},
+			Status: gpuv1alpha1.SwiftGPUNodeStatus{
+				GPUCount: 1, FreeGPUs: 1, GPUModel: "GTX 1080", VfioReady: true,
+				LastDiscovery: &lastDiscovery,
+			},
+		},
+		&snapshotv1alpha1.SwiftSnapshotSchedule{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "a", Name: "nightly"},
+			Status:     snapshotv1alpha1.SwiftSnapshotScheduleStatus{LastSuccessfulTime: &lastSuccess},
+		},
+	))
+
+	expected := `
+# HELP kubeswift_gpu_node_gpus GPUs per SwiftGPUNode by state (total|free)
+# TYPE kubeswift_gpu_node_gpus gauge
+kubeswift_gpu_node_gpus{node="boba",state="free"} 1
+kubeswift_gpu_node_gpus{node="boba",state="total"} 1
+# HELP kubeswift_gpu_node_info SwiftGPUNode inventory info (value is always 1)
+# TYPE kubeswift_gpu_node_info gauge
+kubeswift_gpu_node_info{model="GTX 1080",node="boba",vfio_ready="true"} 1
+# HELP kubeswift_gpu_node_last_discovery_timestamp_seconds Unix time of the last successful GPU discovery per node
+# TYPE kubeswift_gpu_node_last_discovery_timestamp_seconds gauge
+kubeswift_gpu_node_last_discovery_timestamp_seconds{node="boba"} 1.7e+09
+# HELP kubeswift_migrations_active In-flight (non-terminal) SwiftMigrations by mode
+# TYPE kubeswift_migrations_active gauge
+kubeswift_migrations_active{mode="live"} 1
+kubeswift_migrations_active{mode="offline"} 0
+# HELP kubeswift_pool_replicas SwiftGuestPool replica counts by state (desired|ready|available|failed|updated)
+# TYPE kubeswift_pool_replicas gauge
+kubeswift_pool_replicas{namespace="a",pool="pool1",state="available"} 2
+kubeswift_pool_replicas{namespace="a",pool="pool1",state="desired"} 3
+kubeswift_pool_replicas{namespace="a",pool="pool1",state="failed"} 1
+kubeswift_pool_replicas{namespace="a",pool="pool1",state="ready"} 2
+kubeswift_pool_replicas{namespace="a",pool="pool1",state="updated"} 3
+# HELP kubeswift_snapshot_schedule_last_success_timestamp_seconds Unix time a SwiftSnapshotSchedule's snapshot last reached Ready
+# TYPE kubeswift_snapshot_schedule_last_success_timestamp_seconds gauge
+kubeswift_snapshot_schedule_last_success_timestamp_seconds{namespace="a",schedule="nightly"} 1.7000001e+09
+# HELP kubeswift_images SwiftImages by namespace and phase
+# TYPE kubeswift_images gauge
+kubeswift_images{namespace="a",phase="Failed"} 0
+kubeswift_images{namespace="a",phase="Importing"} 1
+kubeswift_images{namespace="a",phase="Pending"} 0
+kubeswift_images{namespace="a",phase="Preparing"} 0
+kubeswift_images{namespace="a",phase="Ready"} 0
+kubeswift_images{namespace="a",phase="Snapshotting"} 0
+kubeswift_images{namespace="a",phase="Validating"} 0
+`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected),
+		"kubeswift_pool_replicas", "kubeswift_images", "kubeswift_migrations_active",
+		"kubeswift_gpu_node_gpus", "kubeswift_gpu_node_info",
+		"kubeswift_gpu_node_last_discovery_timestamp_seconds",
+		"kubeswift_snapshot_schedule_last_success_timestamp_seconds"); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestStateCollector_Lint keeps the exported series within Prometheus
+// naming/label conventions.
+func TestStateCollector_Lint(t *testing.T) {
+	c := NewStateCollector(newStateReader(t,
+		guest("a", "g1", swiftv1alpha1.SwiftGuestPhaseRunning, "miles", "cloud-hypervisor"),
+	))
+	problems, err := testutil.CollectAndLint(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range problems {
+		// The deprecated alias keeps its historical (lint-violating) name —
+		// a gauge with a _total suffix — until removal; everything else
+		// must lint clean. Drop this carve-out together with the alias.
+		if p.Metric == "kubeswift_guest_running_total" {
+			continue
+		}
+		t.Errorf("lint: %s: %s", p.Metric, p.Text)
+	}
+}


### PR DESCRIPTION
## Summary

Phase O2 of the observability program ([design doc](https://github.com/projectbeskar/kubeswift/blob/main/docs/design/observability.md), D1 + §1.5): CR-state gauges for every feature arc, computed from the informer cache at scrape time — plus fixes for the two latent metric defects the architect review found.

## New series (all bounded-label aggregates)

| Series | Answers |
|---|---|
| `kubeswift_guests{namespace,phase}` | how many guests, in what state (zero-filled per namespace → `phase="Failed" > 0` alerts work) |
| `kubeswift_guests_by_node{node,hypervisor}` | where, CH vs QEMU |
| `kubeswift_guests_by_boot_source{source}` | image / kernel / clone mix |
| `kubeswift_pool_replicas{namespace,pool,state}` | desired vs ready vs failed per pool |
| `kubeswift_images{namespace,phase}` / `kubeswift_kernels{phase}` / `kubeswift_snapshots{namespace,phase}` | stuck imports/pulls/captures |
| `kubeswift_migrations_active{mode}` | in-flight migrations |
| `kubeswift_gpu_node_gpus{node,state}` + `_info` + `_last_discovery_timestamp_seconds` | GPU capacity/free, vfioReady, discovery staleness |
| `kubeswift_snapshot_schedule_last_success_timestamp_seconds` | schedule staleness |

## Defect fixes
1. **Restart drift**: `kubeswift_guest_running_total` was an Inc/Dec transition gauge — controller restart reset it to 0 (negative after a pre-restart guest stopped). Now emitted from cluster state, **deprecated** in favor of `kubeswift_guests{phase="Running"}`, kept one release. `TestStateCollector_SurvivesRestart` is the contract test.
2. **Unbounded cardinality**: `vm_failures_total{reason}` carried condition free-text *Messages* (pod/node names). Now the bounded condition *Reason* token from the first non-True condition; regression test asserts message text can't leak into labels.

## Validation
- Unit: collector compare-tests (guests/pools/images/migrations/GPU/schedule), restart contract, prom lint (legacy alias carved out until removal), reason-label regression. `go test ./...` green.
- Cluster (post-merge): deploy the main image to the lab → guests Running → `kubectl rollout restart` controller-manager → gauges re-converge to true counts (current code provably reports 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)