### PR TITLE
feat(networking): ovnKubernetesBackend — OVN-Kubernetes layer2 primary-on-NAD (OVN-K arc P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to KubeSwift are documented here.
 
 ## [Unreleased]
 
+### Added
+- **OVN-Kubernetes as a second OVN CNI backend (OVN-K arc P2).** `ovnKubernetesBackend`
+  implements the `ovnBackend` seam for OVN-Kubernetes **layer2 primary-on-NAD** guests:
+  it detects `type: ovn-k8s-cni-overlay` + `topology: layer2`, injects the guest MAC
+  (the logical-switch-port identity) + an `ipam-claim-reference` into the Multus
+  network-selection element, and creates+owns a per-guest `IPAMClaim` to pin the
+  primary IP (OVN-K does not auto-create it). The identity mechanism — the `mac`
+  field of the selection element — was confirmed on a real OVN-K cluster (a foreign
+  MAC requested there comes up reachable cross-node). Live-migration IP preservation
+  rides the already-carried-over Multus annotation: OVN-K allows the cross-node claim
+  overlap by **default**, so no `migrationJobName`-style marker is needed (simpler
+  than kube-ovn). Adds `ipamclaims` RBAC (`get,list,watch,create`; GC via owner-ref
+  cascade). The `PrimaryIPPreservedCrossNode()` live-eligibility gate already covers
+  it (CNI-agnostic). End-to-end validation on a real OVN-K cluster is P3.
+  ([RFC](docs/design/ovn-cni-backends.md))
+
 ### Changed
 - **Internal: pluggable OVN CNI backend seam (OVN-K arc P1).** Lifted the kube-ovn
   primary-on-NAD identity logic behind an internal `ovnBackend` interface

--- a/charts/kubeswift/templates/controller-manager/rbac.yaml
+++ b/charts/kubeswift/templates/controller-manager/rbac.yaml
@@ -29,11 +29,17 @@ rules:
   - apiGroups: ["seed.kubeswift.io"]
     resources: ["swiftseedprofiles"]
     verbs: ["get", "list", "watch"]
-  # Multus NADs — read-only, to detect a kube-ovn-class primary NAD and program
-  # the launcher pod's OVN logical-switch-port identity (kube-ovn integration).
+  # Multus NADs — read-only, to detect an OVN-class primary NAD (kube-ovn or
+  # ovn-kubernetes) and program the launcher pod's OVN logical-switch-port identity.
   - apiGroups: ["k8s.cni.cncf.io"]
     resources: ["network-attachment-definitions"]
     verbs: ["get", "list", "watch"]
+  # OVN-Kubernetes IPAMClaims — created+owned per guest to pin the primary IP of an
+  # OVN-K layer2 primary-on-NAD guest (OVN-K does not auto-create them). GC is via
+  # owner-ref cascade on the SwiftGuest, so no delete verb is needed.
+  - apiGroups: ["k8s.cni.cncf.io"]
+    resources: ["ipamclaims"]
+    verbs: ["get", "list", "watch", "create"]
   # Core resources
   - apiGroups: [""]
     resources: ["pods", "pods/status"]

--- a/config/manager/controller-manager-rbac.yaml
+++ b/config/manager/controller-manager-rbac.yaml
@@ -25,11 +25,17 @@ rules:
   - apiGroups: ["seed.kubeswift.io"]
     resources: ["swiftseedprofiles"]
     verbs: ["get", "list", "watch"]
-  # Multus NADs — read-only, to detect a kube-ovn-class primary NAD and program
-  # the launcher pod's OVN logical-switch-port identity (kube-ovn integration).
+  # Multus NADs — read-only, to detect an OVN-class primary NAD (kube-ovn or
+  # ovn-kubernetes) and program the launcher pod's OVN logical-switch-port identity.
   - apiGroups: ["k8s.cni.cncf.io"]
     resources: ["network-attachment-definitions"]
     verbs: ["get", "list", "watch"]
+  # OVN-Kubernetes IPAMClaims — created+owned per guest to pin the primary IP of an
+  # OVN-K layer2 primary-on-NAD guest (OVN-K does not auto-create them). GC is via
+  # owner-ref cascade on the SwiftGuest, so no delete verb is needed.
+  - apiGroups: ["k8s.cni.cncf.io"]
+    resources: ["ipamclaims"]
+    verbs: ["get", "list", "watch", "create"]
   # SwiftKernel
   - apiGroups: ["kernel.kubeswift.io"]
     resources: ["swiftkernels", "swiftkernels/status"]

--- a/internal/controller/swiftguest/multus.go
+++ b/internal/controller/swiftguest/multus.go
@@ -11,20 +11,30 @@ import (
 const MultusAnnotationKey = "k8s.v1.cni.cncf.io/networks"
 
 // multusNetworkEntry represents a single entry in the Multus networks annotation JSON.
+//
+// MAC and IPAMClaimReference are the NPWG network-selection-element fields an OVN
+// backend injects on the guest's primary entry (see ovnkubernetes.go): OVN-K binds
+// the logical-switch-port to the requested MAC (so it delivers to the guest behind
+// the re-MAC'd pod NIC) and pins the IP via the referenced IPAMClaim. They are
+// omitempty, so a plain (kube-ovn / bridge / SR-IOV) entry serializes exactly as
+// before — no behavior change for non-OVN-Kubernetes networks.
 type multusNetworkEntry struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace,omitempty"`
-	Interface string `json:"interface"`
+	Name               string `json:"name"`
+	Namespace          string `json:"namespace,omitempty"`
+	Interface          string `json:"interface"`
+	MAC                string `json:"mac,omitempty"`
+	IPAMClaimReference string `json:"ipam-claim-reference,omitempty"`
 }
 
-// BuildMultusAnnotation builds the k8s.v1.cni.cncf.io/networks JSON annotation
-// from the SwiftGuest's interfaces. Returns empty string if no secondary NICs.
-func BuildMultusAnnotation(guest *swiftv1alpha1.SwiftGuest) string {
-	if len(guest.Spec.Interfaces) == 0 {
-		return ""
-	}
-
+// buildMultusEntries returns the per-interface Multus selection elements for the
+// guest's NAD-bearing interfaces (in spec order, numbered net1, net2, ...) and the
+// index of the guest's PRIMARY interface within that slice (-1 if the primary is
+// not NAD-bearing — e.g. node-local primary). Exposed within the package so an OVN
+// backend can augment the primary entry (mac + ipam-claim-reference) before the
+// annotation is marshaled.
+func buildMultusEntries(guest *swiftv1alpha1.SwiftGuest) ([]multusNetworkEntry, int) {
 	var entries []multusNetworkEntry
+	primaryIdx := -1
 	multusIdx := 1 // net1, net2, etc.
 	for _, iface := range guest.Spec.Interfaces {
 		if iface.NetworkRef == nil {
@@ -34,6 +44,9 @@ func BuildMultusAnnotation(guest *swiftv1alpha1.SwiftGuest) string {
 		if ns == "" {
 			ns = guest.Namespace
 		}
+		if iface.Primary {
+			primaryIdx = len(entries)
+		}
 		entries = append(entries, multusNetworkEntry{
 			Name:      iface.NetworkRef.Name,
 			Namespace: ns,
@@ -41,11 +54,16 @@ func BuildMultusAnnotation(guest *swiftv1alpha1.SwiftGuest) string {
 		})
 		multusIdx++
 	}
+	return entries, primaryIdx
+}
 
+// BuildMultusAnnotation builds the k8s.v1.cni.cncf.io/networks JSON annotation
+// from the SwiftGuest's interfaces. Returns empty string if no secondary NICs.
+func BuildMultusAnnotation(guest *swiftv1alpha1.SwiftGuest) string {
+	entries, _ := buildMultusEntries(guest)
 	if len(entries) == 0 {
 		return ""
 	}
-
 	data, err := json.Marshal(entries)
 	if err != nil {
 		return ""

--- a/internal/controller/swiftguest/ovn_backend.go
+++ b/internal/controller/swiftguest/ovn_backend.go
@@ -4,7 +4,10 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
 )
@@ -41,11 +44,13 @@ type ovnIdentity struct {
 	// nothing beyond the carried-over Multus annotation, or has no live-overlap
 	// mechanism (the latter would make live migration offline-only — surfaced by the
 	// migration webhook gate, never a silent unreachable boot).
-	//
-	// (A future field — ClaimsToEnsure, the per-guest objects a backend needs
-	// created before the pod, e.g. an OVN-Kubernetes IPAMClaim — lands in P2 with
-	// its only user; kube-ovn needs none.)
 	MigrationDstAnnotations map[string]string
+	// ClaimsToEnsure are per-guest cluster objects a backend needs created BEFORE
+	// the launcher pod references them — e.g. an OVN-Kubernetes IPAMClaim (OVN-K
+	// does not auto-create it; spike §8). The stamp dispatch creates each one
+	// owner-referenced to the guest (so it GCs with the guest via cascade) before
+	// applying PodAnnotations. Nil for kube-ovn (it needs none).
+	ClaimsToEnsure []*unstructured.Unstructured
 }
 
 // ovnBackend is the internal seam for one OVN-based CNI's primary-on-NAD identity.
@@ -71,7 +76,7 @@ type ovnBackend interface {
 func ovnBackends() []ovnBackend {
 	return []ovnBackend{
 		kubeOVNBackend{},
-		// ovnKubernetesBackend{} — P2 (docs/design/ovn-cni-backends.md §8).
+		ovnKubernetesBackend{},
 	}
 }
 
@@ -110,6 +115,14 @@ func (r *SwiftGuestReconciler) stampOVNIdentity(ctx context.Context, guest *swif
 	if err != nil {
 		return err
 	}
+	// Ensure any backend-required objects (e.g. an OVN-Kubernetes IPAMClaim) exist
+	// BEFORE the pod references them — fail closed so a create failure requeues
+	// rather than booting a pod that references a non-existent claim.
+	for _, claim := range id.ClaimsToEnsure {
+		if err := r.ensureOVNClaim(ctx, guest, claim); err != nil {
+			return err
+		}
+	}
 	if len(id.PodAnnotations) == 0 {
 		return nil
 	}
@@ -118,6 +131,21 @@ func (r *SwiftGuestReconciler) stampOVNIdentity(ctx context.Context, guest *swif
 	}
 	for k, v := range id.PodAnnotations {
 		pod.Annotations[k] = v
+	}
+	return nil
+}
+
+// ensureOVNClaim creates a backend-required cluster object (e.g. an OVN-Kubernetes
+// IPAMClaim) owner-referenced to the guest so it GCs with the guest via cascade.
+// Idempotent: AlreadyExists is success (the claim is stable across pod recreate and
+// the migration dst pod, which references the same name). Create-only — no Get, so
+// it opens no informer (no extra list/watch RBAC needed beyond create).
+func (r *SwiftGuestReconciler) ensureOVNClaim(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, claim *unstructured.Unstructured) error {
+	if err := controllerutil.SetControllerReference(guest, claim, r.Scheme); err != nil {
+		return err
+	}
+	if err := r.Create(ctx, claim); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
 	}
 	return nil
 }

--- a/internal/controller/swiftguest/ovnkubernetes.go
+++ b/internal/controller/swiftguest/ovnkubernetes.go
@@ -1,0 +1,174 @@
+package swiftguest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// OVN-Kubernetes primary-on-NAD integration — the ovnKubernetesBackend
+// implementation of the ovnBackend seam (ovn_backend.go).
+//
+// Like kube-ovn, OVN-Kubernetes binds each logical-switch port to a MAC and answers
+// ARP for the port IP; unless the LSP identity is the guest, OVN delivers the
+// guest's traffic to the wrong MAC behind the re-MAC'd pod NIC. The mechanism is
+// DIFFERENT from kube-ovn's flat per-provider annotations: OVN-K's identity rides
+// INSIDE the Multus network-selection element (the spike P2-step-1 finding,
+// 2026-06-17):
+//   - "mac": <guest MAC>             -> OVN-K creates the LSP with this MAC, so its
+//     ARP responder + L2 delivery target the guest (the kube-ovn mac_address
+//     equivalent — empirically a foreign MAC requested here is honored and reachable
+//     cross-node).
+//   - "ipam-claim-reference": <claim> -> pins the IP via a pre-created IPAMClaim
+//     (OVN-K does NOT auto-create it — there is no kubevirt-ipam-claims webhook here,
+//     so this backend creates+owns it per guest; spike P0-c / §8).
+//
+// Both fields land on the guest's PRIMARY NAD entry of k8s.v1.cni.cncf.io/networks
+// (MultusAnnotationKey) — the SAME annotation the SwiftGuest pod builder sets and
+// the live-migration dst pod already inherits (mergeAnnotationsForDst). And OVN-K
+// cross-node claim OVERLAP is allowed by default (spike P0-c — no migrationJobName
+// marker needed, unlike kube-ovn), so the dst keeps the identity + IP automatically:
+// MigrationDstAnnotations is empty for this backend.
+//
+// v1 scope: topology layer2 (the IP-preserving, IPAMClaim-capable topology proven in
+// the spike). localnet/provider OVN-K networks are documented-advanced (a later
+// addition), so Detect narrows to layer2.
+
+const (
+	// OVNKubernetesCNIType is the NAD config "type" of an OVN-Kubernetes network.
+	OVNKubernetesCNIType = "ovn-k8s-cni-overlay"
+	// OVNKubernetesLayer2Topology is the v1-supported topology (IP-preserving,
+	// IPAMClaim-capable). localnet is a later, advanced addition.
+	OVNKubernetesLayer2Topology = "layer2"
+)
+
+// ipamClaimGVK identifies the NPWG IPAMClaim CRD for an unstructured create (the
+// type is not registered in the controller scheme — like the NAD).
+var ipamClaimGVK = schema.GroupVersionKind{
+	Group:   "k8s.cni.cncf.io",
+	Version: "v1alpha1",
+	Kind:    "IPAMClaim",
+}
+
+// ovnKubernetesPrimaryNAD returns the OVN logical-network name + the primary
+// interface's Multus name (net1, ...) when the guest's primary rides an
+// OVN-Kubernetes layer2 NAD. ok=false (no error) means "not an OVN-K layer2
+// primary-on-NAD guest" → the caller skips. A Get error is returned so the caller
+// requeues (fail closed).
+func ovnKubernetesPrimaryNAD(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest) (network, iface string, ok bool, err error) {
+	prim := guest.PrimaryInterface()
+	if prim == nil || prim.NetworkRef == nil {
+		return "", "", false, nil
+	}
+	ns := prim.NetworkRef.Namespace
+	if ns == "" {
+		ns = guest.Namespace
+	}
+	nad := &unstructured.Unstructured{}
+	nad.SetGroupVersionKind(networkAttachmentDefinitionGVK)
+	if e := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: prim.NetworkRef.Name}, nad); e != nil {
+		return "", "", false, fmt.Errorf("get NAD %s/%s for ovn-kubernetes identity: %w", ns, prim.NetworkRef.Name, e)
+	}
+	cfgStr, _, _ := unstructured.NestedString(nad.Object, "spec", "config")
+	if cfgStr == "" {
+		return "", "", false, nil
+	}
+	var cfg struct {
+		Type     string `json:"type"`
+		Topology string `json:"topology"`
+		Name     string `json:"name"`
+	}
+	if json.Unmarshal([]byte(cfgStr), &cfg) != nil {
+		return "", "", false, nil
+	}
+	// v1: only ovn-k8s-cni-overlay + layer2 + a named OVN network (the IPAMClaim's
+	// spec.network). Any other type/topology is not this backend's (kube-ovn,
+	// bridge, localnet → skip).
+	if cfg.Type != OVNKubernetesCNIType || cfg.Topology != OVNKubernetesLayer2Topology || cfg.Name == "" {
+		return "", "", false, nil
+	}
+	// The primary's Multus interface name (net1, ...) — the IPAMClaim spec.interface
+	// and the entry to augment. primaryIdx is the primary's position among the
+	// NAD-bearing entries; it is >= 0 here because the primary has a NetworkRef.
+	entries, primaryIdx := buildMultusEntries(guest)
+	if primaryIdx < 0 || primaryIdx >= len(entries) {
+		return "", "", false, nil
+	}
+	return cfg.Name, entries[primaryIdx].Interface, true, nil
+}
+
+// ovnKubernetesClaimName is the deterministic, per-guest-per-interface IPAMClaim
+// name. Stable across pod recreate and the migration dst pod (which references the
+// same name via the inherited Multus annotation).
+func ovnKubernetesClaimName(guest *swiftv1alpha1.SwiftGuest, iface string) string {
+	return fmt.Sprintf("%s-%s", guest.Name, iface)
+}
+
+// ovnKubernetesBackend is the ovnBackend for OVN-Kubernetes layer2 primary NADs.
+// Stateless; the client is passed per call.
+type ovnKubernetesBackend struct{}
+
+func (ovnKubernetesBackend) Name() string { return "ovn-kubernetes" }
+
+// Detect reports whether the guest's primary interface rides an OVN-Kubernetes
+// layer2 NAD.
+func (ovnKubernetesBackend) Detect(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest) (bool, error) {
+	_, _, ok, err := ovnKubernetesPrimaryNAD(ctx, c, guest)
+	return ok, err
+}
+
+// Identity injects the guest MAC (the LSP identity) + the ipam-claim-reference into
+// the primary NAD's Multus selection element, and returns the per-guest IPAMClaim to
+// ensure. MigrationDstAnnotations is empty: the augmented Multus annotation is carried
+// onto the dst pod by mergeAnnotationsForDst and OVN-K allows the cross-node claim
+// overlap by default (spike P0-c), so the dst keeps the identity + IP with no marker.
+func (ovnKubernetesBackend) Identity(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest, _ string) (ovnIdentity, error) {
+	network, iface, ok, err := ovnKubernetesPrimaryNAD(ctx, c, guest)
+	if err != nil {
+		return ovnIdentity{}, err
+	}
+	if !ok {
+		return ovnIdentity{}, nil
+	}
+	mac := primaryMAC(guest, guest.PrimaryInterface())
+	if mac == "" {
+		return ovnIdentity{}, nil
+	}
+	claimName := ovnKubernetesClaimName(guest, iface)
+
+	// Rebuild the full networks annotation (matching the pod builder's, since both
+	// use buildMultusEntries) with mac + ipam-claim-reference on the primary entry.
+	entries, primaryIdx := buildMultusEntries(guest)
+	if primaryIdx < 0 || primaryIdx >= len(entries) {
+		return ovnIdentity{}, nil
+	}
+	entries[primaryIdx].MAC = mac
+	entries[primaryIdx].IPAMClaimReference = claimName
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return ovnIdentity{}, fmt.Errorf("marshal ovn-kubernetes networks annotation: %w", err)
+	}
+
+	// The IPAMClaim this guest's pod (and its migration dst) reference. spec.network
+	// is the OVN logical-network name (the NAD config "name"), spec.interface the
+	// primary's Multus interface. Owner-ref + create are applied by the stamp
+	// dispatch (ensureOVNClaim).
+	claim := &unstructured.Unstructured{}
+	claim.SetGroupVersionKind(ipamClaimGVK)
+	claim.SetNamespace(guest.Namespace)
+	claim.SetName(claimName)
+	_ = unstructured.SetNestedField(claim.Object, network, "spec", "network")
+	_ = unstructured.SetNestedField(claim.Object, iface, "spec", "interface")
+
+	return ovnIdentity{
+		PodAnnotations:          map[string]string{MultusAnnotationKey: string(data)},
+		MigrationDstAnnotations: nil,
+		ClaimsToEnsure:          []*unstructured.Unstructured{claim},
+	}, nil
+}

--- a/internal/controller/swiftguest/ovnkubernetes_test.go
+++ b/internal/controller/swiftguest/ovnkubernetes_test.go
@@ -1,0 +1,217 @@
+package swiftguest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+// ovnkNADObj builds an ovn-k8s-cni-overlay NAD with the given topology and OVN
+// network name (the config "name", which the IPAMClaim references).
+func ovnkNADObj(ns, nadName, ovnNetwork, topology string) *unstructured.Unstructured {
+	cfg := `{"cniVersion":"0.3.1","type":"ovn-k8s-cni-overlay"`
+	if ovnNetwork != "" {
+		cfg += `,"name":"` + ovnNetwork + `"`
+	}
+	if topology != "" {
+		cfg += `,"topology":"` + topology + `"`
+	}
+	cfg += `,"netAttachDefName":"` + ns + `/` + nadName + `","allowPersistentIPs":true}`
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(networkAttachmentDefinitionGVK)
+	u.SetNamespace(ns)
+	u.SetName(nadName)
+	_ = unstructured.SetNestedField(u.Object, cfg, "spec", "config")
+	return u
+}
+
+// Detect matches only ovn-k8s-cni-overlay + layer2 + a named OVN network.
+func TestOVNKubernetesDetect_Matrix(t *testing.T) {
+	cases := []struct {
+		name    string
+		nad     *unstructured.Unstructured
+		wantOK  bool
+		wantErr bool
+	}{
+		{"layer2+name", ovnkNADObj("ns", "n", "ovnnet", "layer2"), true, false},
+		{"no-topology", ovnkNADObj("ns", "n", "ovnnet", ""), false, false},
+		{"layer3", ovnkNADObj("ns", "n", "ovnnet", "layer3"), false, false},
+		{"layer2-no-name", ovnkNADObj("ns", "n", "", "layer2"), false, false},
+		{"kube-ovn-type", nadObj("ns", "n", "kube-ovn", ""), false, false},
+		{"bridge-type", nadObj("ns", "n", "bridge", ""), false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			guest := guestWithPrimaryNAD("ns", "g", "n", "52:54:00:00:00:01")
+			c := nadAwareClientBuilder(tc.nad).Build()
+			ok, err := (ovnKubernetesBackend{}).Detect(context.Background(), c, guest)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
+			}
+			if ok != tc.wantOK {
+				t.Errorf("Detect ok=%v, want %v", ok, tc.wantOK)
+			}
+		})
+	}
+}
+
+// Node-local primary (no networkRef) -> Detect false, no NAD Get.
+func TestOVNKubernetesDetect_NodeLocal(t *testing.T) {
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "g"},
+		Spec:       swiftv1alpha1.SwiftGuestSpec{Interfaces: []swiftv1alpha1.GuestInterface{{Name: "mgmt"}}},
+	}
+	c := nadAwareClientBuilder().Build()
+	ok, err := (ovnKubernetesBackend{}).Detect(context.Background(), c, guest)
+	if err != nil || ok {
+		t.Fatalf("node-local: ok=%v err=%v, want false,nil", ok, err)
+	}
+}
+
+// Identity injects mac + ipam-claim-reference into the PRIMARY Multus entry and
+// returns the IPAMClaim to ensure; MigrationDstAnnotations is empty (the dst
+// inherits the Multus annotation + default overlap).
+func TestOVNKubernetesIdentity_InjectsMacAndClaim(t *testing.T) {
+	guest := guestWithPrimaryNAD("ovn-ns", "ovnk-vm", "ovnk-nad", "52:54:00:ab:cd:ef")
+	c := nadAwareClientBuilder(ovnkNADObj("ovn-ns", "ovnk-nad", "ovnknet", "layer2")).Build()
+
+	id, err := (ovnKubernetesBackend{}).Identity(context.Background(), c, guest, "ignored-mig")
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	if len(id.MigrationDstAnnotations) != 0 {
+		t.Errorf("MigrationDstAnnotations must be empty for OVN-K; got %v", id.MigrationDstAnnotations)
+	}
+
+	// PodAnnotations: the networks annotation with mac + ipam-claim-reference on the
+	// primary (net1) entry.
+	var entries []multusNetworkEntry
+	if err := json.Unmarshal([]byte(id.PodAnnotations[MultusAnnotationKey]), &entries); err != nil {
+		t.Fatalf("unmarshal networks annotation: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	if entries[0].Interface != "net1" {
+		t.Errorf("primary interface = %q, want net1", entries[0].Interface)
+	}
+	if entries[0].MAC != "52:54:00:ab:cd:ef" {
+		t.Errorf("primary MAC = %q, want the guest MAC", entries[0].MAC)
+	}
+	if entries[0].IPAMClaimReference != "ovnk-vm-net1" {
+		t.Errorf("ipam-claim-reference = %q, want ovnk-vm-net1", entries[0].IPAMClaimReference)
+	}
+
+	// ClaimsToEnsure: one IPAMClaim with the right GVK, name, ns and spec.
+	if len(id.ClaimsToEnsure) != 1 {
+		t.Fatalf("want 1 claim, got %d", len(id.ClaimsToEnsure))
+	}
+	claim := id.ClaimsToEnsure[0]
+	if claim.GroupVersionKind() != ipamClaimGVK {
+		t.Errorf("claim GVK = %v, want %v", claim.GroupVersionKind(), ipamClaimGVK)
+	}
+	if claim.GetName() != "ovnk-vm-net1" || claim.GetNamespace() != "ovn-ns" {
+		t.Errorf("claim = %s/%s, want ovn-ns/ovnk-vm-net1", claim.GetNamespace(), claim.GetName())
+	}
+	if net, _, _ := unstructured.NestedString(claim.Object, "spec", "network"); net != "ovnknet" {
+		t.Errorf("claim spec.network = %q, want ovnknet (the OVN network name)", net)
+	}
+	if iface, _, _ := unstructured.NestedString(claim.Object, "spec", "interface"); iface != "net1" {
+		t.Errorf("claim spec.interface = %q, want net1", iface)
+	}
+}
+
+// OVNMigrationDstAnnotations is empty for an OVN-K guest (the carried-over Multus
+// annotation IS the dst contract; overlap allowed by default).
+func TestOVNMigrationDstAnnotations_OVNKubernetes_Empty(t *testing.T) {
+	guest := guestWithPrimaryNAD("ovn-ns", "ovnk-vm", "ovnk-nad", "52:54:00:ab:cd:ef")
+	c := nadAwareClientBuilder(ovnkNADObj("ovn-ns", "ovnk-nad", "ovnknet", "layer2")).Build()
+	out, err := OVNMigrationDstAnnotations(context.Background(), c, guest, "ovnk-vm-live")
+	if err != nil {
+		t.Fatalf("OVNMigrationDstAnnotations: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("OVN-K dst annotations must be empty (Multus carry-over handles it); got %v", out)
+	}
+}
+
+// ovnkDispatchScheme has SwiftGuest (for the claim owner-ref) + the NAD/IPAMClaim
+// unstructured GVKs (for the NAD Get + the claim Create). A fresh scheme — no
+// mutation of the shared internal/scheme.Scheme.
+func ovnkDispatchScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	gvSwift := schema.GroupVersion{Group: "swift.kubeswift.io", Version: "v1alpha1"}
+	s.AddKnownTypes(gvSwift, &swiftv1alpha1.SwiftGuest{}, &swiftv1alpha1.SwiftGuestList{})
+	metav1.AddToGroupVersion(s, gvSwift)
+	s.AddKnownTypeWithName(networkAttachmentDefinitionGVK, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(networkAttachmentDefinitionGVK.GroupVersion().WithKind("NetworkAttachmentDefinitionList"), &unstructured.UnstructuredList{})
+	s.AddKnownTypeWithName(ipamClaimGVK, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(ipamClaimGVK.GroupVersion().WithKind("IPAMClaimList"), &unstructured.UnstructuredList{})
+	return s
+}
+
+// The full boot dispatch: stampOVNIdentity on an OVN-K guest creates the IPAMClaim
+// (owner-referenced to the guest, for GC) and stamps the augmented Multus annotation
+// onto the pod.
+func TestStampOVNIdentity_OVNKubernetes_CreatesClaimAndStamps(t *testing.T) {
+	s := ovnkDispatchScheme()
+	guest := guestWithPrimaryNAD("ovn-ns", "ovnk-vm", "ovnk-nad", "52:54:00:ab:cd:ef")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ovnkNADObj("ovn-ns", "ovnk-nad", "ovnknet", "layer2")).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: s}
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ovn-ns", Name: "p"}}
+	if err := r.stampOVNIdentity(context.Background(), guest, pod); err != nil {
+		t.Fatalf("stampOVNIdentity: %v", err)
+	}
+
+	// The IPAMClaim was created with the right spec + owner-ref to the guest.
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(ipamClaimGVK)
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "ovn-ns", Name: "ovnk-vm-net1"}, got); err != nil {
+		t.Fatalf("IPAMClaim not created: %v", err)
+	}
+	if net, _, _ := unstructured.NestedString(got.Object, "spec", "network"); net != "ovnknet" {
+		t.Errorf("created claim spec.network = %q, want ovnknet", net)
+	}
+	owners := got.GetOwnerReferences()
+	if len(owners) != 1 || owners[0].Kind != "SwiftGuest" || owners[0].Name != "ovnk-vm" {
+		t.Errorf("claim owner-refs = %+v, want one controller ref to SwiftGuest/ovnk-vm", owners)
+	}
+
+	// The pod's networks annotation carries the injected mac + ipam-claim-reference.
+	var entries []multusNetworkEntry
+	if err := json.Unmarshal([]byte(pod.Annotations[MultusAnnotationKey]), &entries); err != nil {
+		t.Fatalf("pod networks annotation: %v", err)
+	}
+	if len(entries) != 1 || entries[0].MAC != "52:54:00:ab:cd:ef" || entries[0].IPAMClaimReference != "ovnk-vm-net1" {
+		t.Errorf("pod networks entry not augmented: %+v", entries)
+	}
+}
+
+// First-match-wins dispatch over disjoint NAD types: a kube-ovn guest resolves to
+// the kube-ovn backend, an OVN-K guest to the ovn-kubernetes backend.
+func TestResolveOVNBackend_DisjointTypes(t *testing.T) {
+	koGuest := guestWithPrimaryNAD("ns", "g", "ko", "52:54:00:00:00:02")
+	koClient := nadAwareClientBuilder(nadObj("ns", "ko", "kube-ovn", "ko.ns.ovn")).Build()
+	if b, err := resolveOVNBackend(context.Background(), koClient, koGuest); err != nil || b == nil || b.Name() != "kube-ovn" {
+		t.Errorf("kube-ovn guest resolved to %v (err %v), want kube-ovn", b, err)
+	}
+
+	okGuest := guestWithPrimaryNAD("ns", "g", "ok", "52:54:00:00:00:03")
+	okClient := nadAwareClientBuilder(ovnkNADObj("ns", "ok", "oknet", "layer2")).Build()
+	if b, err := resolveOVNBackend(context.Background(), okClient, okGuest); err != nil || b == nil || b.Name() != "ovn-kubernetes" {
+		t.Errorf("ovn-k guest resolved to %v (err %v), want ovn-kubernetes", b, err)
+	}
+}


### PR DESCRIPTION
## What

**P2 of the OVN-Kubernetes support arc** — the second OVN backend behind the [P1 seam](https://github.com/projectbeskar/kubeswift/pull/243). `ovnKubernetesBackend` brings KubeSwift's primary-on-NAD IP-preserving live migration to **OVN-Kubernetes** (it already works on kube-ovn, v0.4.5), via the spike-proven Mechanism B ([RFC](docs/design/ovn-cni-backends.md) §4.3 / §8).

No CRD / RuntimeIntent / Rust / webhook change. End-to-end cluster validation on a real OVN-K cluster is **P3**.

## §3.5 resolved first (spike before code)

The one not-yet-spiked unknown — *how does OVN-K bind the LSP MAC?* — was resolved on the real OVN-K `ntx` cluster **before** writing this: a pod requesting `net1` with a **foreign** `mac` (`52:54:00:de:ad:01`) + `ipam-claim-reference` on an `allowPersistentIPs` layer2 NAD came up with **exactly that MAC** + the claim-pinned IP, and was **reachable cross-node at 0% loss**. So the kube-ovn `mac_address`-annotation equivalent is the **standard NPWG `mac` field in the Multus selection element** — and `mac` + `ipam-claim-reference` ride the **same** `k8s.v1.cni.cncf.io/networks` entry.

## The backend

- **Detect**: `type: ovn-k8s-cni-overlay` + `topology: layer2` + a named OVN network (v1 scope; localnet is a documented-advanced later addition).
- **Identity**: injects the guest MAC (LSP identity) + `ipam-claim-reference` into the **primary** Multus entry, and returns a per-guest **`IPAMClaim`** (`k8s.cni.cncf.io/v1alpha1`) to ensure — OVN-K does **not** auto-create it.
- **MigrationDstAnnotations is empty**: the augmented Multus annotation is already carried onto the dst pod by `mergeAnnotationsForDst`, and OVN-K allows the cross-node claim overlap **by default** → no `migrationJobName`-style marker (simpler than kube-ovn).

## Plumbing

- `multus.go`: `multusNetworkEntry` gains omitempty `mac` + `ipam-claim-reference`; `BuildMultusAnnotation` factored onto `buildMultusEntries` (entries + primary index) so the backend augments the primary entry. **Behavior-preserving** for non-OVN-K networks (omitempty → identical JSON).
- `ovn_backend.go`: `ovnIdentity` gains `ClaimsToEnsure`; `stampOVNIdentity` ensures each claim (`SetControllerReference` + `Create`, AlreadyExists=success — create-only, opens no informer) before applying PodAnnotations; `ovnKubernetesBackend{}` joins the first-match-wins slice (disjoint NAD types → order-immaterial).
- **RBAC**: `ipamclaims` `get,list,watch,create` in both `config/manager` and the Helm chart (GC via owner-ref cascade — no delete verb).

## Gate

`PrimaryIPPreservedCrossNode()` already covers OVN-K (it's CNI-agnostic: primary rides a NAD → IP preserved → webhook accepts `mode: live` without `allowIPChange`). No webhook change.

## Tests (the regression + new gate)

- Existing kube-ovn boot tests + `BuildMultusAnnotation`/`BuildPod` tests pass **unchanged** (the multus refactor is behavior-preserving).
- New: OVN-K Detect matrix, Identity (Multus injection + IPAMClaim spec), `MigrationDstAnnotations` empty, the full `stampOVNIdentity` dispatch (creates the IPAMClaim **with an owner-ref to the guest** + stamps the pod), and first-match-wins routing over disjoint types.
- `go build` / `go vet` / `gofmt -s` / full `go test ./...` all green; no CRD drift.

## Next

**P3** — full real-VM validation on the OVN-K `ntx` cluster (boot + cross-node live-migrate a real KubeSwift guest, confirming the #240 re-MAC interaction end-to-end). **P4** — operator docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)