### PR TITLE
release: v0.4.3 — lease-poller restore fix + clone-reboot known issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.4.3] — 2026-06-15
+
+Patch release. swiftletd lease-poller fix for cloneFromSnapshot guests, and a
+documented Cloud-Hypervisor-v52 limitation surfaced validating the instant-clone
+flow.
+
+### Fixed
+
+- **swiftletd: the lease poller no longer gives up on restore/clone guests.** A
+  `cloneFromSnapshot` guest boots via CH `--restore` — it RESUMES the source's
+  captured RAM (including its already-configured `eth0` lease) and does not
+  re-run DHCP on start, so a fresh clone has no lease to discover. The guest only
+  re-DHCPs on a later reboot, but the lease poller capped at ~4 min and then
+  exited permanently (`lease_poll_timeout`) — so any post-reboot lease landed
+  into a dead poller and the IP never reached `status.network.primaryIP`. The
+  poll cap is now parameterized: fresh boots keep the ~4 min cap, CH `--restore`
+  receivers (`intent.is_restore()`) keep polling for the pod's lifetime so the
+  eventual lease is discovered. The poller still terminates immediately on the
+  first successful patch. swiftletd-only; no controller/CRD change.
+
+### Known issues
+
+- **A cloneFromSnapshot (memory-snapshot) guest cannot reboot on Cloud
+  Hypervisor v52** — rebooting a `--restore`d guest hangs in UEFI firmware (the
+  EDK2 S3-resume / AP-init path freezes after `MpInitChangeApLoopCallback`),
+  while a *normal* guest reboots through the same point and re-DHCPs in seconds.
+  Because the documented clone-identity remedy is "reboot once to regenerate
+  identity + re-DHCP", this means memory-snapshot clones currently keep the
+  source's guest-visible identity and do not surface their own IP — treat them as
+  warm, read-mostly replicas (collision-safe via per-pod network namespaces). It
+  is a CH-`--restore`+reboot firmware interaction, not a KubeSwift defect; the
+  in-guest vsock identity agent (regenerate without a reboot) is the planned real
+  fix. Investigation:
+  [`docs/design/known-issues-clone-reboot-firmware-hang.md`](docs/design/known-issues-clone-reboot-firmware-hang.md);
+  operator note in
+  [`docs/snapshots/clone-from-snapshot.md`](docs/snapshots/clone-from-snapshot.md).
+
+---
+
 ## [v0.4.2] — 2026-06-14
 
 Code + chart release. Headline: **blank / raw VM data disks** — the

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.4.2
-appVersion: "0.4.2"
+version: 0.4.3
+appVersion: "0.4.3"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/docs/design/known-issues-clone-reboot-firmware-hang.md
+++ b/docs/design/known-issues-clone-reboot-firmware-hang.md
@@ -1,0 +1,90 @@
+# Known issue — cloneFromSnapshot guests hang in firmware on reboot (CH v52)
+
+> Status: OPEN (investigation). Surfaced 2026-06-15 validating demo 06 (instant
+> clones) on the v0.4.2 cluster. Severity: MEDIUM (blocks identity/IP divergence
+> for memory-snapshot clones; does not affect normal guests or the source).
+> Layer: **Cloud Hypervisor v52 `--restore` + guest reboot + EDK2 firmware** —
+> NOT KubeSwift Go/Rust code.
+
+## Symptom
+
+A `SwiftGuest.spec.cloneFromSnapshot` guest (CH `--restore` of an
+`includeMemory: true` snapshot) reaches `Running` by **resuming** the source's
+captured RAM byte-for-byte. The documented way to give the clone its own
+identity + a fresh IP is to reboot it once (the seed's `kubeswift.clone=true`
+bootcmd regenerates machine-id / SSH host keys / hostname, and the guest
+re-runs DHCP). On **Cloud Hypervisor v52 that reboot hangs in UEFI firmware** —
+the guest never reaches the kernel, so it never re-DHCPs and never regenerates
+identity. `status.network.primaryIP` stays empty.
+
+## Isolation (cluster-observed, field-testing, 2026-06-15)
+
+Driving `sudo reboot` over the serial console on two guest classes on the same
+node (boba), both with **2 vCPUs** and **`core_scheduling: "Vm"`** (identical):
+
+| Guest | Kind | Reboot result |
+|---|---|---|
+| `ft-golden` | normal disk-boot | `reboot: Restarting system` → `MpInitChangeApLoopCallback() done!` → **`DHCPACK(br0) 192.168.99.20`** — booted in ~36s ✓ |
+| `ft-clone-a` | cloneFromSnapshot (`--restore`) | `DXE ResetSystem2: ResetType Warm` → … → `MpInitChangeApLoopCallback() done!` → **HANG** (serial log frozen 3–5+ min; never reaches the kernel) ✗ |
+
+So the hang is **specific to restored guests**. The differentiators ruled OUT:
+- **vCPU count** — both are 2.
+- **`core_scheduling`** — both report `"Vm"` (a CH default here, not clone-only).
+- **CH process death** — CH stays alive across the hang (`vm.info` responds;
+  `boot_vcpus: 2`, guest config intact). It is the *guest firmware* that wedges,
+  not the VMM.
+
+The only remaining differentiator is the `--restore` path itself.
+
+## Evidence pointing at the EDK2 S3-resume / AP-init path
+
+The restored guest's reboot loads `S3Resume2Pei.efi` and freezes right after
+`MpInitChangeApLoopCallback() done!` (the multiprocessor / application-processor
+init callback). A normal guest emits the same line and immediately proceeds to
+the kernel. Reading: on a warm reset the restored guest's firmware enters an
+**S3 (suspend-to-RAM) resume** code path — plausibly because the snapshot froze
+ACPI/firmware state that makes EDK2 believe it is resuming from S3 — and then
+**hangs bringing the APs back up**. CLOUDHV.fd (rust-hypervisor-firmware / EDK2)
++ CH v52 + restored memory state is the suspect surface.
+
+## Impact
+
+- **Memory-snapshot clones cannot diverge guest-visible identity or obtain a
+  discoverable IP via the documented reboot.** They are usable as **warm,
+  read-mostly replicas that share the source's identity** (collision-safe because
+  each clone is in its own pod network namespace), but not as independently
+  addressable VMs through the reboot path.
+- **Normal guests and the snapshot source are unaffected** — they reboot and
+  re-DHCP cleanly (`ft-golden` proven above). CH v52 reset-in-place for
+  non-restored guests was already validated during the v52 bump.
+- Composes with the lease-poller fix (v0.4.3): the poller now stays alive for
+  restore guests, so the IP **would** surface automatically the moment a clone
+  re-DHCPs — it just never gets the chance while the reboot is wedged.
+
+## Hypotheses / next steps (not yet attempted)
+
+1. **Disable guest S3 / ACPI sleep so the warm reset takes the cold-boot path.**
+   Investigate whether CH or the firmware can be told the guest has no S3 (e.g. a
+   `_S3` ACPI removal, a CH platform/firmware flag, or a kernel `acpi_sleep=`
+   / `no_console_suspend` cmdline on the source before snapshot). If the firmware
+   stops entering `S3Resume2Pei`, the AP-init hang may not trigger.
+2. **Single-vCPU repro.** The hang is in AP (secondary-CPU) init. Confirm whether
+   a 1-vCPU clone reboots cleanly — if so, the AP bring-up on resume-then-reset is
+   the precise fault and a mitigation can target it.
+3. **CH version sweep.** Check CH `> v52` / upstream rust-hypervisor-firmware for a
+   fixed restore-then-reboot path; this is a strong **upstream-CH candidate**.
+4. **Sidestep the reboot entirely** — the planned **in-guest vsock identity
+   agent** regenerates machine-id / SSH keys / hostname and renews DHCP *without*
+   a reboot. That is the real fix for clone identity/IP and makes the reboot path
+   unnecessary; prioritize it over chasing the firmware hang.
+
+## Related
+
+- The lease-poller-stays-alive fix (v0.4.3): `rust/swiftletd/src/lease.rs`
+  (`LEASE_POLL_ATTEMPTS_RESTORE`). Correct and necessary, but cannot deliver a
+  clone IP while the reboot is wedged.
+- Operator runbook caveat:
+  [`docs/snapshots/clone-from-snapshot.md`](../snapshots/clone-from-snapshot.md)
+  "Known limitation on Cloud Hypervisor v52".
+- The resume-vs-boot identity-inheritance rule (Snapshot Phase 2) is the root
+  reason a reboot is needed at all.

--- a/docs/snapshots/clone-from-snapshot.md
+++ b/docs/snapshots/clone-from-snapshot.md
@@ -110,6 +110,20 @@ intervention every clone inherits the source's identity. Two layers handle it:
 **To diverge guest-visible identity, reboot each replica once after it resumes.**
 (An in-guest vsock agent to do this without a reboot is a future enhancement.)
 
+> ⚠️ **Known limitation on Cloud Hypervisor v52 — a resumed clone cannot reboot.**
+> Rebooting a `--restore`d guest hangs in UEFI firmware (the EDK2 S3-resume / AP
+> init path freezes after `MpInitChangeApLoopCallback`; a *normal* guest reboots
+> fine through the same point). So the "reboot to regenerate" step above does
+> **not** currently complete — the clone keeps the source's guest-visible
+> identity, and because the resumed guest never re-runs DHCP, its IP is not
+> discovered (`status.network.primaryIP` stays empty even though the guest is
+> reachable on the source's address inside its own pod netns). This is a
+> CH-`--restore`+reboot firmware interaction, not a KubeSwift defect; tracked in
+> [`docs/design/known-issues-clone-reboot-firmware-hang.md`](../design/known-issues-clone-reboot-firmware-hang.md).
+> Until it is resolved, treat memory-snapshot clones as **warm read-mostly
+> replicas of the source's identity**; the in-guest vsock identity agent (above)
+> is the real fix and supersedes the reboot path.
+
 ## Quick start (walkthrough)
 
 ```bash
@@ -136,7 +150,8 @@ kubectl get swiftguest -l swift.kubeswift.io/pool-name=clone-pool -o wide -w
 | Guest `Failed`, *"requires spec.cloneFromSnapshot.targetNode"* | Tier C clone without a target node. In a pool the controller assigns it; a standalone clone must set it. |
 | Guest stuck `Pending`, *"waiting for SwiftSnapshot … to be Ready"* | The snapshot is still Capturing/Uploading. |
 | Guest stuck `Pending`, download Job present | The Tier C download is in progress (or `ImagePullBackOff` / `snapshot-s3 image not configured`). |
-| All clones share hostname/machine-id | Expected on resume — reboot each clone once to fire the regen bootcmd. |
+| All clones share hostname/machine-id | Expected on resume. The regen bootcmd fires on first reboot — but on CH v52 a clone reboot hangs in firmware (see the Known-limitation callout above), so this currently persists. |
+| Clone is `Running` but `status.network.primaryIP` is empty | Expected on resume — the guest kept the source's cached lease and never re-ran DHCP, so there is no lease for swiftletd to discover. It would surface after a reboot's fresh DHCP, but the clone-reboot firmware hang (above) blocks that on CH v52. The lease poller stays alive for restore guests (v0.4.3+), so the IP appears automatically *if/when* the guest does re-DHCP. |
 
 ## Cluster walkthrough
 

--- a/rust/swiftletd/src/lease.rs
+++ b/rust/swiftletd/src/lease.rs
@@ -52,8 +52,28 @@ fn parse_first_lease(contents: &str) -> Option<String> {
 }
 
 /// Spawns a background thread that polls the lease file and patches the pod annotation when IP found.
-/// Stops after a SUCCESSFUL patch or after max_attempts (default 120 = 4 min at 2s interval).
-/// First boot of cloud images can take 60–90s for cloud-init + DHCP.
+/// Lease-poll attempt caps (each attempt is `INTERVAL` = 2s apart).
+///
+/// `DEFAULT` (~4 min) covers a fresh boot: cloud images DHCP within ~60-90s.
+///
+/// `RESTORE` keeps the poller alive for the pod's lifetime. A cloneFromSnapshot
+/// guest (and any CH `--restore` receiver) RESUMES the source's captured RAM —
+/// including its already-configured `eth0` lease — so it does NOT re-run DHCP on
+/// start. dnsmasq writes no lease, so a fresh clone has no IP to discover. The
+/// guest only DHCPs on its FIRST REBOOT (which regenerates identity too), and an
+/// operator may reboot it many minutes after it reaches Running. With the
+/// `DEFAULT` cap the poller would have exited (`lease_poll_timeout`) long before
+/// then, so the post-reboot DHCP would land into a dead poller and the IP would
+/// never reach `status.network.primaryIP` (demo-06 finding, 2026-06-15). The
+/// poller still terminates immediately on the first successful patch, so an
+/// unbounded cap only means "wait as long as the pod lives" for a guest that has
+/// not yet acquired an IP.
+pub const LEASE_POLL_ATTEMPTS_DEFAULT: u32 = 120;
+pub const LEASE_POLL_ATTEMPTS_RESTORE: u32 = u32::MAX;
+
+/// Stops after a SUCCESSFUL patch or after `max_attempts` (× 2s interval —
+/// pass [`LEASE_POLL_ATTEMPTS_DEFAULT`] for fresh boots,
+/// [`LEASE_POLL_ATTEMPTS_RESTORE`] for CH `--restore` clone/receiver guests).
 /// `nics` is passed to build the multi-NIC interfaces annotation.
 ///
 /// Retry-on-failure invariant (added 2026-04-29 — Phase 2 walkthrough
@@ -69,19 +89,18 @@ fn parse_first_lease(contents: &str) -> Option<String> {
 /// patch. On any error from the kube client (transient apiserver
 /// unavailability, RBAC gap, etc.), continue polling — eventually
 /// the operator-fix will land and the next attempt will succeed.
-/// Bounded by MAX_ATTEMPTS (~4 min total).
 pub fn spawn_lease_poller(
     lease_path: impl AsRef<Path> + Send + 'static,
     namespace: String,
     pod_name: String,
     nics: Option<Vec<crate::intent::NICIntent>>,
+    max_attempts: u32,
 ) {
     let path = lease_path.as_ref().to_path_buf();
     thread::spawn(move || {
         const INTERVAL: Duration = Duration::from_secs(2);
-        const MAX_ATTEMPTS: u32 = 120;
 
-        for attempt in 0..MAX_ATTEMPTS {
+        for attempt in 0..max_attempts {
             if attempt > 0 {
                 thread::sleep(INTERVAL);
             }

--- a/rust/swiftletd/src/main.rs
+++ b/rust/swiftletd/src/main.rs
@@ -221,7 +221,23 @@ fn main() {
                 if let (Some(ref ns), Some(ref n)) = (&namespace, &name) {
                     let lease_path = runtime_dir.root().join("dnsmasq.leases");
                     let nics_for_poller = intent.nics.clone();
-                    lease::spawn_lease_poller(lease_path, ns.clone(), n.clone(), nics_for_poller);
+                    // A restore (cloneFromSnapshot) guest resumes the source's
+                    // RAM and does not re-DHCP until its first reboot, which may
+                    // be many minutes out — keep the poller alive for the pod's
+                    // lifetime so that post-reboot lease is discovered (a fresh
+                    // boot keeps the ~4 min cap). See lease::spawn_lease_poller.
+                    let max_attempts = if intent.is_restore() {
+                        lease::LEASE_POLL_ATTEMPTS_RESTORE
+                    } else {
+                        lease::LEASE_POLL_ATTEMPTS_DEFAULT
+                    };
+                    lease::spawn_lease_poller(
+                        lease_path,
+                        ns.clone(),
+                        n.clone(),
+                        nics_for_poller,
+                        max_attempts,
+                    );
                 }
             }
 


### PR DESCRIPTION
## v0.4.3 — swiftletd lease-poller fix for clones + documented CH-v52 limitation

Patch release surfaced validating demo 06 (instant clones) on v0.4.2.

### Fixed
- **swiftletd: the lease poller no longer permanently exits for restore/clone
  guests.** A `cloneFromSnapshot` guest boots via CH `--restore` — it RESUMES the
  source's RAM (incl. its `eth0` lease) and does not re-DHCP on start, so a fresh
  clone has no lease. The guest only re-DHCPs on a later reboot, but the poller
  capped at ~4 min then exited (`lease_poll_timeout`), so the post-reboot lease
  landed into a dead poller and the IP never reached `status.network.primaryIP`.
  Fix: parameterize the cap — fresh boots keep ~4 min, CH `--restore` receivers
  (`intent.is_restore()`) poll for the pod's lifetime. Still exits on first
  successful patch. swiftletd-only; no controller/CRD change. Cluster-validated
  (poller stays alive: `lease_poll_timeout count: 0` on a recreated clone).

### Known issue (documented, not a KubeSwift defect)
- **A cloneFromSnapshot guest cannot reboot on Cloud Hypervisor v52** — it hangs
  in UEFI firmware (EDK2 S3-resume / AP-init, freezes after
  `MpInitChangeApLoopCallback`); a normal guest reboots through the same point and
  re-DHCPs in ~36s. Cluster-isolated (`ft-golden` ✓ vs `ft-clone-a` ✗, identical
  2 vCPU + core_scheduling; CH stays alive). So the "reboot to regenerate identity
  + re-DHCP" clone remedy doesn't complete and memory-snapshot clones keep the
  source's identity/IP (warm read-mostly replicas, collision-safe via per-pod
  netns). CH-`--restore`+reboot firmware interaction; the in-guest vsock identity
  agent is the planned real fix. Investigation:
  `docs/design/known-issues-clone-reboot-firmware-hang.md`; runbook caveat in
  `docs/snapshots/clone-from-snapshot.md`.

Chart 0.4.2 → 0.4.3. cargo build/test + helm lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)