### PR TITLE
docs: fast-VM snapshots/clones guide + live-migratable guests guide + samples

### DIFF
--- a/config/samples/migratable-guests/01-kernel-boot-live-migratable.yaml
+++ b/config/samples/migratable-guests/01-kernel-boot-live-migratable.yaml
@@ -1,0 +1,29 @@
+# Kernel-boot SwiftGuest — live-migratable (the lightest case).
+#
+# A kernel-boot guest holds NO root-disk PVC, so it has no storage
+# constraint for live migration — it live-migrates on default storage and
+# default networking. This is exactly the workload class the project
+# validated cross-node live migration on (sub-3s downtime).
+#
+# Prerequisites: `kubectl apply -f ../shared/` (default class + minimal seed),
+# a Ready SwiftKernel `faas-minimal`, and a node labeled
+# kubeswift.io/kernel-node=true.
+#
+# Migrate it:  swiftctl migrate live-kernel-vm --to <node> --allow-ip-change
+# (default networking changes the IP cross-node; see 03 to preserve it.)
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: live-kernel-vm
+  namespace: default
+spec:
+  kernelRef:
+    name: faas-minimal
+  guestClassRef:
+    name: default
+  kernelCmdline: "console=ttyS0 root=/dev/ram0 rdinit=/init"
+  runPolicy: Running
+  migration:
+    enabled: true          # default; shown for clarity
+    preferredMode: live    # auto would also pick live for this guest
+    drainPolicy: Migrate   # kubectl drain auto-evacuates it (default)

--- a/config/samples/migratable-guests/02-disk-boot-live-migratable.yaml
+++ b/config/samples/migratable-guests/02-disk-boot-live-migratable.yaml
@@ -1,0 +1,35 @@
+# Disk-boot SwiftGuest — live-migratable via RWX + Block storage.
+#
+# A disk-boot (imageRef) guest holds a per-guest root-disk PVC. Live
+# migration needs that PVC attachable on BOTH nodes during cutover, which
+# requires ReadWriteMany + volumeMode: Block on a live-migration-capable
+# StorageClass (Longhorn `migratable: "true"`). The RWX+Block storage here
+# comes from the `live-migratable` SwiftGuestClass; the default RWO+Filesystem
+# class would make this guest OFFLINE-only.
+#
+# Prerequisites:
+#   kubectl apply -f ../shared/                          # minimal seed
+#   kubectl apply -f ../storage/swiftguestclass-rwx-migratable.yaml
+#     (defines the `live-migratable` class AND the longhorn-migratable
+#      StorageClass — a cluster admin applies the StorageClass once)
+#   a Ready SwiftImage `ubuntu-noble`.
+#
+# Migrate it:  swiftctl migrate live-disk-vm --to <node> --allow-ip-change
+# (default networking changes the IP cross-node; see 03 to preserve it.)
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: live-disk-vm
+  namespace: default
+spec:
+  imageRef:
+    name: ubuntu-noble
+  guestClassRef:
+    name: live-migratable   # RWX + Block + longhorn-migratable
+  seedProfileRef:
+    name: minimal
+  runPolicy: Running
+  migration:
+    enabled: true
+    preferredMode: live
+    drainPolicy: Migrate

--- a/config/samples/migratable-guests/03-ip-preserving-live-migratable.yaml
+++ b/config/samples/migratable-guests/03-ip-preserving-live-migratable.yaml
@@ -1,0 +1,52 @@
+# Disk-boot SwiftGuest — live-migratable AND IP-preserving.
+#
+# Two things make this guest migrate without changing its IP:
+#   1. RWX + Block storage (per-guest spec.storage override here, instead of
+#      a dedicated class) — the live-migration storage requirement.
+#   2. The PRIMARY interface rides a multi-node L2 NAD (primary: true +
+#      networkRef), so the guest's IP is portable across nodes. With this,
+#      the SwiftMigration does NOT need spec.allowIPChange — the IP follows
+#      the guest.
+#
+# Contrast with 01/02, which use default node-local-bridge networking and so
+# take a fresh IP on the destination (requiring --allow-ip-change).
+#
+# Prerequisites:
+#   kubectl apply -f ../shared/                          # minimal seed + default class
+#   kubectl apply -f ../storage/swiftguestclass-rwx-migratable.yaml   # for the StorageClass
+#   kubectl apply -f ../multi-node-l2/ovn-l2-nad.yaml    # the `ovn-l2` NAD
+#   a Ready SwiftImage `ubuntu-noble`.
+#
+# NOTE: the primary-on-NAD runtime datapath is experimental (control-plane —
+# admission + migration IP-preservation classification — is shipped; the
+# datapath validates on an OVN-Kubernetes cluster). See ../multi-node-l2/.
+#
+# Migrate it:  swiftctl migrate ip-stable-vm --to <node>
+# (no --allow-ip-change needed — the primary IP is preserved.)
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: ip-stable-vm
+  namespace: default
+spec:
+  imageRef:
+    name: ubuntu-noble
+  guestClassRef:
+    name: default          # default RWO+Filesystem class...
+  seedProfileRef:
+    name: minimal
+  runPolicy: Running
+  # ...overridden per-guest to the live-migration storage combination.
+  storage:
+    accessMode: ReadWriteMany
+    volumeMode: Block
+    storageClassName: longhorn-migratable
+  interfaces:
+    - name: app
+      primary: true                 # the guest's primary IP...
+      networkRef:
+        name: ovn-l2                 # ...rides the multi-node NAD → portable
+  migration:
+    enabled: true
+    preferredMode: live
+    drainPolicy: Migrate

--- a/config/samples/migratable-guests/README.md
+++ b/config/samples/migratable-guests/README.md
@@ -1,0 +1,84 @@
+# Live-migratable SwiftGuests
+
+SwiftGuests in this directory are configured to **live-migrate** cleanly
+between nodes (sub-3s downtime; the guest keeps running during pre-copy).
+They are also fine for offline migration.
+
+## What makes a guest live-migratable
+
+Live migration (`mode: live`) requires **all** of:
+
+1. **No VFIO devices** — no `gpuProfileRef`, no SR-IOV `interfaces`. VFIO
+   state cannot transfer; such guests are **offline-only** (the
+   webhook/controller resolve them to offline).
+2. **No node-local virtio backends** — no `filesystems` (virtiofs) and no
+   `type: vhost-user` interfaces/`vhostUserDevices`. Those backends live on
+   the source node and don't follow the guest; such guests are
+   **offline-only**.
+3. **Disk-boot guests need RWX + Block storage** — a `imageRef` guest holds a
+   root-disk PVC, and only `ReadWriteMany` + `volumeMode: Block` on a
+   live-migration-capable StorageClass (Longhorn `migratable: "true"`) can be
+   attached on both nodes during cutover. `ReadWriteOnce` + `Filesystem` (the
+   default) is **offline-only**. Get RWX+Block either from a class
+   (`live-migratable`, see [`../storage/`](../storage/)) or a per-guest
+   `spec.storage` override.
+   - **Kernel-boot guests** (`kernelRef`) have **no root PVC**, so they are
+     live-migratable on default storage — the lightest case (and what the
+     project validated live migration on).
+
+`spec.migration.preferredMode: live` makes the intent explicit; with `auto`
+the controller live-migrates when eligible and falls back to offline
+otherwise. `enabled: true` (the default) lets migrations target the guest at
+all; set it `false` to pin a guest in place.
+
+## IP across the move
+
+Default node-local-bridge networking gives the guest a **fresh IP** on the
+destination — the migration then needs `spec.allowIPChange: true` on the
+SwiftMigration. To **preserve the IP**, put the primary interface on a
+multi-node L2 NAD (`primary: true` + `networkRef`) — see
+[`03-ip-preserving-live-migratable.yaml`](03-ip-preserving-live-migratable.yaml)
+and [`../multi-node-l2/`](../multi-node-l2/).
+
+## The manifests
+
+| File | Boot | Storage | Notes |
+|---|---|---|---|
+| [`01-kernel-boot-live-migratable.yaml`](01-kernel-boot-live-migratable.yaml) | kernel | none (no PVC) | lightest live-migratable guest |
+| [`02-disk-boot-live-migratable.yaml`](02-disk-boot-live-migratable.yaml) | disk (Ubuntu Noble) | RWX+Block via `live-migratable` class | realistic disk VM; IP changes cross-node |
+| [`03-ip-preserving-live-migratable.yaml`](03-ip-preserving-live-migratable.yaml) | disk | RWX+Block (per-guest override) | primary on a multi-node NAD → IP preserved |
+
+## Prerequisites
+
+Apply the shared bundle once (it creates the `default` SwiftGuestClass and the
+`minimal` SwiftSeedProfile these manifests reference — a missing seed profile
+is the most common "guest stuck Failed: ResolutionFailed" cause):
+
+```bash
+kubectl apply -f ../shared/                       # default class + minimal seed
+```
+
+Plus, per manifest:
+
+- **01** — a Ready `SwiftKernel` named `faas-minimal` and a node labeled
+  `kubeswift.io/kernel-node=true`.
+- **02 / 03** — a Ready `SwiftImage` named `ubuntu-noble`, the
+  `live-migratable` SwiftGuestClass and the `longhorn-migratable`
+  StorageClass (both in [`../storage/swiftguestclass-rwx-migratable.yaml`](../storage/swiftguestclass-rwx-migratable.yaml);
+  the StorageClass is applied once by a cluster admin).
+- **03** — a multi-node L2 NAD named `ovn-l2`
+  ([`../multi-node-l2/ovn-l2-nad.yaml`](../multi-node-l2/ovn-l2-nad.yaml)).
+
+## Migrating one
+
+Pre-flight, then move (replace the node name with another worker):
+
+```bash
+swiftctl migrate live-disk-vm --to <node> --check     # dry-run: eligibility + mode
+swiftctl migrate live-disk-vm --to <node>             # creates the SwiftMigration
+```
+
+Or apply a SwiftMigration directly — see
+[`../migration/swiftmigration-basic.yaml`](../migration/swiftmigration-basic.yaml).
+For a default-networking guest (01, 02) add `--allow-ip-change` (the IP
+changes on the destination); 03's primary-on-NAD preserves the IP.

--- a/config/samples/migratable-guests/lab-live-migration-set.yaml
+++ b/config/samples/migratable-guests/lab-live-migration-set.yaml
@@ -1,0 +1,48 @@
+# A small set of LIVE-MIGRATABLE guests of different boot types / OSes for
+# exercising live migration. All are eligible for `mode: live`:
+#   - no VFIO/GPU, no virtiofs/vhost-user (those are offline-only)
+#   - disk-boot guests use the live-migratable class (RWX + Block storage)
+#   - kernel-boot has no PVC, so it's live-migratable on default storage
+#
+# Spread across the two worker nodes (frida is tainted control-plane).
+# Migrate one with:  swiftctl migrate <name> --to <worker> --allow-ip-change
+# (default node-local networking changes the IP cross-node).
+---
+# 1. Kernel-boot microVM — the lightest live-migration case (no root PVC).
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: lm-kernel
+  namespace: default
+spec:
+  kernelRef: { name: faas-minimal }
+  guestClassRef: { name: default }
+  kernelCmdline: "console=ttyS0 root=/dev/ram0 rdinit=/init"
+  runPolicy: Running
+  migration: { enabled: true, preferredMode: live }
+---
+# 2. Ubuntu Noble 24.04 disk VM — RWX+Block live-migratable storage.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: lm-ubuntu
+  namespace: default
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: live-migratable }
+  seedProfileRef: { name: minimal }
+  runPolicy: Running
+  migration: { enabled: true, preferredMode: live }
+---
+# 3. Rocky Linux 9 disk VM — different OS, same live-migratable storage.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: lm-rocky
+  namespace: default
+spec:
+  imageRef: { name: rocky9-cloud }
+  guestClassRef: { name: live-migratable }
+  seedProfileRef: { name: minimal }
+  runPolicy: Running
+  migration: { enabled: true, preferredMode: live }

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ KubeSwift is a Kubernetes-native VM runtime built on Cloud Hypervisor (default) 
 | Connect VMs to physical networks | [networking/operations-guide.md](networking/operations-guide.md) |
 | Migrate from VMware/Proxmox | [networking/virtualization-comparison.md](networking/virtualization-comparison.md) |
 | Set up GPU passthrough | [gpu-passthrough.md](gpu-passthrough.md) |
+| Create fast VMs with snapshots & clones | [snapshots/fast-vms.md](snapshots/fast-vms.md) |
+| Live-migrate VMs between nodes | [migration/migratable-guests.md](migration/migratable-guests.md) |
 | Manage VM fleets | [swiftguestpool-guide.md](swiftguestpool-guide.md) |
 | Use the swiftctl CLI | [swiftctl.md](swiftctl.md) |
 | Monitor with Prometheus & Grafana | [observability/README.md](observability/README.md) |

--- a/docs/migration/migratable-guests.md
+++ b/docs/migration/migratable-guests.md
@@ -1,0 +1,89 @@
+# Creating live-migratable SwiftGuests
+
+This page is the practical "how do I make a VM that live-migrates" guide.
+For the migration *operation* and its phases, see [overview.md](overview.md).
+
+## What makes a guest live-migratable
+
+A guest is eligible for `mode: live` only when **all** of these hold:
+
+1. **No VFIO devices** — no `gpuProfileRef`, no SR-IOV `interfaces`. VFIO state
+   cannot transfer; such guests are **offline-only**.
+2. **No node-local virtio backends** — no `filesystems` (virtiofs) and no
+   `type: vhost-user` interfaces / `vhostUserDevices`. Those backends live on
+   the source node and don't follow the guest; **offline-only**.
+3. **Disk-boot guests need RWX + Block storage.** An `imageRef` guest holds a
+   root-disk PVC, and only `ReadWriteMany` + `volumeMode: Block` on a
+   live-migration-capable StorageClass (Longhorn `migratable: "true"`) can be
+   attached on both nodes during cutover. The default `ReadWriteOnce` +
+   `Filesystem` is **offline-only**. Get RWX+Block from a class
+   (`live-migratable`) or a per-guest `spec.storage` override.
+   - **Kernel-boot guests** (`kernelRef`) have **no root PVC**, so they are
+     live-migratable on default storage — the lightest case.
+
+`spec.migration.preferredMode: live` states the intent (with `auto` the
+controller live-migrates when eligible, else falls back to offline).
+`spec.migration.enabled: false` pins a guest in place.
+
+## A ready-to-use guest set
+
+[`config/samples/migratable-guests/lab-live-migration-set.yaml`](../../config/samples/migratable-guests/lab-live-migration-set.yaml)
+defines three live-migratable guests of different boot types / OSes:
+
+| Guest | Type / OS | Storage |
+|---|---|---|
+| `lm-kernel` | kernel-boot microVM (faas-minimal) | none (no PVC) — lightest |
+| `lm-ubuntu` | Ubuntu Noble 24.04 disk VM | RWX+Block (`live-migratable` class) |
+| `lm-rocky` | Rocky Linux 9 disk VM | RWX+Block (`live-migratable` class) |
+
+```bash
+# Prerequisites (once): default class + minimal seed, the live-migratable class
+# + the longhorn-migratable StorageClass, and the ubuntu-noble / rocky9-cloud images.
+kubectl apply -f config/samples/shared/
+kubectl apply -f config/samples/storage/swiftguestclass-rwx-migratable.yaml
+kubectl apply -f config/samples/disk-boot/swiftimage-ubuntu-noble.yaml \
+               -f config/samples/rocky/swiftimage-rocky9.yaml
+# wait for both SwiftImages to reach Ready, THEN:
+kubectl apply -f config/samples/migratable-guests/lab-live-migration-set.yaml
+```
+
+> **Apply images before guests.** A disk-boot guest created while its image is
+> still `Importing` fails resolution (`SwiftImage not Ready`) and a Failed guest
+> does not self-recover — recreate it once the image is `Ready`.
+
+More focused single-guest examples (incl. an IP-preserving variant) are in the
+[`migratable-guests/`](../../config/samples/migratable-guests/) directory README.
+
+## Migrating one
+
+```bash
+swiftctl migrate lm-ubuntu --to <worker> --check          # pre-flight: capacity, mode, IP, CPU
+swiftctl migrate lm-ubuntu --to <worker> --allow-ip-change
+```
+
+`--allow-ip-change` is required on default node-local networking (the guest gets
+a fresh IP on the destination). To preserve the IP, put the primary interface on
+a multi-node L2 NAD (`primary: true` + `networkRef`) — see
+[`config/samples/migratable-guests/03-ip-preserving-live-migratable.yaml`](../../config/samples/migratable-guests/03-ip-preserving-live-migratable.yaml)
+and [networking-requirements.md](networking-requirements.md). That path needs
+OVN-Kubernetes; it does not work on a plain Calico cluster.
+
+## Operational notes (learned on the dev cluster)
+
+These bite in practice — check them before blaming the migration logic:
+
+- **Target-node capacity.** The Validating phase refuses a target without CPU
+  headroom (`insufficient CPU headroom: need 2, have ...`). Always `--check`
+  first and target a node with room.
+- **mTLS identity is worker-node-only.** With `migration.mtls.enabled` (Phase
+  3c), each **worker** node gets a per-node identity Secret
+  (`kubeswift-migration-node-<node>`). A guest running on the **control-plane**
+  node has no such cert, so it **cannot be a live-migration source**
+  (`MigrationIdentityNotReady`). Keep the control plane **tainted** so guests
+  don't land there; move any that did off with an **offline** migration.
+- **Offline always works** — it uses no mTLS tunnel (stop → detach → recreate).
+  Use `--preferred-mode offline` for VFIO/virtiofs guests, or any time the live
+  path is unavailable.
+- **Cluster load matters.** The mTLS live-migration handshake has tight
+  sidecar-readiness sequencing; on a CPU-saturated cluster (slow container/
+  stunnel startup) it can race and fail. Keep migration headroom.

--- a/docs/migration/overview.md
+++ b/docs/migration/overview.md
@@ -13,6 +13,11 @@
 
 ## What you can do today
 
+> **New to this?** Start with [migratable-guests.md](migratable-guests.md) —
+> what makes a guest live-migratable, a ready-to-use multi-OS guest set, and the
+> operational gotchas (target capacity, mTLS worker-only certs, offline
+> fallback).
+
 - Move any non-VFIO SwiftGuest from one Kubernetes node to another
   with the disk content preserved.
 - Use `swiftctl migrate <guest> --to <node>` or apply a

--- a/docs/snapshots/fast-vms.md
+++ b/docs/snapshots/fast-vms.md
@@ -1,0 +1,174 @@
+# Fast VMs with snapshots and clones
+
+KubeSwift has **two distinct mechanisms** for spinning up VMs faster than a
+plain cold boot. They make *different* things fast — pick by what you need.
+
+| Mechanism | What it makes fast | Still cold-boots the OS? |
+|---|---|---|
+| **A — `cloneStrategy: snapshot`** on a SwiftImage | root-disk **provisioning** | yes |
+| **B — `SwiftSnapshot(includeMemory)` + `cloneFromSnapshot`** | the **boot itself** (memory resume) | no — it resumes |
+
+> **Read this first — when "fast clone" is actually faster.** Both mechanisms
+> trade on your storage driver. On a **CoW** CSI driver (Ceph RBD, EBS,
+> true-CoW Longhorn), a disk clone is near-instant and these are a big win. On a
+> **full-copy** driver (default Longhorn), provisioning a clone disk copies the
+> whole image — so the "fast" path can be **no faster, or slower**, than a cold
+> boot of a quick-booting cloud image. Measured numbers and the honest caveat
+> are in [Demo results](#demo-results-tier-b-on-longhorn-full-copy) below.
+
+---
+
+## Mechanism A — `cloneStrategy: snapshot` (fast disk provisioning)
+
+By default each guest's root disk is a **full copy** of the prepared image (a
+Copy Job). With `cloneStrategy: snapshot`, the SwiftImage controller takes **one**
+CSI VolumeSnapshot of the prepared image (the "clone-seed"); every new guest then
+provisions its root PVC as a CSI clone (`dataSource: VolumeSnapshot`) of that
+seed — near-instant on a CoW driver.
+
+```yaml
+apiVersion: image.kubeswift.io/v1alpha1
+kind: SwiftImage
+metadata:
+  name: ubuntu-fast
+  namespace: default
+spec:
+  format: qcow2
+  rootDisk: { size: "10Gi" }
+  cloneStrategy: snapshot              # vs the default "copy"
+  volumeSnapshotClassName: longhorn-snapshot   # a VolumeSnapshotClass on your cluster
+  source:
+    http: { url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img }
+```
+
+The guest **still cold-boots** the OS (cloud-init runs as usual). Only disk
+materialization is faster.
+
+**Use it for:** scaling a `SwiftGuestPool` of many identical VMs.
+
+---
+
+## Mechanism B — `cloneFromSnapshot` (fast boot via memory resume)
+
+Boot **one** "golden" VM, configure it (install your app, warm caches), then
+capture its **live memory + device state**. Clones boot via Cloud Hypervisor
+`--restore` — they **resume the captured RAM byte-for-byte**: no cold boot, no
+cloud-init, no app start-up. The VM comes up already at the captured state.
+
+### Step 1 — capture a memory snapshot of a Running, configured guest
+
+```yaml
+apiVersion: snapshot.kubeswift.io/v1alpha1
+kind: SwiftSnapshot
+metadata:
+  name: golden-snap
+  namespace: default
+spec:
+  guestRef: { name: golden-src }       # a Running, already-configured source
+  backend:
+    type: local                         # Tier B — node-local; see Tier note below
+    local: { hostPath: /var/lib/kubeswift/snapshots/golden-snap }
+  includeMemory: true                   # captures RAM — this is what enables resume
+  resumeAfterSnapshot: true             # source keeps running after the capture
+```
+
+Capture pauses the source only for a short **pause window** (sub-second for a
+small guest), then resumes it.
+
+### Step 2 — boot a guest as an instant clone
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: golden-clone-1
+  namespace: default
+spec:
+  cloneFromSnapshot:
+    snapshotRef: { name: golden-snap }
+    regenerate: [macAddresses, hostname, machineId, sshHostKeys]
+  guestClassRef: { name: default }      # required by the CRD; CPU/mem actually come from the snapshot
+```
+
+Or template it on a `SwiftGuestPool` to spin up **N clones from one snapshot**
+(see [`config/samples/clone-from-snapshot/`](../../config/samples/clone-from-snapshot/)).
+
+**Tier B (local) vs Tier C (s3).** A Tier B (`type: local`) snapshot lives on the
+**capture node**, so its clones run on that same node (`targetNode` is ignored).
+For **cross-node** clones or a pool that spreads across nodes, use a Tier C
+(`type: s3`) snapshot and set `cloneFromSnapshot.targetNode` per clone — a
+node-pinned download Job stages the artifacts onto the target node first. See
+[`clone-from-snapshot.md`](clone-from-snapshot.md).
+
+### The identity caveat (fundamental — resume-vs-boot)
+
+A clone **resumes**, it does not boot. So `machine-id`, SSH host keys, hostname,
+and the **guest-visible** MAC are inherited from the source. KubeSwift
+regenerates the **hypervisor** MAC per clone (bridge-visible, no L2 collision)
+and each clone has its own pod network namespace, but in-guest identity collides
+until you **reboot each clone once** — cloud-init then re-runs and the
+`regenerate:` list fires. For stateless / ephemeral workloads it's fine as-is.
+Detail: [`identity-regeneration.md`](identity-regeneration.md).
+
+### Block-root clones are not yet supported
+
+`cloneFromSnapshot` is validated for **Filesystem-root** source guests (the
+default `RWO`+`Filesystem` storage). A source on `RWX`+`Block` storage (the
+live-migration-capable class) is **not** a supported clone source yet
+(Block-root-clone is deferred — snapshot Phase 4 OQ4). Use a Filesystem-root
+guest as your golden source.
+
+---
+
+## Demo results (Tier B on Longhorn full-copy)
+
+Measured end-to-end on the dev cluster (3-node k0s, **Longhorn full-copy** storage,
+CH v52, stock Ubuntu Noble cloud image, 4Gi guest):
+
+| Step | Time |
+|---|---|
+| `golden-src` cold boot (disk copy + OS boot + cloud-init) | **50 s** |
+| Memory snapshot capture — **pause window** | **645 ms** |
+| `golden-clone-1`: disk-copy Job (Longhorn full-copy, 40 GiB) | **54 s** |
+| `golden-clone-1`: memory-stage + `--restore` + resume | ~47 s |
+| **`golden-clone-1` total** | **101 s** |
+
+**The clone was slower than the cold boot here — and that's expected on this
+storage.** Two things drive it:
+
+1. **Full-copy storage.** `cloneFromSnapshot` provisions a *fresh* root disk for
+   the clone (the memory snapshot captures RAM + device state, **not** the disk
+   contents), and on Longhorn full-copy that disk copy is ~54 s — the dominant
+   cost. On a CoW driver it would be near-instant and the clone would come up in
+   **single-digit seconds**.
+2. **Trivial workload.** Stock Ubuntu cold-boots in ~50 s with nothing to warm
+   up, so resuming saves nothing to offset the disk copy.
+
+**When Mechanism B wins:**
+- **CoW storage** — the disk clone is near-instant, so resume → seconds.
+- **Expensive in-VM warmup** — an app that takes minutes to start (JIT, model
+  load, cache warm) is captured *running* in the snapshot; every clone skips all
+  of it. A cold boot would repeat it every time.
+
+**What it always gives**, regardless of storage: **state preservation** — the
+clone comes up at the exact captured memory state, no cold boot and no cloud-init
+re-run.
+
+The mechanism itself is proven on this cluster: `golden-clone-1` reached
+`GuestRunning=True` via the restore-receive path (`snapshot-stager` +
+CH `--restore`), resuming the captured state; the source's pause window during
+capture was only 645 ms.
+
+---
+
+## See also
+
+- [`clone-from-snapshot.md`](clone-from-snapshot.md) — full cloneFromSnapshot
+  reference (Tier B/C, pools, cross-node).
+- [`local-snapshots.md`](local-snapshots.md) / [`s3-snapshots.md`](s3-snapshots.md)
+  — the snapshot backends.
+- [`identity-regeneration.md`](identity-regeneration.md) — the resume-vs-boot
+  identity model.
+- [`../../config/samples/clone-from-snapshot/`](../../config/samples/clone-from-snapshot/),
+  [`../../config/samples/local-snapshots/`](../../config/samples/local-snapshots/)
+  — runnable manifests.


### PR DESCRIPTION
## Summary

Two operator guides (both validated on the dev cluster this session) plus the migratable-guest sample manifests they reference.

### `docs/snapshots/fast-vms.md`
The two fast-VM mechanisms and **when each is actually faster** — with honest measured numbers, not marketing:
- **A** `cloneStrategy: snapshot` — fast disk provisioning, still cold-boots.
- **B** `SwiftSnapshot(includeMemory)` + `cloneFromSnapshot` — fast boot via CH `--restore` memory resume.

Demo results (Tier B local clone, Longhorn full-copy): cold boot **50s**; snapshot capture pause window **645ms**; clone **101s** (54s disk-copy + ~47s memory-stage/restore). **The clone was slower than cold boot here** — cloneFromSnapshot still does a full disk copy (the memory snapshot captures RAM, not disk) and stock Ubuntu cold-boots fast. The speed win needs **CoW storage** or an **expensive in-VM warmup**; the universal win is **state preservation**. Also documents the resume-vs-boot identity caveat and the Block-root-clone deferral.

### `docs/migration/migratable-guests.md`
What makes a guest live-migratable (no VFIO, no node-local virtio backends, disk-boot needs RWX+Block; kernel-boot exempt), a ready-to-use multi-OS guest set, and the **operational gotchas** surfaced this session: target-node CPU capacity, mTLS identity being **worker-node-only** (control-plane guests can't be a live source → keep it tainted), offline always works (no mTLS tunnel), cluster-load handshake races.

### `config/samples/migratable-guests/`
Kernel / Ubuntu / Rocky live-migratable samples + `lab-live-migration-set.yaml` (server-dry-run + cluster validated). Wired into `docs/README` nav + `migration/overview`.

Docs + samples only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)