### PR TITLE
feat(snapshots): deliver the guest agent via the NoCloud seed disk

### DIFF
--- a/config/samples/seed-profiles/guest-agent.yaml
+++ b/config/samples/seed-profiles/guest-agent.yaml
@@ -24,20 +24,22 @@
 #
 # Two supported paths (pick one):
 #
-#  (a) virtiofs share (this sample). When a source guest references this seed
-#      profile, the SwiftGuest controller bind-mounts the swiftletd image's
-#      /usr/local/share/kubeswift/guest-agent directory into the guest as a
-#      read-only virtiofs share tagged `kubeswift-agent`. The runcmd below
-#      installs the agent from it. (The controller-side share attachment ships in
-#      PR 2 of the arc; until then, install the agent manually — see (b)/(c).)
+#  (a) seed disk (this sample). Set `spec.guestAgent.enabled: true` on the SOURCE
+#      SwiftGuest AND reference this seed profile. swiftletd then drops the agent
+#      binary (shipped in the swiftletd image at
+#      /usr/local/share/kubeswift/guest-agent) onto the NoCloud seed disk, and the
+#      runcmd below installs it from the mounted cidata disk on first boot. The
+#      binary rides a normal disk — no captured PCI device — so the clone restore
+#      is unaffected (the source's and clone's seed disks stay byte-identical).
 #
 #  (b) golden image (recommended for production fleets). Bake
 #      /usr/local/bin/kubeswift-guest-agent + this systemd unit into your
-#      SwiftImage at build time; then no per-guest seed wiring is needed.
+#      SwiftImage at build time; then no per-guest seed wiring is needed. Still
+#      set `spec.guestAgent.enabled: true` on the source to attach the vsock
+#      device the agent listens on.
 #
-#  (c) manual (for testing PR 1 standalone). Copy the binary into a running
-#      source guest, `systemctl enable --now kubeswift-guest-agent`, then
-#      snapshot it.
+#  (c) manual (for testing). Copy the binary into a running source guest,
+#      `systemctl enable --now kubeswift-guest-agent`, then snapshot it.
 #
 # # Fail-safe
 #
@@ -73,11 +75,15 @@ spec:
           [Install]
           WantedBy=multi-user.target
     runcmd:
-      # (a) install from the controller-attached virtiofs share (PR 2).
-      - [ sh, -c, "mkdir -p /mnt/kubeswift-agent" ]
-      - [ sh, -c, "mount -t virtiofs kubeswift-agent /mnt/kubeswift-agent 2>/dev/null || true" ]
-      - [ sh, -c, "if [ -x /mnt/kubeswift-agent/kubeswift-guest-agent ]; then install -m0755 /mnt/kubeswift-agent/kubeswift-guest-agent /usr/local/bin/kubeswift-guest-agent; fi" ]
-      - [ sh, -c, "umount /mnt/kubeswift-agent 2>/dev/null || true" ]
+      # Install the agent from the NoCloud seed disk. When guestAgent.enabled is
+      # set on the SOURCE guest, swiftletd drops the agent binary onto the cidata
+      # seed disk next to user-data/meta-data; mount it by its volume label and
+      # install. (If the binary is absent — agent not enabled, or a golden image
+      # already has it — every step is a harmless no-op.)
+      - [ sh, -c, "mkdir -p /mnt/cidata" ]
+      - [ sh, -c, "mount -o ro /dev/disk/by-label/cidata /mnt/cidata 2>/dev/null || true" ]
+      - [ sh, -c, "if [ -f /mnt/cidata/kubeswift-guest-agent ]; then install -m0755 /mnt/cidata/kubeswift-guest-agent /usr/local/bin/kubeswift-guest-agent; fi" ]
+      - [ sh, -c, "umount /mnt/cidata 2>/dev/null || true" ]
       # enable + start (no-op if the binary is absent — the controller's
       # GuestAgentUnreachable fallback then makes the gap visible, not silent).
       - [ sh, -c, "systemctl daemon-reload" ]

--- a/docs/design/clone-identity-vsock-agent.md
+++ b/docs/design/clone-identity-vsock-agent.md
@@ -166,6 +166,19 @@ shipped:
   needs no external hosting. **This requires the source guest to declare it wants
   the agent** (an opt-in seed profile + a controller flag to attach the share) —
   it is not automatic.
+
+  > **IMPLEMENTATION CORRECTION (2026-06-15) — superseded by the NoCloud seed
+  > disk, NOT virtiofs.** A virtiofs share is a virtio-PCI device; attaching it to
+  > the SOURCE means it is **captured in the snapshot**, and `run_ch_restore` does
+  > not spawn virtiofsd, so every clone restore would break on the orphaned
+  > vhost-user-fs backend. Instead, swiftletd drops the agent binary onto the
+  > guest's **NoCloud seed disk** (`main.rs::create_seed_iso`, gated on
+  > `intent.vsock.is_some()` — true for both the source and a clone, since a clone
+  > resolves off the source spec, keeping the two seed disks byte-identical). The
+  > seed `runcmd` mounts the `cidata` disk by label and installs from it. A disk —
+  > not a captured PCI device — so the clone restore is unaffected. The
+  > `guestAgent.enabled` SwiftGuest field is the opt-in (it also attaches the vsock
+  > device). See `config/samples/seed-profiles/guest-agent.yaml`.
 - **(b) Power path — bake into the golden image.** Operators building a golden
   SwiftImage install the agent + unit at image-build time (documented `apt`/`dnf`
   package or a `curl | install` in their image recipe). The snapshot of any guest

--- a/docs/snapshots/identity-regeneration.md
+++ b/docs/snapshots/identity-regeneration.md
@@ -59,14 +59,16 @@ spec:
   # ... and install the agent in the guest (golden image above, recommended)
 ```
 
-**Seed profile (agent-binary delivery).** The `guest-agent` SwiftSeedProfile
+**Seed profile (no golden image needed).** Set `spec.guestAgent.enabled: true`
+on the source **and** reference the `guest-agent` SwiftSeedProfile
 ([`config/samples/seed-profiles/guest-agent.yaml`](../../config/samples/seed-profiles/guest-agent.yaml))
-installs the agent from a virtiofs share on first boot. The controller-side
-attachment of that share is a tracked follow-up; until it lands, install the
-agent via the **golden image** (recommended) and just set `guestAgent.enabled`
-on the source. (`spec.seedProfileRef` to the profile is harmless meanwhile — the
-runcmd no-ops when the share is absent, and the loud `GuestAgentUnreachable`
-fallback makes a missing agent visible.)
+via `spec.seedProfileRef`. swiftletd then drops the agent binary (shipped in the
+swiftletd image) onto the NoCloud **seed disk**, and the profile's `runcmd`
+installs it from the mounted `cidata` disk on first boot. The binary rides a
+normal disk — no captured PCI device — so the source's and clone's seed disks
+stay byte-identical and the clone restore is unaffected. (If the binary is absent
+the steps no-op and the loud `GuestAgentUnreachable` fallback makes the gap
+visible.)
 
 **Verify it is running on the source before snapshotting:**
 

--- a/rust/swiftletd/src/main.rs
+++ b/rust/swiftletd/src/main.rs
@@ -19,7 +19,14 @@ use std::sync::Arc;
 /// -joliet: Joliet extensions, additional filename compatibility.
 fn create_seed_iso(seed_dir: &Path, output_iso: &Path) -> Result<(), String> {
     let mut files = Vec::new();
-    for name in ["meta-data", "user-data", "network-config"] {
+    // The agent binary (when present) rides the seed disk alongside the NoCloud
+    // files; cloud-init ignores it, the guest-agent seed profile installs it.
+    for name in [
+        "meta-data",
+        "user-data",
+        "network-config",
+        GUEST_AGENT_SEED_FILE,
+    ] {
         let p = seed_dir.join(name);
         if p.exists() {
             files.push(name.to_string());
@@ -49,6 +56,15 @@ fn create_seed_iso(seed_dir: &Path, output_iso: &Path) -> Result<(), String> {
     }
     Ok(())
 }
+
+/// Path the swiftletd image ships the in-guest identity agent binary at (see
+/// images/swiftletd/Containerfile). Copied onto the NoCloud seed disk for an
+/// agent-enabled source guest so its first-boot cloud-init can install it (the
+/// guest-agent SwiftSeedProfile mounts the cidata disk and installs from here).
+const GUEST_AGENT_IMAGE_BINARY: &str =
+    "/usr/local/share/kubeswift/guest-agent/kubeswift-guest-agent";
+/// Filename the agent binary lands under on the cidata seed disk.
+const GUEST_AGENT_SEED_FILE: &str = "kubeswift-guest-agent";
 
 const VERSION: &str = env!("KUBESWIFT_VERSION");
 const GIT_COMMIT: &str = env!("KUBESWIFT_GIT_COMMIT");
@@ -162,6 +178,22 @@ fn main() {
                     std::process::exit(1);
                 }
                 log::info!("nocloud_built path={}", nocloud_output.display());
+                // In-guest identity agent: a vsock device on the intent marks an
+                // agent-enabled guest (source AND clone, since a clone resolves off
+                // the source spec — keeps both seed.isos byte-identical, which the
+                // clone restore needs). Drop the agent binary onto the seed disk so
+                // the source's first-boot cloud-init (guest-agent SwiftSeedProfile)
+                // installs it. See docs/design/clone-identity-vsock-agent.md.
+                if intent.vsock.is_some() && Path::new(GUEST_AGENT_IMAGE_BINARY).exists() {
+                    let dst = nocloud_output.join(GUEST_AGENT_SEED_FILE);
+                    match std::fs::copy(GUEST_AGENT_IMAGE_BINARY, &dst) {
+                        Ok(n) => log::info!("seed_guest_agent_added bytes={}", n),
+                        Err(e) => log::warn!(
+                            "seed_guest_agent_copy_failed src={} err={} (clone identity regen will report GuestAgentUnreachable)",
+                            GUEST_AGENT_IMAGE_BINARY, e
+                        ),
+                    }
+                }
                 // CH expects disk image (ISO), not directory. Create seed.iso for cloud-init.
                 let seed_iso = runtime_dir.root().join("seed.iso");
                 if let Err(e) = create_seed_iso(&nocloud_output, &seed_iso) {


### PR DESCRIPTION
## Summary

Completes the **non-golden-image install path** for the in-guest identity agent — delivered via the **NoCloud seed disk**, chosen over the design's original virtiofs share after finding virtiofs would break the clone restore.

## Why not virtiofs

A virtiofs share is a **virtio-PCI device**, so attaching it to the **source** captures it in the snapshot. `run_ch_restore` doesn't spawn virtiofsd, so every clone restore would break on the orphaned vhost-user-fs backend (and virtiofs-across-`--restore` is unspiked). The seed disk is a normal block device the clone path already handles — **no captured PCI device, restore unaffected.**

## What changed

- **swiftletd (`main.rs`):** when the intent carries a vsock device (the agent-enabled marker — true for the source **and** a clone, since a clone resolves off the source spec, keeping the two `seed.iso`s **byte-identical** as the clone restore requires), copy the agent binary shipped in the swiftletd image (`/usr/local/share/kubeswift/guest-agent/`) onto the NoCloud seed dir; `create_seed_iso` includes it on the `cidata` ISO. Copy failure is a loud warn, never fatal (→ `GuestAgentUnreachable`).
- **`guest-agent` SwiftSeedProfile:** the `runcmd` now mounts the `cidata` disk by label and installs from it (was: mount a virtiofs share). Every step no-ops when the binary is absent (golden image / agent disabled).
- **Docs:** `identity-regeneration.md` — the seed-profile path now works with no golden image (set `guestAgent.enabled` + reference the profile). Design doc Q1 carries the correction (seed disk supersedes virtiofs, with the captured-device rationale).

## Test

swiftletd builds + 106 tests green; `cargo fmt` clean; **no Go change**. End-to-end validated in the upcoming cluster walkthrough (PR 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)