### PR TITLE
fix(migration): preserve Multus networks annotation on the live-migration dst pod

### DIFF
--- a/internal/controller/swiftmigration/dst_pod.go
+++ b/internal/controller/swiftmigration/dst_pod.go
@@ -10,6 +10,7 @@ import (
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
 )
 
 // Pod label keys / values for the destination launcher pod. Per design
@@ -260,29 +261,42 @@ func mergeLabelsForDst(srcLabels map[string]string, guestName, migName string) m
 }
 
 // mergeAnnotationsForDst returns a fresh map containing only the
-// migration-relevant annotations. The src pod's annotations are
+// migration-relevant annotations. The src pod's annotations are mostly
 // dropped intentionally: they include kubeswift.io/guest-ip and other
 // runtime status the dst's swiftletd will repopulate, plus operator
 // annotations that don't transfer to the dst pod cleanly.
 //
-// The Phase 2 plaintext-ack annotation is set ONLY on the plaintext
-// path. Under mTLS (Phase 3c) the channel is TLS, swiftletd bypasses the
-// ack gate in secured mode (KUBESWIFT_MIGRATION_MTLS=1), and emitting an
-// "unsafe-plaintext: ack" annotation on a TLS-secured pod is misleading.
-// So when mtlsEnabled we omit it. This is safe from version skew: mTLS
-// only ever runs against the Phase 3c swiftletd (same release that added
-// the secured-mode bypass), so no in-flight migration sees an old
-// swiftletd that still requires the ack.
+// EXCEPTION — the Multus networks REQUEST annotation MUST transfer. It is
+// boot-time config (which NADs to attach), not runtime status. A guest whose
+// primary rides a multi-node-L2 NAD (primary-on-NAD) — or any guest with a
+// secondary NAD NIC — needs the dst pod to request the same interfaces, or
+// network-init's setup_primary_nad_nic / setup_secondary_nic wait forever for a
+// `net1` that never plumbs and the dst pod never reaches Ready (the migration
+// fails DstNeverReady). Offline migration is unaffected: it rebuilds the pod via
+// the SwiftGuest pod builder, which re-adds this annotation from spec.interfaces;
+// the live path clones the src pod through here, so this allowlist is the only
+// place it can be preserved. (Found in the multi-node-L2 validation spike — the
+// original allowlist predated primary-on-NAD; same default-to-explicit lesson as
+// PR #26 / W26.)
 //
-// The key is NOT deleted outright: the plaintext path still uses the ack
-// gate as the THREAT-MODEL's "operator acknowledged cleartext" guard.
+// The Phase 2 plaintext-ack annotation is set ONLY on the plaintext path. Under
+// mTLS (Phase 3c) the channel is TLS, swiftletd bypasses the ack gate in secured
+// mode (KUBESWIFT_MIGRATION_MTLS=1), and emitting an "unsafe-plaintext: ack"
+// annotation on a TLS-secured pod is misleading. So when mtlsEnabled we omit it.
+// This is safe from version skew: mTLS only ever runs against the Phase 3c
+// swiftletd (same release that added the secured-mode bypass), so no in-flight
+// migration sees an old swiftletd that still requires the ack. The key is NOT
+// deleted outright: the plaintext path still uses the ack gate as the
+// THREAT-MODEL's "operator acknowledged cleartext" guard.
 func mergeAnnotationsForDst(srcAnnotations map[string]string, mtlsEnabled bool) map[string]string {
-	if mtlsEnabled {
-		return map[string]string{}
+	out := map[string]string{}
+	if v, ok := srcAnnotations[swiftguest.MultusAnnotationKey]; ok && v != "" {
+		out[swiftguest.MultusAnnotationKey] = v
 	}
-	return map[string]string{
-		AnnotationMigrationPhase2Ack: AnnotationMigrationPhase2AckValue,
+	if !mtlsEnabled {
+		out[AnnotationMigrationPhase2Ack] = AnnotationMigrationPhase2AckValue
 	}
+	return out
 }
 
 // addReceiverEnvToLauncher mutates the pod's launcher container to

--- a/internal/controller/swiftmigration/dst_pod_test.go
+++ b/internal/controller/swiftmigration/dst_pod_test.go
@@ -10,6 +10,7 @@ import (
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
 )
 
 // templateSrcPod builds a minimal source-pod fixture suitable for
@@ -213,6 +214,50 @@ func TestNewDstPod_NoLauncherContainer_Errors(t *testing.T) {
 
 	if _, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, ""); err == nil {
 		t.Errorf("expected error when launcher container is missing")
+	}
+}
+
+// TestNewDstPod_PreservesMultusAnnotation locks in the multi-node-L2 spike fix:
+// the dst pod MUST carry the Multus networks REQUEST so a NAD-attached guest
+// (primary-on-NAD multi-node L2, or a secondary multi-NIC) gets its interfaces
+// on the dst node. Regression: under mTLS the annotation allowlist returned an
+// empty map and dropped it, so network-init waited forever for `net1` and the
+// dst pod never reached Ready -> the migration failed DstNeverReady. Runtime
+// status (guest-ip) must still be dropped.
+func TestNewDstPod_PreservesMultusAnnotation(t *testing.T) {
+	const nets = `[{"name":"ksl2-a","namespace":"default","interface":"net1"}]`
+	for _, tc := range []struct {
+		name string
+		mtls bool
+	}{
+		{"mtls", true}, // the case that was broken
+		{"plaintext", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := testScheme(t)
+			mig := newMigrationWithUID("mig-a", "default", "abcdef1234567890abcdef1234567890")
+			mig.Spec.Target.NodeName = "miles"
+			guest := &swiftv1alpha1.SwiftGuest{
+				ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
+			}
+			src := templateSrcPod("guest", "default")
+			src.Annotations[swiftguest.MultusAnnotationKey] = nets
+
+			dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
+				mtlsEnabled: tc.mtls,
+				srcNodeName: "boba",
+				dstNodeName: "miles",
+			}, "")
+			if err != nil {
+				t.Fatalf("newDstPod: %v", err)
+			}
+			if got := dst.Annotations[swiftguest.MultusAnnotationKey]; got != nets {
+				t.Errorf("dst pod must preserve the Multus networks annotation; want %q, got %q", nets, got)
+			}
+			if _, ok := dst.Annotations["kubeswift.io/guest-ip"]; ok {
+				t.Errorf("dst pod must NOT carry runtime-status annotation kubeswift.io/guest-ip")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Live migration of any **NAD-attached guest** fails with `DstNeverReady`: the
destination pod comes up with only the default pod network, `network-init` waits
forever for a `net1` that never plumbs, and the migration times out.

**Root cause:** `mergeAnnotationsForDst` (in `internal/controller/swiftmigration/dst_pod.go`)
rebuilds the dst pod's annotations from an allowlist — and under **mTLS it returned
an empty map**, dropping the `k8s.v1.cni.cncf.io/networks` Multus request. Without
it the dst pod never asks for its NAD interfaces, so `setup_primary_nad_nic` /
`setup_secondary_nic` block and the pod never reaches Ready.

## Breadth

This breaks live migration for **every NAD-using guest** — both **primary-on-NAD**
(multi-node L2 / IP-preserving migration) and **secondary multi-NIC** guests. It
stayed hidden because no prior live-migration validation used a NAD-attached guest.
**Offline migration is unaffected**: it rebuilds the pod via the SwiftGuest pod
builder, which re-adds the annotation from `spec.interfaces` (which is exactly why
offline IP-preservation passed and live didn't during the multi-node-L2 spike).

Same default-to-explicit lesson as PR #26 / W26: an allowlist written before a
feature existed silently drops what that feature needs.

## Fix

`mergeAnnotationsForDst` now preserves `swiftguest.MultusAnnotationKey` from the
source pod in both the mTLS and plaintext paths. Runtime-status annotations
(`kubeswift.io/guest-ip`, etc.) are still dropped as before.

Regression test `TestNewDstPod_PreservesMultusAnnotation` covers both mTLS and
plaintext and is load-bearing against the old empty-map behavior.

## How it was found

The multi-node-L2 runtime-datapath validation spike (the first live migration of a
primary-on-NAD guest). Datapath, cross-node L2 reachability, and **offline**
migration IP-preservation all validated on-cluster; live migration surfaced this.

## Verification

- `gofmt -s` clean; `go build ./...` OK; full `swiftmigration` suite green.
- On-cluster live-migration re-validation of a primary-on-NAD guest to follow on
  the post-merge dev image (CI publishes images on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)