### PR TITLE
docs(dra): user guide + apply-ready samples for the DRA GPU backend

### DIFF
--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -23,6 +23,7 @@ kubectl apply -f config/samples/shared/swiftseedprofile-minimal.yaml
 | [qemu-boot/](qemu-boot/) | Ubuntu Noble via QEMU/OVMF | QEMU | No |
 | [gpu-pcie/](gpu-pcie/) | Tier 1 PCIe GPU passthrough | Cloud Hypervisor | Yes |
 | [gpu-hgx/](gpu-hgx/) | Tier 2 HGX SXM shared NVSwitch | QEMU | Yes |
+| [dra-gpu/](dra-gpu/) | GPU passthrough via DRA ResourceClaims (scheduler-allocated) | Cloud Hypervisor | Yes |
 | [datadisk/](datadisk/) | Secondary data disk attachment | Cloud Hypervisor | No |
 | [rocky/](rocky/) | Rocky Linux 9 alternative distro | Cloud Hypervisor | No |
 

--- a/config/samples/dra-gpu/README.md
+++ b/config/samples/dra-gpu/README.md
@@ -1,0 +1,87 @@
+# GPU Passthrough — DRA Allocation Backend
+
+GPU passthrough where the **kube-scheduler** allocates the GPU through a
+`ResourceClaim` (Kubernetes Dynamic Resource Allocation), instead of the
+native SwiftGPU controller picking node + devices. The VM runtime path is
+identical — VFIO whole-GPU passthrough into Cloud Hypervisor (or QEMU for
+`hgx-*` tiers).
+
+Full operator guide: [docs/gpu/dra-allocation.md](../../../docs/gpu/dra-allocation.md).
+Design + cluster-validation evidence: [docs/design/dra-gpu-integration.md](../../../docs/design/dra-gpu-integration.md).
+
+## Files
+
+| File | What it shows |
+|------|---------------|
+| `resourceclaimtemplate-single-gpu.yaml` | One GPU per guest, claim minted per pod (recommended) |
+| `swiftguest-dra-gpu.yaml` | SwiftGuest with `gpuResourceClaim.resourceClaimTemplateName` (the cluster-validated shape) |
+| `resourceclaim-shared.yaml` | Pre-created claim — the reservation outlives the pod |
+| `swiftguest-dra-shared-claim.yaml` | SwiftGuest with `gpuResourceClaim.resourceClaimName` |
+| `resourceclaimtemplate-selectors.yaml` | CEL device selectors (GPU model, vfio-ready nodes only) |
+
+## Prerequisites
+
+- Kubernetes **>= 1.34** (`resource.k8s.io/v1` GA)
+- **CDI enabled** in containerd on GPU nodes (off by default in containerd 1.7 —
+  see the [node prep section](../../../docs/gpu/dra-allocation.md#prerequisites)
+  for the k0s drop-in)
+- GPU node labeled `kubeswift.io/gpu-node=true`, IOMMU on, `vfio-pci` module loaded
+- The reference DRA driver + DeviceClass installed:
+
+```bash
+kubectl apply -f config/dra-driver/dra-driver.yaml    # DaemonSet + RBAC
+kubectl apply -f config/dra-driver/deviceclass.yaml   # DeviceClass kubeswift-vfio-gpu
+kubectl get resourceslice                             # one slice per GPU node
+```
+
+- SwiftImage `ubuntu-noble` Ready (create via `disk-boot/` scenario first)
+
+## Apply
+
+```bash
+kubectl apply -f config/samples/shared/swiftguestclass-default.yaml
+kubectl apply -f config/samples/shared/swiftseedprofile-minimal.yaml
+kubectl apply -f config/samples/dra-gpu/resourceclaimtemplate-single-gpu.yaml
+kubectl apply -f config/samples/dra-gpu/swiftguest-dra-gpu.yaml
+kubectl get swiftguest dra-gpu-vm -w
+```
+
+## Expected result
+
+```
+$ kubectl get resourceclaim
+NAME                   STATE                AGE
+dra-gpu-vm-gpu-vkt4l   allocated,reserved   1m
+
+$ kubectl get swiftguest dra-gpu-vm
+NAME         PHASE     NODE   IP              AGE
+dra-gpu-vm   Running   boba   192.168.99.13   2m
+
+$ kubectl get swiftguest dra-gpu-vm -o jsonpath='{.status.gpu}'
+{"devices":["0000:01:00.0"],"hypervisor":"cloud-hypervisor","nodeName":"boba","partitionId":-1}
+```
+
+- Condition `GPUAllocated=True` (`allocated 1 GPU(s) on node boba`); while the
+  scheduler is still deciding, the guest shows `GPUClaimPending` instead.
+- Inside the guest: `lspci | grep -i nvidia` shows the GPU.
+
+No `SwiftGPUProfile` and no `SwiftGPUNode` are involved — allocation state
+lives in the `ResourceClaim`.
+
+## Cleanup
+
+```bash
+kubectl delete swiftguest dra-gpu-vm
+# per-pod claims are garbage-collected with the pod; shared claims are not:
+kubectl delete swiftguest dra-gpu-vm-reserved --ignore-not-found
+kubectl delete resourceclaim reserved-vfio-gpu --ignore-not-found
+```
+
+## Limitations (v1)
+
+- Whole-GPU `tier: pcie` passthrough is the cluster-validated path; `hgx-*`
+  tiers under DRA are untested (no HGX hardware).
+- DRA guests are **excluded from automated offline GPU migration on drain**
+  (that choreography is native-backend-only); they block a drain like other
+  VFIO guests.
+- No MIG/fractional, no multi-node NVLink/IMEX yet (later, hardware-gated phases).

--- a/config/samples/dra-gpu/resourceclaim-shared.yaml
+++ b/config/samples/dra-gpu/resourceclaim-shared.yaml
@@ -1,0 +1,23 @@
+# Pre-created (shared) ResourceClaim: the GPU allocation outlives any single
+# launcher pod. Reference it from a SwiftGuest via
+# spec.gpuResourceClaim.resourceClaimName instead of resourceClaimTemplateName.
+#
+# Use this when you want a STABLE device reservation that survives guest
+# stop/start and pod recreation — the claim stays allocated to the same device
+# until the claim itself is deleted.
+#
+# IMPORTANT — VFIO is exclusive: DRA allows many pods to reference a shared
+# claim, but a VFIO-passed GPU can only back ONE running VM. Ensure at most one
+# SwiftGuest references this claim at a time (e.g. one claim per guest name).
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: reserved-vfio-gpu
+  namespace: default
+spec:
+  devices:
+    requests:
+      - name: gpu
+        exactly:
+          deviceClassName: kubeswift-vfio-gpu
+          count: 1

--- a/config/samples/dra-gpu/resourceclaimtemplate-selectors.yaml
+++ b/config/samples/dra-gpu/resourceclaimtemplate-selectors.yaml
@@ -1,0 +1,33 @@
+# ResourceClaimTemplate with CEL device selectors: constrain WHICH GPUs the
+# scheduler may allocate, using the attributes the kubeswift-dra-driver
+# publishes on its ResourceSlices:
+#
+#   pciAddress   (string)  e.g. "0000:01:00.0"
+#   vendorDevice (string)  PCI vendor:device, e.g. "10de:1b80" (GTX 1080)
+#   numaNode     (int)     NUMA node the GPU is attached to (-1 if unknown)
+#   iommuGroup   (int)     IOMMU group number
+#   vfioReady    (bool)    true when the node has the vfio-pci driver loaded
+#
+# Attributes are accessed in CEL via the driver-qualified map:
+#   device.attributes["gpu.kubeswift.io"].<name>
+#
+# This example only allocates a specific GPU model AND only on nodes where
+# vfio-pci is already loaded (so gpu-init's bind cannot fail on a module gap).
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gtx1080-vfio-ready
+  namespace: default
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: kubeswift-vfio-gpu
+            count: 1
+            selectors:
+              - cel:
+                  expression: >-
+                    device.attributes["gpu.kubeswift.io"].vendorDevice == "10de:1b80" &&
+                    device.attributes["gpu.kubeswift.io"].vfioReady == true

--- a/config/samples/dra-gpu/resourceclaimtemplate-single-gpu.yaml
+++ b/config/samples/dra-gpu/resourceclaimtemplate-single-gpu.yaml
@@ -1,0 +1,22 @@
+# ResourceClaimTemplate: one whole VFIO GPU per guest, allocated by the
+# kube-scheduler at pod-schedule time (DRA structured parameters).
+#
+# Each SwiftGuest referencing this template gets its OWN ResourceClaim minted
+# when the launcher pod is created; the claim is garbage-collected with the pod.
+# This is the recommended mode for most workloads.
+#
+# The request name "gpu" matches GPUResourceClaimSpec's default requestName —
+# if you rename it, set spec.gpuResourceClaim.requestName on the SwiftGuest.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: single-vfio-gpu
+  namespace: default
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: kubeswift-vfio-gpu
+            count: 1

--- a/config/samples/dra-gpu/swiftguest-dra-gpu.yaml
+++ b/config/samples/dra-gpu/swiftguest-dra-gpu.yaml
@@ -1,0 +1,37 @@
+# SwiftGuest with GPU passthrough via the DRA allocation backend.
+#
+# Instead of a SwiftGPUProfile (native backend), this guest carries a
+# gpuResourceClaim: the launcher pod references a ResourceClaimTemplate, the
+# kube-scheduler allocates a GPU from the ResourceSlices published by the
+# kubeswift-dra-driver, and the driver's CDI spec hands the PCI address to
+# gpu-init. No nodeName pinning — the scheduler picks the node.
+#
+# This exact shape is cluster-validated (design doc dra-gpu-integration.md §A8).
+#
+# Prerequisites (see config/samples/dra-gpu/README.md):
+#   1. Kubernetes >= 1.34 (resource.k8s.io/v1) with CDI enabled in containerd
+#   2. kubeswift-dra-driver DaemonSet + DeviceClass (config/dra-driver/)
+#   3. ResourceClaimTemplate single-vfio-gpu (this directory)
+#   4. SwiftImage ubuntu-noble Ready, SwiftGuestClass default, SwiftSeedProfile minimal
+#
+# Verify:
+#   kubectl get swiftguest dra-gpu-vm -w          # Pending -> Running with IP
+#   kubectl get resourceclaim                     # dra-gpu-vm-gpu-* allocated,reserved
+#   kubectl get swiftguest dra-gpu-vm -o jsonpath='{.status.gpu}'
+#   swiftctl ssh dra-gpu-vm -- lspci | grep -i nvidia
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: dra-gpu-vm
+  namespace: default
+spec:
+  imageRef:
+    name: ubuntu-noble
+  gpuResourceClaim:
+    resourceClaimTemplateName: single-vfio-gpu
+    tier: pcie # pcie -> Cloud Hypervisor (default); hgx-shared/hgx-full -> QEMU
+  guestClassRef:
+    name: default
+  seedProfileRef:
+    name: minimal
+  runPolicy: Running

--- a/config/samples/dra-gpu/swiftguest-dra-shared-claim.yaml
+++ b/config/samples/dra-gpu/swiftguest-dra-shared-claim.yaml
@@ -1,0 +1,22 @@
+# SwiftGuest using a PRE-CREATED shared ResourceClaim (resourceClaimName)
+# instead of a per-pod template. The device reservation is held by the claim,
+# not the pod — stop/start of the guest reuses the same GPU.
+#
+# Apply resourceclaim-shared.yaml first. Only one SwiftGuest may reference the
+# claim at a time (VFIO passthrough is exclusive — see the claim's comments).
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: dra-gpu-vm-reserved
+  namespace: default
+spec:
+  imageRef:
+    name: ubuntu-noble
+  gpuResourceClaim:
+    resourceClaimName: reserved-vfio-gpu
+    tier: pcie
+  guestClassRef:
+    name: default
+  seedProfileRef:
+    name: minimal
+  runPolicy: Running

--- a/docs/gpu-passthrough.md
+++ b/docs/gpu-passthrough.md
@@ -2,6 +2,8 @@
 
 KubeSwift supports GPU passthrough using VFIO. GPUs appear as PCI devices inside the VM. The approach differs based on GPU hardware class — the `tier` field in SwiftGPUProfile is the single selection point.
 
+> This page covers the **native** allocation backend (`spec.gpuProfileRef`), where the SwiftGPU controller picks node + devices from its own inventory. KubeSwift can alternatively let the **kube-scheduler** allocate GPUs through standard Kubernetes ResourceClaims — see [GPU allocation via DRA](gpu/dra-allocation.md) (`spec.gpuResourceClaim`). The runtime passthrough path is identical for both.
+
 ## Prerequisites
 
 ### Host requirements

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -1,0 +1,317 @@
+# GPU Allocation via DRA (Dynamic Resource Allocation)
+
+KubeSwift has two GPU allocation backends. The **native** backend
+(`spec.gpuProfileRef`) is the default: the SwiftGPU controller inventories GPUs
+through the discovery DaemonSet and picks node + devices itself. The **DRA**
+backend (`spec.gpuResourceClaim`) delegates that decision to Kubernetes: the
+launcher pod carries a `ResourceClaim`, and the **kube-scheduler** allocates a
+GPU from the `ResourceSlice`s a DRA driver publishes — the standard
+`resource.k8s.io/v1` API (GA since Kubernetes 1.34).
+
+Either way, the VM runtime path is identical: the GPU is VFIO-passed whole into
+the guest by Cloud Hypervisor (`tier: pcie`) or QEMU (`tier: hgx-*`). DRA only
+changes *who decides which GPU on which node*.
+
+This guide covers the operator workflow with KubeSwift's **reference DRA
+driver** (`kubeswift-dra-driver`, driver name `gpu.kubeswift.io`). The design,
+rationale, and cluster-validation evidence live in
+[docs/design/dra-gpu-integration.md](../design/dra-gpu-integration.md).
+
+## Choosing a backend
+
+| | Native (`gpuProfileRef`) | DRA (`gpuResourceClaim`) |
+|---|---|---|
+| Who allocates | SwiftGPU controller (`SwiftGPUNode` inventory) | kube-scheduler (`ResourceClaim` + `ResourceSlice`) |
+| Allocation API | KubeSwift CRDs (`SwiftGPUProfile`/`SwiftGPUNode`) | Standard Kubernetes `resource.k8s.io/v1` |
+| Requires | gpu-discovery DaemonSet | a DRA driver + CDI enabled in containerd |
+| Device selection | profile `model`/`tier`/NUMA matching | `DeviceClass` + CEL selectors on device attributes |
+| GPU sharing across the cluster's stack | KubeSwift-only view | claims/slices visible to any DRA-aware component |
+| Drain auto-migration (offline GPU migration) | yes (reserve-and-reallocate) | **no** — DRA guests block a drain like other VFIO guests |
+| HGX tiers (2/3), Fabric Manager partitions | yes (validated on Tier 1; HGX hardware-gated) | untested under DRA |
+| MIG / fractional, multi-node NVLink (IMEX) | not expressible | future, hardware-gated phases |
+| Maturity | the long-validated default | cluster-validated for whole-GPU `tier: pcie` |
+
+Pick exactly one per guest — `gpuProfileRef` and `gpuResourceClaim` are
+mutually exclusive (webhook-enforced). Both backends can coexist in one
+cluster, even on the same node; a GPU allocated by one is simply busy from the
+other's perspective only if something tracks it — **do not point both backends
+at the same physical GPUs** unless you partition them (e.g. dedicate nodes to
+one backend).
+
+## How it works
+
+```
+SwiftGuest (spec.gpuResourceClaim)
+   │ SwiftGPU controller: GPUClaimPending=True (no node, no device yet)
+   ▼
+launcher pod with pod.spec.resourceClaims  ──►  kube-scheduler picks node + GPU
+   │                                            (from the driver's ResourceSlice)
+   ▼
+kubelet calls the DRA driver (NodePrepareResources)
+   │ driver writes a CDI spec: inject GPU_PCI_ADDRESSES=<bdf> into the
+   │ containers referencing the claim
+   ▼
+gpu-init (unchanged) binds the BDF to vfio-pci
+   ▼
+swiftletd reads GPU_PCI_ADDRESSES (intent gpu.deviceSource: env)
+   ▼
+cloud-hypervisor --device path=/sys/bus/pci/devices/<bdf>/
+   │
+   └─ controller reads the allocation back from the claim → status.gpu,
+      GPUAllocated=True
+```
+
+Key property: the device identity travels through **CDI container edits**, not
+a controller round-trip — there is no race between allocation and the gpu-init
+init container, and `kubectl get` status is purely observational.
+
+## Prerequisites
+
+1. **Kubernetes >= 1.34** (`resource.k8s.io/v1` is GA there).
+2. **CDI enabled in containerd** on every GPU node. containerd 1.7 ships with
+   `enable_cdi = false`. On k0s, add an import drop-in and restart the worker
+   (running guests survive the restart):
+
+   ```toml
+   # /etc/k0s/containerd.d/99-kubeswift-cdi.toml
+   [plugins."io.containerd.grpc.v1.cri"]
+     enable_cdi = true
+     cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
+   ```
+
+   ```bash
+   sudo systemctl restart k0sworker
+   ```
+
+   On other distributions, set the same keys in the containerd CRI plugin
+   config. containerd 2.x enables CDI by default.
+3. **GPU node prep** — the same host requirements as the native backend
+   ([gpu-passthrough.md](../gpu-passthrough.md)): IOMMU on, `vfio-pci` module
+   loaded persistently, node labeled `kubeswift.io/gpu-node=true`.
+4. A **DRA driver**. The rest of this guide uses KubeSwift's reference driver;
+   adapting an external driver (e.g. NVIDIA's `k8s-dra-driver-gpu`) is a
+   hardware-gated follow-up — see [External drivers](#external-dra-drivers).
+
+## Install the reference driver
+
+```bash
+kubectl apply -f config/dra-driver/dra-driver.yaml    # DaemonSet + RBAC (kubeswift-system)
+kubectl apply -f config/dra-driver/deviceclass.yaml   # DeviceClass: kubeswift-vfio-gpu
+```
+
+The driver runs on `kubeswift.io/gpu-node=true` nodes, discovers GPUs from
+sysfs (no NVIDIA userspace needed), and publishes one `ResourceSlice` per node:
+
+```
+$ kubectl get resourceslice
+NAME                          NODE   DRIVER             POOL   AGE
+boba-gpu.kubeswift.io-mg7pp   boba   gpu.kubeswift.io   boba   18m
+```
+
+Each device carries the attributes `pciAddress`, `vendorDevice` (PCI
+vendor:device, e.g. `10de:1b80`), `numaNode`, `iommuGroup`, and `vfioReady`
+(whether the node has the vfio-pci driver loaded). Device names encode the PCI
+address (`gpu-0000-01-00-0` ⇄ `0000:01:00.0`) so an allocation is identifiable
+even without the device-status feature.
+
+The driver only advertises devices and hands identity over — **vfio-pci binding
+stays with the launcher pod's gpu-init**, same as the native backend.
+
+## Boot a GPU guest
+
+Create a `ResourceClaimTemplate` (one GPU per guest; each guest gets its own
+claim, garbage-collected with the pod):
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: single-vfio-gpu
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu # matches gpuResourceClaim's default requestName
+          exactly:
+            deviceClassName: kubeswift-vfio-gpu
+            count: 1
+```
+
+Reference it from a SwiftGuest — note there is **no SwiftGPUProfile and no
+nodeName**; the scheduler picks the node:
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: dra-gpu-vm
+spec:
+  imageRef:
+    name: ubuntu-noble
+  gpuResourceClaim:
+    resourceClaimTemplateName: single-vfio-gpu
+    tier: pcie # pcie -> Cloud Hypervisor (default); hgx-* -> QEMU
+  guestClassRef:
+    name: default
+  seedProfileRef:
+    name: minimal
+  runPolicy: Running
+```
+
+Ready-to-apply versions of these (plus the variants below) are in
+[config/samples/dra-gpu/](../../config/samples/dra-gpu/).
+
+Verify:
+
+```
+$ kubectl get resourceclaim
+NAME                   STATE                AGE
+dra-gpu-vm-gpu-vkt4l   allocated,reserved   1m
+
+$ kubectl get swiftguest dra-gpu-vm
+NAME         PHASE     NODE   IP              AGE
+dra-gpu-vm   Running   boba   192.168.99.13   2m
+
+$ kubectl get swiftguest dra-gpu-vm -o jsonpath='{.status.gpu}'
+{"devices":["0000:01:00.0"],"hypervisor":"cloud-hypervisor","nodeName":"boba","partitionId":-1}
+
+$ swiftctl ssh dra-gpu-vm -- lspci | grep -i nvidia
+01:00.0 VGA compatible controller: NVIDIA Corporation GP104 [GeForce GTX 1080]
+```
+
+## Pre-created (shared) claims
+
+A standalone `ResourceClaim` referenced via `resourceClaimName` holds its
+allocation independently of any pod — the guest reuses the **same physical
+GPU** across stop/start and pod recreation:
+
+```yaml
+spec:
+  gpuResourceClaim:
+    resourceClaimName: reserved-vfio-gpu
+    tier: pcie
+```
+
+**Constraint:** DRA itself lets many pods share a claim, but a VFIO-passed GPU
+can back only one running VM. Keep a 1:1 claim-to-guest mapping; never point
+two running SwiftGuests at the same shared claim.
+
+## Selecting devices with CEL
+
+Requests can constrain which devices qualify, using the driver's published
+attributes (qualified by the driver name in CEL):
+
+```yaml
+requests:
+  - name: gpu
+    exactly:
+      deviceClassName: kubeswift-vfio-gpu
+      count: 1
+      selectors:
+        - cel:
+            expression: >-
+              device.attributes["gpu.kubeswift.io"].vendorDevice == "10de:1b80" &&
+              device.attributes["gpu.kubeswift.io"].vfioReady == true
+```
+
+The `vfioReady` guard is recommended in mixed fleets: it keeps the scheduler
+from placing a GPU guest on a node where the vfio-pci module is missing (where
+gpu-init's bind would fail after scheduling).
+
+## `spec.gpuResourceClaim` reference
+
+| Field | Meaning |
+|---|---|
+| `resourceClaimTemplateName` | Mint a per-pod claim from this template (recommended). Mutually exclusive with `resourceClaimName`. |
+| `resourceClaimName` | Use a pre-created shared claim (reservation outlives the pod). |
+| `requestName` | Device-request name inside the claim to read the allocation from. Default `"gpu"`. |
+| `tier` | Hypervisor selection, same semantics as `SwiftGPUProfile.tier`: `pcie` (default, Cloud Hypervisor), `hgx-shared`/`hgx-full` (QEMU). |
+| `hugepages` | GPU memory hugepage backing (`1Gi`, `2Mi`, or empty). |
+
+Because there is no profile, these are the only VM-shape knobs; everything
+else (which device, which node) is the claim's job. `gpuResourceClaim` is
+mutually exclusive with `gpuProfileRef`, `kernelRef`, `cloneFromSnapshot`, and
+`osType: windows` — the same constraint family as `gpuProfileRef`.
+
+## Conditions and status
+
+- **`GPUClaimPending=True`** — the guest is DRA-backed and the scheduler has
+  not allocated yet (or the controller hasn't observed it). The launcher pod
+  exists and is what the scheduler is placing. Cleared once resolved.
+- **`GPUAllocated=True`** (`allocated 1 GPU(s) on node boba`) — the allocation
+  was read back from the claim into `status.gpu`
+  (`devices`, `nodeName`, `hypervisor`, `partitionId: -1`).
+- `kubectl get resourceclaim` shows the authoritative allocation state
+  (`allocated,reserved`); `kubectl get swiftgpunode` plays **no role** for
+  DRA-backed guests.
+
+## Limitations (v1)
+
+- **Whole-GPU `tier: pcie` is the validated path.** `hgx-shared`/`hgx-full`
+  under DRA are untested (no HGX hardware); Fabric Manager partition selection
+  is native-only.
+- **No automated drain evacuation.** The offline GPU migration choreography
+  (reserve-on-target-before-stop) is native-backend-only. A DRA GPU guest
+  blocks `kubectl drain` and needs manual handling, like other VFIO guests
+  without that support.
+- **No MIG/fractional, no multi-node NVLink (IMEX)** — these are precisely the
+  capabilities DRA will eventually unlock, but they need datacenter hardware
+  and are tracked as later phases in the design doc.
+- NUMA placement inside the guest is not derived from the claim in v1
+  (single-node topology; `numaNode` attribute is informational).
+
+## Troubleshooting
+
+**Guest stuck with `GPUClaimPending=True`, claim `pending`.** The scheduler
+found no allocatable device. Check `kubectl get resourceslice` (does a slice
+exist for a GPU node? is the driver pod running?), and your CEL selectors
+(e.g. `vfioReady == true` excludes nodes without the vfio-pci module —
+`modprobe vfio-pci` on the node, the next driver republish updates the
+attribute).
+
+**Launcher pod Running but the guest never gets an IP / `GuestRunning` stays
+false; swiftletd log shows:**
+
+```
+gpu.deviceSource=env but GPU_PCI_ADDRESSES is empty — CDI injection from the
+DRA driver did not happen (is enable_cdi on, and does the container reference
+the claim?)
+```
+
+CDI is not enabled in containerd on that node (the prerequisite drop-in +
+worker restart), or the CDI spec write failed (check the driver pod's logs).
+This is fail-loud by design — the VM is never booted GPU-less. Judge DRA GPU
+guests by `GuestRunning`/IP, not by the pod phase.
+
+**Driver pod CrashLoopBackOff with `bind: no such file or directory` on
+`/var/lib/kubelet/plugins/gpu.kubeswift.io/dra.sock`.** You are running a
+driver image older than the fix that creates its plugin directory — upgrade
+the DaemonSet image.
+
+**Webhook rejection on create.** `gpuProfileRef` and `gpuResourceClaim` are
+mutually exclusive, exactly one of `resourceClaimName`/
+`resourceClaimTemplateName` must be set, and the same boot-source rules as the
+native backend apply (disk boot only).
+
+**`strict decoding error: unknown field "spec.gpuResourceClaim"`.** The
+cluster's SwiftGuest CRD predates the field — re-apply the CRDs
+(`kubectl apply -f config/crd/bases/` or `make deploy`; Helm upgrades do not
+touch CRDs).
+
+## External DRA drivers
+
+The reference driver exists to validate the pipeline and serve clusters that
+want VFIO GPU allocation without the NVIDIA software stack. Using NVIDIA's
+`k8s-dra-driver-gpu` instead requires pinning its device-status/CDI schema —
+isolated to a single adapter function in KubeSwift's claim read-back — and
+deciding binding ownership (the reference driver leaves vfio binding to
+gpu-init). That work is hardware-gated; status is tracked in
+[the design doc](../design/dra-gpu-integration.md) (§A6/§A8).
+
+## See also
+
+- [GPU Passthrough (native backend)](../gpu-passthrough.md) — tiers, discovery
+  DaemonSet, SwiftGPUProfile reference, Fabric Manager
+- [Samples](../../config/samples/dra-gpu/) — apply-ready manifests for
+  everything above
+- [Design doc + cluster-validation evidence](../design/dra-gpu-integration.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,11 @@ KubeSwift runs Linux VMs on Kubernetes using [Cloud Hypervisor](https://www.clou
 - [Running Windows guests](windows/overview.md) — Overview: `osType: windows`, the end-to-end lifecycle, RDP management, limitations
 - [Windows image prep](windows/image-prep.md) — Operator runbook: build a virtio-ready, CH-bootable Windows image
 
+### GPU Passthrough
+
+- [GPU Passthrough](gpu-passthrough.md) — VFIO passthrough, compatibility tiers, GPU Discovery DaemonSet, SwiftGPUProfile reference, Fabric Manager
+- [GPU allocation via DRA](gpu/dra-allocation.md) — Scheduler-allocated GPUs through ResourceClaims (`spec.gpuResourceClaim`), the reference DRA driver, CDI node prep
+
 ### Installation
 
 - [Local cluster](install/local-cluster.md) — kind, minikube, build and deploy
@@ -102,6 +107,7 @@ KubeSwift runs Linux VMs on Kubernetes using [Cloud Hypervisor](https://www.clou
 | Run smoke test | [Smoke verification](operator/smoke-verification.md) |
 | Validate worker node | [Worker-node preflight](operator/worker-node-preflight.md) |
 | Connect VMs to physical networks | [Networking Operations Guide](networking/operations-guide.md) |
+| Pass a GPU through to a VM | [GPU Passthrough](gpu-passthrough.md) / [via DRA](gpu/dra-allocation.md) |
 | Migrate from VMware/Proxmox | [Virtualization Comparison](networking/virtualization-comparison.md) |
 | Build locally | [Build](developer/build.md) |
 | Understand CRDs | [API overview](api/overview.md) |


### PR DESCRIPTION
## What

Operator-facing material for the DRA GPU allocation backend (`spec.gpuResourceClaim`), which shipped and was cluster-validated in #211 / #213 / #214. Until now the only documentation was the design doc/RFC — this adds the user guide and an apply-ready sample scenario.

## New

### `docs/gpu/dra-allocation.md` — operator guide
- **Choosing a backend**: native (`gpuProfileRef`) vs DRA (`gpuResourceClaim`) comparison table, incl. the honest caveats (DRA guests are excluded from drain auto-migration; HGX tiers untested under DRA).
- **How it works**: the scheduler-allocates / CDI-env-hand-off / status-read-back pipeline in one diagram.
- **Prerequisites**: k8s ≥ 1.34, the containerd `enable_cdi` node prep (the exact k0s drop-in verified on the dev cluster), standard GPU host prep.
- **Workflows**: reference-driver install, per-pod ResourceClaimTemplate guest (the cluster-validated shape), pre-created shared claims (with the VFIO-is-exclusive constraint), CEL device selectors on the driver's published attributes.
- **Reference**: `gpuResourceClaim` field table, `GPUClaimPending`/`GPUAllocated` conditions.
- **Troubleshooting**: each entry uses the real failure surface (swiftletd's fail-loud `GPU_PCI_ADDRESSES is empty` message, claim stuck `pending`, the plugin-dir CrashLoop, stale-CRD strict-decode, webhook rules). All example outputs are captured from the validated cluster run, not invented.

### `config/samples/dra-gpu/` — sample scenario
| File | Shows |
|---|---|
| `resourceclaimtemplate-single-gpu.yaml` | one GPU per guest, per-pod claim (recommended) |
| `swiftguest-dra-gpu.yaml` | the cluster-validated SwiftGuest shape |
| `resourceclaim-shared.yaml` + `swiftguest-dra-shared-claim.yaml` | reservation that outlives the pod |
| `resourceclaimtemplate-selectors.yaml` | CEL selectors: GPU model + `vfioReady` guard |
| `README.md` | prerequisites, apply order, expected results, cleanup, v1 limitations |

### Index wiring
- `config/samples/README.md` scenario row; `docs/index.md` new **GPU Passthrough** section + quick-link row; cross-link banner on `docs/gpu-passthrough.md` (the native-backend page).

## Verification

- All five sample manifests pass **server-side dry-run against the dev cluster** — exercises the `resource.k8s.io/v1` schemas, server-side CEL compilation of the selector expression, and the SwiftGuest webhook for both the template and shared-claim variants. `swiftguest-dra-gpu.yaml` reports **unchanged** against the live, Running `dra-gpu-vm` (the sample is byte-equivalent to the validated guest).
- All relative links resolve; docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)