### PR TITLE
feat(metrics): image-import outcome counter + migration failure-reason breakdown (observability O3 PR 5)

### DIFF
--- a/internal/controller/swiftimage/controller.go
+++ b/internal/controller/swiftimage/controller.go
@@ -192,6 +192,17 @@ func (r *SwiftImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	// ImageImportTotal (observability O3): count the import's terminal
+	// outcome. The Ready/Failed starting-phase cases return early above, so
+	// reaching here with a terminal status.Phase is always a fresh
+	// non-terminal -> terminal transition — no separate guard needed.
+	switch status.Phase {
+	case imagev1alpha1.SwiftImagePhaseReady:
+		metrics.ImageImportTotal.WithLabelValues(img.Namespace, "ready").Inc()
+	case imagev1alpha1.SwiftImagePhaseFailed:
+		metrics.ImageImportTotal.WithLabelValues(img.Namespace, "failed").Inc()
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/swiftimage/metrics_test.go
+++ b/internal/controller/swiftimage/metrics_test.go
@@ -1,0 +1,57 @@
+package swiftimage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	imagev1alpha1 "github.com/projectbeskar/kubeswift/api/image/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/metrics"
+)
+
+// TestReconcile_FailedImport_CountsImageImportTotal proves the O3 import
+// outcome counter fires on a failed import — the case that was invisible
+// before O3 (only the success-latency histogram existed). A no-source
+// SwiftImage fails in StartImport, drives the reconcile to phase=Failed, and
+// must increment image_import_total{result="failed"}.
+func TestReconcile_FailedImport_CountsImageImportTotal(t *testing.T) {
+	scheme := testScheme()
+	img := &imagev1alpha1.SwiftImage{
+		ObjectMeta: metav1.ObjectMeta{Name: "badimg", Namespace: "imgns"},
+		Spec: imagev1alpha1.SwiftImageSpec{
+			Format: imagev1alpha1.DiskFormatRaw,
+			Source: imagev1alpha1.ImageSource{}, // no source -> Failed
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&imagev1alpha1.SwiftImage{}).
+		WithObjects(img).Build()
+	r := &SwiftImageReconciler{Client: client, Scheme: scheme}
+
+	before := testutil.ToFloat64(metrics.ImageImportTotal.WithLabelValues("imgns", "failed"))
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "badimg", Namespace: "imgns"},
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got := testutil.ToFloat64(metrics.ImageImportTotal.WithLabelValues("imgns", "failed")); got != before+1 {
+		t.Errorf("image_import_total{failed} = %v, want %v", got, before+1)
+	}
+
+	// Re-reconcile a terminal (Failed) image: the Ready/Failed switch case
+	// returns early, so the counter must NOT move.
+	stable := testutil.ToFloat64(metrics.ImageImportTotal.WithLabelValues("imgns", "failed"))
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "badimg", Namespace: "imgns"},
+	}); err != nil {
+		t.Fatalf("re-reconcile: %v", err)
+	}
+	if got := testutil.ToFloat64(metrics.ImageImportTotal.WithLabelValues("imgns", "failed")); got != stable {
+		t.Errorf("terminal-image re-reconcile must not re-count; %v -> %v", stable, got)
+	}
+}

--- a/internal/controller/swiftmigration/controller.go
+++ b/internal/controller/swiftmigration/controller.go
@@ -489,6 +489,15 @@ func recordMigrationTerminal(status *migrationv1alpha1.SwiftMigrationStatus) {
 		return
 	}
 	metrics.MigrationTotal.WithLabelValues(mode, result).Inc()
+	if status.Phase == migrationv1alpha1.SwiftMigrationPhaseFailed {
+		// Break failures down by the bounded failureReason enum. Offline
+		// mode does not populate it -> "Unknown".
+		reason := string(status.FailureReason)
+		if reason == "" {
+			reason = "Unknown"
+		}
+		metrics.MigrationFailuresTotal.WithLabelValues(mode, reason).Inc()
+	}
 	if status.Phase == migrationv1alpha1.SwiftMigrationPhaseCompleted && status.ObservedDowntime != nil {
 		metrics.MigrationDowntimeSeconds.WithLabelValues(mode).Observe(status.ObservedDowntime.Duration.Seconds())
 	}

--- a/internal/controller/swiftmigration/controller_metrics_test.go
+++ b/internal/controller/swiftmigration/controller_metrics_test.go
@@ -33,6 +33,39 @@ func TestRecordMigrationTerminal_CounterByModeAndResult(t *testing.T) {
 	}
 }
 
+func TestRecordMigrationTerminal_FailuresByReason(t *testing.T) {
+	// A failed migration breaks down by the bounded failureReason enum.
+	before := testutil.ToFloat64(metrics.MigrationFailuresTotal.WithLabelValues("live", "DstNeverReady"))
+	recordMigrationTerminal(&migrationv1alpha1.SwiftMigrationStatus{
+		Mode:          migrationv1alpha1.SwiftMigrationModeLive,
+		Phase:         migrationv1alpha1.SwiftMigrationPhaseFailed,
+		FailureReason: migrationv1alpha1.FailureReasonDstNeverReady,
+	})
+	if got := testutil.ToFloat64(metrics.MigrationFailuresTotal.WithLabelValues("live", "DstNeverReady")); got != before+1 {
+		t.Errorf("MigrationFailuresTotal{live,DstNeverReady} = %v, want %v", got, before+1)
+	}
+
+	// Offline mode does not populate failureReason -> "Unknown".
+	ub := testutil.ToFloat64(metrics.MigrationFailuresTotal.WithLabelValues("offline", "Unknown"))
+	recordMigrationTerminal(&migrationv1alpha1.SwiftMigrationStatus{
+		Mode:  migrationv1alpha1.SwiftMigrationModeOffline,
+		Phase: migrationv1alpha1.SwiftMigrationPhaseFailed,
+	})
+	if got := testutil.ToFloat64(metrics.MigrationFailuresTotal.WithLabelValues("offline", "Unknown")); got != ub+1 {
+		t.Errorf("MigrationFailuresTotal{offline,Unknown} = %v, want %v", got, ub+1)
+	}
+
+	// A completed migration must NOT touch the failures counter.
+	cb := testutil.ToFloat64(metrics.MigrationFailuresTotal.WithLabelValues("live", "Unknown"))
+	recordMigrationTerminal(&migrationv1alpha1.SwiftMigrationStatus{
+		Mode:  migrationv1alpha1.SwiftMigrationModeLive,
+		Phase: migrationv1alpha1.SwiftMigrationPhaseCompleted,
+	})
+	if got := testutil.ToFloat64(metrics.MigrationFailuresTotal.WithLabelValues("live", "Unknown")); got != cb {
+		t.Errorf("a completed migration must not increment failures; %v -> %v", cb, got)
+	}
+}
+
 func TestRecordMigrationTerminal_DowntimeOnlyOnCompleted(t *testing.T) {
 	before := testutil.CollectAndCount(metrics.MigrationDowntimeSeconds)
 	// A failed migration must NOT observe downtime.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -58,6 +58,19 @@ var (
 		[]string{"namespace"},
 	)
 
+	// ImageImportTotal counts SwiftImage imports by terminal result
+	// (ready|failed), once per image on the transition into Ready or Failed.
+	// Before O3 a failed import was invisible — only the success-latency
+	// histogram existed. Recorded behind a transition guard so a re-reconcile
+	// of a terminal image does not re-count.
+	ImageImportTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubeswift_image_import_total",
+			Help: "SwiftImage imports that reached a terminal phase, by result (ready|failed)",
+		},
+		[]string{"namespace", "result"},
+	)
+
 	// MigrationTotal counts SwiftMigrations that reached a terminal phase,
 	// labelled by resolved mode (live/offline) and result
 	// (completed/failed/cancelled). Recorded once per migration on the
@@ -68,6 +81,20 @@ var (
 			Help: "Total SwiftMigrations that reached a terminal phase, by mode and result",
 		},
 		[]string{"mode", "result"},
+	)
+
+	// MigrationFailuresTotal counts failed SwiftMigrations by mode and the
+	// bounded status.failureReason enum (Cancelled/PodTerminated/Timeout/
+	// DstScheduleFailed/...). A sibling of MigrationTotal{result="failed"}:
+	// that series stays for the overall failed rate; this one breaks the
+	// failures down by cause without widening MigrationTotal's labels.
+	// reason="" maps to "Unknown" (offline mode does not populate the enum).
+	MigrationFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubeswift_migration_failures_total",
+			Help: "Failed SwiftMigrations by mode and failureReason",
+		},
+		[]string{"mode", "reason"},
 	)
 
 	// MigrationDowntimeSeconds observes status.observedDowntime for completed
@@ -277,6 +304,7 @@ func init() {
 		VMFailuresTotal,
 		ImageImportSeconds,
 		MigrationTotal,
+		MigrationFailuresTotal,
 		MigrationDowntimeSeconds,
 		MigrationTransferSeconds,
 		SnapshotTotal,
@@ -293,5 +321,6 @@ func init() {
 		GPUAllocationsTotal,
 		GPUReleasesTotal,
 		DrainMigrationsTotal,
+		ImageImportTotal,
 	)
 }


### PR DESCRIPTION
## Summary

Phase O3 PR 5 ([design doc](https://github.com/projectbeskar/kubeswift/blob/main/docs/design/observability.md)). The schedule-staleness gauge this phase also planned already landed in O2's collector, so PR 5 is these two:

- **`kubeswift_image_import_total{namespace,result}`** — imports by terminal result (`ready|failed`). A **failed import was previously invisible** (only the success-latency histogram existed). Recorded at the single status-write site; the Ready/Failed starting cases return early so a terminal phase there is always a fresh transition. Tested: no-source image → `failed`; terminal re-reconcile doesn't re-count.
- **`kubeswift_migration_failures_total{mode,reason}`** — failed migrations by the **bounded** `status.failureReason` enum (`DstNeverReady`/`PodTerminated`/`Timeout`/…). A sibling of `migration_total{result="failed"}` (kept for the overall rate) — does **not** widen `migration_total`'s labels. Offline mode → `reason="Unknown"`. Typed `FailureReasonCode`, so no cardinality risk.

## Validation
- Unit: import failure counter + terminal-no-recount; migration failure-by-reason + offline→Unknown + completed-doesn't-count. `go test ./...` green, gofmt clean.
- Cluster: rides the O3 validation pass on the lab (bad-URL image → `failed` increments; a failed migration → the reason breakdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)