### PR TITLE
fix(migration): retry live-migration send when the dst CH receiver isn't listening yet

### DIFF
--- a/internal/controller/swiftmigration/source_mtls.go
+++ b/internal/controller/swiftmigration/source_mtls.go
@@ -84,6 +84,31 @@ func isLocalStunnelNotReady(detail string) bool {
 	return strings.HasPrefix(d, "send_migration:") && strings.Contains(d, "connection_refused")
 }
 
+// isDestReceiverNotReady reports whether a src-side migration-status-detail
+// indicates the DESTINATION CH receiver had not yet bound its listener when
+// the src CH tried to send. Under mTLS the src CH dials its (up) LOCAL stunnel,
+// which forwards to the dst stunnel -> dst CH `vm.receive-migration`
+// (127.0.0.1:6790 on the dst). If the dst CH receiver hasn't called
+// receive-migration yet, the dst stunnel cannot forward and resets; the src
+// local stunnel resets the loopback with 0 bytes sent; CH surfaces a generic
+// Status-500 that swiftletd sanitizes to "internal_server_error". Because the
+// channel never carried data, re-issuing the send is safe.
+//
+// This is distinct from a dst *disappearance* mid-transfer (data had flowed),
+// which surfaces as "transport_error" and is a genuine failure (excluded here).
+// The caller MUST additionally gate on the dst pod NOT terminating so the W18
+// dst-K8s-termination case (same "internal_server_error" symptom, but the dst
+// is going away) is never mistaken for a not-ready-yet race.
+//
+// The race bites primary-on-NAD guests: the NAD dst pod's network-init runs the
+// multi-node-L2 datapath, making it slower to reach receive-migration, so the
+// controller's PreSend can out-run the dst receiver. Non-NAD dst pods get ready
+// fast enough to win the race. Found in the multi-node-L2 validation spike.
+func isDestReceiverNotReady(detail string) bool {
+	d := strings.ToLower(strings.TrimSpace(detail))
+	return strings.HasPrefix(d, "send_migration:") && strings.Contains(d, "internal_server_error")
+}
+
 // stampSourceMigrationInputs idempotently patches the dst-ip / peer-san
 // annotations onto the source pod. The SwiftGuest controller's downward-API
 // volume projects these into files the idle client sidecar polls; stamping

--- a/internal/controller/swiftmigration/source_mtls_test.go
+++ b/internal/controller/swiftmigration/source_mtls_test.go
@@ -37,6 +37,31 @@ func TestIsLocalStunnelNotReady(t *testing.T) {
 	}
 }
 
+// TestIsDestReceiverNotReady covers the primary-on-NAD send-retry case found in
+// the multi-node-L2 spike: the dst CH receiver hadn't bound its listener yet, so
+// the src send reset early and CH surfaced a generic Status-500 →
+// "internal_server_error". This is retryable (no data flowed, dst still alive);
+// it must NOT collide with the src-local case or the dst-gone transport_error.
+func TestIsDestReceiverNotReady(t *testing.T) {
+	cases := []struct {
+		detail string
+		want   bool
+	}{
+		{"send_migration: internal_server_error", true},
+		{"SEND_MIGRATION: INTERNAL_SERVER_ERROR", true},     // case-insensitive
+		{"send_migration: transport_error", false},          // dst-gone mid-transfer, not a not-ready race
+		{"send_migration: connection_refused", false},       // that is the src-local-stunnel case
+		{"receive_migration: internal_server_error", false}, // dst-side verb, not the src send
+		{"", false},
+		{"some other error", false},
+	}
+	for _, tc := range cases {
+		if got := isDestReceiverNotReady(tc.detail); got != tc.want {
+			t.Errorf("isDestReceiverNotReady(%q)=%v, want %v", tc.detail, got, tc.want)
+		}
+	}
+}
+
 // --- target_url repoint (substatePreSend) --------------------------------
 
 func setupPreSend(t *testing.T, mtls bool) (*SwiftMigrationReconciler, *corev1.Pod) {
@@ -180,6 +205,35 @@ func TestStopAndCopyLive_SrcFailed_MTLS_DstTerminating_NoRetry(t *testing.T) {
 	res := r.handleStopAndCopyLive(context.Background(), mig, status)
 	if res.FailureReason == "" {
 		t.Fatalf("terminating dst must not be retried; expected failure")
+	}
+}
+
+func TestStopAndCopyLive_SrcFailed_MTLS_DestReceiverNotReady_RetriesSend(t *testing.T) {
+	// Multi-node-L2 spike fix: internal_server_error with the dst pod ALIVE is the
+	// dst-CH-receiver-not-ready race (early reset, no data flowed) — must retry.
+	r, mig := srcFailedReconciler(t, true, 1, "send_migration: internal_server_error", false)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureMsg != "" || res.FailureReason != "" {
+		t.Fatalf("expected retry (no failure); got msg=%q reason=%q", res.FailureMsg, res.FailureReason)
+	}
+	if res.Requeue == 0 {
+		t.Errorf("expected requeue on retry")
+	}
+	if status.SendAttempts != 2 {
+		t.Errorf("SendAttempts: want 2 (bumped for retry), got %d", status.SendAttempts)
+	}
+}
+
+func TestStopAndCopyLive_SrcFailed_MTLS_InternalServerError_DstTerminating_NoRetry(t *testing.T) {
+	// The W18 gate: internal_server_error while the dst is TERMINATING is a genuine
+	// dst-K8s-termination (shares the symptom but the dst is going away) — must fail,
+	// NOT be mistaken for the not-ready-yet race.
+	r, mig := srcFailedReconciler(t, true, 1, "send_migration: internal_server_error", true)
+	status := mig.Status.DeepCopy()
+	res := r.handleStopAndCopyLive(context.Background(), mig, status)
+	if res.FailureReason == "" {
+		t.Fatalf("terminating dst must not be retried even on internal_server_error; expected failure")
 	}
 }
 

--- a/internal/controller/swiftmigration/stopandcopy_live.go
+++ b/internal/controller/swiftmigration/stopandcopy_live.go
@@ -543,29 +543,44 @@ func (r *SwiftMigrationReconciler) handleStopAndCopyLive(
 		if srcArg != nil {
 			detail = srcArg.Annotations[AnnotationMigrationStatusDtl]
 		}
-		// Phase 3d — bounded retry for the mTLS source-sidecar readiness
-		// race. With mTLS on, target_url is the LOCAL stunnel client
-		// (127.0.0.1:6790); a "send_migration: connection_refused" means
-		// the client sidecar hasn't finished idle-polling its inputs and
-		// brought stunnel up yet (CH couldn't connect to localhost). The
-		// src CH never reached the dst, so NO migration data flowed and
-		// re-issuing is safe. The dst is still receive-ready (it never saw
-		// a connection), so bumping SendAttempts yields a fresh $SEND_ID
-		// that re-drives substatePreSend on the next reconcile. Bounded by
-		// maxMTLSSendRetries; the overall spec.timeout is the hard cap.
-		// Gated on dst NOT terminating so a genuine dst-gone failure (which
-		// surfaces as transport_error, not connection_refused) is never
-		// mistaken for sidecar-not-ready.
-		if r.MigrationMTLSEnabled && isLocalStunnelNotReady(detail) &&
+		// Phase 3d — bounded retry for the mTLS migration-channel readiness
+		// races. With mTLS on, target_url is the LOCAL stunnel client
+		// (127.0.0.1:6790). Two "not-ready-yet" failures leave the channel
+		// never established, so NO migration data flowed and re-issuing the
+		// send is safe (bumping SendAttempts yields a fresh $SEND_ID that
+		// re-drives substatePreSend on the next reconcile):
+		//   - SOURCE sidecar not ready: CH couldn't connect to the local
+		//     stunnel (it hasn't started yet) -> "connection_refused".
+		//   - DESTINATION receiver not ready: the local stunnel is up but the
+		//     dst CH hasn't called vm.receive-migration yet, so the dst
+		//     stunnel resets the forward and CH sees a generic Status-500 ->
+		//     "internal_server_error". This is the primary-on-NAD race (the
+		//     NAD dst pod's network-init runs the multi-node-L2 datapath and
+		//     is slower to reach receive-migration; non-NAD dst pods win the
+		//     race). Found in the multi-node-L2 validation spike.
+		// Bounded by maxMTLSSendRetries; spec.timeout is the hard cap. BOTH
+		// are gated on dst NOT terminating, so a genuine dst-gone failure
+		// (transport_error after data flowed, or W18 dst-K8s-termination which
+		// shares the internal_server_error symptom but is going away) is never
+		// mistaken for a not-ready-yet race.
+		srcNotReady := isLocalStunnelNotReady(detail)
+		dstNotReady := isDestReceiverNotReady(detail)
+		if r.MigrationMTLSEnabled && (srcNotReady || dstNotReady) &&
 			dstPod.DeletionTimestamp == nil && sendAttemptNumber(mig) < maxMTLSSendRetries {
 			status.SendAttempts = sendAttemptNumber(mig) + 1
-			setPhaseDetail(status, "source mTLS sidecar not ready; retrying send")
-			setReadyCondition(status, metav1.ConditionFalse, ReasonStopAndCopy,
-				"waiting for source mTLS sidecar to become ready; retrying send")
+			detailMsg := "source mTLS sidecar not ready; retrying send"
+			condMsg := "waiting for source mTLS sidecar to become ready; retrying send"
+			eventMsg := "source mTLS sidecar not yet listening (attempt %d/%d); re-issuing send"
+			if dstNotReady && !srcNotReady {
+				detailMsg = "destination receiver not ready; retrying send"
+				condMsg = "waiting for destination CH receiver to bind its listener; retrying send"
+				eventMsg = "destination receiver not yet listening (attempt %d/%d); re-issuing send"
+			}
+			setPhaseDetail(status, detailMsg)
+			setReadyCondition(status, metav1.ConditionFalse, ReasonStopAndCopy, condMsg)
 			if r.Recorder != nil {
 				r.Recorder.Eventf(mig, corev1.EventTypeNormal, "SendRetry",
-					"source mTLS sidecar not yet listening (attempt %d/%d); re-issuing send",
-					sendAttemptNumber(mig), maxMTLSSendRetries)
+					eventMsg, sendAttemptNumber(mig), maxMTLSSendRetries)
 			}
 			return phaseRequeue(stopAndCopyLivePollInterval)
 		}


### PR DESCRIPTION
## Summary

Primary-on-NAD live migration fails intermittently (`RpcError` / fast
`PodTerminated`) on a **destination-CH-receiver-not-ready race**.

**Root cause** (found in the multi-node-L2 validation spike): a NAD destination pod
runs the multi-node-L2 datapath in `network-init`, so it is slower to reach
`vm.receive-migration` than a node-local guest. The controller's StopAndCopy
`PreSend` can out-run the dst receiver: the src CH dials its (up) local stunnel,
which can't yet forward to the not-listening dst, resets the loopback with **0 bytes
sent**, and CH surfaces a generic `Status-500` → swiftletd sanitizes it to
`internal_server_error`. The existing bounded send-retry only matched
`connection_refused` (the *source*-sidecar-not-ready race), so this *destination*
race fell straight through to failure.

Non-NAD dst pods get ready fast enough to win the race — which is why only NAD guests
hit it, and why prior live-migration validation (all non-NAD) never saw it.

**Isolating evidence:** a non-NAD live migration on the same cluster Completed in
~3s; a repro pod with the exact NAD dst-pod networking is reachable cross-node; the
dst swiftletd logs show it *does* enter receiver mode and spawn CH-receive. The
failure is a timing race, not reachability or substrate.

## Fix (controller-only)

Treat `send_migration: internal_server_error` **while the dst pod is ALIVE** as the
dst-receiver-not-ready race and re-issue the send (new `isDestReceiverNotReady`,
OR'd into the existing `maxMTLSSendRetries`-bounded retry). The channel never carried
data (0 bytes), so re-issuing is safe.

Already gated on `dstPod.DeletionTimestamp == nil`, so:
- W18 dst-K8s-termination (same `internal_server_error` symptom, but the dst is going
  away) still fails correctly.
- A genuine mid-transfer dst loss surfaces as `transport_error` and is still not
  retried.

## Tests

`isDestReceiverNotReady` classifier table; dst-alive `internal_server_error` retries
(SendAttempts bumped); dst-terminating `internal_server_error` still fails (W18 gate
preserved). gofmt clean; full `swiftmigration` suite green.

Companion to #235 (the multus-annotation fix that got NAD live migration *to* the
transfer stage). Cluster re-validation of primary-on-NAD live-migration completion
follows on the post-merge dev image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)