### PR TITLE
refactor(networking): pluggable ovnBackend seam — lift kube-ovn behind it (OVN-K arc P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to KubeSwift are documented here.
 
 ## [Unreleased]
 
+### Changed
+- **Internal: pluggable OVN CNI backend seam (OVN-K arc P1).** Lifted the kube-ovn
+  primary-on-NAD identity logic behind an internal `ovnBackend` interface
+  (`internal/controller/swiftguest/ovn_backend.go`) — `Detect`/`Identity` per
+  backend, first-match-wins, "two implementations, not a framework". The two call
+  sites (the launcher-pod stamp and the live-migration dst-pod annotations) now
+  dispatch through the seam, so additional OVN-based CNIs (OVN-Kubernetes next)
+  plug in without touching the controller. **Behavior-preserving** — no
+  user-facing change; the shipped kube-ovn IP-preserving live-migration path is
+  identical and its tests pass unchanged. Foundation for OVN-Kubernetes support
+  ([RFC](docs/design/ovn-cni-backends.md)).
+
 ---
 
 ## [v0.4.5] — 2026-06-17

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -474,12 +474,13 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		logger.Error(err, "failed to build pod spec")
 		return ctrl.Result{}, err
 	}
-	// kube-ovn primary-on-NAD: stamp the guest's MAC (+ pinned IP) so the OVN
+	// OVN primary-on-NAD: stamp the guest's MAC (+ pinned IP) so the OVN
 	// logical-switch port identity is the guest, not the pod NIC — otherwise the
-	// bridged guest MAC is unreachable on the segment. No-op for every other
+	// bridged guest MAC is unreachable on the segment. Dispatches to the backend
+	// that owns the guest's primary network (kube-ovn today). No-op for every other
 	// networking mode. Fails closed on a NAD Get error (boot-time correctness).
-	if err := r.stampKubeOVNIdentity(ctx, &guest, desiredPod); err != nil {
-		logger.Error(err, "failed to stamp kube-ovn primary-NAD identity")
+	if err := r.stampOVNIdentity(ctx, &guest, desiredPod); err != nil {
+		logger.Error(err, "failed to stamp OVN primary-NAD identity")
 		return ctrl.Result{}, err
 	}
 	if err := controllerutil.SetControllerReference(&guest, desiredPod, r.Scheme); err != nil {

--- a/internal/controller/swiftguest/kubeovn.go
+++ b/internal/controller/swiftguest/kubeovn.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,7 +14,8 @@ import (
 	"github.com/projectbeskar/kubeswift/internal/runtimeintent"
 )
 
-// kube-ovn primary-on-NAD integration.
+// kube-ovn primary-on-NAD integration — the kubeOVNBackend implementation of the
+// ovnBackend seam (ovn_backend.go).
 //
 // When a SwiftGuest's PRIMARY interface rides a kube-ovn-managed NAD, the guest's
 // portable IP lives on a real OVN logical switch. OVN binds each logical-switch
@@ -24,7 +24,7 @@ import (
 // hypervisor MAC behind the pod NIC (network-init's setup_primary_nad_nic), so
 // without telling kube-ovn the guest's MAC, OVN delivers the guest's traffic to
 // the wrong MAC and the guest is unreachable on the segment. This was diagnosed
-// and fixed-by-hand on the multi-node-L2 OVN validation spike; this file makes it
+// and fixed-by-hand on the multi-node-L2 OVN validation spike; this makes it
 // automatic — the KubeVirt model: program the LSP identity to be the guest.
 //
 // Mechanism (all pod annotations; no CNI/datapath change):
@@ -33,9 +33,9 @@ import (
 //   - "<provider>.kubernetes.io/ip_address"  = the guest's current IP   -> a stable
 //     static IP across pod recreate (and, with the migration path below, across a
 //     live migration).
-//   - (migration dst only, in swiftmigration) "kubevirt.io/migrationJobName" -> kube-ovn
-//     skips the IPAM conflict check so the dst pod can acquire the SAME static IP
-//     the src still holds during the cutover overlap.
+//   - (migration dst only) "kubevirt.io/migrationJobName" -> kube-ovn skips the IPAM
+//     conflict check so the dst pod can acquire the SAME static IP the src still
+//     holds during the cutover overlap.
 //
 // "<provider>" is the kube-ovn provider of the NAD (its config "provider", e.g.
 // "ovn-l2.<ns>.ovn") — the PER-PROVIDER annotation form a Multus secondary uses;
@@ -91,7 +91,7 @@ func primaryMAC(guest *swiftv1alpha1.SwiftGuest, iface *swiftv1alpha1.GuestInter
 // (unstructured) and inspects its config. ok=false (no error) means "not a
 // kube-ovn primary-on-NAD guest" and the caller skips stamping. A Get error is
 // returned so the caller requeues.
-func (r *SwiftGuestReconciler) kubeOVNPrimaryProvider(ctx context.Context, guest *swiftv1alpha1.SwiftGuest) (provider, mac string, ok bool, err error) {
+func kubeOVNPrimaryProvider(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest) (provider, mac string, ok bool, err error) {
 	iface := guest.PrimaryInterface()
 	if iface == nil || iface.NetworkRef == nil {
 		return "", "", false, nil
@@ -102,7 +102,7 @@ func (r *SwiftGuestReconciler) kubeOVNPrimaryProvider(ctx context.Context, guest
 	}
 	nad := &unstructured.Unstructured{}
 	nad.SetGroupVersionKind(networkAttachmentDefinitionGVK)
-	if e := r.Get(ctx, client.ObjectKey{Namespace: ns, Name: iface.NetworkRef.Name}, nad); e != nil {
+	if e := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: iface.NetworkRef.Name}, nad); e != nil {
 		return "", "", false, fmt.Errorf("get NAD %s/%s for kube-ovn identity: %w", ns, iface.NetworkRef.Name, e)
 	}
 	cfgStr, _, _ := unstructured.NestedString(nad.Object, "spec", "config")
@@ -124,33 +124,56 @@ func (r *SwiftGuestReconciler) kubeOVNPrimaryProvider(ctx context.Context, guest
 	return provider, primaryMAC(guest, iface), true, nil
 }
 
-// stampKubeOVNIdentity adds the kube-ovn LSP-identity annotations to a launcher
-// pod when the guest's primary interface rides a kube-ovn NAD; a no-op for every
-// other networking mode (node-local bridge, non-kube-ovn NAD, SR-IOV).
-//
-// A NAD Get failure is returned (fails closed): identity is a boot-time
-// correctness requirement — a guest that boots without it is unreachable on the
-// OVN segment — so requeuing rather than booting a broken guest is correct.
-func (r *SwiftGuestReconciler) stampKubeOVNIdentity(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, pod *corev1.Pod) error {
-	provider, mac, ok, err := r.kubeOVNPrimaryProvider(ctx, guest)
+// kubeOVNBackend is the ovnBackend for kube-ovn-managed primary NADs. Stateless;
+// the client is passed per call.
+type kubeOVNBackend struct{}
+
+func (kubeOVNBackend) Name() string { return KubeOVNCNIType }
+
+// Detect reports whether the guest's primary interface rides a kube-ovn-class NAD.
+func (kubeOVNBackend) Detect(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest) (bool, error) {
+	_, _, ok, err := kubeOVNPrimaryProvider(ctx, c, guest)
+	return ok, err
+}
+
+// Identity computes the kube-ovn LSP-identity annotations for the launcher pod and
+// the live-migration dst pod. The pinned IP (status's kube-ovn-assigned IP) is set
+// once known; on first boot it is empty and kube-ovn allocates dynamically.
+func (kubeOVNBackend) Identity(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest, migName string) (ovnIdentity, error) {
+	provider, mac, ok, err := kubeOVNPrimaryProvider(ctx, c, guest)
 	if err != nil {
-		return err
+		return ovnIdentity{}, err
 	}
 	if !ok || mac == "" {
-		return nil
+		return ovnIdentity{}, nil
 	}
-	if pod.Annotations == nil {
-		pod.Annotations = map[string]string{}
-	}
-	pod.Annotations[KubeOVNMACAnnotationKey(provider)] = mac
+	macKey := KubeOVNMACAnnotationKey(provider)
+
 	// Pin the IP once it is known (status carries the kube-ovn-assigned IP from a
-	// prior boot). On first boot it is empty -> kube-ovn allocates dynamically and
-	// the controller records it; subsequent pods pin it. net.ParseIP guards a
-	// malformed status value.
+	// prior boot). net.ParseIP guards a malformed status value.
+	ip := ""
 	if guest.Status.Network != nil {
-		if ip := guest.Status.Network.PrimaryIP; ip != "" && net.ParseIP(ip) != nil {
-			pod.Annotations[KubeOVNIPAnnotationKey(provider)] = ip
+		if pip := guest.Status.Network.PrimaryIP; pip != "" && net.ParseIP(pip) != nil {
+			ip = pip
 		}
 	}
-	return nil
+
+	pod := map[string]string{macKey: mac}
+	if ip != "" {
+		pod[KubeOVNIPAnnotationKey(provider)] = ip
+	}
+
+	// The dst set keeps the same LSP identity (MAC) and IP pin, plus the
+	// migrationJobName marker so kube-ovn's IPAM skips the conflict check during
+	// the cutover overlap. migName is "" for the boot-time pod-identity call, whose
+	// caller uses only PodAnnotations.
+	dst := map[string]string{macKey: mac}
+	if ip != "" {
+		dst[KubeOVNIPAnnotationKey(provider)] = ip
+	}
+	if migName != "" {
+		dst[MigrationJobNameAnnotation] = migName
+	}
+
+	return ovnIdentity{PodAnnotations: pod, MigrationDstAnnotations: dst}, nil
 }

--- a/internal/controller/swiftguest/kubeovn_test.go
+++ b/internal/controller/swiftguest/kubeovn_test.go
@@ -53,17 +53,19 @@ func guestWithPrimaryNAD(ns, name, nadName, mac string) *swiftv1alpha1.SwiftGues
 	}
 }
 
+// --- boot-time pod identity (stampOVNIdentity → kubeOVNBackend.Identity PodAnnotations) ---
+
 // kube-ovn-class primary NAD -> the pod gets the provider-scoped mac_address (the
 // guest's MAC) and, once status carries an IP, the pinned ip_address.
-func TestStampKubeOVNIdentity_KubeOVNPrimary_StampsMacAndIP(t *testing.T) {
+func TestStampOVNIdentity_KubeOVNPrimary_StampsMacAndIP(t *testing.T) {
 	guest := guestWithPrimaryNAD("ovn-val", "ovn-vm", "ovn-l2", "52:54:00:c4:0d:90")
 	guest.Status.Network = &swiftv1alpha1.GuestNetworkStatus{PrimaryIP: "10.20.0.4"}
 	c := nadAwareClientBuilder(nadObj("ovn-val", "ovn-l2", "kube-ovn", "ovn-l2.ovn-val.ovn")).Build()
 	r := &SwiftGuestReconciler{Client: c}
 
 	pod := &corev1.Pod{}
-	if err := r.stampKubeOVNIdentity(context.Background(), guest, pod); err != nil {
-		t.Fatalf("stampKubeOVNIdentity: %v", err)
+	if err := r.stampOVNIdentity(context.Background(), guest, pod); err != nil {
+		t.Fatalf("stampOVNIdentity: %v", err)
 	}
 	if got := pod.Annotations[KubeOVNMACAnnotationKey("ovn-l2.ovn-val.ovn")]; got != "52:54:00:c4:0d:90" {
 		t.Errorf("mac_address annotation = %q, want the guest MAC", got)
@@ -74,14 +76,14 @@ func TestStampKubeOVNIdentity_KubeOVNPrimary_StampsMacAndIP(t *testing.T) {
 }
 
 // First boot (no recorded IP): MAC is stamped, IP is not (kube-ovn allocates).
-func TestStampKubeOVNIdentity_NoIPUntilRecorded(t *testing.T) {
+func TestStampOVNIdentity_NoIPUntilRecorded(t *testing.T) {
 	guest := guestWithPrimaryNAD("ovn-val", "ovn-vm", "ovn-l2", "")
 	c := nadAwareClientBuilder(nadObj("ovn-val", "ovn-l2", "kube-ovn", "")).Build()
 	r := &SwiftGuestReconciler{Client: c}
 
 	pod := &corev1.Pod{}
-	if err := r.stampKubeOVNIdentity(context.Background(), guest, pod); err != nil {
-		t.Fatalf("stampKubeOVNIdentity: %v", err)
+	if err := r.stampOVNIdentity(context.Background(), guest, pod); err != nil {
+		t.Fatalf("stampOVNIdentity: %v", err)
 	}
 	// provider falls back to the kube-ovn convention <name>.<ns>.ovn when omitted.
 	wantMAC := runtimeintent.GenerateMAC(runtimeintent.InterfaceMACSeed("ovn-val", "ovn-vm", "app"))
@@ -93,23 +95,23 @@ func TestStampKubeOVNIdentity_NoIPUntilRecorded(t *testing.T) {
 	}
 }
 
-// A non-kube-ovn NAD (e.g. a bridge NAD) -> no kube-ovn annotations.
-func TestStampKubeOVNIdentity_NonKubeOVN_NoOp(t *testing.T) {
+// A non-kube-ovn NAD (e.g. a bridge NAD) -> no OVN annotations.
+func TestStampOVNIdentity_NonKubeOVN_NoOp(t *testing.T) {
 	guest := guestWithPrimaryNAD("ns", "g", "bridge-nad", "")
 	c := nadAwareClientBuilder(nadObj("ns", "bridge-nad", "bridge", "")).Build()
 	r := &SwiftGuestReconciler{Client: c}
 
 	pod := &corev1.Pod{}
-	if err := r.stampKubeOVNIdentity(context.Background(), guest, pod); err != nil {
-		t.Fatalf("stampKubeOVNIdentity: %v", err)
+	if err := r.stampOVNIdentity(context.Background(), guest, pod); err != nil {
+		t.Fatalf("stampOVNIdentity: %v", err)
 	}
 	for k := range pod.Annotations {
-		t.Errorf("non-kube-ovn NAD should stamp nothing; got annotation %q", k)
+		t.Errorf("non-OVN NAD should stamp nothing; got annotation %q", k)
 	}
 }
 
 // A node-local (no networkRef) primary guest -> no NAD Get, no annotations.
-func TestStampKubeOVNIdentity_NodeLocal_NoOp(t *testing.T) {
+func TestStampOVNIdentity_NodeLocal_NoOp(t *testing.T) {
 	guest := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "g"},
 		Spec: swiftv1alpha1.SwiftGuestSpec{
@@ -120,10 +122,73 @@ func TestStampKubeOVNIdentity_NodeLocal_NoOp(t *testing.T) {
 	r := &SwiftGuestReconciler{Client: c}
 
 	pod := &corev1.Pod{}
-	if err := r.stampKubeOVNIdentity(context.Background(), guest, pod); err != nil {
-		t.Fatalf("stampKubeOVNIdentity: %v", err)
+	if err := r.stampOVNIdentity(context.Background(), guest, pod); err != nil {
+		t.Fatalf("stampOVNIdentity: %v", err)
 	}
 	if len(pod.Annotations) != 0 {
 		t.Errorf("node-local guest should stamp nothing; got %v", pod.Annotations)
+	}
+}
+
+// --- live-migration dst identity (OVNMigrationDstAnnotations → kubeOVNBackend.Identity MigrationDstAnnotations) ---
+
+// A kube-ovn primary-on-NAD guest's dst pod must preserve the MAC (LSP identity),
+// pin the guest's CURRENT IP, and carry migrationJobName (so kube-ovn lets the dst
+// share the src's still-held static IP across cutover).
+func TestOVNMigrationDstAnnotations_KubeOVN_MacIPAndJobName(t *testing.T) {
+	provider := "ovn-l2.ovn-val.ovn"
+	guest := guestWithPrimaryNAD("ovn-val", "ovn-vm", "ovn-l2", "52:54:00:c4:0d:90")
+	guest.Status.Network = &swiftv1alpha1.GuestNetworkStatus{PrimaryIP: "10.20.0.4"}
+	c := nadAwareClientBuilder(nadObj("ovn-val", "ovn-l2", "kube-ovn", provider)).Build()
+
+	out, err := OVNMigrationDstAnnotations(context.Background(), c, guest, "ovn-vm-live")
+	if err != nil {
+		t.Fatalf("OVNMigrationDstAnnotations: %v", err)
+	}
+	if out[KubeOVNMACAnnotationKey(provider)] != "52:54:00:c4:0d:90" {
+		t.Errorf("dst must preserve the kube-ovn mac_address (LSP identity); got %q", out[KubeOVNMACAnnotationKey(provider)])
+	}
+	if out[KubeOVNIPAnnotationKey(provider)] != "10.20.0.4" {
+		t.Errorf("dst must pin the guest's current IP; got %q", out[KubeOVNIPAnnotationKey(provider)])
+	}
+	if out[MigrationJobNameAnnotation] != "ovn-vm-live" {
+		t.Errorf("dst must carry migrationJobName so kube-ovn shares the src IP; got %q", out[MigrationJobNameAnnotation])
+	}
+}
+
+// IP not yet recorded in status -> preserve MAC + set migrationJobName but skip
+// the ip pin (kube-ovn allocates; the controller records it; a later pod pins it).
+func TestOVNMigrationDstAnnotations_KubeOVN_NoIPWhenStatusEmpty(t *testing.T) {
+	provider := "ovn-l2.ns.ovn"
+	guest := guestWithPrimaryNAD("ns", "ovn-vm", "ovn-l2", "52:54:00:aa:bb:cc")
+	c := nadAwareClientBuilder(nadObj("ns", "ovn-l2", "kube-ovn", provider)).Build()
+
+	out, err := OVNMigrationDstAnnotations(context.Background(), c, guest, "m2")
+	if err != nil {
+		t.Fatalf("OVNMigrationDstAnnotations: %v", err)
+	}
+	if out[KubeOVNMACAnnotationKey(provider)] != "52:54:00:aa:bb:cc" {
+		t.Errorf("MAC must be preserved even before the IP is known")
+	}
+	if _, ok := out[KubeOVNIPAnnotationKey(provider)]; ok {
+		t.Errorf("no ip pin should be set when the guest IP is unknown")
+	}
+	if out[MigrationJobNameAnnotation] != "m2" {
+		t.Errorf("migrationJobName should still be set")
+	}
+}
+
+// A non-kube-ovn (or node-local) guest -> the dst annotation set is empty (the OVN
+// path is inert for every other networking mode).
+func TestOVNMigrationDstAnnotations_NonKubeOVN_Empty(t *testing.T) {
+	guest := guestWithPrimaryNAD("ns", "g", "bridge-nad", "")
+	c := nadAwareClientBuilder(nadObj("ns", "bridge-nad", "bridge", "")).Build()
+
+	out, err := OVNMigrationDstAnnotations(context.Background(), c, guest, "m1")
+	if err != nil {
+		t.Fatalf("OVNMigrationDstAnnotations: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("non-OVN guest must yield no dst annotations; got %v", out)
 	}
 }

--- a/internal/controller/swiftguest/ovn_backend.go
+++ b/internal/controller/swiftguest/ovn_backend.go
@@ -1,0 +1,145 @@
+package swiftguest
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// Pluggable OVN CNI backends.
+//
+// When a SwiftGuest's PRIMARY interface rides an OVN-managed NAD, the guest's
+// portable IP lives on a real OVN logical switch. OVN binds each logical-switch
+// port (LSP) to the POD interface's MAC and answers ARP for the port IP, while
+// KubeSwift's datapath bridges the guest's OWN (distinct) hypervisor MAC behind
+// the pod NIC (network-init's setup_primary_nad_nic). So unless the LSP identity
+// is programmed to BE the guest, OVN delivers the guest's traffic to the wrong MAC
+// and the guest is unreachable on the segment. Each OVN-based CNI has its own way
+// to program that identity (and its own live-migration IP-overlap contract); the
+// ovnBackend interface is the single seam those differences live behind.
+//
+// The bar is TWO implementations, not a framework (design principle #1): a slice
+// of backends, first-match-wins on Detect — no registry, loader, or config. Today
+// the slice holds only kubeOVNBackend (shipped #239/#240); ovnKubernetesBackend
+// lands in P2 (docs/design/ovn-cni-backends.md). The datapath stays single-sourced
+// in network-init.sh (CNI-agnostic); nothing here touches Rust/RuntimeIntent.
+
+// ovnIdentity is what an ovnBackend computes for a guest whose primary rides one
+// of its NADs: the per-pod annotations that program the OVN port to BE the guest,
+// plus the extra annotations the live-migration DST pod needs to keep the src's IP
+// through cutover.
+type ovnIdentity struct {
+	// PodAnnotations to add to the launcher pod at boot (the OVN port identity:
+	// the guest MAC, plus an optional static IP pin once it is known).
+	PodAnnotations map[string]string
+	// MigrationDstAnnotations to add to the live-migration DST pod so it keeps the
+	// src's IP through cutover (kube-ovn: the IP pin + kubevirt.io/migrationJobName,
+	// which lets its IPAM skip the conflict check). Empty when the backend needs
+	// nothing beyond the carried-over Multus annotation, or has no live-overlap
+	// mechanism (the latter would make live migration offline-only — surfaced by the
+	// migration webhook gate, never a silent unreachable boot).
+	//
+	// (A future field — ClaimsToEnsure, the per-guest objects a backend needs
+	// created before the pod, e.g. an OVN-Kubernetes IPAMClaim — lands in P2 with
+	// its only user; kube-ovn needs none.)
+	MigrationDstAnnotations map[string]string
+}
+
+// ovnBackend is the internal seam for one OVN-based CNI's primary-on-NAD identity.
+// Unexported: it is an internal abstraction, not a public API.
+type ovnBackend interface {
+	// Name is for logs/conditions ("kube-ovn", "ovn-kubernetes").
+	Name() string
+	// Detect inspects the guest's PRIMARY NAD config. ok=true means "this backend
+	// owns this guest's primary network". A NAD Get failure returns err (fail
+	// closed → the caller requeues). ok=false,nil means "not mine" → next backend.
+	Detect(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest) (ok bool, err error)
+	// Identity computes the launcher-pod + migration-dst annotations for a guest
+	// this backend Detected. guest.Status carries the assigned IP once known (for
+	// the IP pin). migName is the SwiftMigration name for the dst set's
+	// migration marker; it is "" for the boot-time pod-identity computation (whose
+	// caller uses only PodAnnotations).
+	Identity(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest, migName string) (ovnIdentity, error)
+}
+
+// ovnBackends is the ordered backend list (first-match-wins on Detect). Two
+// implementations is the explicit bar; the disjoint NAD config types make order
+// immaterial for correctness — it is just a stable iteration.
+func ovnBackends() []ovnBackend {
+	return []ovnBackend{
+		kubeOVNBackend{},
+		// ovnKubernetesBackend{} — P2 (docs/design/ovn-cni-backends.md §8).
+	}
+}
+
+// resolveOVNBackend returns the backend that owns the guest's primary network, or
+// (nil, nil) if the guest's primary does not ride an OVN-backend NAD, or (nil, err)
+// on a NAD Get failure (fail closed).
+func resolveOVNBackend(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest) (ovnBackend, error) {
+	for _, b := range ovnBackends() {
+		ok, err := b.Detect(ctx, c, guest)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return b, nil
+		}
+	}
+	return nil, nil
+}
+
+// stampOVNIdentity adds the OVN LSP-identity annotations to a launcher pod when
+// the guest's primary interface rides an OVN-backend NAD; a no-op for every other
+// networking mode (node-local bridge, non-OVN NAD, SR-IOV).
+//
+// A NAD Get failure is returned (fails closed): identity is a boot-time
+// correctness requirement — a guest that boots without it is unreachable on the
+// OVN segment — so requeuing rather than booting a broken guest is correct.
+func (r *SwiftGuestReconciler) stampOVNIdentity(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, pod *corev1.Pod) error {
+	b, err := resolveOVNBackend(ctx, r.Client, guest)
+	if err != nil {
+		return err
+	}
+	if b == nil {
+		return nil
+	}
+	id, err := b.Identity(ctx, r.Client, guest, "")
+	if err != nil {
+		return err
+	}
+	if len(id.PodAnnotations) == 0 {
+		return nil
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	for k, v := range id.PodAnnotations {
+		pod.Annotations[k] = v
+	}
+	return nil
+}
+
+// OVNMigrationDstAnnotations returns the OVN backend's extra annotations for a
+// live-migration DESTINATION pod of the guest, or an empty map when the guest's
+// primary does not ride an OVN-backend NAD (so the call is inert for every other
+// networking mode). Resolved from the guest. A NAD Get failure is returned (fail
+// closed) so the migration step requeues rather than building a dst pod without
+// the identity. Exported for the swiftmigration dst-pod builder, which lives in a
+// different package and has no access to the unexported backend seam.
+func OVNMigrationDstAnnotations(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest, migName string) (map[string]string, error) {
+	b, err := resolveOVNBackend(ctx, c, guest)
+	if err != nil {
+		return nil, err
+	}
+	if b == nil {
+		return nil, nil
+	}
+	id, err := b.Identity(ctx, c, guest, migName)
+	if err != nil {
+		return nil, err
+	}
+	return id.MigrationDstAnnotations, nil
+}

--- a/internal/controller/swiftmigration/dst_pod.go
+++ b/internal/controller/swiftmigration/dst_pod.go
@@ -2,7 +2,6 @@ package swiftmigration
 
 import (
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -170,6 +169,7 @@ func newDstPod(
 	scheme *runtime.Scheme,
 	sidecar dstSidecarConfig,
 	frozenIntentCMName string,
+	ovnDstAnnotations map[string]string,
 ) (*corev1.Pod, error) {
 	name, err := dstPodName(mig, guest.Name)
 	if err != nil {
@@ -184,11 +184,7 @@ func newDstPod(
 	// useful labels (guest, etc) by starting from src.Labels and
 	// adding migration-specific keys.
 	preservedLabels := mergeLabelsForDst(srcPod.Labels, guest.Name, mig.Name)
-	guestPrimaryIP := ""
-	if guest.Status.Network != nil {
-		guestPrimaryIP = guest.Status.Network.PrimaryIP
-	}
-	preservedAnnotations := mergeAnnotationsForDst(srcPod.Annotations, sidecar.mtlsEnabled, guestPrimaryIP, mig.Name)
+	preservedAnnotations := mergeAnnotationsForDst(srcPod.Annotations, sidecar.mtlsEnabled, ovnDstAnnotations)
 
 	pod.ObjectMeta = metav1.ObjectMeta{
 		Name:        name,
@@ -293,7 +289,7 @@ func mergeLabelsForDst(srcLabels map[string]string, guestName, migName string) m
 // migration sees an old swiftletd that still requires the ack. The key is NOT
 // deleted outright: the plaintext path still uses the ack gate as the
 // THREAT-MODEL's "operator acknowledged cleartext" guard.
-func mergeAnnotationsForDst(srcAnnotations map[string]string, mtlsEnabled bool, guestPrimaryIP, migName string) map[string]string {
+func mergeAnnotationsForDst(srcAnnotations map[string]string, mtlsEnabled bool, ovnDstAnnotations map[string]string) map[string]string {
 	out := map[string]string{}
 	if v, ok := srcAnnotations[swiftguest.MultusAnnotationKey]; ok && v != "" {
 		out[swiftguest.MultusAnnotationKey] = v
@@ -301,30 +297,21 @@ func mergeAnnotationsForDst(srcAnnotations map[string]string, mtlsEnabled bool, 
 	if !mtlsEnabled {
 		out[AnnotationMigrationPhase2Ack] = AnnotationMigrationPhase2AckValue
 	}
-	// kube-ovn primary-on-NAD IP preservation. If the src pod carries a kube-ovn
-	// per-provider mac_address annotation (stamped by the SwiftGuest controller for
-	// a kube-ovn-class primary NAD — internal/controller/swiftguest/kubeovn.go),
-	// the dst pod must: (a) keep the SAME LSP identity (the guest MAC); (b) pin the
-	// guest's CURRENT static IP so the resumed guest stays reachable at its address;
-	// (c) carry kubevirt.io/migrationJobName so kube-ovn treats this dst as a
-	// migration target and its IPAM SKIPS the conflict check — without (c) kube-ovn
-	// rejects the dst's request for the IP the src still holds during the cutover
-	// overlap (empirically confirmed). Keyed off the src annotation, so this is
-	// inert for every non-kube-ovn networking mode. Offline migration is unaffected
-	// (it rebuilds the pod via the SwiftGuest pod builder, which re-stamps from
-	// scratch); the live path clones the src pod through here, so this allowlist is
-	// the only place to carry it — same default-to-explicit lesson as the Multus
-	// annotation above (W26 / PR #26).
-	for k, v := range srcAnnotations {
-		if v == "" || !strings.HasSuffix(k, swiftguest.KubeOVNMACAnnotationSuffix) {
-			continue
-		}
+	// OVN primary-on-NAD IP preservation. The backend that owns the guest's primary
+	// network (kube-ovn today) computed the dst-pod identity annotations from the
+	// guest — resolved by the migration controller via
+	// swiftguest.OVNMigrationDstAnnotations before this clone, so the per-CNI
+	// knowledge stays single-sourced in the swiftguest OVN backend, not here. For
+	// kube-ovn that map is the LSP identity MAC + the guest's current IP pin +
+	// kubevirt.io/migrationJobName (so its IPAM skips the conflict check and the dst
+	// shares the src's still-held static IP across the cutover overlap). It is empty
+	// for every non-OVN networking mode, so this merge is inert there. Offline
+	// migration is unaffected (it rebuilds the pod via the SwiftGuest pod builder,
+	// which re-stamps from scratch); the live path clones the src pod through here,
+	// so this is the only place to carry it — same default-to-explicit lesson as the
+	// Multus annotation above (W26 / PR #26).
+	for k, v := range ovnDstAnnotations {
 		out[k] = v
-		provider := strings.TrimSuffix(k, swiftguest.KubeOVNMACAnnotationSuffix)
-		if guestPrimaryIP != "" {
-			out[swiftguest.KubeOVNIPAnnotationKey(provider)] = guestPrimaryIP
-		}
-		out[swiftguest.MigrationJobNameAnnotation] = migName
 	}
 	return out
 }

--- a/internal/controller/swiftmigration/dst_pod_kubeovn_test.go
+++ b/internal/controller/swiftmigration/dst_pod_kubeovn_test.go
@@ -6,67 +6,57 @@ import (
 	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
 )
 
-// A kube-ovn primary-on-NAD src pod carries the per-provider mac_address
-// annotation (stamped by the SwiftGuest controller). The dst pod must preserve
-// the MAC (LSP identity), pin the guest's CURRENT IP, and carry migrationJobName
-// (so kube-ovn lets the dst share the src's still-held static IP across cutover).
-func TestMergeAnnotationsForDst_KubeOVNIdentityPreservedAndIPKept(t *testing.T) {
+// mergeAnnotationsForDst merges the OVN backend's pre-computed dst annotations
+// (resolved from the guest by the migration controller via
+// swiftguest.OVNMigrationDstAnnotations — the per-CNI derivation itself is tested
+// in the swiftguest package) alongside the preserved Multus networks annotation.
+// For a kube-ovn guest that map is the LSP identity MAC + the IP pin +
+// migrationJobName.
+func TestMergeAnnotationsForDst_MergesOVNDstAnnotations(t *testing.T) {
 	provider := "ovn-l2.ovn-val.ovn"
 	macKey := swiftguest.KubeOVNMACAnnotationKey(provider)
 	ipKey := swiftguest.KubeOVNIPAnnotationKey(provider)
-	src := map[string]string{
-		swiftguest.MultusAnnotationKey: "ovn-val/ovn-l2",
-		macKey:                         "52:54:00:c4:0d:90",
+	src := map[string]string{swiftguest.MultusAnnotationKey: "ovn-val/ovn-l2"}
+	ovnDst := map[string]string{
+		macKey:                                "52:54:00:c4:0d:90",
+		ipKey:                                 "10.20.0.4",
+		swiftguest.MigrationJobNameAnnotation: "ovn-vm-live",
 	}
 
-	out := mergeAnnotationsForDst(src, true /*mtls*/, "10.20.0.4", "ovn-vm-live")
+	out := mergeAnnotationsForDst(src, true /*mtls*/, ovnDst)
 
 	if out[macKey] != "52:54:00:c4:0d:90" {
-		t.Errorf("dst must preserve the kube-ovn mac_address (LSP identity); got %q", out[macKey])
+		t.Errorf("dst must carry the OVN backend's mac_address (LSP identity); got %q", out[macKey])
 	}
 	if out[ipKey] != "10.20.0.4" {
-		t.Errorf("dst must pin the guest's current IP at %s; got %q", ipKey, out[ipKey])
+		t.Errorf("dst must carry the OVN backend's IP pin; got %q", out[ipKey])
 	}
 	if out[swiftguest.MigrationJobNameAnnotation] != "ovn-vm-live" {
-		t.Errorf("dst must carry migrationJobName so kube-ovn shares the src IP; got %q", out[swiftguest.MigrationJobNameAnnotation])
+		t.Errorf("dst must carry migrationJobName; got %q", out[swiftguest.MigrationJobNameAnnotation])
 	}
 	if out[swiftguest.MultusAnnotationKey] != "ovn-val/ovn-l2" {
 		t.Errorf("dst must still preserve the Multus networks annotation")
 	}
+	if _, ok := out[AnnotationMigrationPhase2Ack]; ok {
+		t.Errorf("mtls dst should NOT carry the plaintext ack")
+	}
 }
 
-// A plain (node-local or non-kube-ovn-NAD) guest has no kube-ovn mac annotation
-// on the src pod -> the dst must NOT get a migrationJobName or any ip pin (the
-// kube-ovn path is inert), and the plaintext ack gate is preserved.
-func TestMergeAnnotationsForDst_NonKubeOVN_Inert(t *testing.T) {
+// A plain (node-local or non-OVN-NAD) guest yields an empty OVN dst-annotation map
+// -> the dst must NOT get a migrationJobName or any pin (the OVN path is inert),
+// and the plaintext ack gate is preserved.
+func TestMergeAnnotationsForDst_NonOVN_Inert(t *testing.T) {
 	src := map[string]string{swiftguest.MultusAnnotationKey: "ns/bridge-nad"}
 
-	out := mergeAnnotationsForDst(src, false /*plaintext*/, "10.244.1.5", "m1")
+	out := mergeAnnotationsForDst(src, false /*plaintext*/, nil)
 
 	if _, ok := out[swiftguest.MigrationJobNameAnnotation]; ok {
-		t.Errorf("non-kube-ovn dst must not carry migrationJobName")
+		t.Errorf("non-OVN dst must not carry migrationJobName")
 	}
 	if out[AnnotationMigrationPhase2Ack] != AnnotationMigrationPhase2AckValue {
 		t.Errorf("plaintext dst should keep the phase2 ack gate")
 	}
-}
-
-// IP not yet recorded in status -> preserve MAC + set migrationJobName but skip
-// the ip pin (kube-ovn allocates; the controller records it; a later pod pins it).
-func TestMergeAnnotationsForDst_KubeOVN_NoIPWhenStatusEmpty(t *testing.T) {
-	provider := "ovn-l2.ns.ovn"
-	macKey := swiftguest.KubeOVNMACAnnotationKey(provider)
-	src := map[string]string{macKey: "52:54:00:aa:bb:cc"}
-
-	out := mergeAnnotationsForDst(src, true, "" /*no IP yet*/, "m2")
-
-	if out[macKey] == "" {
-		t.Errorf("MAC must be preserved even before the IP is known")
-	}
-	if _, ok := out[swiftguest.KubeOVNIPAnnotationKey(provider)]; ok {
-		t.Errorf("no ip pin should be set when the guest IP is unknown")
-	}
-	if out[swiftguest.MigrationJobNameAnnotation] != "m2" {
-		t.Errorf("migrationJobName should still be set")
+	if out[swiftguest.MultusAnnotationKey] != "ns/bridge-nad" {
+		t.Errorf("dst must still preserve the Multus networks annotation")
 	}
 }

--- a/internal/controller/swiftmigration/dst_pod_test.go
+++ b/internal/controller/swiftmigration/dst_pod_test.go
@@ -114,7 +114,7 @@ func TestNewDstPod_SetsNameLabelsAnnotationsEnvNodeName(t *testing.T) {
 	}
 	src := templateSrcPod("guest", "default")
 
-	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, "")
+	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, "", nil)
 	if err != nil {
 		t.Fatalf("newDstPod: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestNewDstPod_NoLauncherContainer_Errors(t *testing.T) {
 	src := templateSrcPod("guest", "default")
 	src.Spec.Containers[0].Name = "not-launcher"
 
-	if _, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, ""); err == nil {
+	if _, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, "", nil); err == nil {
 		t.Errorf("expected error when launcher container is missing")
 	}
 }
@@ -247,7 +247,7 @@ func TestNewDstPod_PreservesMultusAnnotation(t *testing.T) {
 				mtlsEnabled: tc.mtls,
 				srcNodeName: "boba",
 				dstNodeName: "miles",
-			}, "")
+			}, "", nil)
 			if err != nil {
 				t.Fatalf("newDstPod: %v", err)
 			}
@@ -279,7 +279,7 @@ func TestNewDstPod_MTLS_InjectsServerSidecar(t *testing.T) {
 		mtlsEnabled: true,
 		srcNodeName: "boba",  // source node — dst pins this SAN
 		dstNodeName: "miles", // destination node — dst presents this identity
-	}, "")
+	}, "", nil)
 	if err != nil {
 		t.Fatalf("newDstPod (mTLS): %v", err)
 	}
@@ -372,7 +372,7 @@ func TestNewDstPod_MTLS_FlipsInheritedClientSidecarToServer(t *testing.T) {
 
 	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
 		mtlsEnabled: true, srcNodeName: "boba", dstNodeName: "miles",
-	}, "")
+	}, "", nil)
 	if err != nil {
 		t.Fatalf("newDstPod: %v", err)
 	}
@@ -429,7 +429,7 @@ func TestNewDstPod_MTLS_OmitsPlaintextAck(t *testing.T) {
 	}
 	src := templateSrcPod("guest", "default")
 
-	off, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, "")
+	off, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, "", nil)
 	if err != nil {
 		t.Fatalf("newDstPod (plaintext): %v", err)
 	}
@@ -439,7 +439,7 @@ func TestNewDstPod_MTLS_OmitsPlaintextAck(t *testing.T) {
 
 	on, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
 		mtlsEnabled: true, srcNodeName: "boba", dstNodeName: "miles",
-	}, "")
+	}, "", nil)
 	if err != nil {
 		t.Fatalf("newDstPod (mTLS): %v", err)
 	}
@@ -461,7 +461,7 @@ func TestNewDstPod_MTLS_EmptyNode_Errors(t *testing.T) {
 		mtlsEnabled: true,
 		srcNodeName: "", // unresolved
 		dstNodeName: "miles",
-	}, ""); err == nil {
+	}, "", nil); err == nil {
 		t.Errorf("expected error when mTLS enabled but source node name empty")
 	}
 }

--- a/internal/controller/swiftmigration/frozen_intent_test.go
+++ b/internal/controller/swiftmigration/frozen_intent_test.go
@@ -123,7 +123,7 @@ func TestNewDstPod_RepointsRuntimeIntentVolume(t *testing.T) {
 	})
 
 	frozenName := "guest-mig-abcdef" + swiftguest.IntentConfigMapSuffix
-	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, frozenName)
+	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, frozenName, nil)
 	if err != nil {
 		t.Fatalf("newDstPod: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestNewDstPod_RepointsRuntimeIntentVolume(t *testing.T) {
 	}
 
 	// Empty frozen name leaves the inherited live CM in place.
-	dst2, _ := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, "")
+	dst2, _ := newDstPod(mig, guest, src, scheme, dstSidecarConfig{}, "", nil)
 	if got := intentVolumeCM(dst2); got != "guest"+swiftguest.IntentConfigMapSuffix {
 		t.Errorf("empty frozen name must leave the live CM; got %q", got)
 	}

--- a/internal/controller/swiftmigration/preparing_live.go
+++ b/internal/controller/swiftmigration/preparing_live.go
@@ -13,6 +13,7 @@ import (
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
 	"github.com/projectbeskar/kubeswift/internal/controller/migrationcert"
+	"github.com/projectbeskar/kubeswift/internal/controller/swiftguest"
 )
 
 // preparingLiveReadyBudget is the wall-clock window for the dst pod
@@ -160,11 +161,20 @@ func (r *SwiftMigrationReconciler) handlePreparingLive(
 		if frozenErr != nil {
 			return phaseTransient(fmt.Errorf("ensure frozen dst intent: %w", frozenErr))
 		}
+		// Resolve the OVN backend's dst-pod identity annotations from the guest
+		// (kube-ovn: the LSP MAC + IP pin + kubevirt.io/migrationJobName so the dst
+		// keeps the src's IP through cutover). Empty for non-OVN guests. Fail closed
+		// on a NAD Get error: a dst that boots without its OVN identity is
+		// unreachable on the segment, so requeue rather than build a broken pod.
+		ovnDstAnnotations, ovnErr := swiftguest.OVNMigrationDstAnnotations(ctx, r.Client, &guest, mig.Name)
+		if ovnErr != nil {
+			return phaseTransient(fmt.Errorf("resolve OVN dst identity: %w", ovnErr))
+		}
 		dst, buildErr := newDstPod(mig, &guest, &srcPod, r.Scheme, dstSidecarConfig{
 			mtlsEnabled: r.MigrationMTLSEnabled,
 			srcNodeName: guest.Status.NodeName,
 			dstNodeName: mig.Spec.Target.NodeName,
-		}, frozenIntentCM)
+		}, frozenIntentCM, ovnDstAnnotations)
 		if buildErr != nil {
 			return phaseFailure(
 				fmt.Sprintf("construct dst pod: %v", buildErr),


### PR DESCRIPTION
## What

**P1 of the OVN-Kubernetes support arc** ([RFC #242](https://github.com/projectbeskar/kubeswift/pull/242), `docs/design/ovn-cni-backends.md` §8). A **behavior-preserving** refactor that lifts the shipped kube-ovn primary-on-NAD identity logic (#239/#240) behind an internal `ovnBackend` interface, so the next OVN-based CNI (OVN-Kubernetes, P2) plugs in behind one seam instead of a new branch through the controller.

**No behavior change.** No CRD / RuntimeIntent / Rust change. The datapath stays single-sourced in `network-init.sh`. The shipped kube-ovn IP-preserving live-migration path is identical.

## The seam

New `internal/controller/swiftguest/ovn_backend.go`:
- `ovnBackend` interface — `Name()`, `Detect()`, `Identity()`; `ovnIdentity{PodAnnotations, MigrationDstAnnotations}`.
- An ordered, first-match-wins backend slice — **kube-ovn only today** (`ovnKubernetesBackend` is P2). "Two implementations, not a framework" — no registry/loader/config.
- `stampOVNIdentity` (boot dispatch) + the exported `OVNMigrationDstAnnotations` (the swiftmigration dst-pod builder calls it across the package boundary).

## The two call sites rewired

- **Boot** (`controller.go`): `stampKubeOVNIdentity` → `stampOVNIdentity` (dispatches to the backend that owns the guest's primary network).
- **Live-migration dst** (`preparing_live.go` → `newDstPod`): the migration controller resolves the dst annotations from the guest via `swiftguest.OVNMigrationDstAnnotations` (fail-closed on a NAD Get error) and passes the map into `newDstPod`. **The per-CNI suffix knowledge leaves the swiftmigration package entirely** — `mergeAnnotationsForDst` now just merges the pre-computed map.

`kubeovn.go`: `kubeOVNPrimaryProvider` is now a package func taking a client; `kubeOVNBackend` implements the interface (computes both the launcher-pod and the dst-pod annotations from the guest). Old `stampKubeOVNIdentity` removed.

## Regression gate

The existing kube-ovn behavior is the correctness gate (RFC §8):
- kube-ovn boot-identity tests renamed to `stampOVNIdentity` (**assertions unchanged**).
- The dst-derivation tests move to `swiftguest` (`OVNMigrationDstAnnotations`); `mergeAnnotationsForDst` gets a thin merge test.
- `go build ./...`, `go vet`, `gofmt -s`, **full `go test ./...`** all green.

## Deferred to P2 (with its only user)

`ClaimsToEnsure` (the OVN-Kubernetes `IPAMClaim` create/own/GC lifecycle) is intentionally NOT added here — kube-ovn needs none, and adding an unused field/loop now would be speculative (Principle #1/#7). It lands in P2 alongside `ovnKubernetesBackend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)