### PR TITLE
feat(snapshots): controller auto-drives clone identity regen (PR 4)

### DIFF
--- a/docs/snapshots/identity-regeneration.md
+++ b/docs/snapshots/identity-regeneration.md
@@ -42,14 +42,31 @@ install -m0644 kubeswift-guest-agent.service /etc/systemd/system/
 systemctl enable kubeswift-guest-agent
 ```
 
-**Seed profile.** Attach the `guest-agent` SwiftSeedProfile
+Opt in on the **source** guest with `spec.guestAgent.enabled: true` — that
+attaches the vsock device the agent needs. KubeSwift then drives the
+regeneration automatically: once a `cloneFromSnapshot` clone reaches
+`GuestRunning`, the controller sends the agent a one-shot regenerate over
+vsock and reports the result on the clone's `CloneIdentityRegenerated`
+condition (`True`, or `False` with reason `GuestAgentUnreachable` if the agent
+is absent). The clone's own IP then lands in `status.network.primaryIP` via the
+v0.4.3 restore lease-poller — no reboot, no operator action.
+
+```yaml
+# the SOURCE SwiftGuest (the one you snapshot + clone from):
+spec:
+  guestAgent:
+    enabled: true        # attach the vsock device
+  # ... and install the agent in the guest (golden image above, recommended)
+```
+
+**Seed profile (agent-binary delivery).** The `guest-agent` SwiftSeedProfile
 ([`config/samples/seed-profiles/guest-agent.yaml`](../../config/samples/seed-profiles/guest-agent.yaml))
-to the source SwiftGuest via `spec.seedProfileRef`; it installs the
-agent from a controller-attached virtiofs share on first boot. (The
-controller-side share attachment and the auto-drive on clone resume
-ship in later PRs of the arc; once they land, a clone's identity is
-regenerated automatically and `status.network.primaryIP` populates
-with no operator action.)
+installs the agent from a virtiofs share on first boot. The controller-side
+attachment of that share is a tracked follow-up; until it lands, install the
+agent via the **golden image** (recommended) and just set `guestAgent.enabled`
+on the source. (`spec.seedProfileRef` to the profile is harmless meanwhile — the
+runcmd no-ops when the share is absent, and the loud `GuestAgentUnreachable`
+fallback makes a missing agent visible.)
 
 **Verify it is running on the source before snapshotting:**
 

--- a/internal/controller/swiftguest/clone.go
+++ b/internal/controller/swiftguest/clone.go
@@ -159,7 +159,17 @@ func cloneRestoreAnnotations(
 		// pod's lifetime, so lazy paging is safe (snapshot-ch-v52-efficiency.md).
 		AnnotationRestoreMemoryMode: "ondemand",
 	}
-	if cloneRegenIncludesNonMAC(guest.Spec.CloneFromSnapshot) {
+	// In-guest identity agent: if the SOURCE opted in (and the device is in the
+	// snapshot), the agent regenerates identity in place over vsock once the
+	// clone is Running (ensureCloneIdentityRegen). Record it on the clone so the
+	// controller knows to drive the action — and SKIP the legacy reboot-bootcmd
+	// cmdline marker, since the agent owns regeneration (the two must not both
+	// fire). When the agent is absent, fall back to the marker (broken on CH
+	// v52; docs/snapshots/identity-regeneration.md).
+	agentEnabled := source.Spec.GuestAgent != nil && source.Spec.GuestAgent.Enabled
+	if agentEnabled {
+		annos[AnnotationCloneAgentEnabled] = "true"
+	} else if cloneRegenIncludesNonMAC(guest.Spec.CloneFromSnapshot) {
 		annos[AnnotationRestoreAppendCmdlineMarker] = "true"
 	}
 	return annos

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -480,6 +480,7 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	var existingPod corev1.Pod
 	var podForMetrics *corev1.Pod
+	var cloneIdentityRequeue time.Duration
 	if err := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: canonicalPodName(&guest)}, &existingPod); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
@@ -512,6 +513,16 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Pod exists; update status from pod
 		podForMetrics = &existingPod
 		MapPodToStatus(&existingPod, status)
+		// In-guest identity agent (PR 4): for an agent-enabled cloneFromSnapshot
+		// clone, drive the one-shot identity-regen over vsock once it is Running.
+		// MUST run BEFORE the IP-not-discovered requeue below: a fresh clone has
+		// no IP precisely because the agent has not re-DHCP'd yet, so deferring
+		// the stamp would deadlock the IP wait. No-op for non-clones / agent-absent.
+		var idErr error
+		cloneIdentityRequeue, idErr = r.ensureCloneIdentityRegen(ctx, &guest, &existingPod, status)
+		if idErr != nil {
+			return ctrl.Result{}, idErr
+		}
 		// cloneFromSnapshot (Snapshot Phase 4): CH loads the snapshot PAUSED,
 		// but swiftletd now passes `resume=true` on `--restore` (CH v52) when the
 		// restore intent's AutoResume is set, so the clone comes up RUNNING with
@@ -551,7 +562,9 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, nil
+	// Requeue while an agent-enabled clone's identity regen is still in flight
+	// (0 = no requeue once it reaches a terminal CloneIdentityRegenerated state).
+	return ctrl.Result{RequeueAfter: cloneIdentityRequeue}, nil
 }
 
 func recordGuestMetrics(guest *swiftv1alpha1.SwiftGuest, oldStatus, newStatus *swiftv1alpha1.SwiftGuestStatus, pod *corev1.Pod) {

--- a/internal/controller/swiftguest/identity.go
+++ b/internal/controller/swiftguest/identity.go
@@ -1,0 +1,178 @@
+package swiftguest
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// Identity-action annotation keys — the Go side of swiftletd's IDENTITY_KEYS
+// (rust/swiftletd/src/action.rs). The controller writes the action keys; it
+// reads the status keys back as swiftletd's mirror.
+const (
+	identityActionKey     = "kubeswift.io/identity-action"
+	identityActionIDKey   = "kubeswift.io/identity-action-id"
+	identityActionArgsKey = "kubeswift.io/identity-action-args"
+	identityStatusKey     = "kubeswift.io/identity-status"
+	identityStatusIDKey   = "kubeswift.io/identity-status-id"
+	identityStatusDetail  = "kubeswift.io/identity-status-detail"
+
+	identityVerbRegenerate = "regenerate"
+)
+
+// identityRegenArgs is the JSON the controller writes to identityActionArgsKey;
+// it matches swiftletd's IdentityRegenArgs (camelCase). Items map verbatim from
+// SwiftGuest.spec.cloneFromSnapshot.regenerate.
+type identityRegenArgs struct {
+	Items      []string `json:"items,omitempty"`
+	MAC        string   `json:"mac,omitempty"`
+	Hostname   string   `json:"hostname,omitempty"`
+	RenewLease bool     `json:"renewLease,omitempty"`
+}
+
+// cloneIdentityActionID returns a stable per-guest action-id (immutable across
+// reconciles, mirrors resumeActionID): the regen fires exactly once per clone.
+func cloneIdentityActionID(guest *swiftv1alpha1.SwiftGuest) string {
+	uid := string(guest.UID)
+	if len(uid) > 8 {
+		uid = uid[:8]
+	}
+	return guest.Name + "-" + uid + "-identity"
+}
+
+// ensureCloneIdentityRegen drives the one-shot in-guest identity regeneration
+// for a cloneFromSnapshot guest whose SOURCE opted into the agent. It stamps the
+// identity-action on the launcher pod once the clone is Running, reads
+// swiftletd's status mirror, and maps it to the CloneIdentityRegenerated
+// condition. Returns a requeue delay while the action is in flight.
+//
+// LOAD-BEARING: the agent must already be RUNNING in the clone's resumed RAM
+// (it was captured from the source). If it is not (source had no agent / device
+// absent / not yet up), swiftletd reports GuestAgentUnreachable and the clone
+// keeps the source's identity — a loud, status-visible fallback, never silent.
+func (r *SwiftGuestReconciler) ensureCloneIdentityRegen(
+	ctx context.Context,
+	guest *swiftv1alpha1.SwiftGuest,
+	pod *corev1.Pod,
+	status *swiftv1alpha1.SwiftGuestStatus,
+) (time.Duration, error) {
+	// Only for an agent-enabled clone with a running launcher.
+	if !guest.UsesCloneFromSnapshot() || guest.Annotations[AnnotationCloneAgentEnabled] != "true" {
+		return 0, nil
+	}
+	if pod == nil || status.Phase != swiftv1alpha1.SwiftGuestPhaseRunning || !isLauncherReady(pod) {
+		return 0, nil
+	}
+
+	actionID := cloneIdentityActionID(guest)
+	annos := pod.GetAnnotations()
+
+	// First pass: stamp the action (idempotent — swiftletd dedupes by action-id).
+	if annos[identityActionIDKey] != actionID {
+		args := identityRegenArgs{
+			Items:      cloneRegenItems(guest.Spec.CloneFromSnapshot),
+			MAC:        primaryCloneMAC(guest),
+			Hostname:   guest.Name,
+			RenewLease: true,
+		}
+		argsJSON, err := json.Marshal(args)
+		if err != nil {
+			return 0, err
+		}
+		if err := r.patchPodIdentityAction(ctx, pod, actionID, string(argsJSON)); err != nil {
+			return 0, err
+		}
+		SetCloneIdentityRegeneratedCondition(status, false, "Regenerating",
+			"identity-regen action sent to launcher pod "+pod.Name)
+		return 3 * time.Second, nil
+	}
+
+	// Action stamped — read swiftletd's status mirror.
+	if annos[identityStatusIDKey] != actionID {
+		// mirror not yet visible
+		SetCloneIdentityRegeneratedCondition(status, false, "Regenerating",
+			"waiting for in-guest agent to acknowledge")
+		return 3 * time.Second, nil
+	}
+	detail := annos[identityStatusDetail]
+	switch annos[identityStatusKey] {
+	case "running", "":
+		SetCloneIdentityRegeneratedCondition(status, false, "Regenerating",
+			"in-guest agent is regenerating identity")
+		return 3 * time.Second, nil
+	case "ready":
+		SetCloneIdentityRegeneratedCondition(status, true, "", detail)
+		return 0, nil
+	case "failed":
+		// swiftletd reports "GuestAgentUnreachable: ..." when the agent does not
+		// answer (absent / device-less / timeout); surface that reason verbatim.
+		reason := "RegenFailed"
+		if strings.Contains(detail, "GuestAgentUnreachable") {
+			reason = "GuestAgentUnreachable"
+		}
+		SetCloneIdentityRegeneratedCondition(status, false, reason, detail)
+		return 0, nil
+	case "rejected":
+		SetCloneIdentityRegeneratedCondition(status, false, "RegenRejected", detail)
+		return 0, nil
+	default:
+		SetCloneIdentityRegeneratedCondition(status, false, "RegenFailed",
+			"unexpected identity-status: "+annos[identityStatusKey])
+		return 0, nil
+	}
+}
+
+// patchPodIdentityAction merge-patches the identity-action annotations onto the
+// launcher pod. Mirrors swiftrestore's patchPodActionAnnotations.
+func (r *SwiftGuestReconciler) patchPodIdentityAction(
+	ctx context.Context, pod *corev1.Pod, actionID, argsJSON string,
+) error {
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				identityActionKey:     identityVerbRegenerate,
+				identityActionIDKey:   actionID,
+				identityActionArgsKey: argsJSON,
+			},
+		},
+	}
+	data, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+	return r.Patch(ctx, pod, client.RawPatch(types.MergePatchType, data))
+}
+
+// cloneRegenItems maps spec.cloneFromSnapshot.regenerate to the agent's item
+// strings. An empty list is passed through empty — the agent defaults to all
+// four (matching the CRD's "empty defaults to all").
+func cloneRegenItems(src *swiftv1alpha1.CloneFromSnapshotSource) []string {
+	if src == nil || len(src.Regenerate) == 0 {
+		return nil
+	}
+	items := make([]string, 0, len(src.Regenerate))
+	for _, it := range src.Regenerate {
+		items = append(items, string(it))
+	}
+	return items
+}
+
+// primaryCloneMAC returns the per-clone MAC for the guest's primary interface —
+// the first entry of the AnnotationRestoreMACRewrites CSV the clone path already
+// computed (so the guest-visible MAC the agent sets matches the host-side
+// config.net[0].mac that was rewritten). Empty if unavailable (the agent then
+// skips macAddresses but still re-DHCPs).
+func primaryCloneMAC(guest *swiftv1alpha1.SwiftGuest) string {
+	csv := guest.Annotations[AnnotationRestoreMACRewrites]
+	if csv == "" {
+		return ""
+	}
+	return strings.TrimSpace(strings.SplitN(csv, ",", 2)[0])
+}

--- a/internal/controller/swiftguest/identity_test.go
+++ b/internal/controller/swiftguest/identity_test.go
@@ -1,0 +1,173 @@
+package swiftguest
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/scheme"
+)
+
+func identityCloneGuest() *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "clone-a", Namespace: "default", UID: "clone-uid-12345678",
+			Annotations: map[string]string{
+				AnnotationCloneAgentEnabled:  "true",
+				AnnotationRestoreMACRewrites: "52:54:00:11:22:33,52:54:00:44:55:66",
+			},
+		},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			CloneFromSnapshot: &swiftv1alpha1.CloneFromSnapshotSource{
+				SnapshotRef: corev1.LocalObjectReference{Name: "snap"},
+				Regenerate:  []swiftv1alpha1.CloneIdentityItem{swiftv1alpha1.CloneRegenMachineID, swiftv1alpha1.CloneRegenMACAddresses},
+			},
+		},
+	}
+}
+
+func readyClonePod(annos map[string]string) *corev1.Pod {
+	if annos == nil {
+		annos = map[string]string{}
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-a", Namespace: "default", Annotations: annos},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+}
+
+func TestEnsureCloneIdentityRegen_StampsActionFirstPass(t *testing.T) {
+	g := identityCloneGuest()
+	pod := readyClonePod(nil)
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(g, pod).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme}
+	status := &swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning}
+
+	rq, err := r.ensureCloneIdentityRegen(context.Background(), g, pod, status)
+	if err != nil {
+		t.Fatalf("ensureCloneIdentityRegen: %v", err)
+	}
+	if rq != 3*time.Second {
+		t.Errorf("expected 3s requeue while regenerating, got %v", rq)
+	}
+	// pod gained the identity-action annotations
+	var got corev1.Pod
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "clone-a"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Annotations[identityActionKey] != identityVerbRegenerate {
+		t.Errorf("identity-action = %q, want regenerate", got.Annotations[identityActionKey])
+	}
+	if got.Annotations[identityActionIDKey] != cloneIdentityActionID(g) {
+		t.Errorf("identity-action-id = %q, want %q", got.Annotations[identityActionIDKey], cloneIdentityActionID(g))
+	}
+	args := got.Annotations[identityActionArgsKey]
+	for _, want := range []string{`"machineId"`, `"macAddresses"`, `"52:54:00:11:22:33"`, `"hostname":"clone-a"`, `"renewLease":true`} {
+		if !strings.Contains(args, want) {
+			t.Errorf("args %q missing %q", args, want)
+		}
+	}
+	if cond := findCondition(status, ConditionCloneIdentityRegenerated); cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Errorf("expected CloneIdentityRegenerated=False (Regenerating), got %+v", cond)
+	}
+}
+
+func TestEnsureCloneIdentityRegen_Ready(t *testing.T) {
+	g := identityCloneGuest()
+	id := cloneIdentityActionID(g)
+	pod := readyClonePod(map[string]string{
+		identityActionIDKey:  id,
+		identityStatusIDKey:  id,
+		identityStatusKey:    "ready",
+		identityStatusDetail: "regenerated [machineId macAddresses], ip=192.168.99.12",
+	})
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(g, pod).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme}
+	status := &swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning}
+
+	rq, err := r.ensureCloneIdentityRegen(context.Background(), g, pod, status)
+	if err != nil || rq != 0 {
+		t.Fatalf("expected terminal (0 requeue), got rq=%v err=%v", rq, err)
+	}
+	cond := findCondition(status, ConditionCloneIdentityRegenerated)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected CloneIdentityRegenerated=True, got %+v", cond)
+	}
+}
+
+func TestEnsureCloneIdentityRegen_GuestAgentUnreachable(t *testing.T) {
+	g := identityCloneGuest()
+	id := cloneIdentityActionID(g)
+	pod := readyClonePod(map[string]string{
+		identityActionIDKey:  id,
+		identityStatusIDKey:  id,
+		identityStatusKey:    "failed",
+		identityStatusDetail: "GuestAgentUnreachable: vsock io: No such file or directory",
+	})
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(g, pod).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme}
+	status := &swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning}
+
+	if _, err := r.ensureCloneIdentityRegen(context.Background(), g, pod, status); err != nil {
+		t.Fatal(err)
+	}
+	cond := findCondition(status, ConditionCloneIdentityRegenerated)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "GuestAgentUnreachable" {
+		t.Fatalf("expected CloneIdentityRegenerated=False/GuestAgentUnreachable, got %+v", cond)
+	}
+}
+
+func TestEnsureCloneIdentityRegen_NoOpWhenNotAgentClone(t *testing.T) {
+	// plain guest (not a clone)
+	g := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "default"}}
+	pod := readyClonePod(nil)
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(g, pod).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme}
+	status := &swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning}
+	rq, err := r.ensureCloneIdentityRegen(context.Background(), g, pod, status)
+	if err != nil || rq != 0 {
+		t.Fatalf("plain guest must be a no-op, got rq=%v err=%v", rq, err)
+	}
+	if findCondition(status, ConditionCloneIdentityRegenerated) != nil {
+		t.Error("must not set the condition for a non-clone")
+	}
+
+	// clone but agent not enabled (no AnnotationCloneAgentEnabled)
+	g2 := identityCloneGuest()
+	delete(g2.Annotations, AnnotationCloneAgentEnabled)
+	status2 := &swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning}
+	if _, err := r.ensureCloneIdentityRegen(context.Background(), g2, readyClonePod(nil), status2); err != nil {
+		t.Fatal(err)
+	}
+	if findCondition(status2, ConditionCloneIdentityRegenerated) != nil {
+		t.Error("must not set the condition when the agent is not enabled")
+	}
+}
+
+func TestCloneIdentityHelpers(t *testing.T) {
+	g := identityCloneGuest()
+	if a := cloneIdentityActionID(g); a != cloneIdentityActionID(g) || a != "clone-a-clone-ui-identity" {
+		t.Errorf("actionID not stable/expected: %q", a)
+	}
+	if items := cloneRegenItems(g.Spec.CloneFromSnapshot); len(items) != 2 || items[0] != "machineId" {
+		t.Errorf("cloneRegenItems = %v", items)
+	}
+	if items := cloneRegenItems(&swiftv1alpha1.CloneFromSnapshotSource{}); items != nil {
+		t.Errorf("empty regenerate must map to nil (agent defaults all), got %v", items)
+	}
+	if mac := primaryCloneMAC(g); mac != "52:54:00:11:22:33" {
+		t.Errorf("primaryCloneMAC = %q, want first CSV entry", mac)
+	}
+	if mac := primaryCloneMAC(&swiftv1alpha1.SwiftGuest{}); mac != "" {
+		t.Errorf("primaryCloneMAC with no rewrites must be empty, got %q", mac)
+	}
+}

--- a/internal/controller/swiftguest/restore.go
+++ b/internal/controller/swiftguest/restore.go
@@ -89,6 +89,14 @@ const (
 	// host keys, and hostname on first wake (see
 	// docs/snapshots/identity-regeneration.md).
 	AnnotationRestoreAppendCmdlineMarker = "snapshot.kubeswift.io/restore-append-cmdline-marker"
+	// AnnotationCloneAgentEnabled, when "true" on a cloneFromSnapshot guest,
+	// records that the snapshot SOURCE opted into the in-guest identity agent
+	// (source.spec.guestAgent.enabled). The controller reads it after the clone
+	// reaches GuestRunning to drive the one-shot identity-action regen over
+	// vsock (see ensureCloneIdentityRegen). When set, the controller does NOT
+	// also append the kubeswift.clone=true cmdline marker — the agent owns
+	// identity regeneration, so the legacy reboot-bootcmd path is skipped.
+	AnnotationCloneAgentEnabled = "snapshot.kubeswift.io/clone-agent-enabled"
 	// AnnotationRestoreRuntimeDirFromPrefix is the source pod's
 	// runtime_dir prefix that the stager must rewrite in
 	// disks[].path and serial.socket. Must end in "/". Empty disables

--- a/internal/controller/swiftguest/status.go
+++ b/internal/controller/swiftguest/status.go
@@ -220,6 +220,33 @@ func SetDataDisksReadyCondition(status *swiftv1alpha1.SwiftGuestStatus, ok bool,
 	setCondition(status, cond)
 }
 
+// ConditionCloneIdentityRegenerated is set on a cloneFromSnapshot guest whose
+// source opted into the in-guest identity agent: True once the agent has
+// regenerated the clone's identity in place (machine-id / SSH keys / hostname /
+// MAC + re-DHCP), False with reason GuestAgentUnreachable when the agent does
+// not answer (the clone still runs as a warm replica sharing the source's
+// identity — a loud, never-silent fallback). Absent when the guest is not an
+// agent-enabled clone. See docs/design/clone-identity-vsock-agent.md.
+const ConditionCloneIdentityRegenerated = "CloneIdentityRegenerated"
+
+// SetCloneIdentityRegeneratedCondition sets CloneIdentityRegenerated.
+func SetCloneIdentityRegeneratedCondition(status *swiftv1alpha1.SwiftGuestStatus, ok bool, reason, message string) {
+	cond := metav1.Condition{Type: ConditionCloneIdentityRegenerated}
+	if ok {
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = "Regenerated"
+		cond.Message = message
+		if cond.Message == "" {
+			cond.Message = "Clone identity regenerated in place by the in-guest agent"
+		}
+	} else {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = reason
+		cond.Message = message
+	}
+	setCondition(status, cond)
+}
+
 // SetResolvedCondition sets the Resolved condition.
 func SetResolvedCondition(status *swiftv1alpha1.SwiftGuestStatus, ok bool, reason string) {
 	cond := metav1.Condition{


### PR DESCRIPTION
## Summary

The capstone of the vsock identity-agent arc (#228 → #229 → #230, all merged). KubeSwift now regenerates a `cloneFromSnapshot` clone's identity **automatically — no operator action, no reboot.**

Once an agent-enabled clone reaches `GuestRunning`, the SwiftGuest controller stamps a one-shot `identity-action: regenerate` on the launcher pod (mirrors the removed `resumeCloneIfNeeded` / SwiftRestore's resume one-shot), with args from `spec.cloneFromSnapshot.regenerate` + the per-clone **primary MAC** (the first of the clone's MAC-rewrite CSV, so the guest-visible MAC matches the host-side `config.net[0].mac`) + the clone name as hostname + `renewLease`. swiftletd's status mirror maps to a new **`CloneIdentityRegenerated`** condition:
- `ready` → **True**
- `failed` → **False**, reason **`GuestAgentUnreachable`** when the agent didn't answer (absent / device-less / timeout) — a loud, status-visible fallback (the clone still runs as a warm replica), **never silent**.

The clone's own IP then lands in `status.network.primaryIP` via the v0.4.3 restore lease-poller (the agent's `dhclient` gives it a lease to find).

## Critical ordering

The action is stamped **before** the existing IP-not-discovered requeue — a fresh clone has no IP *precisely because* the agent hasn't re-DHCP'd yet, so deferring the stamp would deadlock the IP wait.

## Opt-in + precedence

`source.spec.guestAgent.enabled` (PR 2) is recorded onto the clone as `snapshot.kubeswift.io/clone-agent-enabled` during clone prep; the controller gates the regen on it. When the agent is present the controller also **skips the legacy `kubeswift.clone=true` cmdline marker** — the agent owns regeneration, so the reboot-bootcmd path (broken on CH v52) and the agent never both fire.

## Files

- `identity.go` (new): `ensureCloneIdentityRegen` + `cloneIdentityActionID` + arg/MAC helpers + Go-side identity-action keys.
- `status.go`: `CloneIdentityRegenerated` condition + setter.
- `clone.go`: record clone-agent-enabled; skip the marker when agent present.
- `controller.go`: drive it in the Running block; requeue while in flight.
- `restore.go`: `AnnotationCloneAgentEnabled`.
- `docs/snapshots/identity-regeneration.md`: `guestAgent.enabled` + the auto-drive.

## Test

stamp-first-pass (pod gains the action + args + `Regenerating`), `ready`→True, `failed`→False/`GuestAgentUnreachable`, no-op for non-clones / agent-disabled, + pure helpers. `go test ./...` green; `gofmt -s` clean; **no `make generate`** (conditions are generic — no schema change).

## Remaining

PR 5 — cluster walkthrough on the dev cluster (multi-replica clone pool: distinct identity + IPs, no reboot) + flip the demo-06 caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)