### PR TITLE
fix(controller): tolerate absent CSI VolumeSnapshot CRDs (don't crash-loop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ All notable changes to KubeSwift are documented here.
   identical and its tests pass unchanged. Foundation for OVN-Kubernetes support
   ([RFC](docs/design/ovn-cni-backends.md)).
 
+### Fixed
+- **Controller no longer crash-loops on a cluster without the CSI VolumeSnapshot
+  CRDs.** The snapshot controllers `Owns(VolumeSnapshot)`; when the
+  external-snapshotter CRDs (`snapshot.storage.k8s.io/v1`) are absent, that watch's
+  cache could never sync and the manager exited fatally — so on a bare cluster
+  (e.g. one whose CSI driver doesn't bundle them) KubeSwift never started. The
+  manager now does a one-time discovery check and **gates those watches** on it,
+  logging a clear warning and degrading gracefully: the **core VM runtime**, the
+  **local/s3 snapshot backends**, and `cloneStrategy=copy` all keep working; only
+  the **CSI VolumeSnapshot backend** and `cloneStrategy=snapshot` are disabled
+  until the CRDs are installed. Surfaced by the OVN-K P3 cluster validation (the
+  W5 pattern — a bare cluster exposes a hard dependency unit tests can't see).
+
 ---
 
 ## [v0.4.5] — 2026-06-17

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -130,16 +130,30 @@ func main() {
 		os.Exit(1)
 	}
 
+	// CSI VolumeSnapshot CRDs are optional. The snapshot controllers
+	// Owns(VolumeSnapshot); if the external-snapshotter CRDs are absent that watch
+	// can never sync its cache and the manager fatally exits. Gate those watches on
+	// a one-time discovery check so a cluster without the snapshot CRDs still runs
+	// the core VM runtime (only CSI snapshots / cloneStrategy=snapshot degrade).
+	volumeSnapshotEnabled := volumeSnapshotCRDsInstalled(clientset)
+	if !volumeSnapshotEnabled {
+		klog.Warning("CSI VolumeSnapshot CRDs (snapshot.storage.k8s.io/v1) are not installed; " +
+			"the csi-volume-snapshot snapshot backend and SwiftImage cloneStrategy=snapshot are disabled. " +
+			"Core VM runtime, local/s3 snapshots, and cloneStrategy=copy are unaffected. " +
+			"Install the external-snapshotter CRDs to enable CSI snapshots.")
+	}
+
 	// CR-state gauges (kubeswift_guests, kubeswift_pool_replicas, ...) are
 	// computed from the informer cache at scrape time — every listed type
 	// already has a controller-driven informer, so scrapes are in-memory.
 	kubeswiftmetrics.RegisterStateCollector(mgr.GetClient())
 
 	if err = (&swiftimage.SwiftImageReconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		Converter: swiftimage.StubConverter{},
-		Clientset: clientset,
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		Converter:             swiftimage.StubConverter{},
+		Clientset:             clientset,
+		VolumeSnapshotEnabled: volumeSnapshotEnabled,
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftImage controller")
 		os.Exit(1)
@@ -185,9 +199,10 @@ func main() {
 	}
 
 	if err = (&swiftsnapshot.SwiftSnapshotReconciler{
-		Client:          mgr.GetClient(),
-		Scheme:          mgr.GetScheme(),
-		SnapshotS3Image: swiftsnapshot.SnapshotS3Image(),
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		SnapshotS3Image:       swiftsnapshot.SnapshotS3Image(),
+		VolumeSnapshotEnabled: volumeSnapshotEnabled,
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftSnapshot controller")
 		os.Exit(1)
@@ -318,4 +333,23 @@ func main() {
 		klog.ErrorS(err, "manager exited with error")
 		os.Exit(1)
 	}
+}
+
+// volumeSnapshotCRDsInstalled reports whether the CSI external-snapshotter
+// VolumeSnapshot CRD (snapshot.storage.k8s.io/v1) is present, via a discovery
+// lookup. Used to gate the snapshot controllers' Owns(VolumeSnapshot) watch: that
+// watch cannot sync its cache when the CRD is absent and would fatally exit the
+// manager, so on a cluster without the snapshot CRDs we skip it and run the core
+// VM runtime regardless.
+func volumeSnapshotCRDsInstalled(cs kubernetes.Interface) bool {
+	list, err := cs.Discovery().ServerResourcesForGroupVersion("snapshot.storage.k8s.io/v1")
+	if err != nil {
+		return false
+	}
+	for _, r := range list.APIResources {
+		if r.Kind == "VolumeSnapshot" {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/controller-manager/main_test.go
+++ b/cmd/controller-manager/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// volumeSnapshotCRDsInstalled gates the snapshot controllers' Owns(VolumeSnapshot)
+// watch so a cluster without the external-snapshotter CRDs runs the core VM
+// runtime instead of fatally exiting (the P3 install-blocker finding).
+func TestVolumeSnapshotCRDsInstalled(t *testing.T) {
+	// Present: discovery advertises VolumeSnapshot in snapshot.storage.k8s.io/v1.
+	present := fake.NewSimpleClientset()
+	present.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "snapshot.storage.k8s.io/v1",
+		APIResources: []metav1.APIResource{{Name: "volumesnapshots", Kind: "VolumeSnapshot"}},
+	}}
+	if !volumeSnapshotCRDsInstalled(present) {
+		t.Errorf("want true when the VolumeSnapshot CRD is advertised by discovery")
+	}
+
+	// Absent: no snapshot group-version → ServerResourcesForGroupVersion errors → false.
+	absent := fake.NewSimpleClientset()
+	if volumeSnapshotCRDsInstalled(absent) {
+		t.Errorf("want false when the VolumeSnapshot CRD is absent")
+	}
+
+	// Group-version present but only another kind in it → still false.
+	otherKind := fake.NewSimpleClientset()
+	otherKind.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "snapshot.storage.k8s.io/v1",
+		APIResources: []metav1.APIResource{{Name: "volumesnapshotclasses", Kind: "VolumeSnapshotClass"}},
+	}}
+	if volumeSnapshotCRDsInstalled(otherKind) {
+		t.Errorf("want false when the group-version lacks the VolumeSnapshot kind")
+	}
+}

--- a/internal/controller/swiftimage/controller.go
+++ b/internal/controller/swiftimage/controller.go
@@ -26,6 +26,12 @@ type SwiftImageReconciler struct {
 	Scheme    *runtime.Scheme
 	Converter ImageConverter
 	Clientset kubernetes.Interface
+	// VolumeSnapshotEnabled gates the Owns(VolumeSnapshot) watch. When the CSI
+	// external-snapshotter CRDs (snapshot.storage.k8s.io/v1) are absent, that watch
+	// cannot sync its cache and the manager fatally exits. Set from a one-time
+	// discovery check in main. When false, cloneStrategy=snapshot is unavailable;
+	// the import pipeline and cloneStrategy=copy are unaffected.
+	VolumeSnapshotEnabled bool
 }
 
 // Reconcile implements the reconcile loop.
@@ -220,10 +226,13 @@ func (r *SwiftImageReconciler) swiftGuestToSwiftImage(_ context.Context, obj cli
 
 // SetupWithManager registers the reconciler with the manager.
 func (r *SwiftImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&imagev1alpha1.SwiftImage{}).
-		Owns(&batchv1.Job{}).
-		Owns(&volumesnapshotv1.VolumeSnapshot{}).
+		Owns(&batchv1.Job{})
+	if r.VolumeSnapshotEnabled {
+		b = b.Owns(&volumesnapshotv1.VolumeSnapshot{})
+	}
+	return b.
 		Watches(&swiftv1alpha1.SwiftGuest{}, handler.EnqueueRequestsFromMapFunc(r.swiftGuestToSwiftImage)).
 		Complete(r)
 }

--- a/internal/controller/swiftsnapshot/controller.go
+++ b/internal/controller/swiftsnapshot/controller.go
@@ -38,6 +38,12 @@ type SwiftSnapshotReconciler struct {
 	// SnapshotS3Image is the snapshot-s3 uploader image used by the s3
 	// (Tier C) backend's upload Job. Wired from KUBESWIFT_SNAPSHOT_S3_IMAGE.
 	SnapshotS3Image string
+	// VolumeSnapshotEnabled gates the Owns(VolumeSnapshot) watch. When the CSI
+	// external-snapshotter CRDs (snapshot.storage.k8s.io/v1) are absent, that watch
+	// cannot sync its cache and the manager fatally exits. Set from a one-time
+	// discovery check in main. When false, the csi-volume-snapshot backend is
+	// unavailable; the local and s3 backends are unaffected.
+	VolumeSnapshotEnabled bool
 }
 
 // Reconcile drives the SwiftSnapshot state machine.
@@ -387,10 +393,13 @@ func isNotFound(err error) bool {
 // SwiftSnapshot, so EnqueueRequestsFromMapFunc maps Pod events to
 // the SwiftSnapshots that reference that pod's guest.
 func (r *SwiftSnapshotReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&snapshotv1alpha1.SwiftSnapshot{}).
-		Owns(&volumesnapshotv1.VolumeSnapshot{}).
-		Owns(&batchv1.Job{}).
+		Owns(&batchv1.Job{})
+	if r.VolumeSnapshotEnabled {
+		b = b.Owns(&volumesnapshotv1.VolumeSnapshot{})
+	}
+	return b.
 		Watches(
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.podToSnapshots),


### PR DESCRIPTION
## What

KubeSwift's controller-manager **crash-loops on a cluster that doesn't have the CSI `VolumeSnapshot` CRDs** (`snapshot.storage.k8s.io/v1`). This makes the controller tolerate their absence and degrade gracefully.

## Why

The swiftimage + swiftsnapshot controllers `Owns(&volumesnapshotv1.VolumeSnapshot{})`. When the external-snapshotter CRDs are absent, that watch's informer can never sync, and controller-runtime fatally exits the manager:

```
E ... "Could not wait for Cache to sync" ... "failed to wait for swiftimage caches to sync kind source: *v1.VolumeSnapshot: timed out waiting for cache to be synced"
E ... "manager exited with error" err="failed to wait for swiftimage caches to sync ... VolumeSnapshot"
```

So on a bare cluster — e.g. one whose CSI driver doesn't bundle the snapshot CRDs — **KubeSwift never starts**, even though it doesn't need snapshots to run VMs.

## Fix

`main` does a **one-time discovery check** (`volumeSnapshotCRDsInstalled`) and **gates the `Owns(VolumeSnapshot)` watch** in both controllers on it (via a `VolumeSnapshotEnabled` field). When absent, it logs a clear warning and degrades gracefully:

- ✅ keep working: **core VM runtime**, the **local** + **s3** snapshot backends, `cloneStrategy=copy`
- ⏸️ disabled until the CRDs are installed: the **CSI VolumeSnapshot** snapshot backend, `cloneStrategy=snapshot`

Not OVN-K-specific — this is a general install-robustness fix.

## How it surfaced

The **OVN-Kubernetes P3 cluster validation** on a fresh cluster whose Longhorn install didn't include the snapshot CRDs (the W5 pattern — only a bare cluster exposes the hard dependency; unit tests with fake clients never hit it).

## Tests

- New `volumeSnapshotCRDsInstalled` unit test (present / absent / group-version-without-the-kind) via a fake discovery client.
- Existing swiftimage + swiftsnapshot tests pass unchanged; `go build` / `vet` / `gofmt -s` / full `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)