### PR TITLE
docs(dra): record the cluster-validated DRA e2e (A8) + roadmap update

### DIFF
--- a/docs/design/dra-gpu-integration.md
+++ b/docs/design/dra-gpu-integration.md
@@ -290,3 +290,45 @@ QEMU/HGX tiers under DRA. Everything else moves to "validated".
    retries; DaemonSet restart recovers; document the failure surface.
 5. **The reference schema is ours, not NVIDIA's** — explicitly a *reference*;
    `extractDeviceBDFs` stays the single adapter point (P1 risk #2 unchanged).
+
+## A8. Workstream C results — CLUSTER-VALIDATED (2026-06-12)
+
+The full `ResourceClaim → scheduler allocation → CDI → vfio → VM` chain is
+validated end-to-end on the dev cluster (k0s 1.34.3, containerd 1.7.30 with the
+§A5 CDI drop-in, boba's GTX 1080):
+
+| Step | Evidence |
+|---|---|
+| ResourceSlice published | device `gpu-0000-01-00-0` (§A3 naming), attrs `pciAddress/vendorDevice(10de:1b80)/numaNode/iommuGroup/vfioReady:true` |
+| Real scheduler allocation | SwiftGuest `gpuResourceClaim` → minted claim `dra-gpu-vm-gpu-*` → kube-scheduler bound the pod to boba AND allocated `gpu-0000-01-00-0` |
+| CDI env injection (§A2) | `gpu-init` logged `GPU_PCI_ADDRESSES=0000:01:00.0` — an env the pod spec deliberately does NOT set; only the driver's CDI containerEdits can produce it. gpu-init ran UNCHANGED (idempotent vfio bind) |
+| Tier-1 read-back (§A3) | the driver's `status.devices[].data{pciAddress}` write LANDED (`DRAResourceClaimDeviceStatus` is enabled on k8s 1.34) → `Resolve` → `status.GPU` + `GPUAllocated=True` |
+| The VM | swiftletd `gpu_device … source=env`; the CH process cmdline carries `--device path=/sys/bus/pci/devices/0000:01:00.0/`; guest Running with a DHCP IP |
+
+**Three findings (fixed same-day, PR #214 — the W5 pattern again):**
+1. `"devices": null` in the intent broke swiftletd — Go marshals nil slices as
+   JSON null and Rust's `#[serde(default)]` covers *missing*, not explicit
+   null. The VM silently never spawned behind a Running pod. Fixed both sides
+   (`omitempty` + a `null_to_default` deserializer + regression test).
+2. The kubeletplugin helper does not create its socket dir
+   (`/var/lib/kubelet/plugins/<driver>/`) → bind failure → CrashLoopBackOff.
+   The driver now `MkdirAll`s it before `Start`.
+3. The new ghcr package was born private (TFU #26) — one-time manual
+   publicize by the maintainer.
+
+**Operator quickstart** (GPU node prepped per §A5):
+
+```sh
+kubectl apply -f config/dra-driver/dra-driver.yaml        # driver DaemonSet (+RBAC)
+kubectl apply -f config/dra-driver/deviceclass.yaml       # kubeswift-vfio-gpu
+kubectl apply -f config/dra-driver/resourceclaimtemplate-sample.yaml
+# then on the SwiftGuest:
+#   spec:
+#     gpuResourceClaim:
+#       resourceClaimTemplateName: single-vfio-gpu
+#       tier: pcie
+```
+
+**Residual hardware gate after this arc** (unchanged from §A6): the NVIDIA
+`k8s-dra-driver-gpu` schema adapter (one function), ComputeDomains/IMEX (P3),
+MIG (P4), QEMU/HGX tiers under DRA.

--- a/kubeswift_context.md
+++ b/kubeswift_context.md
@@ -2662,8 +2662,24 @@ Shipped across 6 PRs (design + 5 build):
 
 ### Paused (roadmap — resume when hardware lands)
 
-- **DRA / NVIDIA-ecosystem GPU integration — Phase 1 SHIPPED (PR #211,
-  2026-06-12); Phases 2–5 PAUSED, hardware-gated.** RFC:
+- **DRA / NVIDIA-ecosystem GPU integration — Phases 1+2 SHIPPED + CLUSTER-VALIDATED
+  (PRs #211, #213, #214, 2026-06-12); P3–P5 hardware-gated.** The "P2 needs
+  datacenter hardware" framing was overturned (RFC Addendum §A1): the dev
+  cluster speaks DRA (k8s 1.34.3, resource.k8s.io/v1) and a **KubeSwift
+  reference DRA driver** (`cmd/kubeswift-dra-driver`, driver `gpu.kubeswift.io`)
+  made boba's GTX 1080 sufficient for the whole passthrough path. **The full
+  chain is cluster-validated** (§A8): ResourceSlice (BDF-encoding device names)
+  → real kube-scheduler allocation of a SwiftGuest's minted ResourceClaim →
+  the driver's CDI containerEdits injecting GPU_PCI_ADDRESSES (gpu-init runs
+  UNCHANGED; no controller/init-container race) → swiftletd deviceSource=env
+  synthesis → CH `--device .../0000:01:00.0` → guest Running with an IP +
+  `status.GPU` read back tier-1 (`status.devices[].data` — the device-status
+  feature is on). Cluster prep: k0s containerd `enable_cdi` drop-in
+  (`/etc/k0s/containerd.d/99-kubeswift-cdi.toml`) + k0sworker restart (guests
+  survive). Walkthrough findings (all fixed in #214, the W5 pattern): intent
+  `devices: null` broke swiftletd serde (omitempty + null_to_default both
+  sides); kubeletplugin helper doesn't create its socket dir (driver MkdirAll);
+  ghcr package born private (TFU #26, publicized). RFC:
   [`docs/design/dra-gpu-integration.md`](docs/design/dra-gpu-integration.md).
   Decision: **hybrid/pluggable** — DRA is an opt-in allocation backend; the
   native SwiftGPU model stays the default (right tool for heterogeneous estates
@@ -2677,12 +2693,12 @@ Shipped across 6 PRs (design + 5 build):
   synthetic-ResourceClaim unit test, and the native backend refactor
   (behavior-preserving — existing swiftgpu tests unchanged). A DRA guest is
   held Pending (`GPUDRARuntimePending`) so it never boots GPU-less.
-  **Paused at the P1/P2 boundary** (operator decision 2026-06-12):
-  - **P2 — DRA-cluster spike** (needs a datacenter NVIDIA GPU + k8s-dra-driver-gpu):
-    pin the driver's `AllocatedDeviceStatus.Data` schema (isolated in
-    `gpualloc.extractDeviceBDFs` — the one P1 guess), resolve gpu-init-vs-driver
-    vfio binding ownership, wire the claim-bearing unpinned launcher pod +
-    buildGPUIntent feed, boot one VM end-to-end.
+  **Remaining (hardware-gated):**
+  - **NVIDIA k8s-dra-driver-gpu adapter** (needs a datacenter NVIDIA GPU): pin
+    that driver's `AllocatedDeviceStatus.Data`/CDI schema — now a one-function
+    adapter in `gpualloc.extractDeviceBDFs` (the reference schema
+    `{"pciAddress"}` + BDF-encoded device names are validated), plus its
+    binding-ownership mode (the reference driver leaves binding to gpu-init).
   - **P3 — ComputeDomains/IMEX** (multi-node NVLink, GB200) — DRA-only.
   - **P4 — MIG/fractional** — a MIG instance is NOT a PCI BDF; needs a
     mediated-device `runtimeintent` variant + CH/QEMU args.


### PR DESCRIPTION
Records Workstream C's result in the RFC (§A8 evidence table + operator quickstart + the three same-day findings fixed in [#214](https://github.com/projectbeskar/kubeswift/pull/214)) and updates the roadmap: **DRA Phases 1+2 are SHIPPED + CLUSTER-VALIDATED** — a SwiftGuest received the GTX 1080 through a real scheduler ResourceClaim allocation, CDI-injected device identity, and VFIO passthrough into a booted, IP-bearing VM. P3–P5 (+ the NVIDIA-driver schema adapter, now a one-function change) remain hardware-gated.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)