### PR TITLE
docs(network): de-experimentalize multi-node L2 with the honest validation outcome

### DIFF
--- a/config/samples/migratable-guests/03-ip-preserving-live-migratable.yaml
+++ b/config/samples/migratable-guests/03-ip-preserving-live-migratable.yaml
@@ -17,9 +17,12 @@
 #   kubectl apply -f ../multi-node-l2/ovn-l2-nad.yaml    # the `ovn-l2` NAD
 #   a Ready SwiftImage `ubuntu-noble`.
 #
-# NOTE: the primary-on-NAD runtime datapath is experimental (control-plane —
-# admission + migration IP-preservation classification — is shipped; the
-# datapath validates on an OVN-Kubernetes cluster). See ../multi-node-l2/.
+# STATUS: the primary-on-NAD datapath + OFFLINE migration IP-preservation are
+# cluster-validated. End-to-end LIVE-migration IP-preservation is OVN-K-gated
+# (the `ovn-l2` NAD here is the right one for it). On a hand-rolled mesh the live
+# path hits a multi-homed-pod issue — see the validation matrix in
+# docs/networking/multi-node-l2.md. For a guaranteed-IP move today, use offline
+# migration (swiftctl migrate ... --mode offline).
 #
 # Migrate it:  swiftctl migrate ip-stable-vm --to <node>
 # (no --allow-ip-change needed — the primary IP is preserved.)

--- a/config/samples/multi-node-l2/bridge-nad.yaml
+++ b/config/samples/multi-node-l2/bridge-nad.yaml
@@ -1,0 +1,45 @@
+# Recipe B NAD — a Multus `bridge` NAD on the VXLAN-mesh bridge (br-ksl2 from
+# vxlan-mesh-daemonset.yaml). A primary-on-NAD SwiftGuest referencing this NAD
+# gets a portable IP on the mesh L2.
+#
+# IPAM: `host-local` is per-NODE and does NOT coordinate across nodes, so two
+# nodes would hand out the same address on the shared L2. Options:
+#   - whereabouts (cluster-wide IPAM) for a multi-IP pool (recommended for >1 guest);
+#   - per-node non-overlapping host-local rangeStart/rangeEnd (operator-managed);
+#   - a single-IP range (below) to PIN one guest's IP across nodes (migration-stable).
+# Match `mtu` to the mesh MTU so the pod veth doesn't exceed the overlay.
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ksl2
+  namespace: default
+spec:
+  config: |
+    {
+      "cniVersion": "0.4.0",
+      "name": "ksl2",
+      "type": "bridge",
+      "bridge": "br-ksl2",
+      "mtu": 1450,
+      "ipam": {
+        "type": "host-local",
+        "subnet": "10.77.0.0/24",
+        "rangeStart": "10.77.0.11",
+        "rangeEnd": "10.77.0.11"
+      }
+    }
+---
+# A guest whose PRIMARY rides the mesh NAD (portable IP, no allowIPChange on migrate).
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: portable-ip-guest
+  namespace: default
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: default }
+  seedProfileRef: { name: default }
+  interfaces:
+    - name: app
+      primary: true
+      networkRef: { name: ksl2 }

--- a/config/samples/multi-node-l2/swiftguest-primary-on-nad.yaml
+++ b/config/samples/multi-node-l2/swiftguest-primary-on-nad.yaml
@@ -1,8 +1,11 @@
 # A guest whose PRIMARY IP rides a multi-node L2 NAD, so the IP is portable
-# across nodes (e.g. for IP-preserving live migration). Pair with the ovn-l2 NAD.
+# across nodes (e.g. for IP-preserving migration). Pair with the ovn-l2 NAD
+# (Recipe A) or the mesh bridge NAD (Recipe B) — see docs/networking/multi-node-l2.md.
 #
-# NOTE: the runtime datapath for primary-on-NAD is landing in follow-up PRs; the
-# control-plane (admission + migration IP-preservation classification) is shipped.
+# STATUS: the datapath + offline migration IP-preservation are cluster-validated.
+# End-to-end LIVE-migration IP-preservation is OVN-K-gated (use Recipe A / OVN-K
+# layer-2 for it; the hand-rolled mesh validates offline but not live). See the
+# validation matrix in docs/networking/multi-node-l2.md.
 apiVersion: swift.kubeswift.io/v1alpha1
 kind: SwiftGuest
 metadata:

--- a/config/samples/multi-node-l2/vxlan-mesh-daemonset.yaml
+++ b/config/samples/multi-node-l2/vxlan-mesh-daemonset.yaml
@@ -1,0 +1,75 @@
+# Recipe B substrate — hand-rolled VXLAN-mesh multi-node L2 (lab / on-prem).
+#
+# Builds, on every node, a VXLAN uplink (vxksl2) + a host bridge (br-ksl2) and
+# unicast-meshes them into one flat L2 that spans different-subnet nodes. A
+# Multus `bridge` NAD (see bridge-nad.yaml) then attaches launcher pods to
+# br-ksl2. Validated for the primary-on-NAD datapath + offline migration
+# IP-preservation; NOT for end-to-end live migration (see docs/networking/multi-node-l2.md).
+#
+# THREE LOAD-BEARING RULES (each cost a debugging cycle in the validation spike):
+#   1. dstport MUST differ from the cluster CNI's VXLAN port. Calico uses 4789;
+#      sharing it BREAKS Calico's cross-node pod networking. 8472 below assumes a
+#      Calico cluster — on flannel (which uses 8472) pick another free UDP port,
+#      and confirm it is open between nodes.
+#   2. Every node hosting a primary-on-NAD guest (or a migration target) MUST run
+#      Multus, else the NAD never plumbs (`network-init: net1 not found`).
+#   3. Set NODE_IPS below to the InternalIPs of ALL participating nodes (the mesh
+#      FDB is built from this list; each pod skips its own).
+#
+# SECURITY: the mesh carries guest L2 frames unencrypted over the node underlay.
+# On an untrusted underlay, run it over a WireGuard/IPsec node mesh.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ksl2-mesh
+  namespace: kube-system
+  labels: { app: ksl2-mesh }
+spec:
+  selector:
+    matchLabels: { app: ksl2-mesh }
+  template:
+    metadata:
+      labels: { app: ksl2-mesh }
+    spec:
+      hostNetwork: true
+      tolerations:
+        - operator: Exists   # span control-plane + tainted nodes too
+      containers:
+        - name: mesh
+          image: nicolaka/netshoot:latest   # any image with iproute2 (ip + bridge)
+          securityContext:
+            privileged: true
+            capabilities: { add: ["NET_ADMIN"] }
+          env:
+            - name: MY_HOST_IP
+              valueFrom: { fieldRef: { fieldPath: status.hostIP } }
+            # RULE 3: comma/space-separated InternalIPs of ALL participating nodes.
+            - name: NODE_IPS
+              value: "REPLACE_WITH node1ip node2ip node3ip"
+            - name: VXLAN_PORT   # RULE 1: must NOT equal the CNI's VXLAN port (Calico=4789)
+              value: "8472"
+            - name: VNI
+              value: "100"
+            - name: MESH_MTU     # underlay MTU - 50 (VXLAN overhead)
+              value: "1450"
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              SELF="$MY_HOST_IP"
+              ip link del vxksl2 2>/dev/null || true
+              ip link add vxksl2 type vxlan id "$VNI" local "$SELF" dstport "$VXLAN_PORT"
+              ip link set vxksl2 mtu "$MESH_MTU"
+              ip link add br-ksl2 type bridge 2>/dev/null || true
+              ip link set br-ksl2 mtu "$MESH_MTU"
+              ip link set vxksl2 master br-ksl2
+              ip link set vxksl2 up
+              ip link set br-ksl2 up
+              for p in $(echo "$NODE_IPS" | tr ',' ' '); do
+                [ "$p" = "$SELF" ] && continue
+                bridge fdb append 00:00:00:00:00:00 dev vxksl2 dst "$p"
+              done
+              echo "ksl2 mesh up on $SELF (vxksl2 VNI=$VNI port=$VXLAN_PORT -> br-ksl2)"
+              # NOTE: this DS does NOT clean up vxksl2/br-ksl2 on SIGTERM; to remove
+              # the mesh, `ip link del vxksl2; ip link del br-ksl2` on each node.
+              while true; do sleep 3600; done

--- a/docs/design/network-architecture-requirements.md
+++ b/docs/design/network-architecture-requirements.md
@@ -168,6 +168,24 @@ logic are fully unit-testable; an end-to-end IP-preserving live migration
 needs a cluster with a real Tier-C attachment (an OVN-K lab, or a private
 VLAN for macvlan).
 
+**Validation outcome (2026-06, hand-rolled VXLAN-mesh substrate).** A lab
+VXLAN mesh (Recipe B in
+[`../networking/multi-node-l2.md`](../networking/multi-node-l2.md)) let us
+validate most of this on the Calico cluster after all: the **primary-on-NAD
+datapath**, **cross-node L2 reachability**, and **offline migration
+IP-preservation** are all cluster-proven. It surfaced two real KubeSwift
+live-migration bugs (both would break NAD live migration on *any* Tier-C
+network) — fixed in #235 (the dst pod dropped its Multus annotation →
+`DstNeverReady`) and #236 (the dst-receiver-not-ready send-retry) — plus a
+dnsmasq shared-L2 hardening (#237). **End-to-end live-migration
+IP-preservation remains OVN-K-gated**: on the hand-rolled mesh both migration
+pods are multi-homed across two overlays (the mesh + Calico), which
+intermittently breaks the migration channel (isolation: only the NAD↔NAD case
+fails). A real OVN-K layer-2 manages the attachment in-CNI and would not hit
+this — so §3's marquee live-migration capability is the one piece that still
+needs the OVN-K lab. Full diagnosis:
+`docs/design/multi-node-l2-validation-spike.md` (local).
+
 ## 7. Implementation gaps (what code work this implies)
 
 The abstraction is right, so the work is small and well-scoped:

--- a/docs/networking/multi-node-l2.md
+++ b/docs/networking/multi-node-l2.md
@@ -1,24 +1,12 @@
 # Multi-node L2 networking (IP-preserving guests)
 
-> **Status (2026-06): control-plane shipped + runtime EXPERIMENTAL.** The
-> control-plane (the `spec.interfaces[].primary` field, the resolver wiring, and
-> the corrected SwiftMigration IP-preservation gate) is shipped and tested. The
-> launcher **runtime datapath** (attaching the *primary* NIC to a NAD and giving
-> the guest the NAD's IP) is now implemented but the **datapath is UNVALIDATED**
-> — the dev cluster has no working multi-node L2 (Multus secondary attach does
-> not produce an interface there). It will be validated and tuned on an
-> OVN-Kubernetes cluster. Treat primary-on-NAD as experimental until then. See
-> [`../design/network-architecture-requirements.md`](../design/network-architecture-requirements.md)
-> for the framework.
->
-> **Runtime model (KubeVirt-style bridge binding):** network-init reads the IP
-> the NAD's CNI assigned to the pod's Multus interface, flushes it off that
-> interface, bridges the interface to the guest's tap, and the launcher's
-> in-pod dnsmasq hands that exact IP to the guest (matched by MAC) — so the
-> guest's primary IP is the NAD's portable IP, and the existing lease-file IP
-> discovery works unchanged. The in-pod dnsmasq binds via a best-effort helper
-> IP (`<subnet>.254`) in the NAD subnet — a heuristic with a documented
-> collision risk, expected to be refined during real-cluster validation.
+> **Status (2026-06): datapath + offline migration VALIDATED; live-migration
+> IP-preservation is partial (two bugs fixed, full completion OVN-K-gated).**
+> The control-plane (`spec.interfaces[].primary`, the resolver wiring, the
+> `PrimaryIPPreservedCrossNode()` migration gate) and the **runtime datapath**
+> (attaching the *primary* NIC to a NAD and giving the guest the NAD's IP) are
+> cluster-validated on a hand-rolled VXLAN-mesh L2. See the validation matrix
+> below for exactly what is proven vs. what still needs an OVN-Kubernetes lab.
 
 By default a SwiftGuest's primary IP is **node-local** — it comes from a
 per-node dnsmasq on `br0` and is NAT-masqueraded out the pod's `eth0`. That IP
@@ -26,12 +14,32 @@ does **not** survive a move to another node, which is why cross-node migration
 of a default-networking guest requires `spec.allowIPChange=true`.
 
 To give a guest a **portable** primary IP (one that follows it across nodes —
-e.g. for IP-preserving live migration, telco/NFV, or stateful services with
+for IP-preserving live/offline migration, telco/NFV, or stateful services with
 external clients), put its **primary interface on a multi-node L2 network**: a
 single L2 broadcast domain that spans every candidate node. KubeSwift attaches
 to it through a Multus NetworkAttachmentDefinition (NAD), so the technology is
-the operator's choice — the recommended reference is **OVN-Kubernetes
-layer-2** (portable overlay, no physical-NIC dependency).
+the operator's choice — the recommended reference is **OVN-Kubernetes layer-2**
+(portable overlay, no physical-NIC dependency).
+
+## Validation status
+
+| Capability | Status | Notes |
+|---|---|---|
+| Datapath — guest gets the NAD's portable IP | ✅ validated | `setup_primary_nad_nic`: flush NAD IP → bridge → fixed-lease dnsmasq → status |
+| Cross-node L2 reachability | ✅ validated | both directions over a VXLAN-mesh overlay |
+| **Offline** migration IP-preservation | ✅ validated | guest reacquired its NAD IP on the target node, no `allowIPChange` |
+| **Live** migration IP-preservation | ⚠️ partial | two real bugs fixed ([#235](https://github.com/projectbeskar/kubeswift/pull/235) Multus-annotation on the dst pod, [#236](https://github.com/projectbeskar/kubeswift/pull/236) dst-receiver send-retry); end-to-end completion is **OVN-K-gated** — see below |
+
+**Why live migration is OVN-K-gated.** On a *hand-rolled* VXLAN-mesh substrate,
+both the migration source and destination launcher pods end up **multi-homed
+across two overlays** (the cluster CNI's pod network *and* the mesh). That
+specific combination intermittently breaks the cross-node migration channel
+(isolation: plain↔plain, plain↔NAD, NAD↔plain all work; only NAD↔NAD fails).
+A real **OVN-Kubernetes layer-2** secondary network manages the attachment
+*inside the CNI* and never multi-homes a pod across two overlays, so it does not
+hit this — which is why end-to-end live-migration IP-preservation must be
+validated on an OVN-K (or equivalent) Tier-C network, not the lab mesh. See
+[`../design/network-architecture-requirements.md`](../design/network-architecture-requirements.md) §6.
 
 ## The `primary` field
 
@@ -59,7 +67,7 @@ spec:
   multi-node L2: the SwiftMigration webhook then treats the guest as
   IP-preserving and does **not** require `allowIPChange` for cross-node moves.
 
-### Migration-gate behavior (shipped)
+### Migration-gate behavior
 
 The IP-preservation gate keys on the **primary** interface, not on "any
 `networkRef`":
@@ -71,17 +79,11 @@ The IP-preservation gate keys on the **primary** interface, not on "any
 | **Primary on a NAD** (`primary: true` + `networkRef`) | accepted, IP preserved, no `allowIPChange` |
 | Single NAD interface (de-facto primary) | accepted, IP preserved |
 
-(The middle row is the correctness fix from
-[network-architecture-requirements.md §7.2](../design/network-architecture-requirements.md):
-a secondary NAD no longer makes a node-local-primary guest look IP-preserving.)
+## Recipe A (reference): OVN-Kubernetes layer-2 NAD
 
-## Reference recipe: OVN-Kubernetes layer-2 NAD
-
-> Requires OVN-Kubernetes as the cluster CNI (or secondary-network provider).
-> The dev cluster runs Calico, so this path is **not validated there** — it is
-> documented as the reference for clusters on OVN-K. macvlan is the lightweight
-> alternative on operator-controlled L2 (see the design doc §5.1; note the
-> MAC-filtering caveat on clouds / Hetzner).
+> The portable, production-recommended path, and the one that validates
+> end-to-end live-migration IP-preservation. Requires OVN-Kubernetes as the
+> cluster CNI **or** as a secondary-network provider.
 
 A layer-2 NAD defines an overlay L2 segment spanning all nodes:
 
@@ -103,21 +105,53 @@ spec:
     }
 ```
 
-Then reference it from the guest's primary interface as shown above. OVN-K
-provides DHCP/IPAM on the segment, so the guest receives a `10.20.x.y` address
-that the segment delivers to whichever node the guest runs on — the property
-that makes the IP portable across a migration.
+OVN-K provides DHCP/IPAM on the segment, so the guest receives a `10.20.x.y`
+address that the segment delivers to whichever node the guest runs on — the
+property that makes the IP portable across a migration. Because OVN-K does *not*
+multi-home the pod across a second overlay, it avoids the NAD↔NAD migration-channel
+issue of the hand-rolled mesh.
+
+> **Note on the per-pod dnsmasq.** KubeSwift's datapath synthesizes DHCP for the
+> guest via a per-pod dnsmasq (needed for a plain bridge NAD whose IPAM gives the
+> *pod* an IP but no guest-reachable DHCP server). On a NAD that already serves
+> DHCP on the segment (OVN-K layer-2), the per-pod dnsmasq is redundant; a
+> "segment-DHCP" mode that skips it is a follow-up.
+
+## Recipe B (lab / on-prem): hand-rolled VXLAN-mesh + bridge NAD
+
+> The lightweight path that validated the datapath + offline migration here,
+> and works on **any** cluster (no CNI change) including different-subnet nodes.
+> It is **not** suitable for end-to-end live-migration IP-preservation (the
+> multi-homed-pod issue above). Samples: [`../../config/samples/multi-node-l2/`](../../config/samples/multi-node-l2/).
+
+A privileged DaemonSet builds a VXLAN uplink + host bridge on every node → one
+flat L2; a Multus `bridge` NAD attaches launcher pods to it.
+
+**Three load-bearing rules (each cost us a debugging cycle):**
+
+1. **The VXLAN mesh MUST use a UDP port the cluster CNI does NOT use.** Calico's
+   VXLAN is **4789**; sharing it silently breaks Calico's cross-node pod
+   networking (and with it the migration mTLS channel). Use e.g. **8472**. On a
+   flannel cluster (which uses 8472) pick something else.
+2. **Every node that hosts a primary-on-NAD guest — or is a migration target —
+   MUST run Multus.** A node excluded from `kube-multus-ds` silently produces a
+   guest stuck at `network-init: primary NAD interface net1 not found` because
+   the NAD never plumbs there.
+3. **VXLAN MAC-move convergence.** After a migration the moved guest's MAC must
+   GARP for the learning-mesh FDB to re-converge (~tens of seconds); a real L2
+   fabric / OVN-K converges immediately.
+
+The in-pod dnsmasq is hardened for the shared L2 (a single flat segment means
+every pod's dnsmasq sees the others' guests' DHCP): it answers only its own
+guest's MAC (`--dhcp-ignore=tag:!known`), hands an infinite lease (the helper-IP
+server-id is ambiguous on the shared L2, so the guest must never renew), and
+carries the overlay MTU via `option:mtu`.
 
 ## Limitations / follow-ups
 
-- **Runtime datapath is EXPERIMENTAL and unvalidated** (see the status banner) —
-  it needs an OVN-K / working-NAD cluster to validate and tune (the helper-IP /
-  dnsmasq binding in particular).
-- **Prerequisite multi-NIC fixes — shipped.** The `network-init` container now
-  mounts the RuntimeIntent + run dir, the launcher image carries `python3`, and
-  network-init skips vhost-user NICs, so multi-NIC bridging actually runs. (These
-  were latent bugs that meant multi-NIC never worked end-to-end before.)
-- **Helper-IP heuristic.** The in-pod dnsmasq binds to `<NAD-subnet>.254`; if
-  that host is taken on the segment it will collide. Refine during validation.
+- **End-to-end live-migration IP-preservation is OVN-K-gated** (the lab mesh's
+  multi-homed-pod issue). The control-plane gate, the datapath, offline
+  IP-preservation, and the two live-migration bug fixes are all in place; the
+  remaining validation needs an OVN-K (or real Tier-C) network.
 - **SR-IOV** is a hardware-passthrough NIC, not a Tier-C overlay; it is rejected
-  for cross-node migration regardless (Phase 4+).
+  for cross-node migration regardless.


### PR DESCRIPTION
## Summary

The multi-node-L2 primary-on-NAD runtime datapath was shipped EXPERIMENTAL/UNVALIDATED.
The validation spike (hand-rolled VXLAN-mesh substrate on the Calico dev cluster) proved
the datapath, cross-node L2 reachability, and **offline migration IP-preservation**, and
surfaced two real live-migration bugs (fixed: #235, #236) plus a dnsmasq shared-L2
hardening (#237). This replaces the experimental framing with an honest validation matrix.

**End-to-end LIVE-migration IP-preservation stays OVN-K-gated** and is documented as such:
on a hand-rolled mesh both migration pods are multi-homed across two overlays (mesh +
Calico), which only the NAD↔NAD case trips; a real OVN-K layer-2 manages the attachment
in-CNI and avoids it.

## Changes

- `docs/networking/multi-node-l2.md`: validation-status matrix; **Recipe A** (OVN-K
  layer-2 — reference + the path to live-migration validation) and **Recipe B** (lab
  VXLAN-mesh — validates datapath + offline) with the **three load-bearing rules**: the
  mesh must avoid the cluster CNI's VXLAN port (Calico=4789 → use 8472); every node
  hosting a NAD guest / migration target must run Multus; MAC-move needs a GARP to
  re-converge the FDB.
- `config/samples/multi-node-l2/`: add `vxlan-mesh-daemonset.yaml` + `bridge-nad.yaml`
  (Recipe B); refresh the stale "experimental/follow-up" notes on the existing samples.
- `docs/design/network-architecture-requirements.md` §6: record the validation outcome.

Docs-only. Companion to #235 / #236 / #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)