### PR TITLE
feat(snapshots): swift-vsock-client + swiftletd IdentityRegenerate action (PR 3)

### DIFF
--- a/images/swiftletd/Containerfile
+++ b/images/swiftletd/Containerfile
@@ -18,6 +18,7 @@ COPY rust/swift-runtime ./swift-runtime
 COPY rust/swift-seed ./swift-seed
 COPY rust/swift-ch-client ./swift-ch-client
 COPY rust/swift-qemu-client ./swift-qemu-client
+COPY rust/swift-vsock-client ./swift-vsock-client
 
 RUN KUBESWIFT_VERSION=$VERSION KUBESWIFT_GIT_COMMIT=$GIT_COMMIT KUBESWIFT_BUILD_DATE=$BUILD_DATE \
     cargo build -p swiftletd --release

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1795,6 +1795,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "swift-vsock-client"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "swiftletd"
 version = "0.1.0"
 dependencies = [
@@ -1810,6 +1818,7 @@ dependencies = [
  "swift-qemu-client",
  "swift-runtime",
  "swift-seed",
+ "swift-vsock-client",
  "tempfile",
  "tokio",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["swiftletd", "swift-runtime", "swift-seed", "swift-ch-client", "swift-qemu-client"]
+members = ["swiftletd", "swift-runtime", "swift-seed", "swift-ch-client", "swift-qemu-client", "swift-vsock-client"]

--- a/rust/swift-vsock-client/Cargo.toml
+++ b/rust/swift-vsock-client/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "swift-vsock-client"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "swift_vsock_client"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/rust/swift-vsock-client/src/lib.rs
+++ b/rust/swift-vsock-client/src/lib.rs
@@ -1,0 +1,266 @@
+//! Thin synchronous client for the in-guest identity agent over Cloud
+//! Hypervisor's hybrid vsock.
+//!
+//! CH bridges the guest's AF_VSOCK to a host-side Unix socket
+//! (`--vsock cid=<N>,socket=<rt>/vsock.sock`). To reach a guest AF_VSOCK
+//! listener the host connects that Unix socket and performs CH's hybrid-vsock
+//! handshake — writes `CONNECT <port>\n`, reads `OK <port>\n`, then the stream
+//! is bridged to the guest's listener on `<port>`. (PR-0 spike pinned this; see
+//! docs/design/clone-identity-vsock-agent-spike.md.)
+//!
+//! Synchronous on purpose — one request/response per connection, no tokio,
+//! mirroring `swift-qemu-client`'s QMP choice. swiftletd runs the call on a
+//! blocking task so the async action loop keeps ticking.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::time::Duration;
+
+/// AF_VSOCK port the guest agent (`cmd/kubeswift-guest-agent`) listens on.
+/// Shared constant — must match the agent's `DefaultPort`.
+pub const AGENT_PORT: u32 = 1024;
+
+/// Protocol version (must match the agent's `ProtocolVersion`).
+pub const PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Debug)]
+pub enum VsockError {
+    /// Could not connect / read / write the host-side Unix socket. This is the
+    /// "agent unreachable" case (no socket, no listener, or timeout).
+    Io(std::io::Error),
+    /// CH's hybrid-vsock handshake did not return `OK` — the guest has no
+    /// listener on the port (agent absent / not yet up).
+    Handshake(String),
+    /// Response was not valid JSON / could not be (de)serialized.
+    Decode(String),
+}
+
+impl std::fmt::Display for VsockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VsockError::Io(e) => write!(f, "vsock io: {}", e),
+            VsockError::Handshake(s) => write!(f, "vsock handshake: {}", s),
+            VsockError::Decode(s) => write!(f, "vsock decode: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for VsockError {}
+
+impl From<std::io::Error> for VsockError {
+    fn from(e: std::io::Error) -> Self {
+        VsockError::Io(e)
+    }
+}
+
+/// Identity-regeneration request sent to the guest agent. Field names match the
+/// agent's `Request` (and map directly from
+/// `CloneFromSnapshotSource.regenerate`).
+#[derive(Debug, Clone, serde::Serialize, Default)]
+pub struct IdentityRequest {
+    pub v: u32,
+    pub op: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub items: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mac: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+    #[serde(rename = "renewLease", skip_serializing_if = "is_false")]
+    pub renew_lease: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+impl IdentityRequest {
+    /// Build a `regenerate-identity` request at the current protocol version.
+    pub fn regenerate(
+        items: Vec<String>,
+        mac: Option<String>,
+        hostname: Option<String>,
+        renew_lease: bool,
+    ) -> Self {
+        Self {
+            v: PROTOCOL_VERSION,
+            op: "regenerate-identity".to_string(),
+            items,
+            mac,
+            hostname,
+            renew_lease,
+        }
+    }
+}
+
+/// Identity-regeneration response from the guest agent. Unknown fields are
+/// ignored and missing fields default (forward/backward compatible).
+#[derive(Debug, Clone, serde::Deserialize, Default)]
+pub struct IdentityResponse {
+    #[serde(default)]
+    pub v: u32,
+    #[serde(default)]
+    pub ok: bool,
+    #[serde(default)]
+    pub regenerated: Vec<String>,
+    #[serde(rename = "newIP", default)]
+    pub new_ip: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// Connect to CH's host-side vsock Unix socket, do the CONNECT handshake, send
+/// one newline-terminated request line, and read one newline-terminated
+/// response line. Low-level — most callers want [`regenerate_identity`].
+pub fn request_line(
+    socket_path: &Path,
+    port: u32,
+    req_line: &[u8],
+    timeout: Duration,
+) -> Result<Vec<u8>, VsockError> {
+    let stream = UnixStream::connect(socket_path)?;
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(timeout))?;
+    let mut writer = stream.try_clone()?;
+    let mut reader = BufReader::new(stream);
+
+    // CH hybrid-vsock handshake.
+    writer.write_all(format!("CONNECT {}\n", port).as_bytes())?;
+    writer.flush()?;
+    let mut ok = String::new();
+    reader.read_line(&mut ok)?;
+    if !ok.starts_with("OK") {
+        return Err(VsockError::Handshake(format!("expected OK, got {:?}", ok)));
+    }
+
+    // Send the request (ensure a trailing newline — the agent reads to '\n').
+    writer.write_all(req_line)?;
+    if !req_line.ends_with(b"\n") {
+        writer.write_all(b"\n")?;
+    }
+    writer.flush()?;
+
+    // Read the response line (the agent writes one line then closes).
+    let mut resp = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        resp.extend_from_slice(&buf[..n]);
+        if resp.contains(&b'\n') {
+            break;
+        }
+    }
+    Ok(resp)
+}
+
+/// Send a `regenerate-identity` request to the guest agent and parse its reply.
+pub fn regenerate_identity(
+    socket_path: &Path,
+    req: &IdentityRequest,
+    timeout: Duration,
+) -> Result<IdentityResponse, VsockError> {
+    let line = serde_json::to_vec(req).map_err(|e| VsockError::Decode(e.to_string()))?;
+    let raw = request_line(socket_path, AGENT_PORT, &line, timeout)?;
+    let trimmed = trim_trailing_newline(&raw);
+    serde_json::from_slice(trimmed)
+        .map_err(|e| VsockError::Decode(format!("{}: {}", e, String::from_utf8_lossy(trimmed))))
+}
+
+fn trim_trailing_newline(b: &[u8]) -> &[u8] {
+    let mut end = b.len();
+    while end > 0 && (b[end - 1] == b'\n' || b[end - 1] == b'\r') {
+        end -= 1;
+    }
+    &b[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixListener;
+    use std::thread;
+
+    // Spawns a fake CH hybrid-vsock endpoint: accepts one connection, expects
+    // the CONNECT handshake, replies OK, reads the request line, writes `resp`.
+    fn fake_agent(path: std::path::PathBuf, resp: &'static str) -> thread::JoinHandle<String> {
+        let listener = UnixListener::bind(&path).unwrap();
+        thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut w = stream.try_clone().unwrap();
+            let mut r = BufReader::new(stream);
+            let mut connect = String::new();
+            r.read_line(&mut connect).unwrap();
+            assert!(connect.starts_with("CONNECT"), "no CONNECT: {:?}", connect);
+            w.write_all(b"OK 1\n").unwrap();
+            let mut req = String::new();
+            r.read_line(&mut req).unwrap();
+            w.write_all(resp.as_bytes()).unwrap();
+            req
+        })
+    }
+
+    #[test]
+    fn regenerate_round_trip() {
+        let dir = std::env::temp_dir().join(format!("vsock-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let sock = dir.join("vsock.sock");
+        let _ = std::fs::remove_file(&sock);
+        let h = fake_agent(
+            sock.clone(),
+            "{\"v\":1,\"ok\":true,\"regenerated\":[\"machineId\",\"macAddresses\"],\"newIP\":\"192.168.99.12\"}\n",
+        );
+        let req = IdentityRequest::regenerate(
+            vec!["machineId".into(), "macAddresses".into()],
+            Some("52:54:00:22:22:22".into()),
+            Some("clone-a".into()),
+            true,
+        );
+        let resp = regenerate_identity(&sock, &req, Duration::from_secs(5)).unwrap();
+        assert!(resp.ok);
+        assert_eq!(resp.new_ip.as_deref(), Some("192.168.99.12"));
+        assert_eq!(resp.regenerated, vec!["machineId", "macAddresses"]);
+
+        // the agent received a regenerate-identity request carrying our fields
+        let sent = h.join().unwrap();
+        assert!(
+            sent.contains("\"op\":\"regenerate-identity\""),
+            "sent={}",
+            sent
+        );
+        assert!(
+            sent.contains("\"mac\":\"52:54:00:22:22:22\""),
+            "sent={}",
+            sent
+        );
+        assert!(sent.contains("\"renewLease\":true"), "sent={}", sent);
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[test]
+    fn handshake_refused_is_error() {
+        let dir = std::env::temp_dir().join(format!("vsock-test-h-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let sock = dir.join("vsock.sock");
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).unwrap();
+        let h = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut w = stream.try_clone().unwrap();
+            let mut r = BufReader::new(stream);
+            let mut connect = String::new();
+            r.read_line(&mut connect).unwrap();
+            // refuse: no listener on the guest port
+            w.write_all(b"ERROR 19\n").unwrap();
+        });
+        let req = IdentityRequest::regenerate(vec![], None, None, false);
+        let err = regenerate_identity(&sock, &req, Duration::from_secs(5)).unwrap_err();
+        assert!(matches!(err, VsockError::Handshake(_)), "got {:?}", err);
+        h.join().unwrap();
+        let _ = std::fs::remove_file(&sock);
+    }
+}

--- a/rust/swiftletd/Cargo.toml
+++ b/rust/swiftletd/Cargo.toml
@@ -17,6 +17,7 @@ swift-seed = { path = "../swift-seed" }
 swift-runtime = { path = "../swift-runtime" }
 swift-ch-client = { path = "../swift-ch-client" }
 swift-qemu-client = { path = "../swift-qemu-client" }
+swift-vsock-client = { path = "../swift-vsock-client" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/swiftletd/src/action.rs
+++ b/rust/swiftletd/src/action.rs
@@ -221,6 +221,19 @@ pub const PROGRESS_BASELINE_MBPS: f64 = 108.0;
 /// removes this annotation entirely once mTLS lands.
 pub const MIGRATION_PHASE2_ACK_KEY: &str = "kubeswift.io/migration-phase2-unsafe-plaintext";
 
+// Identity namespace — controller writes (read by swiftletd). Drives the
+// in-guest identity agent over vsock (regenerate machine-id / SSH keys /
+// hostname / MAC + re-DHCP on a cloneFromSnapshot clone). See
+// docs/design/clone-identity-vsock-agent.md.
+pub const IDENTITY_ACTION_KEY: &str = "kubeswift.io/identity-action";
+pub const IDENTITY_ACTION_ID_KEY: &str = "kubeswift.io/identity-action-id";
+pub const IDENTITY_ACTION_ARGS_KEY: &str = "kubeswift.io/identity-action-args";
+
+// Identity namespace — swiftletd writes (read by controller).
+pub const IDENTITY_STATUS_KEY: &str = "kubeswift.io/identity-status";
+pub const IDENTITY_STATUS_ID_KEY: &str = "kubeswift.io/identity-status-id";
+pub const IDENTITY_STATUS_DETAIL_KEY: &str = "kubeswift.io/identity-status-detail";
+
 /// Annotation key set for one action namespace. Each namespace
 /// (snapshot, migration) has its own KeySet; the action loop runs
 /// `decide` against each per tick.
@@ -278,6 +291,21 @@ pub static MIGRATION_KEYS: KeySet = KeySet {
     ack_key: Some(MIGRATION_PHASE2_ACK_KEY),
     parse_verb: parse_migration_verb,
     namespace: "migration",
+};
+
+/// Identity namespace key set. Used by `dispatch_identity_regenerate`. No
+/// ack-gate (the transport is intra-pod host<->guest vsock, not a cross-pod
+/// channel — see docs/design/clone-identity-vsock-agent.md §Q5).
+pub static IDENTITY_KEYS: KeySet = KeySet {
+    action_key: IDENTITY_ACTION_KEY,
+    action_id_key: IDENTITY_ACTION_ID_KEY,
+    action_args_key: IDENTITY_ACTION_ARGS_KEY,
+    status_key: IDENTITY_STATUS_KEY,
+    status_id_key: IDENTITY_STATUS_ID_KEY,
+    status_detail_key: IDENTITY_STATUS_DETAIL_KEY,
+    ack_key: None,
+    parse_verb: parse_identity_verb,
+    namespace: "identity",
 };
 
 /// Env var the SwiftGuest controller sets on the launcher container when
@@ -382,6 +410,14 @@ fn parse_migration_verb(verb: &str) -> ActionKind {
     }
 }
 
+/// Maps an identity-namespace verb string to an [`ActionKind`].
+fn parse_identity_verb(verb: &str) -> ActionKind {
+    match verb {
+        "regenerate" => ActionKind::IdentityRegenerate,
+        other => ActionKind::Unknown(other.to_string()),
+    }
+}
+
 /// Default per-call timeout for pause/resume/snapshot when the action
 /// args don't carry a `timeout_seconds` hint. 600s covers a 200 GiB VM
 /// at the Phase 0 ~2.8s/GiB curve with margin; the controller passes
@@ -421,6 +457,12 @@ pub enum ActionKind {
     /// The source CH automatically resumes on the dst-kill (Q1d-F2).
     /// `docs/design/live-migration-phase-2.md` §2 row 7.
     MigrationCancel,
+
+    // Identity namespace — `kubeswift.io/identity-action` verbs.
+    /// Regenerate a cloneFromSnapshot clone's identity in place over vsock:
+    /// machine-id / SSH host keys / hostname / MAC + re-DHCP, with no reboot.
+    /// See docs/design/clone-identity-vsock-agent.md.
+    IdentityRegenerate,
 
     /// Anything else — surfaces as a malformed-rejection so the
     /// controller learns immediately rather than the launcher silently
@@ -535,6 +577,7 @@ pub struct NamespaceState {
 pub struct ActionState {
     pub snapshot: NamespaceState,
     pub migration: NamespaceState,
+    pub identity: NamespaceState,
 }
 
 /// Pure-function action-decision logic. Tested in isolation — no
@@ -673,6 +716,7 @@ pub async fn dispatch(action: &PendingAction, api_socket: &Path) -> Result<Actio
         ActionKind::MigrationSend => dispatch_migration_send(action, api_socket).await,
         ActionKind::MigrationReceive => dispatch_migration_receive(action, api_socket).await,
         ActionKind::MigrationCancel => dispatch_migration_cancel(action, api_socket).await,
+        ActionKind::IdentityRegenerate => dispatch_identity_regenerate(action, api_socket).await,
         ActionKind::Unknown(verb) => {
             log::warn!(
                 "dispatch_unknown_action_verb verb={} id={}",
@@ -682,6 +726,88 @@ pub async fn dispatch(action: &PendingAction, api_socket: &Path) -> Result<Actio
             Err(format!("unknown action verb: {}", verb))
         }
     }
+}
+
+/// Args parsed from `kubeswift.io/identity-action-args` for the `regenerate`
+/// verb. The controller writes these from
+/// `SwiftGuest.spec.cloneFromSnapshot.regenerate` + the per-clone MAC/hostname.
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IdentityRegenArgs {
+    #[serde(default)]
+    items: Vec<String>,
+    #[serde(default)]
+    mac: Option<String>,
+    #[serde(default)]
+    hostname: Option<String>,
+    #[serde(default)]
+    renew_lease: bool,
+    #[serde(default)]
+    timeout_seconds: Option<u64>,
+}
+
+/// Identity-regen timeout. The agent resumes from RAM (already running on a
+/// clone), so it answers ~immediately; the floor is the in-guest dhclient renew.
+const IDENTITY_ACTION_TIMEOUT_SECS: u64 = 30;
+
+/// Connect to the in-guest identity agent over vsock and ask it to regenerate
+/// the clone's identity in place. The vsock socket lives next to the CH API
+/// socket (`<runtime-dir>/vsock.sock`). Returns a `GuestAgentUnreachable` detail
+/// when the agent does not answer (absent / device-less / timeout) so the
+/// controller maps it to CloneIdentityRegenerated=False (PR 4) — never a silent
+/// success. The new IP is also discovered by the (v0.4.3) restore lease poller
+/// via dnsmasq, so this path does not need to surface it.
+async fn dispatch_identity_regenerate(
+    action: &PendingAction,
+    api_socket: &Path,
+) -> Result<ActionOutcome, String> {
+    let args: IdentityRegenArgs = if action.args.is_null() {
+        IdentityRegenArgs::default()
+    } else {
+        serde_json::from_value(action.args.clone())
+            .map_err(|e| format!("parse identity args: {}", e))?
+    };
+    let vsock_socket = api_socket
+        .parent()
+        .unwrap_or_else(|| Path::new("/"))
+        .join("vsock.sock");
+    let timeout = std::time::Duration::from_secs(
+        args.timeout_seconds.unwrap_or(IDENTITY_ACTION_TIMEOUT_SECS),
+    );
+    let req = swift_vsock_client::IdentityRequest::regenerate(
+        args.items,
+        args.mac,
+        args.hostname,
+        args.renew_lease,
+    );
+    log::info!(
+        "dispatch_identity_regenerate id={} socket={}",
+        action.id,
+        vsock_socket.display()
+    );
+    // The vsock client is synchronous; run it off the action loop's
+    // current_thread runtime so a slow in-guest dhclient cannot wedge the loop
+    // (contrast the migration-send sync-in-async wedge, TFU #14).
+    let resp = tokio::task::spawn_blocking(move || {
+        swift_vsock_client::regenerate_identity(&vsock_socket, &req, timeout)
+    })
+    .await
+    .map_err(|e| format!("identity task join: {}", e))?
+    .map_err(|e| format!("GuestAgentUnreachable: {}", e))?;
+
+    if !resp.ok {
+        return Err(format!(
+            "agent error: {}",
+            resp.error.unwrap_or_else(|| "unknown".to_string())
+        ));
+    }
+    Ok(ActionOutcome::detail(format!(
+        "regenerated {:?}{}",
+        resp.regenerated,
+        resp.new_ip
+            .map(|ip| format!(", ip={}", ip))
+            .unwrap_or_default()
+    )))
 }
 
 /// Args parsed from `kubeswift.io/migration-action-args` for the
@@ -1700,6 +1826,39 @@ pub async fn write_migration_status(
     Ok(())
 }
 
+/// Patch the launcher pod's status annotations for the identity namespace.
+/// Mirrors [`write_status`] (status / status-id / status-detail), written
+/// together in a single Patch::Merge so the controller never sees a status
+/// without its id. The `_pause_window_ms` parameter is unused (identity has no
+/// pause window — the new IP arrives via the lease poller); it is present only
+/// to satisfy the shared `StatusWriter` fn-pointer signature.
+pub async fn write_identity_status(
+    client: &Client,
+    namespace: &str,
+    pod_name: &str,
+    action_id: &str,
+    status: StatusKind,
+    detail: Option<&str>,
+    _pause_window_ms: Option<u64>,
+) -> Result<(), kube::Error> {
+    let api: Api<k8s_openapi::api::core::v1::Pod> = Api::namespaced(client.clone(), namespace);
+    let mut annotations = BTreeMap::new();
+    annotations.insert(IDENTITY_STATUS_KEY.to_string(), status.as_str().to_string());
+    annotations.insert(IDENTITY_STATUS_ID_KEY.to_string(), action_id.to_string());
+    annotations.insert(
+        IDENTITY_STATUS_DETAIL_KEY.to_string(),
+        detail.unwrap_or("").to_string(),
+    );
+    let patch = json!({
+        "metadata": {
+            "annotations": annotations
+        }
+    });
+    let pp = PatchParams::default();
+    api.patch(pod_name, &pp, &Patch::Merge(&patch)).await?;
+    Ok(())
+}
+
 // ─── Phase 3a D2 (`docs/design/live-migration-phase-3a.md` §7.2) ─────────────
 //
 // Auto-write `migration-status: failed` on abnormal CH listener exit.
@@ -2012,6 +2171,23 @@ async fn handle_pod_state(
         write_migration_status_fn,
     )
     .await;
+
+    // Identity namespace (in-guest agent over vsock). A separate namespace with
+    // its own state — it is NOT part of the snapshot<->migration mutual-rejection
+    // above: identity-regen fires once on a fresh cloneFromSnapshot clone (post
+    // GuestRunning) and does not overlap a snapshot/migration of the same guest
+    // in the controller-driven flow (PR 4). See clone-identity-vsock-agent.md.
+    handle_namespace(
+        client,
+        namespace,
+        pod_name,
+        api_socket,
+        &mut state.identity,
+        &IDENTITY_KEYS,
+        annotations,
+        write_identity_status_fn,
+    )
+    .await;
 }
 
 /// Type alias for the namespace-specific status writer used by
@@ -2051,6 +2227,20 @@ fn write_migration_status_fn<'a>(
     pause: Option<u64>,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), kube::Error>> + Send + 'a>> {
     Box::pin(write_migration_status(
+        client, ns, pod, id, status, detail, pause,
+    ))
+}
+
+fn write_identity_status_fn<'a>(
+    client: &'a Client,
+    ns: &'a str,
+    pod: &'a str,
+    id: &'a str,
+    status: StatusKind,
+    detail: Option<&'a str>,
+    pause: Option<u64>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), kube::Error>> + Send + 'a>> {
+    Box::pin(write_identity_status(
         client, ns, pod, id, status, detail, pause,
     ))
 }
@@ -3012,6 +3202,38 @@ mod tests {
             parse_migration_verb("xyz"),
             ActionKind::Unknown("xyz".to_string())
         );
+    }
+
+    #[test]
+    fn parse_identity_verb_maps_known_and_unknown() {
+        assert_eq!(
+            parse_identity_verb("regenerate"),
+            ActionKind::IdentityRegenerate
+        );
+        assert_eq!(
+            parse_identity_verb("xyz"),
+            ActionKind::Unknown("xyz".to_string())
+        );
+    }
+
+    #[test]
+    fn identity_keyset_no_ack_gate_and_accepts_regenerate() {
+        // Identity is a host<->guest vsock channel — no plaintext-ack gate.
+        assert!(IDENTITY_KEYS.ack_key.is_none());
+        let mut a = BTreeMap::new();
+        a.insert(IDENTITY_ACTION_KEY.to_string(), "regenerate".to_string());
+        a.insert(IDENTITY_ACTION_ID_KEY.to_string(), "id-1".to_string());
+        a.insert(
+            IDENTITY_ACTION_ARGS_KEY.to_string(),
+            r#"{"items":["machineId"],"renewLease":true}"#.to_string(),
+        );
+        match decide(&a, &IDENTITY_KEYS, None, None) {
+            ActionDecision::Accept(p) => {
+                assert_eq!(p.kind, ActionKind::IdentityRegenerate);
+                assert_eq!(p.id, "id-1");
+            }
+            other => panic!("expected Accept, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Stacked on #229.** The host side that talks to the in-guest identity agent. Operator-triggered for now (annotation); the controller auto-drives it in PR 4.

## New crate `rust/swift-vsock-client`

- A thin **synchronous** client (no tokio — mirrors `swift-qemu-client`'s QMP choice) for CH's hybrid vsock: connects the host-side Unix socket, performs the `CONNECT`/`OK` handshake the PR-0 spike pinned, sends one JSON request line, reads one JSON response line.
- `IdentityRequest` / `IdentityResponse` serde types matching the agent's protocol (`op: regenerate-identity`; `items` map from `CloneFromSnapshotSource.regenerate`).
- `VsockError` (`Io` / `Handshake` / `Decode`) — "agent unreachable" is the Io/Handshake case. Minimal deps (serde + serde_json).
- Tests: a fake-CH-endpoint round-trip + a handshake-refused case — no real vsock/guest needed.

## swiftletd action loop (`action.rs`)

- A third **`identity` namespace KeySet** alongside snapshot/migration: `identity-action`/`-action-id`/`-action-args` (controller writes), `identity-status`/`-status-id`/`-status-detail` (swiftletd writes). No ack-gate (intra-pod host↔guest channel).
- `ActionKind::IdentityRegenerate` + `parse_identity_verb`.
- `dispatch_identity_regenerate`: derives the vsock socket from the api socket's dir (`<rt>/vsock.sock`), builds the request from the action args, runs the blocking vsock call on `spawn_blocking` so a slow in-guest `dhclient` can't wedge the current_thread loop (contrast the migration-send wedge, TFU #14). No answer/timeout → a **`GuestAgentUnreachable`** detail (PR 4 maps it to `CloneIdentityRegenerated=False` — never a silent success). The new IP is **not** surfaced here — the v0.4.3 restore lease-poller discovers it via dnsmasq.
- `ActionState.identity` + a third `handle_namespace` call + `write_identity_status`/`_fn`. Deliberately **not** in the snapshot↔migration mutual-rejection (it fires once on a fresh clone, no overlap in the controller-driven flow).
- Tests: `parse_identity_verb`; the identity KeySet has no ack-gate and `decide()` accepts a `regenerate` action.

## Containerfile

`COPY rust/swift-vsock-client` into the Rust build stage — the workspace would not build otherwise.

## Test

`cargo test` (full workspace) + `cargo fmt` clean. No Go change; no controller wiring yet (PR 4).

## Not in this PR

PR 4 controller auto-drive (stamp `identity-action` after GuestRunning for cloneFromSnapshot clones) + `CloneIdentityRegenerated` status + `GuestAgentUnreachable` fallback + drop the cmdline marker when the agent is present · PR 5 cluster walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)