### PR TITLE
feat(monitoring): PrometheusRule alert pack + observability runbook (observability O4 PR 8)

### DIFF
--- a/charts/kubeswift/templates/monitoring/prometheusrule.yaml
+++ b/charts/kubeswift/templates/monitoring/prometheusrule.yaml
@@ -1,0 +1,155 @@
+{{- /*
+Nil-safe access (see servicemonitor.yaml): nested keys may be absent under
+`--reuse-values --set monitoring.enabled=true`; explicit `enabled: false`
+must still win (ternary/hasKey, not sprig `default`).
+*/ -}}
+{{- $mon := .Values.monitoring | default dict }}
+{{- $pr := $mon.prometheusRule | default dict }}
+{{- if and $mon.enabled (ternary $pr.enabled true (hasKey $pr "enabled")) }}
+{{- $job := "kubeswift-controller-manager.*" }}
+# Starter alert pack (observability design doc D4). Warning-biased; each rule
+# carries a runbook_url into docs/observability/alerts.md. Certificate expiry
+# is deliberately NOT covered here — cert-manager owns
+# certmanager_certificate_expiration_timestamp_seconds (minimalism).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kubeswift
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: alerts
+    {{- with $pr.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: kubeswift.control-plane
+      rules:
+        - alert: KubeSwiftControllerDown
+          expr: |
+            absent(up{job=~"{{ $job }}"} == 1)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: KubeSwift controller-manager is not being scraped / is down
+            description: No healthy controller-manager scrape target for 5m. VM reconciliation, status reporting, and admission are unavailable.
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftcontrollerdown
+        - alert: KubeSwiftReconcileErrorsHigh
+          expr: |
+            sum by (controller) (rate(controller_runtime_reconcile_errors_total[5m]))
+              / clamp_min(sum by (controller) (rate(controller_runtime_reconcile_total[5m])), 0.001) > 0.1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Controller {{`{{ $labels.controller }}`}} reconcile error ratio > 10%"
+            description: "{{`{{ $labels.controller }}`}} has been erroring on >10% of reconciles for 15m."
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftreconcileerrorshigh
+        - alert: KubeSwiftWebhookRejectionSpike
+          expr: |
+            sum(rate(controller_runtime_webhook_requests_total{code!~"2.."}[5m])) > 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: KubeSwift admission webhooks are rejecting requests at a high rate
+            description: Sustained webhook rejections (>1/s for 15m). Could be a bad manifest loop, a stalling drain (eviction 429s), or a misconfiguration.
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftwebhookrejectionspike
+    - name: kubeswift.guests
+      rules:
+        - alert: KubeSwiftGuestsFailed
+          expr: |
+            sum by (namespace) (kubeswift_guests{phase="Failed"}) > 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SwiftGuests in Failed phase in {{`{{ $labels.namespace }}`}}"
+            description: "{{`{{ $value }}`}} SwiftGuest(s) have been Failed for 10m in namespace {{`{{ $labels.namespace }}`}}."
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftguestsfailed
+        - alert: KubeSwiftGuestStuckPending
+          expr: |
+            sum by (namespace) (kubeswift_guests{phase=~"Pending|Scheduling"}) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SwiftGuests stuck Pending/Scheduling in {{`{{ $labels.namespace }}`}}"
+            description: "{{`{{ $value }}`}} SwiftGuest(s) have not progressed past Pending/Scheduling for 15m (no capacity, image not Ready, or scheduling blocked)."
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftgueststuckpending
+        - alert: KubeSwiftGuestCrashLooping
+          expr: |
+            sum by (namespace) (rate(kubeswift_vm_failures_total[15m])) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SwiftGuests failing repeatedly in {{`{{ $labels.namespace }}`}}"
+            description: "Sustained VM failure rate for 15m in {{`{{ $labels.namespace }}`}} — a guest is likely crash-looping."
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftguestcrashlooping
+        - alert: KubeSwiftPoolDegraded
+          expr: |
+            (kubeswift_pool_replicas{state="ready"} < on (namespace, pool) kubeswift_pool_replicas{state="desired"})
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SwiftGuestPool {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pool }}`}} degraded"
+            description: "Ready replicas below desired for 15m."
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftpooldegraded
+    - name: kubeswift.images-migration
+      rules:
+        - alert: KubeSwiftImageImportStuck
+          expr: |
+            sum by (namespace) (kubeswift_images{phase=~"Importing|Validating|Preparing|Snapshotting"}) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SwiftImage import stuck in {{`{{ $labels.namespace }}`}}"
+            description: "An image import has been non-terminal for 30m (download stalled, conversion hung, or snapshot not readyToUse)."
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftimageimportstuck
+        - alert: KubeSwiftMigrationFailures
+          expr: |
+            increase(kubeswift_migration_total{result="failed"}[1h]) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: SwiftMigrations failing
+            description: "At least one SwiftMigration failed in the last hour. See kubeswift_migration_failures_total for the reason breakdown."
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftmigrationfailures
+    - name: kubeswift.snapshots-gpu
+      rules:
+        - alert: KubeSwiftSnapshotFailures
+          expr: |
+            increase(kubeswift_snapshot_total{result="failed"}[1h]) > 0
+              or increase(kubeswift_restore_total{result="failed"}[1h]) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: SwiftSnapshots or SwiftRestores failing
+            description: "At least one snapshot or restore failed in the last hour."
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftsnapshotfailures
+        - alert: KubeSwiftSnapshotScheduleStale
+          expr: |
+            time() - kubeswift_snapshot_schedule_last_success_timestamp_seconds > 86400
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SwiftSnapshotSchedule {{`{{ $labels.namespace }}`}}/{{`{{ $labels.schedule }}`}} has not succeeded in 24h"
+            description: "No successful scheduled snapshot in over 24h. Adjust the threshold to your schedule period if it fires too eagerly."
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftsnapshotschedulestale
+        - alert: KubeSwiftGPUNodeDiscoveryStale
+          expr: |
+            time() - kubeswift_gpu_node_last_discovery_timestamp_seconds > 600
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "GPU discovery stale on node {{`{{ $labels.node }}`}}"
+            description: "No successful GPU discovery for >10m — the gpu-discovery DaemonSet pod on this node may be down; allocation decisions use stale inventory."
+            runbook_url: https://github.com/projectbeskar/kubeswift/blob/main/docs/observability/alerts.md#kubeswiftgpunodediscoverystale
+{{- end }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -104,6 +104,12 @@ monitoring:
     namespace: ""
     # Extra annotations, e.g. grafana_folder: KubeSwift
     annotations: {}
+  # Starter PrometheusRule alert pack (warning-biased; see
+  # docs/observability/alerts.md).
+  prometheusRule:
+    enabled: true
+    # Extra labels for Prometheus instances that select rules by label.
+    additionalLabels: {}
 
 # Live migration settings.
 migration:

--- a/config/samples/monitoring/kube-state-metrics-crs.yaml
+++ b/config/samples/monitoring/kube-state-metrics-crs.yaml
@@ -1,0 +1,62 @@
+# kube-state-metrics CustomResourceStateMetrics — OPTIONAL per-CR-name series.
+#
+# KubeSwift's controller-manager already exports aggregate state gauges
+# (kubeswift_guests{namespace,phase}, kubeswift_pool_replicas{...}, ...) with
+# bounded labels. If you also want PER-CR-NAME series (one time series per
+# individual SwiftGuest/SwiftImage/...), layer this CustomResourceStateMetrics
+# config onto YOUR kube-state-metrics deployment. This is a zero-code add-on —
+# nothing in KubeSwift depends on it, and the shipped dashboards/alerts do NOT
+# require it.
+#
+# It is NOT part of the KubeSwift Helm chart because kube-state-metrics is a
+# separate release you own. With kube-prometheus-stack, merge the config below
+# into its values:
+#
+#   kube-state-metrics:
+#     rbac:
+#       extraRules:
+#         - apiGroups: ["swift.kubeswift.io","image.kubeswift.io","kernel.kubeswift.io",
+#                       "gpu.kubeswift.io","snapshot.kubeswift.io","migration.kubeswift.io"]
+#           resources: ["*"]
+#           verbs: ["list","watch"]
+#     extraArgs:
+#       - --custom-resource-state-config-file=/etc/ksm/crs.yaml
+#     # ...plus a volume mounting the ConfigMap below at /etc/ksm/crs.yaml
+#
+# See the kube-state-metrics CustomResourceState docs for the volume wiring;
+# the metric spec is:
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: swift.kubeswift.io
+        version: v1alpha1
+        kind: SwiftGuest
+      metricNamePrefix: kubeswift_ksm
+      labelsFromPath:
+        name: [metadata, name]
+        namespace: [metadata, namespace]
+      metrics:
+        - name: guest_phase
+          help: "SwiftGuest phase per object (info-style, value 1)"
+          each:
+            type: StateSet
+            stateSet:
+              path: [status, phase]
+              labelName: phase
+              list: [Pending, Scheduling, Running, Stopped, Failed]
+    - groupVersionKind:
+        group: swift.kubeswift.io
+        version: v1alpha1
+        kind: SwiftGuestPool
+      metricNamePrefix: kubeswift_ksm
+      labelsFromPath:
+        name: [metadata, name]
+        namespace: [metadata, namespace]
+      metrics:
+        - name: pool_ready_replicas
+          help: "SwiftGuestPool ready replicas per object"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, readyReplicas]

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ KubeSwift is a Kubernetes-native VM runtime built on Cloud Hypervisor (default) 
 | Set up GPU passthrough | [gpu-passthrough.md](gpu-passthrough.md) |
 | Manage VM fleets | [swiftguestpool-guide.md](swiftguestpool-guide.md) |
 | Use the swiftctl CLI | [swiftctl.md](swiftctl.md) |
+| Monitor with Prometheus & Grafana | [observability/README.md](observability/README.md) |
 | Build and contribute | [development.md](development.md) |
 
 ---

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,145 @@
+# KubeSwift Observability
+
+KubeSwift exports Prometheus metrics from the controller-manager and ships a
+ServiceMonitor, six Grafana dashboards, and a starter alert pack — all behind
+one Helm flag.
+
+## Enable it
+
+The chart packages everything behind `monitoring.enabled` (default **off**, so
+default installs incur no Prometheus-Operator CRD dependency):
+
+```bash
+helm upgrade --install kubeswift oci://ghcr.io/projectbeskar/charts/kubeswift \
+  --set monitoring.enabled=true \
+  --set monitoring.dashboards.namespace=<your-grafana-namespace>
+```
+
+Requirements when enabled:
+
+- The Prometheus Operator CRDs (`monitoring.coreos.com`) — e.g.
+  kube-prometheus-stack — for the ServiceMonitor and PrometheusRule.
+- A Grafana with the dashboard sidecar (the kube-prometheus-stack default) for
+  the dashboard ConfigMaps. Set `monitoring.dashboards.namespace` to the
+  namespace that Grafana's sidecar watches (often Grafana's own namespace).
+
+Sub-toggles: `monitoring.serviceMonitor.enabled`, `monitoring.dashboards.enabled`,
+`monitoring.prometheusRule.enabled` (all default true once `monitoring.enabled`).
+
+> **Selector labels — the common gotcha.** kube-prometheus-stack's Prometheus
+> selects `ServiceMonitor`s and `PrometheusRule`s **by label**. Its
+> `ruleSelector` defaults to `release: <your-kps-release>`, so unless you set
+> that label the alert rules are created but never loaded (the ServiceMonitor
+> may still be picked up if `serviceMonitorSelectorNilUsesHelmValues=false`, a
+> common kps setting — the rule selector is *not* relaxed by that flag). Match
+> your Prometheus's selectors:
+>
+> ```bash
+> --set monitoring.prometheusRule.additionalLabels.release=<your-kps-release> \
+> --set monitoring.serviceMonitor.additionalLabels.release=<your-kps-release>
+> ```
+>
+> Check what your Prometheus wants with
+> `kubectl get prometheus -A -o jsonpath='{.items[0].spec.ruleSelector}'`.
+
+Non-Helm installs can apply `config/grafana/servicemonitor.yaml` and load the
+dashboards under `config/grafana/*.json` as ConfigMaps labeled
+`grafana_dashboard: "1"`.
+
+## Dashboards
+
+| Dashboard | uid | Answers |
+|---|---|---|
+| Fleet Overview | `kubeswift-fleet` | how many guests, where, how healthy; the front door |
+| VM Lifecycle & Images | `kubeswift-vm-lifecycle` | boot latency, failure reasons, image-import health, kernels, per-VM usage recipe |
+| GPU | `kubeswift-gpu` | per-node capacity/free/allocated, alloc/release rate, vfio-ready, discovery staleness |
+| Snapshots & Restore | `kubeswift-snapshots` | snapshot/restore/clone results + latencies, schedule prune/staleness |
+| Live Migration | `kubeswift-migrations` | results, downtime + transfer quantiles, failures-by-reason, drain activity |
+| Control Plane | `kubeswift-control-plane` | reconcile/workqueue/webhook health, leader, manager memory |
+
+## Metrics
+
+### Feature metrics (controller-recorded)
+
+| Metric | Type | Labels |
+|---|---|---|
+| `kubeswift_vm_boot_seconds` | histogram | namespace |
+| `kubeswift_vm_failures_total` | counter | namespace, reason (bounded condition reason) |
+| `kubeswift_image_import_seconds` | histogram | namespace |
+| `kubeswift_image_import_total` | counter | namespace, result |
+| `kubeswift_migration_total` | counter | mode, result |
+| `kubeswift_migration_failures_total` | counter | mode, reason |
+| `kubeswift_migration_downtime_seconds` / `_transfer_seconds` | histogram | mode |
+| `kubeswift_snapshot_total` / `_capture_seconds` / `_pause_window_seconds` / `_size_bytes` | counter/histogram | backend |
+| `kubeswift_restore_total` / `_seconds`, `kubeswift_clone_total` | counter/histogram | result |
+| `kubeswift_snapshot_upload_bytes_total` / `kubeswift_restore_download_bytes_total` | counter | — |
+| `kubeswift_snapshot_schedule_pruned_total` | counter | — |
+| `kubeswift_gpu_allocations_total` | counter | result (allocated\|no_capacity) |
+| `kubeswift_gpu_releases_total` | counter | — |
+| `kubeswift_drain_migrations_total` | counter | policy, result |
+
+### State gauges (computed from cluster state at scrape time)
+
+Exported by an in-controller cache-backed collector — immune to controller
+restart drift (an event-accumulated gauge would reset to 0 on restart):
+
+`kubeswift_guests{namespace,phase}`, `kubeswift_guests_by_node{node,hypervisor}`,
+`kubeswift_guests_by_boot_source{source}`,
+`kubeswift_pool_replicas{namespace,pool,state}`,
+`kubeswift_images{namespace,phase}`, `kubeswift_kernels{phase}`,
+`kubeswift_snapshots{namespace,phase}`, `kubeswift_migrations_active{mode}`,
+`kubeswift_gpu_node_gpus{node,state}`, `kubeswift_gpu_node_info{...}`,
+`kubeswift_gpu_node_last_discovery_timestamp_seconds{node}`,
+`kubeswift_snapshot_schedule_last_success_timestamp_seconds{namespace,schedule}`.
+
+`kubeswift_guest_running_total{namespace}` is **deprecated** — use
+`kubeswift_guests{phase="Running"}`. It will be removed a release after v0.4.
+
+### Free controller-runtime metrics
+
+The controller-manager also exports the standard controller-runtime surface,
+which the Control Plane dashboard consumes — no KubeSwift code needed:
+`controller_runtime_reconcile_total` / `_errors_total` / `_time_seconds`,
+`workqueue_*`, `controller_runtime_webhook_requests_total{webhook,code}` +
+`_webhook_latency_seconds` (covers all 7 CRD webhooks + the eviction webhook —
+drain denials are `code="429"`), `leader_election_master_status`, Go/process
+metrics.
+
+## Per-VM resource usage (cAdvisor)
+
+There is **no per-VM metrics endpoint** in v1, and it isn't needed: Cloud
+Hypervisor runs inside the launcher container's cgroup, so cAdvisor's
+`container_*` series on launcher pods already report the VM's host-side
+CPU/memory/network/disk. Join on the launcher pod label `swift.kubeswift.io/guest`:
+
+```promql
+sum by (guest) (
+  rate(container_cpu_usage_seconds_total[5m])
+  * on (pod) group_left(guest)
+    label_replace(
+      kube_pod_labels{label_swift_kubeswift_io_guest!=""},
+      "guest", "$1", "label_swift_kubeswift_io_guest", "(.+)")
+)
+```
+
+This needs kube-state-metrics started with
+`--metric-labels-allowlist=pods=[swift.kubeswift.io/guest]` so the label reaches
+`kube_pod_labels`.
+
+**Never join on pod name** — after a live migration the launcher pod is renamed
+`<guest>-mig-<uid>`, so a pod-name join silently loses the migrated guest. The
+guest label is stable across migration.
+
+## Per-CR series (optional, no KubeSwift code)
+
+The state gauges are aggregates (by namespace/phase/node) to keep cardinality
+bounded. For per-CR-name series, layer kube-state-metrics
+`CustomResourceStateMetrics` on top — a zero-code add-on. A starter config is in
+[`config/samples/monitoring/kube-state-metrics-crs.yaml`](../../config/samples/monitoring/kube-state-metrics-crs.yaml).
+
+## Alerts
+
+See [alerts.md](alerts.md) for the 12-rule starter pack, what each alert means,
+and the first diagnostic step. Certificate expiry is intentionally **not**
+covered here — cert-manager owns
+`certmanager_certificate_expiration_timestamp_seconds`.

--- a/docs/observability/alerts.md
+++ b/docs/observability/alerts.md
@@ -1,0 +1,105 @@
+# KubeSwift Alerts
+
+The chart ships a starter `PrometheusRule` (`monitoring.prometheusRule.enabled`,
+default on when `monitoring.enabled`). 12 rules, warning-biased — they flag
+conditions an operator should look at, not page-at-3am criticals (the one
+exception is `KubeSwiftControllerDown`). Tune thresholds to your environment;
+these are conservative defaults.
+
+Each alert below lists what it means and the first diagnostic step.
+
+## Control plane
+
+### KubeSwiftControllerDown
+**critical · `absent(up{job=~"kubeswift-controller-manager.*"} == 1)` for 5m**
+No healthy controller-manager scrape target. VM reconciliation, status
+reporting, and admission are all unavailable.
+→ `kubectl -n kubeswift-system get pods -l app.kubernetes.io/component=controller-manager`;
+check pod events, logs, and that the metrics Service still has endpoints.
+
+### KubeSwiftReconcileErrorsHigh
+**warning · per-controller reconcile error ratio > 10% for 15m**
+A specific controller is failing most of its reconciles.
+→ `kubectl -n kubeswift-system logs deploy/controller-manager | grep -i error`;
+the `controller` label names the failing reconciler. Common causes: RBAC gap
+on a newly-watched resource (the recurring "Failed to watch" pattern — grant
+`list,watch`), a CRD/Go-type drift, or a dependent API being unavailable.
+
+### KubeSwiftWebhookRejectionSpike
+**warning · webhook non-2xx rate > 1/s for 15m**
+Admission webhooks are rejecting at a high rate.
+→ Look at the Control Plane dashboard's "Webhook request rate by code" panel to
+see which webhook + code. A loop of `403`s is usually a bad manifest being
+re-applied; a stream of `429`s on the eviction path is a stalling drain (see
+the Migration dashboard's drain panel).
+
+## Guests
+
+### KubeSwiftGuestsFailed
+**warning · `kubeswift_guests{phase="Failed"} > 0` for 10m**
+→ `kubectl get swiftguest -A | grep -i failed`, then `kubectl describe` one —
+the conditions carry the reason. The `kubeswift_vm_failures_total{reason}` series
+gives the aggregate cause.
+
+### KubeSwiftGuestStuckPending
+**warning · `kubeswift_guests{phase=~"Pending|Scheduling"} > 0` for 15m**
+A guest hasn't progressed past scheduling.
+→ Check the referenced SwiftImage/SwiftKernel is `Ready`, the guest's node
+selector/capacity, and `kubectl describe swiftguest` conditions.
+
+### KubeSwiftGuestCrashLooping
+**warning · `rate(kubeswift_vm_failures_total[15m]) > 0` for 15m**
+Repeated failures in a namespace — likely one guest crash-looping.
+→ `swiftctl logs <guest>` for the launcher/CH output; `swiftctl describe` for
+phase history.
+
+### KubeSwiftPoolDegraded
+**warning · pool ready < desired for 15m**
+A SwiftGuestPool can't reach its desired replica count.
+→ `kubectl describe swiftguestpool <pool>`; usually capacity, a failing
+template, or a stuck rollout. The Fleet dashboard's pool table shows the split.
+
+## Images & migration
+
+### KubeSwiftImageImportStuck
+**warning · image non-terminal (Importing/Validating/Preparing/Snapshotting) for 30m**
+→ `kubectl describe swiftimage <name>`; check the import Job
+(`kubectl get jobs -n <ns>`) and its pod logs. Stalled download, hung
+conversion, or a snapshot not reaching readyToUse are the usual causes.
+
+### KubeSwiftMigrationFailures
+**warning · `increase(kubeswift_migration_total{result="failed"}[1h]) > 0`**
+→ The `kubeswift_migration_failures_total{reason}` series (Migration dashboard)
+breaks failures down by the bounded `failureReason` enum
+(DstNeverReady/PodTerminated/Timeout/…). `kubectl describe swiftmigration` for
+the per-migration detail.
+
+## Snapshots & GPU
+
+### KubeSwiftSnapshotFailures
+**warning · a snapshot or restore failed in the last hour**
+→ `kubectl get swiftsnapshot,swiftrestore -A | grep -i failed`, then
+`kubectl describe`. For Tier C (s3), check the upload/download Job logs.
+
+### KubeSwiftSnapshotScheduleStale
+**warning · `time() - last_success > 24h` for 30m**
+A SwiftSnapshotSchedule hasn't produced a Ready snapshot in 24h. The 24h
+threshold is a generic default — **tune it to your schedule period** (e.g. a
+6-hourly schedule wants a tighter bound).
+→ `kubectl describe swiftsnapshotschedule <name>`; check `suspend`, the cron
+expression, and whether the most recent scheduled snapshot is stuck or failing.
+
+### KubeSwiftGPUNodeDiscoveryStale
+**warning · `time() - last_discovery > 10m` for 10m**
+The gpu-discovery DaemonSet pod on a node has stopped refreshing inventory;
+allocation decisions would use stale data.
+→ `kubectl -n kubeswift-system get pods -l app.kubernetes.io/component=gpu-discovery -o wide`;
+restart the pod on the affected node and check its logs.
+
+## What is deliberately not alerted
+
+- **Certificate expiry** — cert-manager owns the webhook/mTLS certs; use its
+  `certmanager_certificate_expiration_timestamp_seconds` alerts rather than
+  duplicating them here.
+- **Migration in progress / long downtime** — surfaced on the dashboard, not
+  alerted (a slow migration is not an error).


### PR DESCRIPTION
## Summary

Phase O4 PR 8 ([design doc](https://github.com/projectbeskar/kubeswift/blob/main/docs/design/observability.md), D4) — **closes the observability program**.

- **PrometheusRule** (`monitoring.prometheusRule.enabled`, default on): 12-rule warning-biased starter pack — one critical (`KubeSwiftControllerDown`), the rest warnings across control-plane / guests / images+migration / snapshots+gpu. Each has a `runbook_url`. Cert expiry deliberately left to cert-manager.
- **`docs/observability/README.md`** — enable steps, full metrics catalog (feature + state gauges + the free controller-runtime surface), six-dashboard map, the **cAdvisor per-VM-usage join** recipe (join on `swift.kubeswift.io/guest`, never pod name), KSM CRS optional add-on.
- **`docs/observability/alerts.md`** — each alert's meaning + first diagnostic step.
- **`config/samples/monitoring/kube-state-metrics-crs.yaml`** — optional per-CR-name series (zero KubeSwift code).

## Cluster validation (lab rev 49) — full O3+O4 walkthrough
- All 12 rules load into Prometheus, **health=ok**.
- **`KubeSwiftImageImportStuck` went `state=pending`** on a real stuck import — live alert-pipeline proof.
- O3 counters fired on a real **GTX 1080 alloc/release cycle**: `gpu_allocations_total=2`, `gpu_releases_total=1`.
- All six dashboards render with data.

### Operator finding (documented in the runbook)
kube-prometheus-stack's Prometheus selects PrometheusRules by `release: <kps-release>` (its `ruleSelector` default), and that selector is **not** relaxed by `serviceMonitorSelectorNilUsesHelmValues=false` — so rules load only once `monitoring.prometheusRule.additionalLabels.release` matches. That's exactly the `additionalLabels` hook; validated by setting `release=monitoring` → all rules loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)