### PR TITLE
release: v0.4.1 — package the DRA GPU driver in the Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.4.1] — 2026-06-13
+
+Chart-only patch. Identical code and images to v0.4.0 (rebuilt as `v0.4.1`); the
+fix is in the Helm chart.
+
+### Fixed
+- **The DRA GPU driver is now packaged in the Helm chart.** v0.4.0 shipped the
+  DRA GPU allocation backend (`SwiftGuest.spec.gpuResourceClaim`) but its
+  reference driver (`kubeswift-dra-driver`) was only available as standalone
+  manifests under `config/dra-driver/` — a Helm install could not deploy it, so
+  the DRA backend was unreachable on chart-based installs. The chart now ships
+  the DRA driver behind a new **`dra.enabled`** toggle (default `false`): the
+  DaemonSet on `kubeswift.io/gpu-node=true` nodes, its RBAC, and the
+  `kubeswift-vfio-gpu` DeviceClass (`dra.deviceClass.create`, default `true`).
+  `dra` is **independent of `gpuDiscovery`** — the DRA driver does its own GPU
+  discovery (it publishes ResourceSlices), so a DRA-only cluster runs
+  `dra.enabled=true` with `gpuDiscovery.enabled=false`. Enable with
+  `--set dra.enabled=true`. The standalone `config/dra-driver/` manifests remain
+  for kustomize installs.
+
+---
+
 ## [v0.4.0] — 2026-06-13
 
 Everything since v0.3.1 (PRs #198–#223): three feature arcs — **service

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.4.1
+appVersion: "0.4.1"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/charts/kubeswift/templates/dra-driver/daemonset.yaml
+++ b/charts/kubeswift/templates/dra-driver/daemonset.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.dra.enabled }}
+# KubeSwift reference DRA GPU driver (gpu.kubeswift.io). Runs on
+# kubeswift.io/gpu-node=true nodes; publishes the node's GPUs as ResourceSlices
+# and serves the kubelet DRA plugin (per-claim CDI specs injecting
+# GPU_PCI_ADDRESSES). Independent of gpuDiscovery — it does its OWN GPU
+# discovery, so it does NOT require the native gpu-discovery DaemonSet.
+#
+# Node prerequisites: CDI enabled in the container runtime (e.g. k0s:
+# /etc/k0s/containerd.d/99-cdi.toml with enable_cdi=true + restart) and the
+# vfio-pci module loaded (same prerequisite as native GPU nodes).
+# See docs/gpu/dra-allocation.md and docs/design/dra-gpu-integration.md.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kubeswift-dra-driver
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: dra-driver
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubeswift
+      app.kubernetes.io/component: dra-driver
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubeswift
+        app.kubernetes.io/component: dra-driver
+    spec:
+      serviceAccountName: kubeswift-dra-driver
+      nodeSelector:
+        kubeswift.io/gpu-node: "true"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: dra-driver
+          image: {{ .Values.dra.image.registry }}/kubeswift-dra-driver:{{ include "kubeswift.imageTag" (dict "tag" .Values.dra.image.tag "appVersion" .Chart.AppVersion) }}
+          args:
+            - --v=2
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            # Root user (kubelet plugin sockets + /var/run/cdi are root-owned
+            # host paths) but NOT privileged: pure sysfs reads, unix sockets,
+            # and CDI file writes — all capabilities dropped.
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          resources:
+            {{- toYaml .Values.dra.resources | nindent 12 }}
+          volumeMounts:
+            # Kubelet DRA plugin socket dir (the helper creates
+            # plugins/gpu.kubeswift.io/ under it).
+            - name: plugins
+              mountPath: /var/lib/kubelet/plugins
+            # Kubelet plugin-watcher registration socket dir.
+            - name: plugins-registry
+              mountPath: /var/lib/kubelet/plugins_registry
+            # Per-claim CDI specs the container runtime reads.
+            - name: cdi
+              mountPath: /var/run/cdi
+            # GPU discovery (read-only sysfs scan).
+            - name: sysfs
+              mountPath: /sys
+              readOnly: true
+      volumes:
+        - name: plugins
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: Directory
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - name: cdi
+          hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate
+        - name: sysfs
+          hostPath:
+            path: /sys
+            type: Directory
+{{- end }}

--- a/charts/kubeswift/templates/dra-driver/deviceclass.yaml
+++ b/charts/kubeswift/templates/dra-driver/deviceclass.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.dra.enabled .Values.dra.deviceClass.create }}
+# DeviceClass for KubeSwift VFIO GPU passthrough via the reference DRA driver.
+# A ResourceClaim(Template) requests devices of this class; the scheduler
+# allocates from the ResourceSlices the driver publishes.
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: {{ .Values.dra.deviceClass.name }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: dra-driver
+spec:
+  selectors:
+    - cel:
+        expression: device.driver == "gpu.kubeswift.io"
+{{- end }}

--- a/charts/kubeswift/templates/dra-driver/rbac.yaml
+++ b/charts/kubeswift/templates/dra-driver/rbac.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.dra.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeswift-dra-driver
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: dra-driver
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeswift-dra-driver
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: dra-driver
+rules:
+  # ResourceSlice publishing (managed by the kubeletplugin helper).
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceslices"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Read claims at prepare time + best-effort device-status write.
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaims/status"]
+    verbs: ["update", "patch"]
+  # The helper resolves the node UID for ResourceSlice ownership.
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeswift-dra-driver
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: dra-driver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeswift-dra-driver
+subjects:
+  - kind: ServiceAccount
+    name: kubeswift-dra-driver
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -61,12 +61,39 @@ migrationStunnel:
 
 # GPU discovery DaemonSet: auto-discovers GPU hardware on nodes labeled kubeswift.io/gpu-node=true.
 # Populates SwiftGPUNode status with GPU inventory, NUMA topology, and Fabric Manager state.
+# This is the NATIVE GPU backend's discovery (SwiftGPUProfile / SwiftGPUNode). It is
+# INDEPENDENT of the DRA backend below — leave it off for DRA-only clusters.
 gpuDiscovery:
   enabled: false
   image:
     registry: ghcr.io/projectbeskar/kubeswift
     tag: latest
   interval: "60s"
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+# DRA GPU driver DaemonSet: the reference Dynamic Resource Allocation driver
+# (driver name gpu.kubeswift.io) for the DRA GPU backend (SwiftGuest
+# spec.gpuResourceClaim). Runs on nodes labeled kubeswift.io/gpu-node=true; it
+# does its OWN GPU discovery (publishes ResourceSlices), so it is INDEPENDENT of
+# gpuDiscovery above — a DRA-only cluster runs dra.enabled=true with
+# gpuDiscovery.enabled=false. Node prerequisites: CDI enabled in the container
+# runtime + the vfio-pci module loaded. See docs/gpu/dra-allocation.md.
+dra:
+  enabled: false
+  image:
+    registry: ghcr.io/projectbeskar/kubeswift
+    tag: latest
+  # The cluster-scoped DeviceClass a ResourceClaim references. Set create=false
+  # if you manage the DeviceClass out-of-band (e.g. shared across installs).
+  deviceClass:
+    create: true
+    name: kubeswift-vfio-gpu
   resources:
     requests:
       cpu: 10m

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -94,6 +94,22 @@ init container, and `kubectl get` status is purely observational.
 
 ## Install the reference driver
 
+**Helm (recommended).** Enable the `dra` toggle (independent of `gpuDiscovery` —
+the DRA driver does its own discovery, so a DRA-only cluster keeps
+`gpuDiscovery.enabled=false`):
+
+```bash
+helm upgrade --install kubeswift oci://ghcr.io/projectbeskar/charts/kubeswift \
+  --version 0.4.1 -n kubeswift-system --create-namespace \
+  --set dra.enabled=true
+```
+
+This deploys the DaemonSet + RBAC and creates the `kubeswift-vfio-gpu`
+DeviceClass (set `--set dra.deviceClass.create=false` if you manage it
+out-of-band).
+
+**Kustomize / manual.** Apply the standalone manifests:
+
 ```bash
 kubectl apply -f config/dra-driver/dra-driver.yaml    # DaemonSet + RBAC (kubeswift-system)
 kubectl apply -f config/dra-driver/deviceclass.yaml   # DeviceClass: kubeswift-vfio-gpu

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/projectbeskar/charts/kubeswift \
-  --version 0.4.0 \
+  --version 0.4.1 \
   -n kubeswift-system \
   --create-namespace
 ```


### PR DESCRIPTION
## Summary

**Fixes the v0.4.0 gap:** the DRA GPU backend (`spec.gpuResourceClaim`) shipped in v0.4.0, but its reference driver (`kubeswift-dra-driver`) was only standalone `config/dra-driver/` manifests — a Helm install couldn't deploy it. The chart now packages the DRA driver behind a new **`dra.enabled`** toggle.

**Independent of `gpuDiscovery`** (the key design point): the DRA driver does its own GPU discovery (it publishes ResourceSlices), so a DRA-only cluster runs `dra.enabled=true` with `gpuDiscovery.enabled=false`. The two are separate discovery mechanisms for separate allocation backends.

## Changes
- `charts/kubeswift/templates/dra-driver/{daemonset,rbac,deviceclass}.yaml` — gated on `.Values.dra.enabled`: DaemonSet on `kubeswift.io/gpu-node=true` (drop-ALL, non-privileged, ro-rootfs), SA + ClusterRole/Binding, and the `kubeswift-vfio-gpu` DeviceClass (`dra.deviceClass.create`, default true). Image via the `kubeswift.imageTag` helper.
- `values.yaml` — `dra` block mirroring `gpuDiscovery`, with a doc note on the independence.
- Chart `0.4.0 → 0.4.1`; CHANGELOG v0.4.1; quickstart `--version`; `docs/gpu/dra-allocation.md` gains the Helm install path.
- Standalone `config/dra-driver/` manifests kept for kustomize installs.

## Verification
`helm lint` clean; **default install renders 0 DRA resources**; `--set dra.enabled=true` renders DaemonSet + SA + ClusterRole + ClusterRoleBinding + DeviceClass with image `kubeswift-dra-driver:v0.4.1`; `--set dra.deviceClass.create=false` suppresses only the DeviceClass.

Chart-only patch — identical code/images to v0.4.0, rebuilt as `v0.4.1`. Merging + tagging `v0.4.1` triggers `release-stable.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)