### PR TITLE
fix(network): harden primary-on-NAD dnsmasq for a shared multi-node L2

### DIFF
--- a/rust/swiftletd/scripts/launcher-entrypoint.sh
+++ b/rust/swiftletd/scripts/launcher-entrypoint.sh
@@ -59,15 +59,28 @@ if network_enabled; then
     nad_env="$lease_dir/primary-nad.env"
     if [ -f "$nad_env" ]; then
         # shellcheck disable=SC1090
-        . "$nad_env"   # NAD_IP, NAD_PREFIX, NAD_GW, NAD_MAC, NAD_BRIDGE
+        . "$nad_env"   # NAD_IP, NAD_PREFIX, NAD_GW, NAD_MAC, NAD_BRIDGE, NAD_MTU
         dns=$(grep '^nameserver ' /etc/resolv.conf 2>/dev/null | head -1 | awk '{print $2}')
         [ -z "$dns" ] && dns="10.96.0.10"
-        echo "Primary-on-NAD dnsmasq: handing $NAD_IP to $NAD_MAC on $NAD_BRIDGE (gw $NAD_GW)"
+        echo "Primary-on-NAD dnsmasq: handing $NAD_IP to $NAD_MAC on $NAD_BRIDGE (gw $NAD_GW, mtu ${NAD_MTU:-default})"
+        # Multiple primary-on-NAD pods can share ONE flat multi-node L2, so each
+        # pod's in-pod dnsmasq sees the OTHER guests' DHCP broadcasts and every pod
+        # binds a helper IP on the same subnet. Two guards make that safe (the
+        # multi-node-L2 validation spike, finding F-S2.3):
+        #   --dhcp-ignore=tag:!known -> answer ONLY this guest's MAC, so a sibling
+        #     pod's dnsmasq never NAKs/answers another guest's DISCOVER on the L2.
+        #   infinite lease -> the guest never renews, so the helper-IP server-id
+        #     (ambiguous when >1 pod holds it on the shared L2) is never contacted.
+        # Reachability is unaffected -- the guest talks via its NAD IP + gateway,
+        # never the helper. option:mtu carries the overlay MTU so encapsulation
+        # overhead does not silently drop the guest's full-size frames.
         dnsmasq --no-daemon --bind-interfaces --interface="$NAD_BRIDGE" \
-            --dhcp-range="$NAD_IP,$NAD_IP" \
+            --dhcp-range="$NAD_IP,$NAD_IP,infinite" \
             ${NAD_MAC:+--dhcp-host="$NAD_MAC,$NAD_IP"} \
+            ${NAD_MAC:+--dhcp-ignore=tag:!known} \
             ${NAD_GW:+--dhcp-option=option:router,"$NAD_GW"} \
             --dhcp-option=option:dns-server,"$dns" \
+            ${NAD_MTU:+--dhcp-option=option:mtu,"$NAD_MTU"} \
             --dhcp-leasefile="$lease_dir/dnsmasq.leases" \
             --dhcp-authoritative &
         sleep 1

--- a/rust/swiftletd/scripts/network-init.sh
+++ b/rust/swiftletd/scripts/network-init.sh
@@ -191,6 +191,11 @@ setup_primary_nad_nic() {
     nad_gw=$(ip route show default 2>/dev/null | awk -v d="$multus_iface" '$0 ~ ("dev "d){print $3; exit}')
     [ -z "$nad_gw" ] && nad_gw=$(ip route show dev "$multus_iface" 2>/dev/null | awk '/default/{print $3; exit}')
 
+    # The NAD interface's MTU (set by the CNI -- e.g. 1450 on a VXLAN overlay).
+    # Handed to the guest via DHCP so an overlay's encapsulation overhead does not
+    # silently drop the guest's full-size frames.
+    nad_mtu=$(ip -o link show "$multus_iface" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="mtu"){print $(i+1); exit}}')
+
     # Persist for the launcher entrypoint (shared run dir).
     rd=$(guest_run_dir); mkdir -p "$rd"
     {
@@ -199,6 +204,7 @@ setup_primary_nad_nic() {
         echo "NAD_GW=$nad_gw"
         echo "NAD_MAC=$guest_mac"
         echo "NAD_BRIDGE=$bridge"
+        echo "NAD_MTU=$nad_mtu"
     } > "$rd/primary-nad.env"
 
     # The guest claims nad_ip; the host must not also hold it on the L2.


### PR DESCRIPTION
## Summary

On a flat multi-node L2, every primary-on-NAD launcher pod runs its own in-pod
dnsmasq and binds a helper IP on the same subnet, so guests' DHCP traffic crosses
pods. The multi-node-L2 validation spike **empirically confirmed** (finding F-S2.3):
`arping 10.77.0.254` got replies from **two different MACs** — two guests' `br0`
helpers both answering on the shared overlay. Guest↔guest reachability is
unaffected (guests talk via their NAD IP + gateway, never the helper), but DHCP
lease **renewal** is at risk: the guest's server-identifier is the ambiguous helper
IP, so a renewal unicast can land on the wrong pod's dnsmasq.

## Fix (swiftletd: network-init.sh + launcher-entrypoint.sh)

- `--dhcp-ignore=tag:!known` — each dnsmasq answers ONLY its own guest's MAC, so a
  sibling pod's dnsmasq never interferes with another guest's DISCOVER on the L2.
- infinite lease — the guest never renews, so the ambiguous helper-IP server-id is
  never contacted. (No unique-per-pod helper needed; these two guards make the
  shared-L2 multi-guest case safe.)
- `option:mtu` (NAD_MTU, persisted by network-init from the NAD interface) — carries
  the overlay MTU (e.g. 1450 on VXLAN) so encapsulation overhead doesn't silently
  drop the guest's full-size frames.

## Validation

`sh -n` clean on both scripts. The `.254` collision driving this is empirically
confirmed (the spike arping); the multi-guest-renewal *consequence* is reasoned, and
full cluster validation of it is infra-gated along with the rest of multi-node L2
(needs an OVN-K Tier-C lab — see `network-architecture-requirements.md` §6). Companion
to #235 + #236 (the live-migration NAD fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)