### PR TITLE
feat(snapshots): in-guest vsock identity agent — design + spike + agent (PR 0/1)

### DIFF
--- a/cmd/kubeswift-guest-agent/handler.go
+++ b/cmd/kubeswift-guest-agent/handler.go
@@ -1,0 +1,413 @@
+// Command kubeswift-guest-agent is a tiny in-guest agent that regenerates a
+// cloneFromSnapshot clone's identity (machine-id / SSH host keys / hostname /
+// MAC) and renews its DHCP lease IN PLACE — with no reboot — over a host-only
+// vsock channel.
+//
+// WHY THIS EXISTS (load-bearing — read before refactoring):
+//
+// A cloneFromSnapshot SwiftGuest boots via Cloud Hypervisor `--restore`: it
+// RESUMES the source's captured RAM byte-for-byte. A resume is NOT a boot —
+// cloud-init does not re-run — so every clone inherits the source's
+// /etc/machine-id, /etc/ssh/ssh_host_*, hostname, and the cached eth0 MAC + IP.
+// The old remedy ("reboot the clone once") is BROKEN on Cloud Hypervisor v52: a
+// restored guest's reboot hangs in EDK2 firmware (see
+// docs/design/known-issues-clone-reboot-firmware-hang.md). This agent is the
+// real fix — it regenerates identity without a reboot.
+//
+// THE LOAD-BEARING CONSTRAINT: because a clone never boots, this agent must
+// already be RUNNING in the SOURCE guest at snapshot-capture time so it is part
+// of the captured RAM and resumes — alive and listening — in every clone.
+// Installing/starting it on the clone is impossible (nothing new starts on a
+// resume). See docs/design/clone-identity-vsock-agent.md §6.1 (LBA-1).
+//
+// SECURITY: the command surface is exactly two ops (ping, regenerate-identity)
+// with a fixed schema — NO exec, no path argument, no file transfer. Inputs
+// (MAC, hostname) are validated then passed as argv (never shell-interpolated).
+// The transport is vsock — host<->guest only, not network-reachable. An
+// attacker who somehow reached the port could only ask the guest to regenerate
+// its own identity (self-inflicted, non-escalating).
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ProtocolVersion is the wire-protocol version (design §Q3). Bump only on a
+// breaking change; the agent accepts any request and degrades per-item.
+const ProtocolVersion = 1
+
+// DefaultPort is the AF_VSOCK port the agent listens on (above the privileged
+// range; shared constant with the host-side swift-vsock-client).
+const DefaultPort = 1024
+
+// Identity item names — MUST match api/swift/v1alpha1.CloneIdentityItem so the
+// controller can pass SwiftGuest.spec.cloneFromSnapshot.regenerate verbatim.
+const (
+	itemHostname     = "hostname"
+	itemMachineID    = "machineId"
+	itemSSHHostKeys  = "sshHostKeys"
+	itemMACAddresses = "macAddresses"
+)
+
+// allItems is the default set when a request omits items (matches the CRD's
+// "empty defaults to all four").
+var allItems = []string{itemMachineID, itemSSHHostKeys, itemHostname, itemMACAddresses}
+
+// Request is one host->guest command (newline-delimited JSON, one per connection).
+type Request struct {
+	V          int      `json:"v"`
+	Op         string   `json:"op"`
+	Items      []string `json:"items,omitempty"`
+	MAC        string   `json:"mac,omitempty"`
+	Hostname   string   `json:"hostname,omitempty"`
+	RenewLease bool     `json:"renewLease,omitempty"`
+}
+
+// Response is the guest->host reply.
+type Response struct {
+	V            int      `json:"v"`
+	OK           bool     `json:"ok"`
+	Op           string   `json:"op,omitempty"`
+	AgentVersion string   `json:"agentVersion,omitempty"`
+	Regenerated  []string `json:"regenerated,omitempty"`
+	NewIP        string   `json:"newIP,omitempty"`
+	MachineID    string   `json:"machineId,omitempty"`
+	Hostname     string   `json:"hostname,omitempty"`
+	MAC          string   `json:"mac,omitempty"`
+	IP           string   `json:"ip,omitempty"`
+	Error        string   `json:"error,omitempty"`
+}
+
+var (
+	macRE      = regexp.MustCompile(`^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$`)
+	hostnameRE = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
+)
+
+// system abstracts every side effect so the dispatch + validation logic is unit
+// testable without root. The real implementation (realSystem) shells out to
+// ip/hostnamectl/ssh-keygen/dhclient and touches the filesystem.
+type system interface {
+	run(name string, args ...string) (string, error)
+	readFile(path string) (string, error)
+	writeFile(path string, data []byte, perm os.FileMode) error
+	remove(path string) error
+	glob(pattern string) ([]string, error)
+	hostname() (string, error)
+}
+
+type handler struct {
+	sys     system
+	version string
+}
+
+// handle parses one request, dispatches it, and returns the JSON response bytes.
+// It NEVER returns a transport error to the caller for a malformed/uop request —
+// it returns a Response with ok=false so the host always sees a structured
+// answer (no silent failure, design principle #6).
+func (h *handler) handle(raw []byte) []byte {
+	var req Request
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return h.encode(Response{V: ProtocolVersion, OK: false, Error: "bad request: " + err.Error()})
+	}
+	var resp Response
+	switch req.Op {
+	case "ping", "status", "":
+		resp = h.status()
+	case "regenerate-identity":
+		resp = h.regenerate(req)
+	default:
+		resp = Response{OK: false, Error: "unknown op: " + req.Op}
+	}
+	resp.V = ProtocolVersion
+	resp.Op = req.Op
+	resp.AgentVersion = h.version
+	return h.encode(resp)
+}
+
+func (h *handler) encode(r Response) []byte {
+	b, err := json.Marshal(r)
+	if err != nil {
+		// last-resort, should never happen for our flat struct
+		return []byte(`{"v":1,"ok":false,"error":"encode failed"}` + "\n")
+	}
+	return append(b, '\n')
+}
+
+// status reports the guest's current identity (used as the liveness/readiness
+// probe before a regen, and to confirm a regen's effect).
+func (h *handler) status() Response {
+	r := Response{OK: true}
+	r.MachineID = h.machineID()
+	if hn, err := h.sys.hostname(); err == nil {
+		r.Hostname = hn
+	}
+	ifc, _ := h.primaryIface()
+	r.MAC = h.ifaceMAC(ifc)
+	r.IP = h.ifaceIP(ifc)
+	return r
+}
+
+// regenerate applies the requested identity changes in place. Order matters:
+// machine-id / ssh / hostname first, then the MAC, then the lease renew (so the
+// renew happens after the MAC + machine-id-derived DUID change).
+func (h *handler) regenerate(req Request) Response {
+	items := req.Items
+	if len(items) == 0 {
+		items = allItems
+	}
+	want := map[string]bool{}
+	for _, it := range items {
+		want[it] = true
+	}
+
+	resp := Response{OK: true}
+	var done []string
+	var firstErr string
+	fail := func(msg string) {
+		if firstErr == "" {
+			firstErr = msg
+		}
+	}
+
+	if want[itemMachineID] {
+		if err := h.regenMachineID(); err != nil {
+			fail("machineId: " + err.Error())
+		} else {
+			done = append(done, itemMachineID)
+		}
+	}
+	if want[itemSSHHostKeys] {
+		if err := h.regenSSHHostKeys(); err != nil {
+			fail("sshHostKeys: " + err.Error())
+		} else {
+			done = append(done, itemSSHHostKeys)
+		}
+	}
+	if want[itemHostname] {
+		if err := h.setHostname(req.Hostname); err != nil {
+			fail("hostname: " + err.Error())
+		} else {
+			done = append(done, itemHostname)
+		}
+	}
+	if want[itemMACAddresses] {
+		if err := h.setMAC(req.MAC); err != nil {
+			fail("macAddresses: " + err.Error())
+		} else {
+			done = append(done, itemMACAddresses)
+		}
+	}
+	if req.RenewLease {
+		ip, err := h.renewLease()
+		if err != nil {
+			fail("renewLease: " + err.Error())
+		}
+		resp.NewIP = ip
+	}
+
+	sort.Strings(done)
+	resp.Regenerated = done
+	resp.Error = firstErr
+	resp.OK = firstErr == ""
+	// echo the resulting identity so the host can confirm without a second probe
+	resp.MachineID = h.machineID()
+	if hn, err := h.sys.hostname(); err == nil {
+		resp.Hostname = hn
+	}
+	ifc, _ := h.primaryIface()
+	resp.MAC = h.ifaceMAC(ifc)
+	if resp.IP == "" {
+		resp.IP = h.ifaceIP(ifc)
+	}
+	return resp
+}
+
+// --- identity ops -------------------------------------------------------------
+
+func (h *handler) machineID() string {
+	s, _ := h.sys.readFile("/etc/machine-id")
+	return strings.TrimSpace(s)
+}
+
+func (h *handler) regenMachineID() error {
+	// Remove the inherited id (and the dbus copy, which is often a separate file
+	// on older images), then let systemd mint a fresh one.
+	_ = h.sys.remove("/etc/machine-id")
+	_ = h.sys.remove("/var/lib/dbus/machine-id")
+	if _, err := h.sys.run("systemd-machine-id-setup"); err != nil {
+		// fallback for images without systemd-machine-id-setup: dbus-uuidgen
+		if _, e2 := h.sys.run("dbus-uuidgen", "--ensure=/etc/machine-id"); e2 != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *handler) regenSSHHostKeys() error {
+	keys, err := h.sys.glob("/etc/ssh/ssh_host_*")
+	if err != nil {
+		return err
+	}
+	for _, k := range keys {
+		_ = h.sys.remove(k)
+	}
+	if _, err := h.sys.run("ssh-keygen", "-A"); err != nil {
+		return err
+	}
+	// Reload sshd so it picks up the new host keys without dropping the agent.
+	// Best-effort: the service unit name differs across distros (ssh vs sshd).
+	if _, err := h.sys.run("systemctl", "reload", "ssh"); err != nil {
+		_, _ = h.sys.run("systemctl", "reload", "sshd")
+	}
+	return nil
+}
+
+func (h *handler) setHostname(name string) error {
+	if name == "" {
+		return fmt.Errorf("empty hostname")
+	}
+	if !hostnameRE.MatchString(name) {
+		return fmt.Errorf("invalid hostname %q", name)
+	}
+	if _, err := h.sys.run("hostnamectl", "set-hostname", name); err != nil {
+		// fallback for images without hostnamectl
+		if e2 := h.sys.writeFile("/etc/hostname", []byte(name+"\n"), 0o644); e2 != nil {
+			return err
+		}
+		if _, e3 := h.sys.run("hostname", name); e3 != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *handler) setMAC(mac string) error {
+	if mac == "" {
+		return fmt.Errorf("empty mac")
+	}
+	if !macRE.MatchString(mac) {
+		return fmt.Errorf("invalid mac %q", mac)
+	}
+	ifc, err := h.primaryIface()
+	if err != nil {
+		return err
+	}
+	// down -> set address -> up on the LIVE virtio-net link. The PR-0 spike
+	// confirmed this does not wedge the resumed link (ping/fdb/ARP all recover
+	// on the new MAC). See docs/design/clone-identity-vsock-agent-spike.md.
+	_, _ = h.sys.run("ip", "link", "set", ifc, "down")
+	if _, err := h.sys.run("ip", "link", "set", ifc, "address", mac); err != nil {
+		_, _ = h.sys.run("ip", "link", "set", ifc, "up")
+		return err
+	}
+	_, err = h.sys.run("ip", "link", "set", ifc, "up")
+	return err
+}
+
+// renewLease re-DHCPs the primary interface so a lease lands in THIS pod's
+// dnsmasq for the (v0.4.3) restore lease-poller to discover. It does NOT aim for
+// a globally-distinct IP — each clone has its own pod-netns dnsmasq, so the
+// guest-internal address is pod-isolated (spike correction; the MAC-set above is
+// for guest-MAC <-> host-fdb/DNAT consistency, not IP-distinctness).
+func (h *handler) renewLease() (string, error) {
+	ifc, err := h.primaryIface()
+	if err != nil {
+		return "", err
+	}
+	// dhclient first (isc client keys by MAC); fall back to systemd-networkd
+	// (Ubuntu Noble default) which keys by a machine-id-derived DUID.
+	_, _ = h.sys.run("dhclient", "-r", ifc)
+	if _, err := h.sys.run("dhclient", "-1", ifc); err != nil {
+		_, _ = h.sys.run("networkctl", "renew", ifc)
+		_, _ = h.sys.run("networkctl", "reconfigure", ifc)
+	}
+	// give the lease a moment to land, then read the address back
+	time.Sleep(2 * time.Second)
+	return h.ifaceIP(ifc), nil
+}
+
+// --- interface detection ------------------------------------------------------
+
+// primaryIface returns the guest's primary NIC. It does NOT assume "eth0":
+// a stock cloud image under predictable naming calls it enp0sN (PR-0 spike
+// finding). Prefer the default-route iface; else the first non-virtual link.
+func (h *handler) primaryIface() (string, error) {
+	if out, err := h.sys.run("ip", "-o", "-4", "route", "show", "default"); err == nil {
+		fields := strings.Fields(out)
+		for i, f := range fields {
+			if f == "dev" && i+1 < len(fields) {
+				return fields[i+1], nil
+			}
+		}
+	}
+	links, err := h.sys.glob("/sys/class/net/*")
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(links)
+	for _, l := range links {
+		n := filepath.Base(l)
+		if n == "lo" || strings.HasPrefix(n, "veth") || strings.HasPrefix(n, "docker") ||
+			strings.HasPrefix(n, "br") || strings.HasPrefix(n, "virbr") {
+			continue
+		}
+		// a physical/virtio NIC has a device symlink; bridges/veths don't
+		if _, err := h.sys.readFile(l + "/device/uevent"); err == nil {
+			return n, nil
+		}
+	}
+	return "", fmt.Errorf("no primary interface found")
+}
+
+func (h *handler) ifaceMAC(ifc string) string {
+	if ifc == "" {
+		return ""
+	}
+	s, _ := h.sys.readFile("/sys/class/net/" + ifc + "/address")
+	return strings.TrimSpace(s)
+}
+
+func (h *handler) ifaceIP(ifc string) string {
+	if ifc == "" {
+		return ""
+	}
+	out, err := h.sys.run("ip", "-4", "-o", "addr", "show", "dev", ifc)
+	if err != nil {
+		return ""
+	}
+	for _, tok := range strings.Fields(out) {
+		if strings.Contains(tok, "/") && len(tok) > 0 && tok[0] >= '0' && tok[0] <= '9' {
+			return strings.SplitN(tok, "/", 2)[0]
+		}
+	}
+	return ""
+}
+
+// --- real system implementation ----------------------------------------------
+
+type realSystem struct{}
+
+func (realSystem) run(name string, args ...string) (string, error) {
+	// exec.Command uses argv directly — no shell, so validated MAC/hostname args
+	// can never be interpreted (security: no shell interpolation).
+	out, err := exec.Command(name, args...).CombinedOutput()
+	return string(out), err
+}
+func (realSystem) readFile(p string) (string, error) {
+	b, err := os.ReadFile(p)
+	return string(b), err
+}
+func (realSystem) writeFile(p string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(p, data, perm)
+}
+func (realSystem) remove(p string) error           { return os.Remove(p) }
+func (realSystem) glob(p string) ([]string, error) { return filepath.Glob(p) }
+func (realSystem) hostname() (string, error)       { return os.Hostname() }

--- a/cmd/kubeswift-guest-agent/handler_test.go
+++ b/cmd/kubeswift-guest-agent/handler_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// fakeSys records run() invocations and serves canned file/glob/hostname data so
+// the dispatch + validation logic is exercised with no root and no real exec.
+type fakeSys struct {
+	calls    []string
+	runErr   map[string]error // keyed by the joined "name arg0 arg1"
+	runOut   map[string]string
+	files    map[string]string
+	globs    map[string][]string
+	host     string
+	removed  []string
+	hostSet  string // captured from `hostname <x>` / writeFile
+	writeErr error
+}
+
+func newFakeSys() *fakeSys {
+	return &fakeSys{
+		runErr: map[string]error{}, runOut: map[string]string{},
+		files: map[string]string{}, globs: map[string][]string{},
+		host: "vsock-src",
+	}
+}
+
+func key(name string, args ...string) string {
+	return strings.Join(append([]string{name}, args...), " ")
+}
+
+func (f *fakeSys) run(name string, args ...string) (string, error) {
+	k := key(name, args...)
+	f.calls = append(f.calls, k)
+	return f.runOut[k], f.runErr[k]
+}
+func (f *fakeSys) readFile(p string) (string, error) {
+	if v, ok := f.files[p]; ok {
+		return v, nil
+	}
+	return "", os.ErrNotExist
+}
+func (f *fakeSys) writeFile(p string, data []byte, _ os.FileMode) error {
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.files[p] = string(data)
+	return nil
+}
+func (f *fakeSys) remove(p string) error { f.removed = append(f.removed, p); return nil }
+func (f *fakeSys) glob(p string) ([]string, error) {
+	return f.globs[p], nil
+}
+func (f *fakeSys) hostname() (string, error) { return f.host, nil }
+
+func (f *fakeSys) called(sub string) bool {
+	for _, c := range f.calls {
+		if strings.Contains(c, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// newHandler wires a handler whose fake guest has a default-route iface enp0s4.
+func newHandler() (*handler, *fakeSys) {
+	f := newFakeSys()
+	f.runOut[key("ip", "-o", "-4", "route", "show", "default")] = "default via 192.168.99.1 dev enp0s4 proto dhcp"
+	f.runOut[key("ip", "-4", "-o", "addr", "show", "dev", "enp0s4")] = "2: enp0s4    inet 192.168.99.44/24 brd 192.168.99.255 scope global enp0s4"
+	f.files["/etc/machine-id"] = "5d0ca4597dbf4f538ba33a3262b3be7f\n"
+	f.files["/sys/class/net/enp0s4/address"] = "52:54:00:11:11:11\n"
+	return &handler{sys: f, version: "test"}, f
+}
+
+func decode(t *testing.T, b []byte) Response {
+	t.Helper()
+	var r Response
+	if err := json.Unmarshal(b, &r); err != nil {
+		t.Fatalf("decode response: %v (raw=%s)", err, b)
+	}
+	return r
+}
+
+func TestPingReportsIdentity(t *testing.T) {
+	h, _ := newHandler()
+	r := decode(t, h.handle([]byte(`{"op":"ping"}`)))
+	if !r.OK || r.V != ProtocolVersion {
+		t.Fatalf("ping not ok: %+v", r)
+	}
+	if r.MachineID != "5d0ca4597dbf4f538ba33a3262b3be7f" || r.MAC != "52:54:00:11:11:11" || r.IP != "192.168.99.44" {
+		t.Fatalf("ping identity wrong: %+v", r)
+	}
+}
+
+func TestUnknownOp(t *testing.T) {
+	h, _ := newHandler()
+	r := decode(t, h.handle([]byte(`{"op":"exec","cmd":"rm -rf /"}`)))
+	if r.OK || !strings.Contains(r.Error, "unknown op") {
+		t.Fatalf("unknown op should fail loudly: %+v", r)
+	}
+}
+
+func TestBadJSON(t *testing.T) {
+	h, _ := newHandler()
+	r := decode(t, h.handle([]byte(`{not json`)))
+	if r.OK || r.Error == "" {
+		t.Fatalf("bad json should fail loudly: %+v", r)
+	}
+}
+
+func TestRegenerateAllItems(t *testing.T) {
+	h, f := newHandler()
+	req := `{"op":"regenerate-identity","items":["machineId","sshHostKeys","hostname","macAddresses"],"mac":"52:54:00:22:22:22","hostname":"ft-clone-a","renewLease":true}`
+	r := decode(t, h.handle([]byte(req)))
+	if !r.OK {
+		t.Fatalf("regenerate failed: %+v", r)
+	}
+	got := strings.Join(r.Regenerated, ",")
+	for _, it := range []string{"machineId", "sshHostKeys", "hostname", "macAddresses"} {
+		if !strings.Contains(got, it) {
+			t.Errorf("item %q not regenerated: %v", it, r.Regenerated)
+		}
+	}
+	if !f.called("systemd-machine-id-setup") {
+		t.Error("machine-id not regenerated")
+	}
+	if !f.called("ssh-keygen -A") {
+		t.Error("ssh host keys not regenerated")
+	}
+	if !f.called("hostnamectl set-hostname ft-clone-a") {
+		t.Error("hostname not set")
+	}
+	if !f.called("ip link set enp0s4 address 52:54:00:22:22:22") {
+		t.Error("mac not set on detected iface enp0s4")
+	}
+	if !f.called("dhclient -1 enp0s4") {
+		t.Error("lease not renewed")
+	}
+}
+
+func TestRegenerateEmptyItemsDefaultsToAll(t *testing.T) {
+	h, f := newHandler()
+	r := decode(t, h.handle([]byte(`{"op":"regenerate-identity","mac":"52:54:00:22:22:22","hostname":"c1"}`)))
+	if !r.OK || len(r.Regenerated) != 4 {
+		t.Fatalf("empty items should default to all four: %+v", r)
+	}
+	if !f.called("ssh-keygen -A") || !f.called("systemd-machine-id-setup") {
+		t.Error("default-all did not run all ops")
+	}
+}
+
+func TestInvalidMACRejected(t *testing.T) {
+	h, f := newHandler()
+	r := decode(t, h.handle([]byte(`{"op":"regenerate-identity","items":["machineId","macAddresses"],"mac":"not-a-mac"}`)))
+	if r.OK {
+		t.Fatalf("invalid mac must make ok=false: %+v", r)
+	}
+	if !strings.Contains(r.Error, "macAddresses") || !strings.Contains(r.Error, "invalid mac") {
+		t.Errorf("error should name the bad mac: %q", r.Error)
+	}
+	// machineId still applied even though macAddresses failed (partial success surfaced)
+	if !contains(r.Regenerated, "machineId") {
+		t.Errorf("machineId should still be done: %v", r.Regenerated)
+	}
+	if f.called("ip link set enp0s4 address") {
+		t.Error("must NOT set an invalid mac on the link")
+	}
+}
+
+func TestInvalidHostnameRejected(t *testing.T) {
+	h, _ := newHandler()
+	r := decode(t, h.handle([]byte(`{"op":"regenerate-identity","items":["hostname"],"hostname":"bad host!"}`)))
+	if r.OK || !strings.Contains(r.Error, "invalid hostname") {
+		t.Fatalf("invalid hostname must be rejected: %+v", r)
+	}
+}
+
+func TestMACSetOrderingDownAddressUp(t *testing.T) {
+	h, f := newHandler()
+	h.handle([]byte(`{"op":"regenerate-identity","items":["macAddresses"],"mac":"52:54:00:22:22:22"}`))
+	var idxDown, idxAddr, idxUp = -1, -1, -1
+	for i, c := range f.calls {
+		switch {
+		case c == "ip link set enp0s4 down":
+			idxDown = i
+		case c == "ip link set enp0s4 address 52:54:00:22:22:22":
+			idxAddr = i
+		case c == "ip link set enp0s4 up":
+			idxUp = i
+		}
+	}
+	if !(idxDown >= 0 && idxAddr > idxDown && idxUp > idxAddr) {
+		t.Fatalf("mac change must be down->address->up; got down=%d addr=%d up=%d", idxDown, idxAddr, idxUp)
+	}
+}
+
+func TestPrimaryIfaceFallbackToGlob(t *testing.T) {
+	f := newFakeSys()
+	// no default route -> fall back to the first non-virtual link with a device
+	f.runErr[key("ip", "-o", "-4", "route", "show", "default")] = os.ErrNotExist
+	f.globs["/sys/class/net/*"] = []string{"/sys/class/net/lo", "/sys/class/net/enp0s4"}
+	f.files["/sys/class/net/enp0s4/device/uevent"] = "DRIVER=virtio_net"
+	h := &handler{sys: f, version: "test"}
+	ifc, err := h.primaryIface()
+	if err != nil || ifc != "enp0s4" {
+		t.Fatalf("fallback iface detect wrong: %q err=%v", ifc, err)
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/kubeswift-guest-agent/kubeswift-guest-agent.service
+++ b/cmd/kubeswift-guest-agent/kubeswift-guest-agent.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=KubeSwift in-guest identity agent (vsock)
+Documentation=https://github.com/projectbeskar/kubeswift docs/design/clone-identity-vsock-agent.md
+# LOAD-BEARING: this agent must be RUNNING in the SOURCE guest when its memory
+# snapshot is captured, so it is part of the captured RAM and resumes — alive
+# and listening — in every cloneFromSnapshot clone (a clone never boots, so
+# nothing new can start on it). Do not "fix" this to start later or on the
+# clone. See docs/design/clone-identity-vsock-agent.md §6.1 (LBA-1).
+After=network-pre.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/kubeswift-guest-agent
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/cmd/kubeswift-guest-agent/main.go
+++ b/cmd/kubeswift-guest-agent/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"log"
+	"os"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+// version is overridden at build time via -ldflags "-X main.version=...".
+var version = "dev"
+
+const (
+	maxRequestBytes = 64 * 1024
+	recvTimeoutSecs = 30
+)
+
+func main() {
+	port := flag.Int("port", DefaultPort, "AF_VSOCK port to listen on")
+	flag.Parse()
+	if env := os.Getenv("KUBESWIFT_GUEST_AGENT_PORT"); env != "" {
+		if p, err := strconv.Atoi(env); err == nil {
+			*port = p
+		}
+	}
+
+	h := &handler{sys: realSystem{}, version: version}
+
+	lfd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
+	if err != nil {
+		log.Fatalf("kubeswift-guest-agent: AF_VSOCK socket: %v", err)
+	}
+	sa := &unix.SockaddrVM{CID: unix.VMADDR_CID_ANY, Port: uint32(*port)}
+	if err := unix.Bind(lfd, sa); err != nil {
+		log.Fatalf("kubeswift-guest-agent: bind vsock port %d: %v", *port, err)
+	}
+	if err := unix.Listen(lfd, 16); err != nil {
+		log.Fatalf("kubeswift-guest-agent: listen: %v", err)
+	}
+	log.Printf("kubeswift-guest-agent %s listening on AF_VSOCK port %d", version, *port)
+
+	for {
+		nfd, _, err := unix.Accept(lfd)
+		if err != nil {
+			if err == unix.EINTR {
+				continue
+			}
+			log.Printf("kubeswift-guest-agent: accept: %v", err)
+			continue
+		}
+		go serve(h, nfd)
+	}
+}
+
+// serve reads one newline-delimited JSON request, dispatches it, writes the JSON
+// response, and closes the connection (one request/response per connection).
+func serve(h *handler, nfd int) {
+	defer unix.Close(nfd)
+	// bound the connection so a stuck/hostile client cannot pin a goroutine
+	tv := unix.Timeval{Sec: recvTimeoutSecs}
+	_ = unix.SetsockoptTimeval(nfd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &tv)
+
+	var buf []byte
+	tmp := make([]byte, 4096)
+	for len(buf) < maxRequestBytes {
+		n, err := unix.Read(nfd, tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			if i := bytes.IndexByte(buf, '\n'); i >= 0 {
+				buf = buf[:i]
+				break
+			}
+		}
+		if err != nil || n == 0 {
+			break
+		}
+	}
+
+	resp := h.handle(buf)
+	for len(resp) > 0 {
+		n, err := unix.Write(nfd, resp)
+		if n > 0 {
+			resp = resp[n:]
+		}
+		if err != nil {
+			break
+		}
+	}
+}

--- a/config/samples/seed-profiles/guest-agent.yaml
+++ b/config/samples/seed-profiles/guest-agent.yaml
@@ -1,0 +1,84 @@
+# SwiftSeedProfile that installs and starts the KubeSwift in-guest identity
+# agent on a SOURCE guest's first boot, so the agent is RUNNING when the guest's
+# memory snapshot is captured — and therefore resumes, alive and listening, in
+# every cloneFromSnapshot clone.
+#
+# # Why this supersedes clone-identity-regen.yaml
+#
+# The old approach regenerated a clone's identity from a cloud-init `bootcmd`
+# that fired on the clone's first REBOOT. That is BROKEN on Cloud Hypervisor v52:
+# a `--restore`d guest hangs in EDK2 firmware on reboot
+# (docs/design/known-issues-clone-reboot-firmware-hang.md). This agent
+# regenerates identity + re-DHCPs IN PLACE over vsock — no reboot — so it works
+# on CH v52. See docs/design/clone-identity-vsock-agent.md.
+#
+# # THE load-bearing constraint
+#
+# A cloneFromSnapshot clone never boots — it RESUMES the source's captured RAM.
+# So nothing new can start on a clone. The agent must already be running in the
+# SOURCE at snapshot time. That is exactly what this seed profile arranges:
+# attach it to the SOURCE SwiftGuest via spec.seedProfileRef; the agent is then
+# baked into every snapshot of that guest and resumes in every clone.
+#
+# # How the agent binary reaches the guest
+#
+# Two supported paths (pick one):
+#
+#  (a) virtiofs share (this sample). When a source guest references this seed
+#      profile, the SwiftGuest controller bind-mounts the swiftletd image's
+#      /usr/local/share/kubeswift/guest-agent directory into the guest as a
+#      read-only virtiofs share tagged `kubeswift-agent`. The runcmd below
+#      installs the agent from it. (The controller-side share attachment ships in
+#      PR 2 of the arc; until then, install the agent manually — see (b)/(c).)
+#
+#  (b) golden image (recommended for production fleets). Bake
+#      /usr/local/bin/kubeswift-guest-agent + this systemd unit into your
+#      SwiftImage at build time; then no per-guest seed wiring is needed.
+#
+#  (c) manual (for testing PR 1 standalone). Copy the binary into a running
+#      source guest, `systemctl enable --now kubeswift-guest-agent`, then
+#      snapshot it.
+#
+# # Fail-safe
+#
+# If a clone is created from a snapshot that did NOT have the agent running, the
+# controller surfaces CloneIdentityRegenerated=False / GuestAgentUnreachable
+# (PR 4) — the clone is still usable as a warm replica with the source's
+# identity, never a silent failure.
+
+apiVersion: seed.kubeswift.io/v1alpha1
+kind: SwiftSeedProfile
+metadata:
+  name: guest-agent
+spec:
+  datasource: NoCloud
+  userData: |
+    #cloud-config
+    # The systemd unit is written inline (it is tiny) so only the binary needs to
+    # come from the share / golden image.
+    write_files:
+      - path: /etc/systemd/system/kubeswift-guest-agent.service
+        permissions: '0644'
+        content: |
+          [Unit]
+          Description=KubeSwift in-guest identity agent (vsock)
+          # LOAD-BEARING: must be RUNNING in the SOURCE at snapshot time so it is
+          # captured in RAM and resumes in every clone (a clone never boots).
+          After=network-pre.target
+          [Service]
+          Type=simple
+          ExecStart=/usr/local/bin/kubeswift-guest-agent
+          Restart=always
+          RestartSec=2
+          [Install]
+          WantedBy=multi-user.target
+    runcmd:
+      # (a) install from the controller-attached virtiofs share (PR 2).
+      - [ sh, -c, "mkdir -p /mnt/kubeswift-agent" ]
+      - [ sh, -c, "mount -t virtiofs kubeswift-agent /mnt/kubeswift-agent 2>/dev/null || true" ]
+      - [ sh, -c, "if [ -x /mnt/kubeswift-agent/kubeswift-guest-agent ]; then install -m0755 /mnt/kubeswift-agent/kubeswift-guest-agent /usr/local/bin/kubeswift-guest-agent; fi" ]
+      - [ sh, -c, "umount /mnt/kubeswift-agent 2>/dev/null || true" ]
+      # enable + start (no-op if the binary is absent — the controller's
+      # GuestAgentUnreachable fallback then makes the gap visible, not silent).
+      - [ sh, -c, "systemctl daemon-reload" ]
+      - [ sh, -c, "if [ -x /usr/local/bin/kubeswift-guest-agent ]; then systemctl enable --now kubeswift-guest-agent; fi" ]

--- a/docs/design/clone-identity-vsock-agent.md
+++ b/docs/design/clone-identity-vsock-agent.md
@@ -1,0 +1,587 @@
+# In-guest vsock identity agent — regenerate clone identity without a reboot
+
+> Status: DESIGN — **PR 0 spike COMPLETE / PASS (2026-06-15)**, see
+> [`clone-identity-vsock-agent-spike.md`](clone-identity-vsock-agent-spike.md).
+> The spike confirmed every load-bearing assumption (vsock device + agent survive
+> CH v52 `--restore`; identity regen + MAC-set + re-DHCP work **in place, no
+> reboot**) and **corrected one framing**: "distinct IP across clones" is a
+> non-goal — per-pod-netns isolation makes the agent's real job *re-DHCP-for-status
+> + MAC-alignment*, not a globally-unique guest-internal IP (§Q4 note). Proceed to
+> PR 1. Supersedes the reboot-based clone-identity remedy, which is BROKEN on
+> Cloud Hypervisor v52
+> ([`known-issues-clone-reboot-firmware-hang.md`](known-issues-clone-reboot-firmware-hang.md)).
+> Anchors on the Snapshot Phase 2 resume-vs-boot limitation
+> ([`snapshots.md`](snapshots.md) + context doc "Known limitation: identity
+> regeneration on clone resume") and Snapshot Phase 4 cloneFromSnapshot
+> ([`snapshot-phase-4-clonefromsnapshot.md`](snapshot-phase-4-clonefromsnapshot.md)).
+> Last updated: 2026-06-15.
+
+## 1. Problem
+
+A `SwiftGuest.spec.cloneFromSnapshot` guest boots via Cloud Hypervisor
+`--restore` — it **resumes** the source's captured RAM byte-for-byte (CH v52
+`resume=true`, see `swift-ch-client/src/spawn.rs::restore_args`). A resume is
+**not a boot**: cloud-init does not re-run, systemd-firstboot does not run, and
+the guest kernel's device/driver state is the source's. Every clone therefore
+inherits the source's **guest-visible identity**:
+
+| Identity field | After clone resume | Set per-clone today? |
+|---|---|---|
+| `/etc/machine-id` | inherited from source | no |
+| `/etc/ssh/ssh_host_*_key*` | inherited from source | no |
+| hostname | inherited from source | no |
+| guest-visible `eth0` MAC (virtio-net driver cache) | inherited from source | no |
+| guest's DHCP-acquired IP (lease in RAM) | inherited; no re-DHCP on resume | no |
+| hypervisor `config.net[].mac` (host-side tap/bridge fdb) | **rewritten per-clone** (`clonecommon.ComputeMACRewrites`) | yes |
+| pod network namespace | per-clone (Kubernetes-isolated) | yes |
+
+The per-pod-netns isolation makes N coexisting clones **L2-collision-safe**
+regardless of the shared guest MAC, so clones are usable today as **warm,
+read-mostly replicas** that share the source's identity. They are NOT
+independently addressable: `status.network.primaryIP` stays empty (no re-DHCP),
+and machine-id/SSH-key/hostname collisions break anything that keys on them
+(dbus, journald dedup, SSH host-key pinning, cluster membership).
+
+The documented remedy was **"reboot the clone once"**: the controller appends
+`kubeswift.clone=true` to the snapshot's config.json cmdline
+(`internal/snapshot/configjson/`), and the source's `SwiftSeedProfile` ships a
+`bootcmd` (`config/samples/seed-profiles/clone-identity-regen.yaml`) that, gated
+on the marker + a sentinel, regenerates machine-id / SSH keys / hostname and the
+guest re-DHCPs on the reboot. **That remedy is broken on CH v52**: a `--restore`d
+guest's reboot hangs in EDK2 firmware (S3-resume / AP-init, freezes after
+`MpInitChangeApLoopCallback`) — a normal guest reboots fine
+([`known-issues-clone-reboot-firmware-hang.md`](known-issues-clone-reboot-firmware-hang.md),
+cluster-isolated 2026-06-15). The firmware never reaches the kernel, so identity
+is never regenerated and no IP is ever discovered. That is an upstream CH/EDK2
+issue, not KubeSwift code.
+
+**The vsock identity agent is the real fix: regenerate identity + renew the IP
+in place, with no reboot.**
+
+## 2. Goals / Non-goals
+
+### Goals
+
+- Regenerate a clone's `/etc/machine-id`, SSH host keys, and hostname **in
+  place** (no reboot), driven by the existing
+  `CloneFromSnapshotSource.Regenerate []CloneIdentityItem` list.
+- **Re-DHCP the clone in place** (no reboot) so a fresh lease lands in the clone's
+  own per-pod dnsmasq and surfaces in `status.network.primaryIP` via the existing
+  lease-poller path (v0.4.3 `LEASE_POLL_ATTEMPTS_RESTORE`). (Spike correction: the
+  goal is *re-DHCP-for-status*, **not** a globally-distinct guest-internal IP —
+  per-pod-netns isolation already separates clones; see §Q4 note + the spike doc.)
+- A **host↔guest-only** control channel (vsock) — not network-reachable, minimal
+  command surface (identity-regen only, no arbitrary exec).
+- **Opt-in, fail-safe**: images without the agent keep today's
+  inherited-identity behavior with a loud, status-visible "agent absent" signal
+  — never a silent failure (Design Principle #6).
+
+### Non-goals
+
+- **Not** a general guest agent (no exec, no file transfer, no metrics — those
+  are a separate future surface if ever wanted). The agent does identity-regen
+  and nothing else in v1.
+- **Not** a fix for the CH v52 restore-then-reboot firmware hang itself — this
+  sidesteps the reboot. The hang stays an upstream-CH tracked issue; if a future
+  CH fixes it, the bootcmd path can co-exist (see §6.6) but the agent remains the
+  primary path.
+- **Not** Windows (osType: windows) in v1 — cloudbase-init + Windows identity
+  regen (sysprep/Restart-Computer) is a different mechanism; out of scope, noted
+  in §6.7.
+- **Not** live-migration related. Live migration deliberately preserves identity
+  byte-for-byte; the agent is never invoked on a migration receiver.
+
+## 3. Architecture
+
+```
+                         launcher pod (per clone, own netns)
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  swiftletd (host side)                                                 │
+  │  ───────────────────                                                   │
+  │  action loop (action.rs)  ──dispatch IdentityRegen──┐                  │
+  │   (annotation-driven, new                           │                  │
+  │    "identity" KeySet)                                ▼                  │
+  │                                          ┌───────────────────────┐     │
+  │                                          │ swift-vsock-client     │     │
+  │                                          │ connect AF_VSOCK port  │     │
+  │                                          │ over the unix socket   │     │
+  │                                          └──────────┬────────────┘     │
+  │                                                     │                  │
+  │  cloud-hypervisor  --vsock cid=<N>,socket=<rt>/vsock.sock              │
+  │   (spawn.rs / config.rs)                            │                  │
+  └─────────────────────────────────────────────────────┼─────────────────┘
+                  vsock AF_VSOCK (host CID 2 ↔ guest CID │N), localhost-only
+  ┌─────────────────────────────────────────────────────▼─────────────────┐
+  │  GUEST (resumed from snapshot; cloud-init did NOT re-run)              │
+  │  kubeswift-guest-agent.service  — listens AF_VSOCK port 1024           │
+  │    on RegenerateIdentity{items, mac, hostname}:                        │
+  │      machine-id  → systemd-machine-id-setup                            │
+  │      sshHostKeys → ssh-keygen -A + reload sshd                         │
+  │      hostname    → hostnamectl set-hostname                            │
+  │      macAddresses→ ip link set eth0 address <mac>                      │
+  │      IP          → dhclient -r eth0 && dhclient eth0  → return new IP  │
+  │    reply {ok, newIP, regenerated[]}                                    │
+  └────────────────────────────────────────────────────────────────────────┘
+```
+
+The agent is a tiny static binary + systemd unit that **must already be running
+in the SOURCE guest at snapshot-capture time** so it is part of the captured RAM
+and resumes — alive and listening — in every clone (the load-bearing constraint,
+§6.1). The host side reuses the existing annotation-driven action-loop surface;
+the only genuinely new runtime piece is a thin vsock client in swiftletd and the
+`--vsock` arg on the CH spawn.
+
+The host's host-side AF_VSOCK CID is always **2** (`VMADDR_CID_HOST`). The guest
+CID is the per-guest `cid=<N>` we assign on the CH `--vsock` arg; CH bridges the
+guest's AF_VSOCK to the host-side **unix socket** we name under the runtime dir.
+
+## 4. Resolved decisions
+
+### Q1 — Agent delivery (THE crux): cloud-init install from a KubeSwift-shipped seed snippet, opt-in via the SwiftSeedProfile; golden-image bake is the documented power path
+
+**Decision.** KubeSwift ships:
+
+1. **The agent binary** built in-repo (`cmd/kubeswift-guest-agent`, a small
+   static Go binary — language rationale below) and **embedded in the swiftletd
+   image** at a stable path (e.g. `/usr/local/share/kubeswift/guest-agent/<arch>/
+   kubeswift-guest-agent`). It is NOT a container the guest runs; it is a file
+   that must land **inside the guest filesystem**.
+2. **A canonical `SwiftSeedProfile` cloud-init snippet** (a sample +
+   documented include) whose `write_files` drops a tiny systemd unit and whose
+   `runcmd` fetches-or-installs the agent binary into the guest and `systemctl
+   enable --now`s it on the SOURCE guest's **first boot**, BEFORE the snapshot is
+   taken.
+
+**How the binary gets into the guest** is the sub-decision. Two mechanisms, both
+shipped:
+
+- **(a) Primary — install via the source's cloud-init over a virtiofs read-only
+  share.** The launcher already has a virtiofs path (`launch.rs::spawn_virtiofsd`
+  + `--fs`). For a source guest opted into the agent, the controller mounts the
+  swiftletd image's agent directory as a read-only virtiofs share (tag e.g.
+  `kubeswift-agent`); the seed `runcmd` does `mount -t virtiofs kubeswift-agent
+  /mnt/...; install -m0755 .../kubeswift-guest-agent /usr/local/bin/; systemctl
+  enable --now kubeswift-guest-agent`. This keeps "what KubeSwift ships" as a file
+  in the swiftletd image (one source of truth, version-pinned with the image) and
+  needs no external hosting. **This requires the source guest to declare it wants
+  the agent** (an opt-in seed profile + a controller flag to attach the share) —
+  it is not automatic.
+- **(b) Power path — bake into the golden image.** Operators building a golden
+  SwiftImage install the agent + unit at image-build time (documented `apt`/`dnf`
+  package or a `curl | install` in their image recipe). The snapshot of any guest
+  from that image then carries a running agent with zero per-guest seed wiring.
+  This is the recommended path for production fleets.
+
+**Opt-in & fallback (Principle #6 — no silent failure).** The agent's presence is
+**not assumed**. When the controller drives a regen and the agent does not answer
+on vsock within a bounded window, the clone:
+
+- keeps today's inherited-identity behavior (still usable as a warm replica),
+- gets a status condition `CloneIdentityRegenerated=False` with reason
+  `GuestAgentUnreachable` and a message pointing at the seed-profile / golden-image
+  docs,
+- and the documented limitation (shared identity, empty primaryIP) is restated in
+  the runbook.
+
+This is loud and actionable, not a silent degrade.
+
+**Rejected alternatives.**
+
+- *Deliver the agent over a dedicated virtio device at clone time.* Doesn't work:
+  the guest never re-enumerates devices on resume (no boot), and the agent must
+  already be RUNNING in the captured RAM. Anything delivered only at clone time is
+  too late. (This is the same constraint that kills "install the agent on the
+  clone".)
+- *Bake the agent into swiftletd and have swiftletd push it in over vsock at clone
+  time.* Same fatal flaw: nothing is listening on vsock in the guest until the
+  agent is running, and the agent can't be running unless it was in the snapshot.
+  Chicken-and-egg.
+- *Make the agent mandatory (every image must ship it).* Violates minimalism +
+  the "all modern distributions supported" promise; KubeSwift must degrade
+  gracefully on a stock cloud image. Opt-in with a loud fallback is the discipline.
+
+### Q2 — vsock transport: CH `--vsock cid=<N>,socket=<rt>/vsock.sock`; CID derived deterministically; the device MUST be present on the SOURCE snapshot
+
+**Decision.** Add a `--vsock cid=<N>,socket=<runtime-dir>/vsock.sock` argument to
+the CH spawn for guests that use the agent. Conventions:
+
+- **Unix socket path** mirrors the existing `ch.sock` / `serial.sock` /
+  `qmp.sock` runtime-dir paths: `<runtime-dir>/vsock.sock`
+  (`RuntimeDir::root().join("vsock.sock")`, cleaned up by
+  `launch.rs::remove_stale_sockets` exactly like the others — same SIGKILL
+  stale-socket hazard).
+- **Which side connects:** the host (swiftletd) is the **client**. CH listens on
+  the host-side unix socket; swiftletd connects to it and speaks the AF_VSOCK
+  framing (the `CONNECT <port>\n` handshake CH's vsock backend expects), targeting
+  the guest agent's AF_VSOCK port. The guest agent is the AF_VSOCK **server**
+  (listens on a fixed port, see Q3).
+- **CID assignment:** deterministic per guest, derived from `(namespace, name)`
+  the same way MACs are (`runtimeintent.InterfaceMACSeed` style hashing into the
+  valid CID range, ≥ 3; CIDs 0–2 are reserved). Stored implicitly (recomputable);
+  also surfaced read-only in the runtime intent so swiftletd and any debug tooling
+  agree. Uniqueness is **per-host** (one CH per launcher pod, isolated netns/PID),
+  so even a hash collision across pods is harmless — vsock is pod-local.
+- **`--vsock` is added by `swift-ch-client` config/spawn** (a new `vsock:
+  Option<VsockConfig>` field on `VmConfig`, emitted in `to_args()` next to the
+  other devices; the restore path needs its own handling — below).
+
+**The capture-time constraint (load-bearing, ties to Q1).** CH captures the
+guest's **device state** in the snapshot. The vsock device — like every virtio
+device — is part of that captured state. So **the SOURCE guest must have been
+launched WITH `--vsock` for the restored clone to have a working vsock device**.
+This means:
+
+- The controller sets `--vsock` on the **source** guest whenever it is a snapshot
+  source that opted into the agent (the same opt-in that attaches the agent, Q1).
+- On `--restore`, CH re-opens the devices from the snapshot's `config.json`,
+  which will list the vsock device with the source's socket path. As with seed.iso
+  and disk paths (already handled for clones), the clone's runtime-dir differs, so
+  the vsock **socket path** in config.json must be **patched to the clone's
+  runtime-dir path** — this extends the existing `configjson` patcher
+  (`internal/snapshot/configjson/`, which already rewrites disk paths and the
+  serial socket; the vsock socket is the same class of per-pod path). The **CID**
+  is captured in state and resumes as-is; we do not re-CID a restored guest (the
+  guest kernel's vsock is bound to the captured CID — changing it host-side would
+  desync). Per-pod isolation makes the inherited CID safe.
+
+If the source was launched **without** `--vsock`, the snapshot has no vsock device
+and the clone cannot be reached — this collapses into the Q1 fallback
+(`GuestAgentUnreachable`), loud and documented. The webhook can warn at clone-time
+if the referenced snapshot's `CapturedGuestSpec` indicates no agent (best-effort;
+the authoritative signal is the runtime no-answer).
+
+**Rejected alternatives.**
+
+- *Per-migration / ephemeral CID.* No — the CID is baked into captured guest
+  state; it can't be reassigned on resume without the guest noticing.
+- *Network socket instead of vsock.* Defeats the security boundary (vsock is
+  host↔guest only, unroutable); and the clone has no usable IP yet anyway, which
+  is the whole point.
+
+### Q3 — Protocol: minimal length-prefixed JSON request/response over a fixed AF_VSOCK port, versioned
+
+**Decision.** The agent listens on a fixed AF_VSOCK port (**1024**, above the
+privileged range, documented constant shared between agent and
+`swift-vsock-client`). One request/response per connection, newline-or-length-
+prefixed JSON (mirrors how the action surface stays tiny and the snapshot
+`config.json` is JSON; serde-friendly).
+
+**Request (host → guest):**
+
+```json
+{
+  "v": 1,
+  "op": "regenerate-identity",
+  "items": ["machineId", "sshHostKeys", "hostname", "macAddresses"],
+  "mac": "52:54:00:7e:0c:47",
+  "hostname": "ft-clone-a",
+  "renewLease": true
+}
+```
+
+- `items` maps **directly** from `CloneFromSnapshotSource.Regenerate
+  []CloneIdentityItem` (`hostname` / `machineId` / `sshHostKeys` /
+  `macAddresses`). Empty list defaults to all four (matches the CRD default).
+- `mac` is the per-clone hypervisor MAC the controller already computes
+  (`clonecommon.ComputeMACRewrites`) — pushed to the guest so the **guest-visible**
+  MAC matches the host-side fdb (resolving the long-standing split where only the
+  hypervisor MAC was rewritten). Present only when `macAddresses ∈ items`.
+- `hostname` is the controller-chosen name (defaults to the clone's
+  `metadata.name`); the agent uses it directly instead of deriving from machine-id.
+- `renewLease` asks the agent to re-DHCP after the MAC change.
+
+**Response (guest → host):**
+
+```json
+{ "v": 1, "ok": true, "regenerated": ["machineId","sshHostKeys","hostname","macAddresses"],
+  "newIP": "192.168.99.12", "error": null }
+```
+
+- `newIP` is the address from the agent's `dhclient` renew — fed back so the
+  controller (or the lease poller, §Q4) can land it in `status.network.primaryIP`.
+- `regenerated` echoes what actually ran (an old agent that doesn't understand an
+  item omits it — forward-compat).
+
+**Versioning / handshake.** `v` is the protocol version. **Degrade rules:**
+
+- New host + old agent: agent ignores unknown fields (serde default) and omits
+  unsupported items from `regenerated`; the host treats any item it asked for but
+  didn't get back as not-regenerated and reflects that in status (no false claim).
+- Old host + new agent: the agent accepts `v:1` requests; new ops are additive.
+- An agent that doesn't recognize `op` returns `{ok:false, error:"unknown op"}` —
+  the host surfaces it, never silently succeeds.
+
+Command surface is deliberately ONE op in v1 (`regenerate-identity`). No exec, no
+file ops. (A `ping`/`hello` op for liveness probing is the only other candidate;
+fold it in if the spike wants an explicit readiness check before the regen.)
+
+### Q4 — Trigger flow: swiftletd's action loop drives it (annotation-driven, new "identity" KeySet), after GuestRunning; the agent-returned IP feeds the existing restore lease-poller path
+
+**Decision.** Reuse the **annotation-driven action loop** (`rust/swiftletd/src/
+action.rs`) — the same pattern as `kubeswift.io/snapshot-action` and
+`kubeswift.io/migration-action`. Add a third **`identity` namespace KeySet**
+(`IDENTITY_KEYS`) with:
+
+- controller writes: `kubeswift.io/identity-action` (verb `regenerate`),
+  `…/identity-action-id`, `…/identity-action-args` (the JSON request from Q3).
+- swiftletd writes: `kubeswift.io/identity-status` (`running`/`ready`/`failed`),
+  `…/identity-status-id`, `…/identity-status-detail`, and a new
+  `kubeswift.io/identity-new-ip` carrying the agent-returned IP.
+
+**Who drives & when.** The **SwiftGuest controller** (not a new controller)
+stamps `identity-action: regenerate` once the cloneFromSnapshot guest reaches
+**GuestRunning=True** (CH v52 auto-resumes via `resume=true`, so the VM is
+running, not paused — `controller.go` already keys off this). The action is
+**one-shot, idempotent** via the action-id (the decide()/`last_completed_id`
+machinery already guarantees exactly-once), mirroring how the former
+`resumeCloneIfNeeded` sent a one-shot `snapshot-action: resume`.
+
+swiftletd's `dispatch` gains an `ActionKind::IdentityRegenerate` arm that calls
+the new `swift-vsock-client` to connect `<runtime-dir>/vsock.sock`, send the Q3
+request, await the reply (bounded timeout, e.g. 30 s), and:
+
+1. write `identity-status: ready` + `identity-new-ip: <newIP>` on success, or
+   `identity-status: failed` with a sanitized detail on agent error/timeout
+   (`GuestAgentUnreachable` when no connect/no answer).
+
+**Reconciling with the lease poller (v0.4.3).** The clone's lease poller is
+already alive for the pod's lifetime (`LEASE_POLL_ATTEMPTS_RESTORE`, because
+`is_restore()`), watching `dnsmasq.leases`. When the agent runs `dhclient -r &&
+dhclient`, the per-pod-netns **dnsmasq issues a fresh lease**, which the poller
+discovers and writes to `kubeswift.io/guest-ip` → `status.network.primaryIP`
+**by the existing path, with no new plumbing**. The `identity-new-ip` annotation
+is a **belt-and-suspenders** secondary surface (the agent already knows the IP it
+got, so reporting it directly removes the race where the controller patches status
+before the lease file is written). The controller prefers the lease-poller
+`guest-ip` (authoritative, comes from dnsmasq) and uses `identity-new-ip` only to
+short-circuit the wait. **This is the resolution of "compose with the v0.4.3
+fix": the agent's `dhclient` is precisely what finally gives the alive poller a
+lease to find.**
+
+> **MAC-vs-renew sub-question (called out in the prompt).** Is a MAC change
+> actually *required* for a distinct IP? Each clone has its **own pod-netns
+> dnsmasq** with its own lease DB, so the inherited source MAC would NOT collide
+> across clones at the dnsmasq layer — a bare `dhclient -r && dhclient` renew
+> *might* suffice to get an address. **BUT** the source's lease in the new
+> dnsmasq's DB is keyed by the source MAC, and the guest still presents the
+> source's MAC, so dnsmasq may hand back the *same* address the source had — not
+> distinct, and worse, two clones on the **same node** (Tier B is node-local!)
+> share one dnsmasq and WOULD then collide on MAC → same IP / lease thrash.
+> **Decision: set the per-clone MAC (`ip link set eth0 address <mac>`) AND renew.**
+> The MAC is the per-clone-unique key the controller already computes; setting it
+> guarantees distinct dnsmasq lease identities, which guarantees distinct IPs, and
+> aligns the guest-visible MAC with the host fdb. The spike must confirm the
+> `ip link set` → `dhclient` ordering works cleanly on a live virtio-net link
+> without a link bounce that wedges (and whether NetworkManager vs ifupdown vs
+> systemd-networkd in the guest needs different renew commands — likely the agent
+> shells `dhclient` directly and falls back to `networkctl`/`nmcli`).
+>
+> **SPIKE RESULT (2026-06-15 — corrects this decision).** `ip link set` on the
+> resumed link works with NO wedge (ping 2/2, fdb learned the new MAC, ARP
+> REACHABLE on it). **But the MAC change does NOT produce a distinct IP** — the
+> guest re-requests its in-RAM address on renew and dnsmasq grants it back. The
+> "two clones share one dnsmasq" premise is **FALSE in production**: each clone is
+> its own launcher pod with its own netns + own dnsmasq, so the guest-internal IP
+> is pod-isolated and need not be distinct (the pod IPs already differ). **Revised:
+> the per-clone MAC-set is for guest-visible-MAC ↔ host-`config.net[].mac` (fdb /
+> DNAT) consistency, not IP-distinctness; the renew's job is to land a lease in
+> this pod's dnsmasq for the v0.4.3 poller** (confirmed — the lease file gained the
+> clone's entry). Renew order: `dhclient`, fallback `networkctl renew/reconfigure`
+> (Noble = networkd); optional `ip addr flush` first for a clean lease. Evidence:
+> [`clone-identity-vsock-agent-spike.md`](clone-identity-vsock-agent-spike.md).
+
+**Rejected alternative.** *Controller connects to vsock directly (host process
+outside the launcher pod).* The vsock unix socket lives in the launcher pod's
+mount namespace under the runtime dir; only swiftletd (in-pod) can reach it.
+Driving via swiftletd's action loop is the only clean path and reuses the proven
+annotation surface + idempotency.
+
+### Q5 — Security: vsock is host↔guest-only; agent runs as root in-guest; one-op surface; no migration/mTLS interaction
+
+**Decision & trust boundary.**
+
+- **vsock is not network-reachable.** AF_VSOCK host↔guest only; there is no
+  route from the pod network or any other guest to this channel. The unix-socket
+  endpoint is under the launcher pod's runtime dir (pod-local mount namespace),
+  reachable only by swiftletd in that pod. So the channel's confines are the
+  launcher pod itself — the same boundary that already holds CH's API socket and
+  the serial socket.
+- **The agent runs as root in the guest** (it writes `/etc/machine-id`,
+  `/etc/ssh/ssh_host_*`, sets the link MAC, drives dhclient — all root-only). This
+  is acceptable because the **command surface is exactly one op** with a fixed
+  schema (regenerate-identity); there is **no exec, no path argument, no file
+  transfer**. An attacker who somehow reached the vsock port could only ask the
+  guest to regenerate its own identity — a self-inflicted, non-escalating action.
+  The agent MUST validate inputs (MAC format, hostname charset) and refuse
+  anything else; it must never shell out with attacker-controlled strings
+  (hostname/MAC are validated then passed as argv, never interpolated into a
+  shell).
+- **No interaction with the live-migration mTLS / threat model.** That stack
+  (`migration-stunnel`, the S1 URLs-from-CR concern, the plaintext-ack gate) is
+  about a **cross-pod TCP** guest-state channel. The identity vsock is
+  **intra-pod host↔guest**; it carries no guest RAM and crosses no node boundary.
+  The two are orthogonal; the agent is never invoked on a migration receiver
+  (`is_migration_receiver()` guests skip identity-regen). No ack gate, no TLS —
+  the transport's locality is the control.
+
+### Q6 — Composition
+
+- **`cloneFromSnapshot.Regenerate` list** — the agent **consumes** it directly
+  (Q3 `items`). No CRD change to the list. `macAddresses` is no longer
+  "host-side only": the agent now applies it guest-side too, closing the
+  resume-vs-boot MAC gap.
+- **The seed bootcmd path** (`clone-identity-regen.yaml` + the configjson cmdline
+  marker `kubeswift.clone=true`) — the agent **replaces** it as the primary path.
+  Disposition: **keep the bootcmd as a documented fallback** for (a) images with
+  the agent absent AND a working reboot (i.e. *not* CH v52 — the very bug that
+  motivated this), and (b) belt-and-suspenders if an operator both ships the
+  bootcmd seed and reboots. They are not mutually exclusive (the bootcmd is gated
+  on a sentinel + the cmdline marker; the agent writes the same files, so a
+  later reboot's bootcmd sees the sentinel-absent state and is harmless/idempotent
+  if it runs). **Recommendation: when the agent is present, the controller does
+  NOT append the cmdline marker** (the agent owns regen), so the two never both
+  fire on the same clone. Document the precedence: agent present → agent path;
+  agent absent → bootcmd-on-reboot path (broken on CH v52; documented).
+- **Snapshot-action annotation surface** — the identity action is a sibling
+  KeySet in the same action loop; mutual exclusion across namespaces is already
+  enforced at dispatch (`handle_pod_state`). A clone's lifecycle is: restore →
+  GuestRunning → (one-shot identity-action) → steady state. No overlap with a
+  concurrent snapshot/migration on the same guest (those are guarded).
+- **SwiftGuestPool clone pools** — `cloneFromSnapshot` is templated per replica
+  for free (pool DeepCopy). The controller drives one identity-action per replica;
+  each replica gets its own deterministic MAC/CID/hostname from its own
+  `(namespace, name)`. No pool-level change. (Same-node replica caveat from
+  Phase 4 — the MAC-distinct lease identity per Q4 is exactly what makes
+  same-node clones get distinct IPs.)
+- **Windows guests (osType: windows)** — **out of scope v1.** A Windows agent
+  would be a service speaking the same vsock protocol but using
+  sysprep/`Rename-Computer`/`netsh`/cloudbase-init metadata; identity regen
+  semantics and the reboot requirement differ materially. Noted as a follow-up;
+  the protocol is OS-neutral enough to extend later.
+
+## 5. Component-by-component change surface
+
+| Component | Change | Files (cited) |
+|---|---|---|
+| **Go API** | No new CRD field (reuse `CloneFromSnapshotSource.Regenerate`). Add a status condition `CloneIdentityRegenerated` + reason enum; optionally echo the regenerated items in `status`. Add an **opt-in flag** for attaching the agent to a SOURCE guest (e.g. a `SwiftSeedProfile`-level or `SwiftGuest`-level boolean, or inferred from the seed including the agent snippet — spike to choose the least-surface signal). | `api/swift/v1alpha1/swiftguest_types.go` (`CloneFromSnapshotSource`, `SwiftGuestStatus`, conditions) |
+| **SwiftGuest controller** | (1) For a source guest opted into the agent: set the CH `--vsock` device + attach the read-only agent virtiofs share (Q1a). (2) For a clone: drive the one-shot `identity-action: regenerate` after GuestRunning (mirrors the removed `resumeCloneIfNeeded`); read back `identity-new-ip` / lease-poller `guest-ip`; map to status. (3) Stop appending the `kubeswift.clone=true` cmdline marker when the agent is present. | `internal/controller/swiftguest/clone.go` (`prepareCloneFromSnapshot`, `cloneRestoreAnnotations`), `internal/controller/swiftguest/controller.go` (the GuestRunning/IP requeue block ~L515-528) |
+| **configjson patcher** | Extend to rewrite the **vsock socket path** in the restored `config.json` to the clone's runtime-dir path (same class as the existing disk-path + serial-socket rewrites). | `internal/snapshot/configjson/configjson.go` |
+| **clonecommon** | The CID derivation helper (deterministic from ns/name), alongside the existing `ComputeMACRewrites` / `RuntimeDirPrefix` primitives, so controller + intent agree. | `internal/snapshot/clonecommon/` (new `vsock.go`) |
+| **runtimeintent (Go) + intent.rs (Rust)** | New `VsockIntent { cid, socket_path }` (or fold into the existing `RestoreIntent`): emitted by the controller, deserialized by swiftletd. Carries CID + (for the source) the socket path. | `internal/runtimeintent/types.go`, `rust/swiftletd/src/intent.rs` (new field on `RuntimeIntent`) |
+| **swift-ch-client (Rust)** | `VmConfig.vsock: Option<VsockConfig>`; `to_args()` emits `--vsock cid=<N>,socket=<path>`; the **restore** spawn leaves vsock to config.json (CH re-opens it) — assert no `--vsock` leaks into `restore_args` (CH reads it from config.json), mirroring the existing "restore_args does not include --disk/--net" contract. | `rust/swift-ch-client/src/config.rs`, `src/spawn.rs` |
+| **swift-vsock-client (NEW Rust crate)** | Thin AF_VSOCK-over-unix-socket client: connect `<rt>/vsock.sock`, do CH's vsock `CONNECT <port>` handshake, send/recv the Q3 JSON. Sync (mirrors the synchronous `swift-qemu-client` QMP choice — no tokio needed for one request/response). Workspace member. | `rust/swift-vsock-client/` (new), `rust/Cargo.toml` |
+| **swiftletd action loop** | Add `IDENTITY_KEYS` KeySet + `ActionKind::IdentityRegenerate` + `dispatch_identity_regenerate` (connect vsock client, send request, write status + `identity-new-ip`). | `rust/swiftletd/src/action.rs` |
+| **The guest agent (NEW)** | `cmd/kubeswift-guest-agent` — small **static Go** binary; AF_VSOCK listener on port 1024; the one regenerate-identity op (machine-id / ssh-keygen -A + sshd reload / hostnamectl / `ip link set` / dhclient). + a systemd unit `kubeswift-guest-agent.service`. Built `CGO_ENABLED=0`, multi-arch, **embedded into the swiftletd image** at a stable path for the virtiofs-install path. | `cmd/kubeswift-guest-agent/` (new), `images/swiftletd/Containerfile` (COPY the agent + unit into the image's share dir) |
+| **Seed delivery** | A canonical `SwiftSeedProfile` sample whose `write_files` drops the unit and `runcmd` installs+enables the agent from the virtiofs share on the SOURCE's first boot. Replaces (deprecates, keeps as fallback) `clone-identity-regen.yaml`. | `config/samples/seed-profiles/` (new `guest-agent.yaml`), docs |
+| **Webhook** | Best-effort warn at clone-time if the referenced snapshot indicates no agent (informational; runtime no-answer is authoritative). | `internal/webhook/swiftguest/validator.go` |
+| **Docs** | Runbook update (`docs/snapshots/clone-from-snapshot.md` — replace the "reboot once / broken on v52" caveat with the agent flow); cross-ref the firmware-hang known-issue. | `docs/snapshots/clone-from-snapshot.md` |
+
+### Language / packaging of the agent
+
+**Static Go**, `CGO_ENABLED=0`, no libc dependency, runs on any glibc/musl guest.
+Rationale: KubeSwift already builds Go binaries (the build infra is there);
+`AF_VSOCK` is reachable via `golang.org/x/sys/unix` or `mdlayher/vsock`; a static
+Go binary is the most portable thing to drop into an arbitrary Linux guest
+(Ubuntu/Rocky/Debian/Fedora) without runtime deps. It is **not** a KubeSwift Rust
+crate because it ships *inside the guest*, not in the swiftletd image's process
+tree — keeping it Go avoids cross-compiling a Rust static binary for the guest
+target and reuses the existing Go toolchain. ~200 LOC. The unit is a 6-line
+`systemd` service (`ExecStart=/usr/local/bin/kubeswift-guest-agent`,
+`Restart=always`, `After=network-pre.target`).
+
+## 6. Phasing into PRs
+
+| PR | Scope | Validatable |
+|---|---|---|
+| **PR 0 — spike** | Off-cluster + 1-node: launch a guest WITH `--vsock`, snapshot it, restore a clone, and prove a host process can reach a hand-run in-guest AF_VSOCK listener through the clone's `<rt>/vsock.sock` after resume (i.e. the device survives capture/restore). Confirm `ip link set eth0 address` + `dhclient` yields a distinct IP on a live link without wedging. Pin the CH `--vsock` socket handshake bytes. **Gate everything on this.** | Manual; the load-bearing "agent-in-snapshot resumes alive on vsock" claim |
+| **PR 1 — guest agent + packaging** | `cmd/kubeswift-guest-agent` + unit + embed in swiftletd image + the canonical seed profile + golden-image docs. No host wiring yet; testable by hand-driving the vsock socket. | Agent answers regenerate-identity over vsock on a guest where it was installed pre-snapshot |
+| **PR 2 — CH `--vsock` + intent + configjson patch** | `VmConfig.vsock`, `to_args`, intent field, CID helper, configjson vsock-path rewrite, controller sets `--vsock` on opted-in source + clone. CH spawns with the device; nothing drives it yet. | Source + clone come up with a working vsock device (manual probe); restore config.json carries the patched socket path |
+| **PR 3 — swift-vsock-client + action loop `IdentityRegenerate`** | The Rust client crate + `IDENTITY_KEYS` + `dispatch_identity_regenerate` + status/`identity-new-ip` writes. Still operator-triggered (annotation). | Operator stamps `identity-action: regenerate` → clone regenerates identity + gets a new IP (manual) |
+| **PR 4 — controller auto-drive + status** | Controller stamps the one-shot identity-action after GuestRunning; maps `identity-new-ip`/lease-poller `guest-ip` → `status.network.primaryIP`; `CloneIdentityRegenerated` condition; drop the cmdline marker when agent present; fallback path on no-answer. | End-to-end: a clone pool comes up with distinct identity + distinct IPs, no reboot |
+| **PR 5 — cluster walkthrough + runbook** | Multi-replica clone pool on the dev cluster; update `clone-from-snapshot.md`; deprecate the bootcmd sample. | Cluster-validated; the demo-06 caveat becomes "works via the agent" |
+
+## 7. Risks (lead with the load-bearing properties)
+
+- **LBA-1 (THE constraint) — the agent must be in the SOURCE snapshot.** Every
+  capability here depends on the agent already running in the captured RAM. A
+  future refactor that tries to install/start the agent on the *clone* (because it
+  "reads cleaner") silently re-breaks everything — the clone never boots, so
+  nothing new starts. **State this explicitly at the controller injection site and
+  in the agent's unit comment**, the way W26 / LBA-2 lessons demand: name the
+  load-bearing property so a maintainer sees it before refactoring. The `--vsock`
+  device, the CID, and the running agent are all captured-state properties, not
+  clone-time properties.
+- **LBA-2 — `--vsock` must be on the SOURCE launch, not just the clone.** Same
+  class: CH captures the device. If a future change only adds `--vsock` to the
+  restore/clone path (the intuitive place), the snapshot has no vsock device and
+  the clone is unreachable. The controller MUST set it on the source whenever that
+  source is an agent-opted snapshot source. (The webhook/runtime fallback catches
+  the miss loudly, but the correct behavior is source-side.)
+- **LBA-3 — CID/socket-path are per-pod; the restored CID is inherited, the
+  socket path is patched.** Don't "helpfully" re-CID a restored guest (desyncs the
+  guest kernel's bound vsock); don't reuse the source's socket path on the clone
+  (wrong runtime dir). The configjson patcher owns the path rewrite; the CID rides
+  the snapshot. A refactor that swaps these breaks reachability subtly.
+- **No-silent-failure (Principle #6).** Agent-absent / device-absent / no-answer
+  MUST surface as `CloneIdentityRegenerated=False` + a clear reason, never a
+  silent "clone is fine" while it shares the source's identity and has no IP. The
+  whole point of this feature is that the *current* state (silent shared identity,
+  empty IP) is unacceptable; the fallback must be visible.
+- **Guest-distro variance (needs the spike).** `dhclient` vs `networkctl renew`
+  vs `nmcli`; `hostnamectl` vs `/etc/hostname`; `systemd-machine-id-setup`
+  availability; `ssh-keygen -A` reading sshd_config. The bootcmd sample already
+  encodes the fallbacks; the agent should port them. Risk: a distro where setting
+  the MAC on a live link bounces it badly enough to wedge the resumed virtio-net.
+- **Security surface creep.** The agent is root-in-guest; the discipline is ONE
+  op, fixed schema, validated inputs, never shell-interpolated. A future "add an
+  exec op for convenience" would turn a benign self-identity-regen channel into a
+  guest-root RCE primitive over a channel the operator can reach. Guard the op set.
+- **Migration interaction (none, but assert it).** The agent must never fire on a
+  migration receiver (identity is preserved by design there). `is_migration_
+  receiver()` already gates the receiver launch path; the identity-action must be
+  controller-gated to cloneFromSnapshot guests only.
+
+## 8. Open questions (flag what needs a spike)
+
+1. **Opt-in signal for attaching the agent to a SOURCE guest.** A `SwiftSeedProfile`
+   convention (the seed includes the agent snippet) vs an explicit
+   `SwiftGuest`/class boolean vs always-on-for-snapshot-sources. Least-surface
+   wins; spike to decide. (Always-on would simplify but attaches a vsock device +
+   virtiofs share to guests that may never be snapshotted — minimalism tension.)
+2. **CH `--vsock` socket handshake exact bytes** (the `CONNECT <port>\n` /
+   `OK <cid>\n` framing CH's vsock backend uses). PR 0 must pin this against the
+   shipped CH v52 binary; the `swift-vsock-client` is trivial once it's known.
+3. **MAC-set-then-renew on a live virtio-net link** (Q4 sub-question) — does `ip
+   link set eth0 address` mid-flight bounce the link cleanly, and does `dhclient`
+   reliably get a *distinct* address? Per-distro renew command matrix. **Spike.**
+4. **Does the restored guest's vsock device actually carry state correctly across
+   CH `--restore`?** The whole design rests on it; PR 0 proves it empirically (a
+   vsock device in a snapshot has not been exercised by KubeSwift before).
+5. **Bounded-wait tuning** for the agent answer (30 s?) and the
+   GuestRunning→identity-action delay (the agent's systemd unit must be up; on a
+   resume it is *already* up in RAM, so ~immediate — but confirm `dhclient`
+   readiness vs `network-pre.target`).
+6. **Hostname source of truth** — controller passes `metadata.name`; should the
+   operator be able to template it (pool ordinal)? Defer; default to clone name.
+7. **Windows agent** (out of scope v1) — the protocol is OS-neutral; the
+   regen mechanics (sysprep/Rename-Computer, which themselves want a reboot
+   Windows handles differently) are a separate design. Flag, don't design.
+8. **Tier C (s3) clones** — identical agent flow once the clone boots
+   (cross-node), since the snapshot carries the agent + vsock device; only the
+   `targetNode`/download differs (already handled). Confirm no node-locality
+   assumption leaks into the CID/socket convention (it doesn't — both are pod-local).
+
+## 9. Cross-references
+
+- [`known-issues-clone-reboot-firmware-hang.md`](known-issues-clone-reboot-firmware-hang.md)
+  — the CH v52 restore-then-reboot firmware hang this feature sidesteps (the
+  motivating bug; its "next step #4" names this agent as the real fix).
+- [`snapshot-phase-4-clonefromsnapshot.md`](snapshot-phase-4-clonefromsnapshot.md)
+  — the cloneFromSnapshot boot path the agent runs on top of.
+- [`snapshots.md`](snapshots.md) + context doc "Known limitation: identity
+  regeneration on clone resume" — the resume-vs-boot inheritance rule (Phase 2)
+  that is the root cause.
+- `config/samples/seed-profiles/clone-identity-regen.yaml` — the bootcmd remedy
+  this agent supersedes (kept as the agent-absent fallback).
+- `rust/swiftletd/src/lease.rs` (`LEASE_POLL_ATTEMPTS_RESTORE`, v0.4.3) — the
+  alive-for-restore poller the agent's `dhclient` finally feeds a lease.

--- a/docs/snapshots/identity-regeneration.md
+++ b/docs/snapshots/identity-regeneration.md
@@ -13,6 +13,61 @@ This document describes what KubeSwift does at the hypervisor layer,
 what does NOT happen automatically inside the guest, and the
 workarounds operators have today.
 
+## The real fix: the in-guest identity agent (vsock)
+
+> The reboot-based remedy further down (`clone-identity-regen.yaml` +
+> a cloud-init `bootcmd`) is **broken on Cloud Hypervisor v52**: a
+> `--restore`d guest hangs in EDK2 firmware on reboot
+> ([`../design/known-issues-clone-reboot-firmware-hang.md`](../design/known-issues-clone-reboot-firmware-hang.md)).
+> The replacement is the **in-guest identity agent** — it regenerates
+> machine-id / SSH host keys / hostname / MAC and re-DHCPs **in place,
+> with no reboot**, over a host-only vsock channel. Design + validated
+> spike:
+> [`../design/clone-identity-vsock-agent.md`](../design/clone-identity-vsock-agent.md),
+> [`../design/clone-identity-vsock-agent-spike.md`](../design/clone-identity-vsock-agent-spike.md).
+
+KubeSwift ships `kubeswift-guest-agent` (a tiny static binary) plus a
+`kubeswift-guest-agent.service` systemd unit inside the `swiftletd`
+image at `/usr/local/share/kubeswift/guest-agent/`. The agent must be
+**running in the SOURCE guest at snapshot-capture time** — a clone
+resumes captured RAM and never boots, so the agent cannot be started
+on the clone; it has to already be there.
+
+**Golden image (recommended for fleets).** Bake the binary + unit into
+your `SwiftImage` at build time:
+
+```sh
+install -m0755 kubeswift-guest-agent /usr/local/bin/kubeswift-guest-agent
+install -m0644 kubeswift-guest-agent.service /etc/systemd/system/
+systemctl enable kubeswift-guest-agent
+```
+
+**Seed profile.** Attach the `guest-agent` SwiftSeedProfile
+([`config/samples/seed-profiles/guest-agent.yaml`](../../config/samples/seed-profiles/guest-agent.yaml))
+to the source SwiftGuest via `spec.seedProfileRef`; it installs the
+agent from a controller-attached virtiofs share on first boot. (The
+controller-side share attachment and the auto-drive on clone resume
+ship in later PRs of the arc; once they land, a clone's identity is
+regenerated automatically and `status.network.primaryIP` populates
+with no operator action.)
+
+**Verify it is running on the source before snapshotting:**
+
+```sh
+systemctl is-active kubeswift-guest-agent   # -> active
+```
+
+If a clone is created from a snapshot whose source did **not** have
+the agent running, the clone still works as a warm replica with the
+source's identity; KubeSwift surfaces the gap as a
+`CloneIdentityRegenerated=False` / `GuestAgentUnreachable` condition
+(later PR) rather than failing silently.
+
+The remainder of this document describes the hypervisor-layer MAC
+rewrite (which the agent complements by setting the *guest-visible*
+MAC to match) and the legacy reboot-based workaround (kept for
+agent-absent guests on pre-v52 hypervisors).
+
 ## The fundamental constraint: resume is not a boot
 
 CH `--restore` resumes the captured guest state byte-for-byte. The

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sys v0.44.0
 	golang.org/x/term v0.43.0
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
@@ -70,7 +71,6 @@ require (
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect

--- a/images/swiftletd/Containerfile
+++ b/images/swiftletd/Containerfile
@@ -46,6 +46,13 @@ COPY cmd ./cmd
 COPY internal ./internal
 COPY api ./api
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/snapshot-stager ./cmd/snapshot-stager
+# kubeswift-guest-agent: the in-guest identity agent. It is NOT run by the
+# launcher pod — it is a static binary embedded here so it can be installed
+# INSIDE a source guest (via the guest-agent SwiftSeedProfile's virtiofs share
+# in PR 2, or a golden-image bake) and captured into the memory snapshot. CGO
+# off so it runs on any glibc/musl guest. See
+# docs/design/clone-identity-vsock-agent.md.
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/kubeswift-guest-agent ./cmd/kubeswift-guest-agent
 
 # Runtime stage
 FROM debian:bookworm-slim
@@ -114,6 +121,13 @@ RUN mkdir -p /usr/share/kubeswift-firmware && \
 
 COPY --from=builder /build/target/release/swiftletd /usr/local/bin/swiftletd
 COPY --from=go-builder /out/snapshot-stager /usr/local/bin/snapshot-stager
+# kubeswift-guest-agent + its systemd unit live in a share dir, NOT on the
+# launcher PATH — the agent runs INSIDE the guest, not in the launcher pod. The
+# guest-agent SwiftSeedProfile (PR 2) bind-mounts this dir read-only into a
+# source guest to install the agent before the snapshot; a golden image can bake
+# it instead. See docs/design/clone-identity-vsock-agent.md §6.1.
+COPY --from=go-builder /out/kubeswift-guest-agent /usr/local/share/kubeswift/guest-agent/kubeswift-guest-agent
+COPY cmd/kubeswift-guest-agent/kubeswift-guest-agent.service /usr/local/share/kubeswift/guest-agent/kubeswift-guest-agent.service
 COPY rust/swiftletd/scripts/network-init.sh /usr/local/bin/network-init.sh
 COPY rust/swiftletd/scripts/launcher-entrypoint.sh /usr/local/bin/launcher-entrypoint.sh
 COPY rust/swiftletd/scripts/gpu-init.sh /usr/local/bin/gpu-init.sh


### PR DESCRIPTION
## Summary

`cloneFromSnapshot` clones **resume** the source's captured RAM, so they inherit its `/etc/machine-id`, SSH host keys, hostname, and the cached MAC/IP. The documented remedy ("reboot the clone once") is **broken on Cloud Hypervisor v52** — a `--restore`d guest hangs in EDK2 firmware on reboot ([known-issue](../blob/main/docs/design/known-issues-clone-reboot-firmware-hang.md)). This arc replaces it with an **in-guest agent** that regenerates identity + re-DHCPs **in place, no reboot**, over a host-only **vsock** channel.

This PR lands **the design, the PR-0 spike result, and PR 1 (the agent itself)**. Host wiring (CH `--vsock`, configjson socket-path patch, `swift-vsock-client`, controller auto-drive) follows in PRs 2–4.

## PR-0 spike — PASS

Off-cluster, with the **real CH v52 binary + `CLOUDHV.fd`** from the shipped `swiftletd` image and an Ubuntu Noble guest running a nonce-stamped AF_VSOCK listener:

| Claim | Result |
|---|---|
| vsock device + an agent **in the source's captured RAM survive `--restore`** | ✅ clone returns the **same startup nonce** + an **advancing counter** |
| regenerate machine-id / hostname / SSH keys **in place, no reboot** | ✅ all changed on the clone; source untouched |
| set per-clone **MAC on the resumed virtio-net link** | ✅ **no wedge** — ping 2/2, fdb learned it, ARP `REACHABLE` |
| re-DHCP lands a lease the **v0.4.3 poller** finds | ✅ `status.network.primaryIP` would populate |

**Design correction the spike forced:** "distinct IP across clones" is a **non-goal** — each clone is its own launcher pod with its own netns + dnsmasq, so the guest-internal IP is pod-isolated (pod IPs already differ). The per-clone MAC-set is for guest-MAC ↔ host-fdb/DNAT consistency, not IP-distinctness; the renew just needs to land a lease for the poller.

## PR 1 — the agent

- **`cmd/kubeswift-guest-agent`** — a tiny static (`CGO_ENABLED=0`) AF_VSOCK listener via `golang.org/x/sys/unix` (no new dependency). Exactly **two ops** (`ping`, `regenerate-identity`); validated MAC/hostname passed as argv (no shell interpolation); **detects the primary interface** (does not assume `eth0`). Unit-tested through an injected `system` fake — no root needed.
- **systemd unit** + **embedded in the swiftletd image** at `/usr/local/share/kubeswift/guest-agent/` (binary + unit) for install **into** a source guest. It is **not** run by the launcher pod.
- **`config/samples/seed-profiles/guest-agent.yaml`** installs+starts it on a source guest's first boot (golden-image bake is the documented power path).
- **docs** — `docs/snapshots/identity-regeneration.md` now leads with the agent as the real fix + install/verify; legacy reboot workaround retained for agent-absent / pre-v52 guests.

## Load-bearing constraint (named at every site)

The agent must be **running in the SOURCE at snapshot time** — a clone never boots, so nothing new can start on it. The `--vsock` device, the CID, and the running agent are all captured-state properties.

## Test

- `go test ./cmd/kubeswift-guest-agent/...` green (dispatch, validation, MAC down→address→up ordering, iface fallback).
- `gofmt -s` / `go vet` / `go build ./...` clean. No CRD/Rust change (no `make generate`).
- CI builds the swiftletd image (validates the agent compiles into it).

## Not in this PR (the rest of the arc)

PR 2 CH `--vsock` + intent + configjson patch · PR 3 `swift-vsock-client` + swiftletd action loop · PR 4 controller auto-drive + `CloneIdentityRegenerated` status · PR 5 cluster walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)