### PR TITLE
fix(dra): three cluster-e2e findings — null devices intent, plugin dir, hotfix removal

### DIFF
--- a/cmd/kubeswift-dra-driver/main.go
+++ b/cmd/kubeswift-dra-driver/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -62,6 +63,16 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+
+	// The kubeletplugin helper binds its gRPC socket under
+	// /var/lib/kubelet/plugins/<driver>/ but does NOT create the directory —
+	// without it the bind fails "no such file or directory" (cluster-e2e
+	// finding, 2026-06-12).
+	pluginDir := filepath.Join("/var/lib/kubelet/plugins", driverName)
+	if err := os.MkdirAll(pluginDir, 0o750); err != nil {
+		logger.Error(err, "create plugin data dir", "dir", pluginDir)
+		os.Exit(1)
+	}
 
 	driver := &draDriver{nodeName: *nodeName, cdiDir: *cdiDir, kube: kube}
 	helper, err := kubeletplugin.Start(ctx, driver,

--- a/internal/runtimeintent/types.go
+++ b/internal/runtimeintent/types.go
@@ -156,8 +156,11 @@ type KernelBootSpec struct {
 // Populated when the SwiftGPU controller has allocated devices (native) or when
 // the guest opts into the DRA backend (deviceSource: env).
 type GPUIntent struct {
-	// Devices lists VFIO GPU devices to pass through to the guest.
-	Devices []VFIODeviceIntent `json:"devices"`
+	// Devices lists VFIO GPU devices to pass through to the guest. omitempty:
+	// the DRA backend writes a nil list (devices come from CDI env at runtime),
+	// and a literal "devices": null breaks swiftletd's serde (null != absent
+	// for #[serde(default)]) — cluster-e2e finding, 2026-06-12.
+	Devices []VFIODeviceIntent `json:"devices,omitempty"`
 	// DeviceSource selects where swiftletd obtains the device list:
 	//   ""    — Devices above (native backend; controller-time allocation).
 	//   "env" — synthesize from the GPU_PCI_ADDRESSES env var, injected by the

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -136,12 +136,27 @@ impl MigrationIntent {
     }
 }
 
+/// Deserialize an explicitly-null field to the type's default. serde's
+/// #[serde(default)] only applies when the field is ABSENT; Go marshals nil
+/// slices as `null`, which otherwise fails with "invalid type: null".
+fn null_to_default<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Default + serde::Deserialize<'de>,
+{
+    let opt = Option::<T>::deserialize(d)?;
+    Ok(opt.unwrap_or_default())
+}
+
 /// GPU passthrough configuration from the controller.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GPUIntent {
-    /// VFIO GPU devices to pass through.
-    #[serde(default)]
+    /// VFIO GPU devices to pass through. null-tolerant: a Go writer can emit
+    /// `"devices": null` for a nil slice, and plain #[serde(default)] only
+    /// covers a MISSING field, not an explicit null (cluster-e2e finding,
+    /// 2026-06-12).
+    #[serde(default, deserialize_with = "null_to_default")]
     pub devices: Vec<GPUDeviceIntent>,
     /// Where the device list comes from:
     ///   ""    — `devices` above (native backend; controller-time allocation).
@@ -821,5 +836,19 @@ mod tests {
         assert_eq!(devs[0].gpu_direct_clique, -1);
         assert!(!devs[0].pcie_root_port);
         assert_eq!(devs[1].pci_address, "0000:02:00.0");
+    }
+
+    /// Regression (cluster-e2e 2026-06-12): the Go controller can emit
+    /// `"devices": null` (nil slice); deserialization must treat it as empty,
+    /// not fail with "invalid type: null".
+    #[test]
+    fn gpu_intent_null_devices() {
+        let dra: GPUIntent = serde_json::from_str(
+            r#"{"devices":null,"deviceSource":"env","firmware":"cloudhv",
+                "fabricManagerPartitionId":-1}"#,
+        )
+        .unwrap();
+        assert!(dra.devices.is_empty());
+        assert_eq!(dra.device_source, "env");
     }
 }


### PR DESCRIPTION
## Summary

The Workstream C walkthrough surfaced three real bugs unit tests structurally couldn't catch (the W5 pattern). The **good news buried in the findings**: the DRA chain worked end-to-end up to the last hop — the scheduler allocated `gpu-0000-01-00-0` (the GTX 1080) to the minted claim, the driver's **CDI containerEdits injected `GPU_PCI_ADDRESSES=0000:01:00.0`** (proven: the pod spec doesn't set that env), gpu-init consumed it unchanged, and the **tier-1 device-status `Data` write worked** (the beta feature is on in k8s 1.34).

| # | Finding | Fix |
|---|---|---|
| 1 | `"devices": null` in the intent broke swiftletd (`intent_load_error`) — Go marshals nil slices as `null`; Rust `#[serde(default)]` covers *missing*, not explicit null → **the VM never spawned** behind a Running pod | `omitempty` (Go) **and** a `null_to_default` deserializer (Rust) + null regression test |
| 2 | kubeletplugin helper doesn't create its socket dir → `bind: no such file or directory` → CrashLoopBackOff | driver `MkdirAll`s `/var/lib/kubelet/plugins/gpu.kubeswift.io` before `Start` (replaces the lab's initContainer hotfix) |
| 3 | ghcr package born private (TFU #26) | operator publicized (no code) |

After merge: rebuild → redeploy → re-run the e2e to completion (CH `--device` + guest IP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)