### PR TITLE
feat(crd): rich kubectl-get printcolumns for SwiftGuest/SwiftImage/SwiftSeedProfile

### DIFF
--- a/api/image/v1alpha1/swiftimage_types.go
+++ b/api/image/v1alpha1/swiftimage_types.go
@@ -183,6 +183,11 @@ type SwiftImageStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=swiftimages,scope=Namespaced,shortName=si
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Size",type=string,JSONPath=`.status.preparedArtifact.size`
+// +kubebuilder:printcolumn:name="Format",type=string,JSONPath=`.status.preparedFormat`,priority=1
+// +kubebuilder:printcolumn:name="Strategy",type=string,JSONPath=`.spec.cloneStrategy`,priority=1
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type SwiftImage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/seed/v1alpha1/swiftseedprofile_types.go
+++ b/api/seed/v1alpha1/swiftseedprofile_types.go
@@ -39,6 +39,8 @@ type SwiftSeedProfileSpec struct {
 // SwiftSeedProfile is the Schema for the swiftseedprofiles API.
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=swiftseedprofiles,scope=Namespaced,shortName=ssp
+// +kubebuilder:printcolumn:name="Datasource",type=string,JSONPath=`.spec.datasource`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type SwiftSeedProfile struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -619,6 +619,12 @@ type SwiftGuestStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=swiftguests,scope=Namespaced,shortName=sg
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.status.nodeName`
+// +kubebuilder:printcolumn:name="IP",type=string,JSONPath=`.status.network.primaryIP`
+// +kubebuilder:printcolumn:name="Hypervisor",type=string,JSONPath=`.status.runtime.hypervisor`,priority=1
+// +kubebuilder:printcolumn:name="OS",type=string,JSONPath=`.spec.osType`,priority=1
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type SwiftGuest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/kubeswift/crds/image.kubeswift.io_swiftimages.yaml
+++ b/charts/kubeswift/crds/image.kubeswift.io_swiftimages.yaml
@@ -16,7 +16,25 @@ spec:
     singular: swiftimage
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.preparedArtifact.size
+      name: Size
+      type: string
+    - jsonPath: .status.preparedFormat
+      name: Format
+      priority: 1
+      type: string
+    - jsonPath: .spec.cloneStrategy
+      name: Strategy
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SwiftImage is the Schema for the swiftimages API.

--- a/charts/kubeswift/crds/seed.kubeswift.io_swiftseedprofiles.yaml
+++ b/charts/kubeswift/crds/seed.kubeswift.io_swiftseedprofiles.yaml
@@ -16,7 +16,14 @@ spec:
     singular: swiftseedprofile
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.datasource
+      name: Datasource
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SwiftSeedProfile is the Schema for the swiftseedprofiles API.
@@ -215,3 +222,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -16,7 +16,28 @@ spec:
     singular: swiftguest
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.nodeName
+      name: Node
+      type: string
+    - jsonPath: .status.network.primaryIP
+      name: IP
+      type: string
+    - jsonPath: .status.runtime.hypervisor
+      name: Hypervisor
+      priority: 1
+      type: string
+    - jsonPath: .spec.osType
+      name: OS
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SwiftGuest is the Schema for the swiftguests API.

--- a/config/crd/bases/image.kubeswift.io_swiftimages.yaml
+++ b/config/crd/bases/image.kubeswift.io_swiftimages.yaml
@@ -16,7 +16,25 @@ spec:
     singular: swiftimage
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.preparedArtifact.size
+      name: Size
+      type: string
+    - jsonPath: .status.preparedFormat
+      name: Format
+      priority: 1
+      type: string
+    - jsonPath: .spec.cloneStrategy
+      name: Strategy
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SwiftImage is the Schema for the swiftimages API.

--- a/config/crd/bases/seed.kubeswift.io_swiftseedprofiles.yaml
+++ b/config/crd/bases/seed.kubeswift.io_swiftseedprofiles.yaml
@@ -16,7 +16,14 @@ spec:
     singular: swiftseedprofile
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.datasource
+      name: Datasource
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SwiftSeedProfile is the Schema for the swiftseedprofiles API.
@@ -215,3 +222,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -16,7 +16,28 @@ spec:
     singular: swiftguest
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.nodeName
+      name: Node
+      type: string
+    - jsonPath: .status.network.primaryIP
+      name: IP
+      type: string
+    - jsonPath: .status.runtime.hypervisor
+      name: Hypervisor
+      priority: 1
+      type: string
+    - jsonPath: .spec.osType
+      name: OS
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SwiftGuest is the Schema for the swiftguests API.

--- a/internal/controller/swiftimage/metrics_test.go
+++ b/internal/controller/swiftimage/metrics_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	imagev1alpha1 "github.com/projectbeskar/kubeswift/api/image/v1alpha1"
 	"github.com/projectbeskar/kubeswift/internal/metrics"


### PR DESCRIPTION
## Summary

`kubectl get` on several KubeSwift CRDs showed only `NAME + AGE` — worst of all `SwiftGuest`, the most-used resource. This adds informative printcolumns to the three that had none.

| Resource | Default columns | `-o wide` adds |
|---|---|---|
| **SwiftGuest** (`sg`) | Phase, Node, IP | Hypervisor, OS |
| **SwiftImage** (`si`) | Phase, Size | Format, Strategy |
| **SwiftSeedProfile** (`ssp`) | Datasource | — |

(The other CRDs — migration, snapshot/restore/schedule, kernel, class, GPU profile/node, pool — already have good columns.)

## Cluster-verified
```
$ kubectl get sg
NAME        PHASE     NODE    IP              AGE
lm-kernel   Running   boba    192.168.99.15   10h
...
$ kubectl get sg -o wide
NAME        PHASE     NODE    IP              HYPERVISOR         OS      AGE
lm-kernel   Running   boba    192.168.99.15   cloud-hypervisor   linux   10h
$ kubectl get si
NAME           PHASE   SIZE     AGE
ubuntu-noble   Ready   3584Mi   10h
$ kubectl get ssp
NAME      DATASOURCE   AGE
default   NoCloud      40d
```

CRDs regenerated + chart-synced (`make generate`). Printcolumns are additive — applying the updated CRDs is non-breaking.

Also reorders one import in `swiftimage/metrics_test.go` that `gofmt -s` flags (latent since #203 — no `.go`-touching PR has run the Go CI job since, so the whole-repo gate didn't re-catch it until this `api/` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)