### PR TITLE
release: v0.4.4 — in-guest vsock identity agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.4.4] — 2026-06-16
+
+Feature release. The **in-guest vsock identity agent** — a `cloneFromSnapshot`
+clone now regenerates its identity (machine-id / SSH host keys / hostname / MAC)
+and re-DHCPs **in place, with no reboot**, sidestepping the Cloud-Hypervisor-v52
+clone-reboot firmware hang documented in v0.4.3. Cluster-validated end-to-end.
+
+### Added
+
+- **In-guest identity agent over vsock.** Opt a snapshot **source** in with
+  `spec.guestAgent.enabled: true`. The controller attaches a Cloud Hypervisor
+  `--vsock` device and (with the `guest-agent` SwiftSeedProfile) delivers a tiny
+  static agent binary onto the source's NoCloud seed disk, installed on first
+  boot. The agent is captured in the memory snapshot and resumes — alive — in
+  every clone. When a clone reaches `GuestRunning`, the SwiftGuest controller
+  drives a one-shot regeneration over the host↔guest vsock channel: it
+  regenerates the items in `cloneFromSnapshot.regenerate`, sets the per-clone
+  guest-visible MAC, and re-DHCPs — all without a reboot. The result is reported
+  on the new **`CloneIdentityRegenerated`** status condition (`True`, or `False`
+  with reason `GuestAgentUnreachable` when the agent is absent — a loud,
+  never-silent fallback), and each clone's own IP lands in
+  `status.network.primaryIP` via the restore lease-poller.
+  - New `cmd/kubeswift-guest-agent` (static Go AF_VSOCK listener; one
+    `regenerate-identity` op; validated argv inputs; primary-interface
+    detection), embedded in the swiftletd image and delivered via the seed disk.
+  - New `rust/swift-vsock-client` crate (the host-side CONNECT-handshake client)
+    + a swiftletd `identity` action namespace driving it.
+  - `SwiftGuest.spec.guestAgent.enabled` (opt-in on the source; Linux only).
+  - Design: [`docs/design/clone-identity-vsock-agent.md`](docs/design/clone-identity-vsock-agent.md);
+    operator guide:
+    [`docs/snapshots/identity-regeneration.md`](docs/snapshots/identity-regeneration.md)
+    + [`docs/snapshots/clone-from-snapshot.md`](docs/snapshots/clone-from-snapshot.md).
+  - Cluster-validated on **Tier B** (local) memory snapshots — a 2-clone fan-out
+    came up with distinct machine-id / hostname / MAC / IP per clone, no reboot.
+    **Tier C** (S3) clones inherit the identical agent flow (the snapshot carries
+    the agent + vsock device regardless of backend); validate in your environment.
+
+### Notes
+
+- No new container image or chart toggle: the agent ships inside the `swiftletd`
+  image and the opt-in is a SwiftGuest field. The `swift.kubeswift.io` CRD gains
+  `spec.guestAgent`; `kubectl apply`/`helm upgrade` updates it.
+- Windows guests (`osType: windows`) are out of scope for the agent in this
+  release (the regeneration mechanics differ); the controller skips the device.
+
+---
+
 ## [v0.4.3] — 2026-06-15
 
 Patch release. swiftletd lease-poller fix for cloneFromSnapshot guests, and a

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.4.3
-appVersion: "0.4.3"
+version: 0.4.4
+appVersion: "0.4.4"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,15 @@ The `docs/` directory also contains these focused reference documents:
 - [swiftguestpool-use-cases.md](swiftguestpool-use-cases.md) — GPU inference, CI/CD runners, VDI, telco NFV, batch/HPC
 - [api/swiftguestpool.md](api/swiftguestpool.md) — SwiftGuestPool API reference
 
+### Snapshots, clones & identity
+
+- [snapshots/fast-vms.md](snapshots/fast-vms.md) — Snapshots, restore, and instant clones overview
+- [snapshots/clone-from-snapshot.md](snapshots/clone-from-snapshot.md) — `cloneFromSnapshot`: fan out N VMs from one snapshot
+- [snapshots/identity-regeneration.md](snapshots/identity-regeneration.md) — Regenerate a clone's identity in place (the in-guest vsock agent)
+- [snapshots/local-snapshots.md](snapshots/local-snapshots.md) — Tier B (local) memory snapshots
+- [snapshots/s3-snapshots.md](snapshots/s3-snapshots.md) — Tier C (S3) cluster-portable snapshots
+- [snapshots/scheduled-snapshots.md](snapshots/scheduled-snapshots.md) — Cron-scheduled snapshots + keep-N retention
+
 ### Kernel boot
 
 - [swiftkernel.md](swiftkernel.md) — SwiftKernel full reference: node setup, profiles, OCI packaging

--- a/images/swiftletd/Containerfile
+++ b/images/swiftletd/Containerfile
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # internal/snapshot/configjson — the source-of-truth for the narrow
 # config.json edits applied to a Tier B clone (see commits 12/13).
 FROM golang:1.25-bookworm AS go-builder
+ARG VERSION=dev
 WORKDIR /go-build
 COPY go.mod go.sum ./
 RUN go mod download
@@ -49,11 +50,13 @@ COPY api ./api
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/snapshot-stager ./cmd/snapshot-stager
 # kubeswift-guest-agent: the in-guest identity agent. It is NOT run by the
 # launcher pod — it is a static binary embedded here so it can be installed
-# INSIDE a source guest (via the guest-agent SwiftSeedProfile's virtiofs share
-# in PR 2, or a golden-image bake) and captured into the memory snapshot. CGO
-# off so it runs on any glibc/musl guest. See
-# docs/design/clone-identity-vsock-agent.md.
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/kubeswift-guest-agent ./cmd/kubeswift-guest-agent
+# INSIDE a source guest (via the guest-agent SwiftSeedProfile's NoCloud seed
+# disk, or a golden-image bake) and captured into the memory snapshot. CGO off
+# so it runs on any glibc/musl guest; -X main.version stamps the release version
+# (reported back on the agent's ping). See docs/design/clone-identity-vsock-agent.md.
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
+    -ldflags "-X main.version=${VERSION}" \
+    -o /out/kubeswift-guest-agent ./cmd/kubeswift-guest-agent
 
 # Runtime stage
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary

Cuts **v0.4.4**, a feature release for the **in-guest vsock identity agent** (the full arc #228–#233, already merged + cluster-validated). A `cloneFromSnapshot` clone now regenerates its identity (machine-id / SSH host keys / hostname / MAC) and re-DHCPs **in place, no reboot**, sidestepping the CH v52 clone-reboot firmware hang documented in v0.4.3.

## Changes

- **`charts/kubeswift/Chart.yaml`** — version + appVersion `0.4.3` → `0.4.4`.
- **`CHANGELOG.md`** — v0.4.4 entry (the agent; Tier B validated, Tier C inherits the same flow).
- **`images/swiftletd/Containerfile`** — stamp the guest-agent binary with the release version (`-X main.version=${VERSION}`; `ARG VERSION` re-declared in the go-builder stage so the existing build-arg reaches it — previously the agent reported `agentVersion: "dev"`). Also corrected the stale "virtiofs share" delivery comment to the NoCloud seed disk.
- **`docs/README.md`** — new "Snapshots, clones & identity" index section surfacing the agent docs.

## Not changed (verified)

- **No build-workflow change** — the agent is built inside the swiftletd Containerfile and embedded in that image; no new image, no new ghcr package, no release-matrix entry.
- **No new chart value/toggle** — the agent rides the swiftletd image; the opt-in is `SwiftGuest.spec.guestAgent.enabled` (a CR field). The `swift.kubeswift.io` CRD already carries `spec.guestAgent` (synced to `charts/kubeswift/crds/`).

## Pre-flight

`go build ./...` clean · `make generate` clean (no CRD drift) · the version-stamp ldflag verified to inject. Tagging `v0.4.4` after merge triggers `release-stable.yaml` (6 images + cosign + OCI chart + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)