### PR TITLE
feat(network): service exposure S2 — egress observability (EgressReady) + DNS search

### DIFF
--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -63,6 +63,12 @@ const ConditionPortsProgrammed = "PortsProgrammed"
 // exist and reference a Ready endpoint.
 const ConditionServiceReady = "ServiceReady"
 
+// ConditionEgressReady reports whether the guest's pod netns can reach the
+// cluster DNS ClusterIP (the egress observability probe — §4). On kube-proxy
+// clusters this reflects the VM's egress; on eBPF kube-proxy-free clusters it is
+// the pod-netns signal (the VM's forwarded traffic can bypass the eth0 hook).
+const ConditionEgressReady = "EgressReady"
+
 // SwiftGuestPhase is the phase of a SwiftGuest.
 // +kubebuilder:validation:Enum=Pending;Scheduling;Running;Stopped;Failed
 type SwiftGuestPhase string
@@ -786,6 +792,7 @@ type SwiftGuestStatus struct {
 // +kubebuilder:printcolumn:name="Hypervisor",type=string,JSONPath=`.status.runtime.hypervisor`,priority=1
 // +kubebuilder:printcolumn:name="OS",type=string,JSONPath=`.spec.osType`,priority=1
 // +kubebuilder:printcolumn:name="Service",type=string,JSONPath=`.status.network.serviceRef.name`,priority=1
+// +kubebuilder:printcolumn:name="Egress",type=string,JSONPath=`.status.network.egress`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type SwiftGuest struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -38,6 +38,10 @@ spec:
       name: Service
       priority: 1
       type: string
+    - jsonPath: .status.network.egress
+      name: Egress
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -38,6 +38,10 @@ spec:
       name: Service
       priority: 1
       type: string
+    - jsonPath: .status.network.egress
+      name: Egress
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/internal/controller/swiftguest/constants.go
+++ b/internal/controller/swiftguest/constants.go
@@ -31,6 +31,11 @@ const PodAnnotationGuestSerialSocket = "kubeswift.io/guest-serial-socket"
 // PodAnnotationGuestHypervisor is the annotation key for the hypervisor type (set by swiftletd on socket ready).
 const PodAnnotationGuestHypervisor = "kubeswift.io/guest-hypervisor"
 
+// PodAnnotationEgress is the annotation key ("true"/"false") for VM->cluster-DNS
+// ClusterIP reachability, set by the launcher entrypoint's egress probe (service
+// exposure §4). Mapped to status.network.egress + the EgressReady condition.
+const PodAnnotationEgress = "kubeswift.io/egress-cluster-reachable"
+
 // Mount path constants. Must match internal/runtimeintent and rust/swiftletd.
 const (
 	DisksRootPath = "/var/lib/kubeswift/disks/root"

--- a/internal/controller/swiftguest/status.go
+++ b/internal/controller/swiftguest/status.go
@@ -42,6 +42,26 @@ func MapPodToStatus(pod *corev1.Pod, status *swiftv1alpha1.SwiftGuestStatus) {
 		}
 	}
 
+	// Egress reachability (service exposure §4): swiftletd reports whether the
+	// pod netns can reach the cluster DNS ClusterIP. No silent failure — surface
+	// it in status.network.egress + the EgressReady condition.
+	if raw, ok := pod.Annotations[PodAnnotationEgress]; ok && raw != "" {
+		if status.Network == nil {
+			status.Network = &swiftv1alpha1.GuestNetworkStatus{}
+		}
+		reachable := raw == "true"
+		if reachable {
+			status.Network.Egress = "ClusterServices"
+			setNetworkCondition(status, swiftv1alpha1.ConditionEgressReady, true,
+				"ClusterServicesReachable", "cluster DNS ClusterIP reachable from the pod netns")
+		} else {
+			status.Network.Egress = "DirectOnly"
+			setNetworkCondition(status, swiftv1alpha1.ConditionEgressReady, false,
+				"ClusterIPUnreachableInPodNetns",
+				"cluster DNS ClusterIP not reachable from the pod netns; on eBPF kube-proxy-free clusters the VM needs egressMode: clusterServices (roadmap)")
+		}
+	}
+
 	// Set runtime from pod annotation (set by swiftletd on socket ready)
 	if pidStr, ok := pod.Annotations[PodAnnotationGuestRuntimePID]; ok && pidStr != "" {
 		if pid, err := strconv.ParseInt(pidStr, 10, 64); err == nil {

--- a/rust/swiftletd/scripts/launcher-entrypoint.sh
+++ b/rust/swiftletd/scripts/launcher-entrypoint.sh
@@ -97,10 +97,30 @@ if network_enabled; then
     dns=$(grep '^nameserver ' /etc/resolv.conf 2>/dev/null | head -1 | awk '{print $2}')
     [ -z "$dns" ] && dns="10.96.0.10"
 
+    # Egress observability (service exposure §4): probe whether the pod netns can
+    # reach the cluster DNS ClusterIP (TCP 53; CoreDNS serves it). swiftletd
+    # reports the result as kubeswift.io/egress-cluster-reachable, which the
+    # controller maps to status.network.egress + the EgressReady condition.
+    # On kube-proxy clusters this reflects the VM's egress (same host kube-proxy
+    # path); on eBPF kube-proxy-free clusters the VM's FORWARDED traffic can
+    # bypass the eth0 ClusterIP hook (the Track-2b roadmap item), so treat this
+    # as the pod-netns signal there. See docs/design/service-exposure.md.
+    if timeout 3 bash -c "echo > /dev/tcp/$dns/53" 2>/dev/null; then
+        echo "EGRESS_CLUSTER_REACHABLE=true" > "$lease_dir/egress.env"
+    else
+        echo "EGRESS_CLUSTER_REACHABLE=false" > "$lease_dir/egress.env"
+    fi
+
+    # Short cluster-name resolution: hand the guest the pod's DNS search list
+    # (e.g. <ns>.svc.cluster.local svc.cluster.local cluster.local) via the
+    # DHCP domain-search option, so the guest resolves bare service names.
+    search=$(grep '^search ' /etc/resolv.conf 2>/dev/null | head -1 | cut -d' ' -f2- | tr ' ' ',')
+
     dnsmasq --no-daemon --bind-interfaces --interface="$BRIDGE" \
         --dhcp-range="$range" \
         --dhcp-option=option:router,"$gateway" \
         --dhcp-option=option:dns-server,"$dns" \
+        ${search:+--dhcp-option=option:domain-search,"$search"} \
         --dhcp-leasefile="$lease_dir/dnsmasq.leases" \
         --dhcp-authoritative &
     sleep 1

--- a/rust/swiftletd/src/lease.rs
+++ b/rust/swiftletd/src/lease.rs
@@ -9,6 +9,28 @@ use std::time::Duration;
 
 pub const ANNOTATION_GUEST_IP: &str = "kubeswift.io/guest-ip";
 pub const ANNOTATION_GUEST_INTERFACES: &str = "kubeswift.io/guest-interfaces";
+/// Egress reachability: "true"/"false" written by the launcher entrypoint's
+/// cluster-DNS-ClusterIP probe (service exposure §4 — egress observability).
+/// The controller maps it to status.network.egress + the EgressReady condition.
+pub const ANNOTATION_EGRESS: &str = "kubeswift.io/egress-cluster-reachable";
+
+/// read_egress_marker reads EGRESS_CLUSTER_REACHABLE=true|false from the
+/// `egress.env` file the launcher entrypoint writes next to the lease file
+/// (same per-guest run dir). Returns None when absent/unparseable (the probe
+/// did not run, e.g. no network), leaving the controller's egress status unset.
+fn read_egress_marker(lease_path: &Path) -> Option<String> {
+    let dir = lease_path.parent()?;
+    let contents = std::fs::read_to_string(dir.join("egress.env")).ok()?;
+    for line in contents.lines() {
+        if let Some(v) = line.trim().strip_prefix("EGRESS_CLUSTER_REACHABLE=") {
+            let v = v.trim();
+            if v == "true" || v == "false" {
+                return Some(v.to_string());
+            }
+        }
+    }
+    None
+}
 
 /// dnsmasq lease file format: timestamp mac ip hostname client_id (space-separated).
 /// Returns the first IP found, or None if no valid lease.
@@ -81,6 +103,7 @@ pub fn spawn_lease_poller(
                 return;
             };
             let nics_ref = nics.as_deref();
+            let egress = read_egress_marker(&path);
             // patched is true iff patch_pod_annotation returned Ok.
             // We continue polling on transient errors (kube-client
             // unavailable, 403 RBAC gap during initial namespace
@@ -94,7 +117,16 @@ pub fn spawn_lease_poller(
                         return false;
                     }
                 };
-                match patch_pod_annotation(&client, &namespace, &pod_name, &ip, nics_ref).await {
+                match patch_pod_annotation(
+                    &client,
+                    &namespace,
+                    &pod_name,
+                    &ip,
+                    nics_ref,
+                    egress.as_deref(),
+                )
+                .await
+                {
                     Err(e) => {
                         log::warn!("patch_pod_annotation_failed (will retry): {}", e);
                         false
@@ -148,6 +180,7 @@ async fn patch_pod_annotation(
     name: &str,
     ip: &str,
     nics: Option<&[crate::intent::NICIntent]>,
+    egress: Option<&str>,
 ) -> Result<(), kube::Error> {
     let interfaces_json = build_interfaces_json(ip, nics);
 
@@ -155,6 +188,9 @@ async fn patch_pod_annotation(
     let mut annotations = std::collections::BTreeMap::new();
     annotations.insert(ANNOTATION_GUEST_IP.to_string(), ip.to_string());
     annotations.insert(ANNOTATION_GUEST_INTERFACES.to_string(), interfaces_json);
+    if let Some(e) = egress {
+        annotations.insert(ANNOTATION_EGRESS.to_string(), e.to_string());
+    }
     let patch = json!({
         "metadata": {
             "annotations": annotations


### PR DESCRIPTION
## What

Implements **S2** of the service-exposure design ([§4](https://github.com/projectbeskar/kubeswift/blob/main/docs/design/service-exposure.md)): the **no-silent-failure egress deliverable**. Turns the notorious VM→ClusterIP reachability question into a `kubectl`-visible state, and lets guests resolve short cluster service names. Parallel to S1; independently shippable.

## Changes

- **`launcher-entrypoint.sh`** — probe whether the pod netns can reach the **cluster DNS ClusterIP** (TCP 53; CoreDNS serves it) → `EGRESS_CLUSTER_REACHABLE=true|false` in `egress.env`. Add the DHCP **domain-search** option (from the pod's `resolv.conf search` list) so the guest resolves bare service names.
- **swiftletd `lease.rs`** — read `egress.env` and report it as the `kubeswift.io/egress-cluster-reachable` pod annotation, alongside `guest-ip` (reuses the existing annotation path; retry-safe).
- **controller** — map the annotation → `status.network.egress` (`ClusterServices` | `DirectOnly`) + an **`EgressReady`** condition (reason `ClusterIPUnreachableInPodNetns` on failure, pointing at the eBPF `egressMode` roadmap item) + an `EGRESS` printcolumn.

## Semantics (honest, documented)

On **kube-proxy** clusters this reflects the VM's egress (same host kube-proxy path the VM's forwarded+SNAT'd traffic takes). On **eBPF kube-proxy-free** clusters it's the pod-netns signal — the VM's *forwarded* traffic can bypass the `eth0` ClusterIP hook (KubeVirt #10388 / Cilium #37669), which is exactly the **Track-2b redirect roadmap item** (gated on a Cilium cluster). VM→internet egress already works (the existing `MASQUERADE`).

## Verification

- `go build`/`vet`/`gofmt -s` clean; `go test ./...` green; `cargo test -p swiftletd` 101 pass; `cargo fmt`; `make generate` + chart CRD sync clean.
- Cluster e2e (an exposed guest shows `EgressReady=True` / `status.network.egress=ClusterServices` on the kube-proxy dev cluster; short-name DNS resolves) to follow on the locally-built image, same flow as S1.

Next: S3 pool-balanced Service, S4 ecosystem glue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)