### PR TITLE
docs(windows): record in-cluster cluster-validation (v1)

### DIFF
--- a/config/samples/windows/README.md
+++ b/config/samples/windows/README.md
@@ -4,11 +4,12 @@ Running a Windows guest as a SwiftGuest. **Windows runs on Cloud Hypervisor**
 (v52.0+) via the same disk-boot path Linux uses — the `osType: windows` gate is
 the single decision point.
 
-> **Asset-gated / illustrative.** These manifests are not cluster-validated (no
-> Windows image/license on the dev cluster), the same caveat as Tier 2/3 GPU. The
-> boot path itself is validated end-to-end on Cloud Hypervisor v52.0; see
+> The full in-cluster Windows path is **cluster-validated** (Cloud Hypervisor
+> v52.0; boot → NetKVM/DHCP → cloudbase-init over NoCloud → Running+IP); see
 > [`docs/windows/overview.md`](../../../docs/windows/overview.md).
-> The image URL is a placeholder — point it at your own virtio-ready image.
+> These manifests are still **illustrative**: the image URL is a placeholder —
+> point `source.http.url` at your own operator-prepped, virtio-ready image
+> (build one with [`tools/windows-image-prep/`](../../../tools/windows-image-prep/)).
 
 ## The three pieces
 

--- a/docs/windows/overview.md
+++ b/docs/windows/overview.md
@@ -4,12 +4,14 @@ KubeSwift runs **Windows** VMs as first-class SwiftGuests on **Cloud Hypervisor*
 (the same default runtime as Linux), gated by a single field: `osType: windows`.
 This page is the operator entry point; the deep dives are linked inline.
 
-> **Status: v1 code-complete, validation asset-gated.** Every layer is implemented
-> and individually validated (unit tests + a local boot spike); the only untested
-> piece is *in-cluster* cloudbase-init provisioning, which needs a Windows
-> image/license the dev cluster doesn't have — the same "asset not available"
-> caveat as Tier 2/3 GPU. The boot path itself is proven end-to-end: a virtio-ready
-> Windows Server 2022 image boots cleanly on **Cloud Hypervisor v52.0**. See the
+> **Status: v1 cluster-validated (2026-06-13).** The full in-cluster chain runs
+> end-to-end on the dev cluster: a virtio-ready Windows Server image imports
+> (qcow2→raw, osType-gated), clones its root disk, and boots on **Cloud
+> Hypervisor v52.0** (`--kernel CLOUDHV.fd`, `--cpus boot=N,kvm_hyperv=on`);
+> NetKVM brings up the NIC and the guest gets a DHCP IP; and **cloudbase-init
+> reads the NoCloud `cidata` seed and runs the first-boot user-data** (RDP
+> enabled), reaching `Running` with an IP — the last previously-untested piece
+> (in-cluster cloudbase-init provisioning) is now closed. See the
 > [design doc](../design/windows-guest-support.md).
 
 ## How it works — `osType: windows`
@@ -64,6 +66,18 @@ kubectl get swiftguest win-guest -o wide    # watch phase + primaryIP
 - An **operator-prepared, virtio-ready** image (viostor/NetKVM + headless BCD prep
   + cloudbase-init). The runbook automates this.
 - Sizing: Windows Server needs ≥ 2 GiB RAM (the default SwiftGuestClass is 4 GiB).
+
+## Provisioning notes
+
+- **Hostname from `local-hostname` applies on the first reboot.** The shipped
+  cloudbase-init config sets `allow_reboot = false` (KubeSwift owns guest
+  reboots), so `SetHostNamePlugin` *stages* the computer name from the seed's
+  `meta-data: local-hostname` but it only takes effect after the guest's next
+  reboot — until then Windows keeps its generated `WIN-…` name. The user-data
+  (RDP enable, scripts) and user/password plugins apply on first boot without a
+  reboot. If you need the name applied immediately, reboot the guest once, or
+  set `allow_reboot = true` in the image's `cloudbase-init.conf` so cloudbase-init
+  reboots itself on first boot.
 
 ## Limitations (v1 non-goals)
 


### PR DESCRIPTION
## What

Records the first **in-cluster end-to-end validation** of the Windows guest path (2026-06-13), closing the one layer the docs flagged as untested.

A virtio-ready Windows Server image (operator-prepped `windows2025.qcow2`, hosted on an in-lab HTTP server) was driven through the field-testing demo:

| Layer | Result |
|---|---|
| Import (qcow2→raw, osType-gated, unprivileged Job) | ✅ Ready, 40Gi raw |
| Root-disk clone | ✅ |
| CH v52 runtime | ✅ `--kernel CLOUDHV.fd`, `--cpus boot=2,kvm_hyperv=on`, raw disk + `seed.iso` |
| Windows boot + NetKVM + DHCP | ✅ Running, IP assigned |
| **cloudbase-init over NoCloud** (was untested) | ✅ ran — RDP (3389) came up open (off by default), proving the `cidata` seed → cloudbase-init user-data path |
| Operator status | ✅ `Running / cloud-hypervisor / windows`, 0 restarts |

## Changes (docs only)

- **`docs/windows/overview.md`** — status banner → *v1 cluster-validated*; new **Provisioning notes** documenting that the seed's `local-hostname` is staged by cloudbase-init's `SetHostNamePlugin` but applies on the next reboot, because the shipped config sets `allow_reboot = false` (KubeSwift owns reboots). User-data (RDP) and user/password apply on first boot. Not a bug — documented behavior; the note tells operators how to get the name applied immediately.
- **`config/samples/windows/README.md`** — drop the "not cluster-validated" caveat; the path is validated (the sample image URL stays a placeholder, since each operator hosts their own image).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)