### PR TITLE
feat(metrics): GPU allocation/release + drain evacuation counters (observability O3 PR 4)

### DIFF
--- a/internal/controller/swiftdrain/controller.go
+++ b/internal/controller/swiftdrain/controller.go
@@ -34,6 +34,7 @@ import (
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
 )
 
 // drainMigrationTTL is the spec.ttl set on drain-created SwiftMigrations so a
@@ -178,8 +179,13 @@ func (r *Reconciler) createDrainMigration(ctx context.Context, guest *swiftv1alp
 		if apierrors.IsAlreadyExists(err) {
 			return nil // raced with another reconcile; next loop observes it
 		}
+		// Webhook rejections land here too — a sustained error rate means
+		// drains are stalling. Migration OUTCOMES are not counted here;
+		// they land in kubeswift_migration_total (reason=node-drain).
+		metrics.DrainMigrationsTotal.WithLabelValues(drainPolicyOf(guest), "error").Inc()
 		return fmt.Errorf("create drain migration %q: %w", migName, err)
 	}
+	metrics.DrainMigrationsTotal.WithLabelValues(drainPolicyOf(guest), "created").Inc()
 	r.event(guest, corev1.EventTypeNormal, "DrainMigrationCreated",
 		fmt.Sprintf("created migration %q (mode %s) to evacuate %q from %q to %q", migName, mode, guest.Name, drainingNode, target))
 	return nil

--- a/internal/controller/swiftdrain/metrics_test.go
+++ b/internal/controller/swiftdrain/metrics_test.go
@@ -1,0 +1,33 @@
+package swiftdrain
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/projectbeskar/kubeswift/internal/metrics"
+)
+
+// TestReconcile_CreatesMigration_CountsDrainMetric: the O3 drain counter
+// fires once per created drain migration, labelled with the guest's
+// drainPolicy. The in-flight duplicate guard means a second reconcile must
+// not re-count.
+func TestReconcile_CreatesMigration_CountsDrainMetric(t *testing.T) {
+	r, c := newR(guest("mg", drain("miles"), statusNode("miles")), node("miles"), node("boba"), smallClass())
+
+	before := testutil.ToFloat64(metrics.DrainMigrationsTotal.WithLabelValues("Migrate", "created"))
+	reconcileGuest(t, r, "mg")
+	if got := testutil.ToFloat64(metrics.DrainMigrationsTotal.WithLabelValues("Migrate", "created")); got != before+1 {
+		t.Errorf("drain_migrations_total{policy=Migrate,result=created} = %v, want %v", got, before+1)
+	}
+	if migs := listMigs(t, c); len(migs) != 1 {
+		t.Fatalf("expected 1 migration; got %d", len(migs))
+	}
+
+	// Second reconcile observes the in-flight migration — no new create, no
+	// re-count.
+	reconcileGuest(t, r, "mg")
+	if got := testutil.ToFloat64(metrics.DrainMigrationsTotal.WithLabelValues("Migrate", "created")); got != before+1 {
+		t.Errorf("in-flight duplicate guard must not re-count; got %v, want %v", got, before+1)
+	}
+}

--- a/internal/controller/swiftgpu/controller.go
+++ b/internal/controller/swiftgpu/controller.go
@@ -17,6 +17,7 @@ import (
 
 	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
 )
 
 const (
@@ -102,6 +103,11 @@ func (r *SwiftGPUReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if err == errNoCapacity {
 			logger.Info("no GPU capacity available, will retry", "guest", req.NamespacedName,
 				"count", profile.Spec.Count, "model", profile.Spec.Model)
+			// Transition-gated: count entering the NoCapacity state once, not
+			// every 30s retry tick while capacity stays exhausted.
+			if !hasGPUAllocatedReason(&guest, "NoCapacity") {
+				metrics.GPUAllocationsTotal.WithLabelValues("no_capacity").Inc()
+			}
 			status := guest.Status.DeepCopy()
 			setGPUAllocatedCondition(status, false, "NoCapacity",
 				"no SwiftGPUNode has sufficient free GPUs matching the profile")
@@ -136,6 +142,10 @@ func (r *SwiftGPUReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 	setGPUAllocatedCondition(status, true, "Allocated",
 		fmt.Sprintf("allocated %d GPU(s) on node %s", len(devices), gpuNode.Name))
+	// At most once per successful allocation: the isGPUAllocated early return
+	// above means this path only runs while the condition is not yet True (a
+	// status-patch-failure retry may rarely re-count — acceptable).
+	metrics.GPUAllocationsTotal.WithLabelValues("allocated").Inc()
 	if err := r.patchStatus(ctx, &guest, status); err != nil {
 		// GPUs are already marked on the node. The finalizer ensures deallocation
 		// will be attempted. On the next reconcile, findAndAllocate will detect the

--- a/internal/controller/swiftgpu/metrics_test.go
+++ b/internal/controller/swiftgpu/metrics_test.go
@@ -1,0 +1,59 @@
+package swiftgpu
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
+)
+
+// TestReleaseFromNode_CountsOnlyChangedReleases guards the O3 release
+// counter: a release that frees devices increments gpu_releases_total once;
+// the idempotent no-op re-release must not count (deallocateGPUs calls
+// ReleaseFromNode for EVERY SwiftGPUNode on every finalizer reconcile).
+func TestReleaseFromNode_CountsOnlyChangedReleases(t *testing.T) {
+	g := gpuGuest("metrics-g")
+	c := newClient(gpuNodeWithDevices("boba", true, dev(0, "0000:01:00.0", 0)), g)
+
+	if _, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "boba"); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+
+	before := testutil.ToFloat64(metrics.GPUReleasesTotal)
+	if err := ReleaseFromNode(context.Background(), c, g, "boba"); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if got := testutil.ToFloat64(metrics.GPUReleasesTotal); got != before+1 {
+		t.Errorf("gpu_releases_total = %v, want %v after a freeing release", got, before+1)
+	}
+
+	// Idempotent re-release: nothing left to free, counter must not move.
+	if err := ReleaseFromNode(context.Background(), c, g, "boba"); err != nil {
+		t.Fatalf("no-op release: %v", err)
+	}
+	if got := testutil.ToFloat64(metrics.GPUReleasesTotal); got != before+1 {
+		t.Errorf("no-op release must not count; gpu_releases_total = %v, want %v", got, before+1)
+	}
+}
+
+// TestHasGPUAllocatedReason covers the transition gate that keeps the
+// no_capacity counter from re-counting on every 30s retry tick.
+func TestHasGPUAllocatedReason(t *testing.T) {
+	g := gpuGuest("gate-g")
+	if hasGPUAllocatedReason(g, "NoCapacity") {
+		t.Error("no condition at all must not match")
+	}
+	g.Status.Conditions = []metav1.Condition{{
+		Type: swiftv1alpha1.ConditionGPUAllocated, Status: metav1.ConditionFalse, Reason: "NoCapacity",
+	}}
+	if !hasGPUAllocatedReason(g, "NoCapacity") {
+		t.Error("existing NoCapacity reason must match (gate suppresses re-count)")
+	}
+	if hasGPUAllocatedReason(g, "Allocated") {
+		t.Error("different reason must not match")
+	}
+}

--- a/internal/controller/swiftgpu/primitives.go
+++ b/internal/controller/swiftgpu/primitives.go
@@ -10,6 +10,7 @@ import (
 
 	gpuv1alpha1 "github.com/projectbeskar/kubeswift/api/gpu/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
 )
 
 // ReserveOnNode reserves profile.Count GPUs (+ an FM partition for shared
@@ -145,5 +146,11 @@ func ReleaseFromNode(ctx context.Context, c client.Client, guest *swiftv1alpha1.
 		return nil
 	}
 	node.Status.FreeGPUs = countFreeGPUs(node.Status.GPUs)
-	return c.Status().Update(ctx, &node)
+	if err := c.Status().Update(ctx, &node); err != nil {
+		return err
+	}
+	// Count only releases that actually freed something (the !changed
+	// early-return above keeps idempotent no-op releases out).
+	metrics.GPUReleasesTotal.Inc()
+	return nil
 }

--- a/internal/controller/swiftgpu/status.go
+++ b/internal/controller/swiftgpu/status.go
@@ -16,6 +16,18 @@ func isGPUAllocated(guest *swiftv1alpha1.SwiftGuest) bool {
 	return false
 }
 
+// hasGPUAllocatedReason returns true when the guest's GPUAllocated condition
+// already carries the given reason — the transition gate for state-entry
+// counters (count once per entry, not per retry tick).
+func hasGPUAllocatedReason(guest *swiftv1alpha1.SwiftGuest, reason string) bool {
+	for _, c := range guest.Status.Conditions {
+		if c.Type == swiftv1alpha1.ConditionGPUAllocated {
+			return c.Reason == reason
+		}
+	}
+	return false
+}
+
 // setGPUAllocatedCondition upserts the GPUAllocated condition on status.
 func setGPUAllocatedCondition(status *swiftv1alpha1.SwiftGuestStatus, ok bool, reason, message string) {
 	s := metav1.ConditionFalse

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -217,6 +217,45 @@ var (
 			Help: "Snapshots deleted by SwiftSnapshotSchedule keep-N retention",
 		},
 	)
+
+	// --- GPU + drain counters (observability Phase O3) ---
+
+	// GPUAllocationsTotal counts GPU allocation outcomes per guest:
+	// "allocated" fires once when the allocation is stamped into guest
+	// status; "no_capacity" fires once per entry into the NoCapacity state
+	// (transition-gated — the 30s retry loop while capacity stays exhausted
+	// does not re-count).
+	GPUAllocationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubeswift_gpu_allocations_total",
+			Help: "GPU allocation outcomes (allocated | no_capacity), once per guest state entry",
+		},
+		[]string{"result"},
+	)
+
+	// GPUReleasesTotal counts release operations that actually freed at
+	// least one GPU device or FM partition on a SwiftGPUNode (idempotent
+	// no-op releases are not counted). Fires for guest deletion, failed
+	// allocations cleaned up by the finalizer, and migration
+	// release-and-reallocate.
+	GPUReleasesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "kubeswift_gpu_releases_total",
+			Help: "GPU release operations that freed devices or FM partitions on a node",
+		},
+	)
+
+	// DrainMigrationsTotal counts SwiftMigrations created by the drain
+	// controller to evacuate guests from draining nodes, by the guest's
+	// drainPolicy and the creation result. Migration outcomes land in
+	// kubeswift_migration_total (drain migrations carry reason=node-drain).
+	DrainMigrationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubeswift_drain_migrations_total",
+			Help: "SwiftMigrations created by node-drain evacuation, by drainPolicy and result (created | error)",
+		},
+		[]string{"policy", "result"},
+	)
 )
 
 // cloneDownloadObserved dedupes the per-(node,snapshot) clone download byte
@@ -251,5 +290,8 @@ func init() {
 		SnapshotUploadBytesTotal,
 		RestoreDownloadBytesTotal,
 		SnapshotSchedulePrunedTotal,
+		GPUAllocationsTotal,
+		GPUReleasesTotal,
+		DrainMigrationsTotal,
 	)
 }


### PR DESCRIPTION
## Summary

Phase O3 PR 4 ([design doc](https://github.com/projectbeskar/kubeswift/blob/main/docs/design/observability.md)): counters for the two arcs the review found completely metric-less — GPU and drain.

## New counters
- **`kubeswift_gpu_allocations_total{result}`** — `allocated` once per successful allocation; `no_capacity` **transition-gated** on the GPUAllocated condition reason (the 30s retry loop while capacity stays exhausted counts the state entry, not every tick).
- **`kubeswift_gpu_releases_total`** — recorded inside `ReleaseFromNode` behind the existing `!changed` early-return, so the finalizer's all-nodes release sweep stays a non-counting no-op. Covers guest deletion and migration release-and-reallocate.
- **`kubeswift_drain_migrations_total{policy,result}`** — drain-created evacuations by drainPolicy; `result=created|error` (sustained error rate = stalling drains). Migration outcomes stay in `kubeswift_migration_total`.

## Tests
- Release counts once; idempotent re-release doesn't count.
- `no_capacity` transition gate unit-tested.
- Drain create counts once; the in-flight duplicate guard doesn't re-count.

Cluster validation: rides the O3 PR 5 validation pass (GTX 1080 alloc/release cycle on boba) — same deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)