### PR TITLE
docs(networking): OVN-Kubernetes backend SHIPPED — install guide + RFC validation (OVN-K arc P4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,13 @@ All notable changes to KubeSwift are documented here.
   overlap by **default**, so no `migrationJobName`-style marker is needed (simpler
   than kube-ovn). Adds `ipamclaims` RBAC (`get,list,watch,create`; GC via owner-ref
   cascade). The `PrimaryIPPreservedCrossNode()` live-eligibility gate already covers
-  it (CNI-agnostic). End-to-end validation on a real OVN-K cluster is P3.
-  ([RFC](docs/design/ovn-cni-backends.md))
+  it (CNI-agnostic). **Cluster-validated end-to-end** on a real OVN-Kubernetes-primary
+  cluster: a RWX+Block disk-boot guest on a `layer2 allowPersistentIPs` NAD booted
+  reachable cross-node, then `mode: live`-migrated with **no `allowIPChange`** in
+  **2.8 s** with the IP preserved and reachable from a third node. Operator guide:
+  [`docs/networking/ovn-kubernetes-install.md`](docs/networking/ovn-kubernetes-install.md).
+  UDN-*secondary* networks ride this backend transparently (a generated `layer2` NAD);
+  UDN-*primary* multi-tenancy is a separate later phase. ([RFC](docs/design/ovn-cni-backends.md))
 
 ### Changed
 - **Internal: pluggable OVN CNI backend seam (OVN-K arc P1).** Lifted the kube-ovn

--- a/config/samples/multi-node-l2/ovn-l2-nad.yaml
+++ b/config/samples/multi-node-l2/ovn-l2-nad.yaml
@@ -18,5 +18,10 @@ spec:
       "name": "ovn-l2",
       "topology": "layer2",
       "subnets": "10.20.0.0/16",
+      "allowPersistentIPs": true,
       "netAttachDefName": "default/ovn-l2"
     }
+# `allowPersistentIPs: true` is REQUIRED by KubeSwift's OVN-Kubernetes backend:
+# it is what lets the backend pin the guest's primary IP via an IPAMClaim, which
+# is in turn what preserves the IP across a `mode: live` migration (no
+# `allowIPChange`). Without it the IPAMClaim mechanism does not engage.

--- a/docs/design/ovn-cni-backends.md
+++ b/docs/design/ovn-cni-backends.md
@@ -1,18 +1,40 @@
 # RFC: Pluggable OVN CNI backends (OVN-Kubernetes as a second substrate)
 
-> Status (2026-06-17): **P0 spike COMPLETE — findings folded in; ALL decisions
-> RESOLVED.** The pivotal unknown (OVN-K non-KubeVirt *live* IP-keep) is
-> **RETIRED — PASS**: OVN-K gets full IP-preserving live migration via the NPWG
-> `IPAMClaim` path, and *simpler* than kube-ovn (no `migrationJobName`-equivalent
-> needed — see §3 / §8 / the spike doc). The §10(b) offline-only fallback is
-> dropped. The two decisions that needed the user's call — **(c) dual-substrate
-> maintenance** and **(d) supported-vs-advanced tiering** — were **signed off
-> 2026-06-17 → "full first-class support"** (accept the dual-substrate cost; ship
-> OVN-K-primary as a documented, validated, SUPPORTED option). **GREEN to proceed.**
-> Remaining = the build: P1 (behavior-preserving `ovnBackend` refactor) →
-> P2 (`ovnKubernetesBackend`) → P3 (full real-VM validation on the OVN-K `ntx`
-> cluster) → P4 (supported-option docs/runbook). UDN-primary multi-tenancy is a
-> separate later phase (P5 / R6). Author: staff-architect.
+> Status (2026-06-17): **SHIPPED (P1+P2 merged #243/#244; P3 cluster-validated
+> 2026-06-17).** OVN-Kubernetes is now a fully-supported second OVN substrate: a
+> SwiftGuest whose **primary** NIC rides an OVN-K `layer2` NAD is reachable
+> cross-node on its own IP and **preserves that IP across a `mode: live` migration
+> with no `allowIPChange`** — the same capability v0.4.5 shipped on kube-ovn, now on
+> a second substrate. P1 (#243) lifted the kube-ovn logic behind the pluggable
+> `ovnBackend` seam; P2 (#244) added `ovnKubernetesBackend`; **P3 validated the full
+> stack on a real OVN-K-primary cluster** (a real RWX+Block disk-boot Ubuntu-Noble
+> guest booted reachable cross-node and live-migrated IP-preserving in **2.806 s** —
+> see the **Validation** callout below and the validated §8 P3 row). The pivotal
+> unknown (OVN-K non-KubeVirt *live* IP-keep) was retired by the P0 spike: OVN-K
+> gets it via the NPWG `IPAMClaim` path, *simpler* than kube-ovn (no
+> `migrationJobName`-equivalent needed — §3 / §8). The two decisions that needed
+> the user's call — **(c) dual-substrate maintenance** and **(d) supported-vs-
+> advanced tiering** — were signed off 2026-06-17 → "full first-class support".
+> Operator install guide: [`ovn-kubernetes-install.md`](../networking/ovn-kubernetes-install.md).
+> UDN-primary multi-tenancy remains a separate later phase (P5 / R6). Author:
+> staff-architect.
+
+> ### Validation (P3, 2026-06-17 — SHIPPED evidence)
+>
+> Validated on a dedicated **OVN-Kubernetes-primary** cluster (3 libvirt VMs
+> `ntx1/2/3`, k0s v1.34.3, nested virt, Longhorn with a `migratable` StorageClass,
+> KubeSwift image `sha-12dad1e`). A **real RWX+Block disk-boot Ubuntu-Noble**
+> SwiftGuest `ovnk-vm`, primary on an `ovn-l2` NAD (`ovn-k8s-cni-overlay` `layer2`
+> `allowPersistentIPs: true`, subnet `10.20.0.0/16`):
+>
+> - **Boot:** the controller stamped the guest `mac` + `ipam-claim-reference` into
+>   the Multus networks annotation; `IPAMClaim ovnk-vm-net1` was created+owned
+>   (`ips: ["10.20.0.1/16"]`); `network-init` re-MAC'd `net1` off the guest MAC (the
+>   #240 datapath); the guest came up **Running, IP `10.20.0.1`, reachable
+>   cross-node** (ping from a pod attached to `ovn-l2` on another node, 0% loss).
+> - **Live migration:** `mode: live` ntx2→ntx1, **no `allowIPChange`** →
+>   **Completed, downtime 2.806 s, IP preserved `10.20.0.1`**, reachable from a
+>   **third** node (ntx3) at 0% loss.
 
 ## 0. TL;DR
 
@@ -499,8 +521,8 @@ follow-on spike), not a gate on starting the work.
 | **P0 — Spike — ✅ DONE (2026-06-17)** | On the OVN-K-primary `ntx` cluster (3 libvirt VMs, k0s 1.34.3, nested virt). **PASS:** (b) **Mechanism B offline** — a layer2 `allowPersistentIPs` NAD + a pre-created `IPAMClaim` + `ipam-claim-reference` persists the IP across pod-recreate; (c) **the pivotal live overlap** — two pods on different nodes referencing the **same `IPAMClaim`** simultaneously is **allowed by default** (dst gets the IP while src holds it; cutover clean; reachable from a 3rd node), **no marker annotation** — simpler than kube-ovn; **plus** UDN-secondary proven end-to-end (generated NAD + pod IP). **Surfaced:** OVN-K does NOT auto-create the `IPAMClaim` (the backend must), `status.ownerPod` goes stale post-cutover (advisory; backend owns it), UDN-*primary* node datapath crashlooped on this small cluster (separate phase, R6), and the OVN-K **identity** mechanism (§3.5) is the one not-yet-spiked residual. Findings doc: [`ovn-cni-backends-spike.md`](ovn-cni-backends-spike.md). | **Done. (c) PASS retired §10-b.** |
 | **P1 — `ovnBackend` refactor (behavior-preserving)** | Introduce the interface; lift the shipped #239/#240 kube-ovn logic into `kubeOVNBackend`; rewire the two call sites. **kube-ovn unit tests pass unchanged; kube-ovn cluster behavior identical** — the existing kube-ovn cluster validation is the regression gate. Zero OVN-K code yet. | PR 1. A pure refactor of shipped behavior; regression-gated by the existing kube-ovn tests + a kube-ovn cluster re-validation. |
 | **P2 — `ovnKubernetesBackend`** | New backend implementing the P0-proven Mechanism B (one mechanism for **both** offline and live — no separate live path needed): the `ovn-k8s-cni-overlay`/`layer2` detector; **`IPAMClaim` create+own+GC per guest** (OVN-K does not auto-create it); `ipam-claim-reference` (+ guest `mac`) in the Multus selection element; **`mergeAnnotationsForDst` carry-over** of the claim reference onto the dst pod (the #235 pattern — the live overlap); the §6 live-eligibility gate. **Pin the §3.5 identity slot here** (the `mac_address`-equivalent: NAD/pod `mac` or `k8s.ovn.org/...`) — short follow-on spike if it doesn't fall out of bring-up. RBAC for `ipamclaims.k8s.cni.cncf.io` (generated-NAD reads already covered by the existing `network-attachment-definitions` grant). UDN-*secondary* needs no extra code (rides the generated NAD, §4.4). | PR 2 (no PR 2b — Mechanism B is one path for offline+live). Unit-tested with fake NADs/claims. |
-| **P3 — Cluster validation (`ntx`, real KubeSwift VMs)** | The §7 matrix on the OVN-K-primary `ntx` cluster — it has nested virt, so this is **real VM boot + live-migrate**, not raw-pod probes. V1 (smoke regression) is the viability gate; V3-V5 + V6a are the ship bar (mechanisms spike-proven, confirmed on real VMs); **V6b (UDN-primary multi-tenancy) is a separate later phase** on a robust OVN-K cluster. | PR 3 (validation log + any walkthrough fixes — the W5 pattern *will* surface cluster-only bugs). |
-| **P4 — Docs** | This RFC → "SHIPPED" with the validation outcome (honest matrix, like the v0.4.5 multi-node-L2 doc). Operator install guide for OVN-K-primary (sibling to [`ovn-l2-install.md`](../networking/ovn-l2-install.md)); update [`ovn-kubernetes.md`](../networking/ovn-kubernetes.md), [`multi-node-l2.md`](../networking/multi-node-l2.md), [`network-architecture-requirements.md`](network-architecture-requirements.md) §6. Promote/annotate the staged UDN-secondary/localnet samples; mark the UDN-primary/CUDN samples as the separate-phase capability. | PR 4. |
+| **P3 — Cluster validation (`ntx`, real KubeSwift VMs) — ✅ DONE (2026-06-17)** | The §7 matrix on the OVN-K-primary `ntx` cluster (3 libvirt VMs, k0s 1.34.3, nested virt, image `sha-12dad1e`) — real VM boot + live-migrate, not raw-pod probes. **PASS:** a **real RWX+Block disk-boot Ubuntu-Noble** guest `ovnk-vm` on a `layer2` `allowPersistentIPs` NAD (subnet `10.20.0.0/16`) came up **Running, IP `10.20.0.1`, reachable cross-node** (V3 — the residual identity slot, the Multus selection-element `mac` field, confirmed: a foreign MAC behind `net1` is delivered to the guest); the controller created+owned `IPAMClaim ovnk-vm-net1` and `network-init` re-MAC'd `net1`. **LIVE** migration ntx2→ntx1 with **no `allowIPChange`** Completed in **2.806 s** with the IP **preserved (`10.20.0.1`) and reachable from a 3rd node** (V5). **Surfaced:** the stock `ovn-l2-nad.yaml` sample was missing `allowPersistentIPs: true` (the IPAMClaim prerequisite — fixed); a bare OVN-K cluster without the `snapshot.storage.k8s.io` CSI VolumeSnapshot CRDs historically crash-looped the controller (an optional snapshot prereq, not a runtime blocker — tracked separately for hard-dependency removal). UDN-secondary rides the same code path (V6a, transparent); **UDN-primary (V6b) remains a separate later phase** (R6). | Done. **SHIPPED.** |
+| **P4 — Docs — ✅ DONE (2026-06-17)** | This RFC → "SHIPPED" with the P3 validation outcome (the **Validation** callout + the validated §8 P3 row). New operator install guide for OVN-K-primary ([`ovn-kubernetes-install.md`](../networking/ovn-kubernetes-install.md), sibling to the kube-ovn [`ovn-l2-install.md`](../networking/ovn-l2-install.md)); updated [`ovn-kubernetes.md`](../networking/ovn-kubernetes.md), [`multi-node-l2.md`](../networking/multi-node-l2.md); fixed the [`ovn-l2-nad.yaml`](../../config/samples/multi-node-l2/ovn-l2-nad.yaml) sample (`allowPersistentIPs`). The UDN-secondary path is documented as transparent; the UDN-primary/CUDN samples are marked as the separate-phase capability. | Done. **SHIPPED.** |
 | **P5 — UDN-primary multi-tenancy *(separate later phase)*** | Guest-on-pod-PRIMARY-network UDN/CUDN multi-tenancy — a **different datapath** than the secondary-NAD backend (§4.4). Requires a robustly-resourced OVN-K cluster (the 3-VM `ntx` ovnkube-node crashlooped on UDN-network bring-up under the segmentation gate, R6). Its own design + spike + PRs when such a cluster exists. | Deferred; not gated by P1-P4. |
 
 ---

--- a/docs/networking/multi-node-l2.md
+++ b/docs/networking/multi-node-l2.md
@@ -1,14 +1,20 @@
 # Multi-node L2 networking (IP-preserving guests)
 
 > **Status (2026-06): datapath + offline + LIVE migration IP-preservation
-> VALIDATED.** Live-migration IP-preservation is proven end-to-end on a real
-> **kube-ovn** Tier-C L2 (cross-node, `mode: live`, no `allowIPChange`, ~3.2 s
-> downtime, IP preserved + reachable from a third node). The control-plane
-> (`spec.interfaces[].primary`, the resolver wiring, the
+> VALIDATED on TWO OVN substrates.** Live-migration IP-preservation is proven
+> end-to-end on **kube-ovn** (cross-node, `mode: live`, no `allowIPChange`, ~3.2 s
+> downtime, IP preserved + reachable from a third node) **and on OVN-Kubernetes-
+> primary** (the same capability, ~2.8 s downtime — see the matrix). The
+> control-plane (`spec.interfaces[].primary`, the resolver wiring, the
 > `PrimaryIPPreservedCrossNode()` migration gate), the runtime datapath, offline
-> migration, and the live path are all cluster-validated. The **zero-touch
-> kube-ovn integration** (automatic OVN port identity) is the recommended path —
-> see the [OVN L2 install guide](ovn-l2-install.md). See the matrix below.
+> migration, and the live path are all cluster-validated. Both integrations are
+> **zero-touch** (automatic OVN port identity):
+> - on a cluster with a different primary CNI (Calico/Cilium) → **kube-ovn
+>   non-primary**: [OVN L2 install guide](ovn-l2-install.md);
+> - on a cluster already on OVN-K as the primary CNI → **OVN-Kubernetes-primary**:
+>   [OVN-Kubernetes-primary install guide](ovn-kubernetes-install.md).
+>
+> See the matrix below.
 
 By default a SwiftGuest's primary IP is **node-local** — it comes from a
 per-node dnsmasq on `br0` and is NAT-masqueraded out the pod's `eth0`. That IP
@@ -30,7 +36,8 @@ the operator's choice — the recommended reference is **OVN-Kubernetes layer-2*
 | Datapath — guest gets the NAD's portable IP | ✅ validated | `setup_primary_nad_nic`: flush NAD IP → bridge → fixed-lease dnsmasq → status |
 | Cross-node L2 reachability | ✅ validated | both directions over a VXLAN-mesh overlay |
 | **Offline** migration IP-preservation | ✅ validated | guest reacquired its NAD IP on the target node, no `allowIPChange` |
-| **Live** migration IP-preservation | ✅ validated (kube-ovn) | proven on a real kube-ovn L2 (cross-node, `mode: live`, no `allowIPChange`, ~3.2 s, IP preserved + reachable). [#235](https://github.com/projectbeskar/kubeswift/pull/235)/[#236](https://github.com/projectbeskar/kubeswift/pull/236) carry the NAD path; the kube-ovn port-identity integration makes it zero-touch (see [install guide](ovn-l2-install.md)) |
+| **Live** migration IP-preservation (kube-ovn non-primary) | ✅ validated (kube-ovn) | proven on a real kube-ovn L2 (cross-node, `mode: live`, no `allowIPChange`, ~3.2 s, IP preserved + reachable). [#235](https://github.com/projectbeskar/kubeswift/pull/235)/[#236](https://github.com/projectbeskar/kubeswift/pull/236) carry the NAD path; the kube-ovn port-identity integration makes it zero-touch (see [install guide](ovn-l2-install.md)) |
+| **Live** migration IP-preservation (OVN-Kubernetes primary) | ✅ validated (OVN-K) | proven on a dedicated OVN-K-primary cluster (image `sha-12dad1e`): a real RWX+Block disk-boot Ubuntu-Noble guest on a `layer2` `allowPersistentIPs` NAD live-migrated cross-node, `mode: live`, **no `allowIPChange`**, **2.806 s** downtime, IP preserved (`10.20.0.1`) + reachable from a third node. The OVN-K backend (#244) is zero-touch — it auto-creates the per-guest `IPAMClaim` + stamps the guest `mac`/`ipam-claim-reference` (see [install guide](ovn-kubernetes-install.md)) |
 
 **Why the lab VXLAN mesh couldn't validate live migration (and kube-ovn does).**
 On a *hand-rolled* VXLAN-mesh substrate, both the migration source and destination

--- a/docs/networking/ovn-kubernetes-install.md
+++ b/docs/networking/ovn-kubernetes-install.md
@@ -1,0 +1,331 @@
+# Running an IP-preserving guest on OVN-Kubernetes-primary
+
+> Goal: on a cluster where **OVN-Kubernetes is the primary CNI**, put a KubeSwift
+> guest's **primary** NIC on an OVN-K `layer2` network so it gets a **portable
+> primary IP** — the substrate for **IP-preserving live migration** (cross-node
+> `mode: live`, no `allowIPChange`), telco/NFV, and stateful services with external
+> clients. This is the OVN-Kubernetes sibling of the kube-ovn-non-primary path in
+> the [OVN L2 install guide](ovn-l2-install.md).
+>
+> **Status: cluster-validated.** A real RWX+Block disk-boot Ubuntu-Noble guest
+> booted reachable cross-node and live-migrated with its IP preserved in **2.806 s**
+> on a dedicated OVN-K-primary cluster (see [Verify](#step-5--verify-boot-cross-node-reach-ip-preserving-migration)).
+>
+> See [Multi-node L2 networking](multi-node-l2.md) for the feature/CRD reference,
+> the [OVN-Kubernetes Integration Guide](ovn-kubernetes.md) for secondary-network
+> use cases (storage / GPU data plane / VLAN / UDN), and the
+> [RFC](../design/ovn-cni-backends.md) for the pluggable `ovnBackend` design.
+
+---
+
+## OVN-Kubernetes-primary vs. kube-ovn-non-primary — pick the right guide
+
+Both deliver the same KubeSwift capability (portable primary IP + IP-preserving
+live migration). The choice is purely about **which CNI runs your cluster's primary
+pod network**:
+
+| Your cluster | Use | Guide |
+|---|---|---|
+| **OVN-Kubernetes is already the primary CNI** (OpenShift, upstream OVN-K, telco) | OVN-K's **native** `layer2` NAD (this guide) | **this guide** |
+| A **different** primary CNI (Calico, Cilium, Flannel…) you want to **keep** | **kube-ovn in non-primary mode** alongside it | [OVN L2 install guide](ovn-l2-install.md) |
+| Greenfield / no primary CNI yet | OVN-Kubernetes or kube-ovn as the primary CNI | either; this guide if you choose OVN-K |
+
+Upstream OVN-Kubernetes secondary networks assume OVN-K *is* the primary CNI — so
+this guide is for clusters already standardized on it. On a Calico/Cilium cluster,
+do **not** install OVN-Kubernetes as a parallel overlay; use kube-ovn-non-primary
+instead (the [other guide](ovn-l2-install.md)).
+
+> KubeSwift does **not** import or depend on any OVN-Kubernetes type. It attaches
+> through the standard **Multus + NetworkAttachmentDefinition** interface, so the
+> same SwiftGuest manifests work whether the NAD is backed by OVN-Kubernetes,
+> kube-ovn, macvlan, or bridge CNI. For an OVN-K-class primary NAD the controller
+> additionally programs the guest's OVN port identity and pins its IP automatically
+> (see [Step 4](#step-4--run-a-guest-on-the-segment) and
+> [Step 5](#step-5--verify-boot-cross-node-reach-ip-preserving-migration)).
+
+---
+
+## How it works (what KubeSwift does for you)
+
+When a SwiftGuest's **primary** interface rides an OVN-K `layer2` NAD, KubeSwift
+makes the guest reachable on the segment and preserves its IP across a migration —
+**zero-touch, no manual `ovn-nbctl` / `IPAMClaim` authoring**:
+
+- **Identity.** OVN-Kubernetes binds each logical-switch port to the *pod NIC's*
+  identity, but KubeSwift's datapath bridges the guest's *own* hypervisor MAC
+  behind the pod NIC. So the controller injects the **guest MAC** as the `mac`
+  field of the guest's entry in the `k8s.v1.cni.cncf.io/networks` (Multus)
+  annotation — making the OVN port identity the guest. (OVN-K's identity rides
+  *inside* that annotation, unlike kube-ovn's flat `<provider>.kubernetes.io/*`
+  keys — the backend handles the difference.)
+- **IP pinning.** The controller creates and owns (per guest, GC'd by owner-ref) an
+  **`IPAMClaim`** (`k8s.cni.cncf.io/v1alpha1`) and references it via
+  `ipam-claim-reference` in the same Multus selection element. OVN-Kubernetes does
+  **not** auto-create this claim — KubeSwift does. This is what pins the primary IP
+  so it survives a move. (Requires `allowPersistentIPs: true` on the NAD — see
+  [Step 3](#step-3--create-the-layer2-segment-the-nad).)
+- **Datapath re-MAC.** Because the pod NIC now carries the guest's MAC, enslaving
+  it to `br0` would make the kernel add a permanent fdb entry `<guest-mac> -> net1`
+  that shadows the guest's tap. `network-init` re-MACs the pod NIC to a dummy
+  **before** enslaving it (the KubeVirt bridge-binding pattern); the OVN port keeps
+  the guest MAC, so OVN still delivers `net1 -> br0 -> tap`.
+- **Live migration.** The destination pod inherits the same Multus annotation (so
+  the same guest MAC + the same claim reference). OVN-Kubernetes allows the
+  cross-node claim **overlap by default** — the dst acquires the IP while the source
+  still holds it through cutover — so **no `migrationJobName`-style marker is
+  needed** (simpler than kube-ovn).
+
+All of this is automatic and a **no-op for every other networking mode** (node-local
+bridge, non-OVN-K NAD, SR-IOV). Both the **controller-manager** and the launcher
+(**`swiftletd`**) image must carry the integration.
+
+---
+
+## Prerequisites
+
+- **OVN-Kubernetes as the cluster's primary CNI**, with the multi-network feature
+  enabled (default in OpenShift 4.14+; upstream OVN-Kubernetes per its
+  multi-network config).
+- **Multus CNI** installed (KubeSwift requires Multus already). Every node that
+  hosts a primary-on-NAD guest — or is a migration target — must run Multus.
+- The **`IPAMClaim` CRD** (`ipamclaims.k8s.cni.cncf.io`, the NPWG
+  network-attachment-definition-client persistent-IP CRD) installed. KubeSwift
+  creates an `IPAMClaim` per guest to pin its primary IP; without the CRD the
+  backend cannot persist the IP. Most OVN-K installs that ship `allowPersistentIPs`
+  also ship this CRD; verify with `kubectl get crd ipamclaims.k8s.cni.cncf.io`.
+- **(Optional) CSI VolumeSnapshot CRDs** (`snapshot.storage.k8s.io`) — only if you
+  want **CSI VM snapshots**. They are **not** needed for the VM runtime or for
+  live migration. A bare OVN-K cluster (e.g. Longhorn without the external
+  snapshotter CRDs) historically crash-looped the controller; if you intend to use
+  snapshots, install the snapshotter CRDs + controller first. (This hard
+  dependency is being removed; until then, install them if you want snapshots and
+  it is harmless to install them regardless.)
+- **RWX + Block storage** (a migratable CSI StorageClass) if you want to **live**
+  migrate the guest — the live-migration storage requirement (KubeVirt model). On
+  Longhorn this is a StorageClass with `parameters.migratable: "true"`.
+- KubeSwift **≥ the release carrying the OVN-Kubernetes backend** (OVN-K arc P2,
+  `#244`) — both the controller stamping/IPAMClaim and the launcher `network-init`
+  datapath re-MAC. Earlier builds boot an OVN-K-primary guest but it is
+  **unreachable** (no OVN port identity, or the pod NIC shadows the guest's tap).
+
+---
+
+## Step 1 — confirm OVN-Kubernetes is the primary CNI
+
+```bash
+# OVN-Kubernetes components Running:
+kubectl get pods -n ovn-kubernetes 2>/dev/null || kubectl get pods -A | grep -i ovnkube
+
+# A plain pod gets an address from OVN-K's pod network (sanity):
+kubectl run cni-check --image=busybox --restart=Never --command -- sleep 60
+kubectl get pod cni-check -o jsonpath='{.status.podIP}{"\n"}'
+kubectl delete pod cni-check
+```
+
+This guide assumes OVN-K is already serving the cluster's primary network. If it is
+not — and you do not want to re-CNI — use the
+[kube-ovn-non-primary guide](ovn-l2-install.md) instead.
+
+---
+
+## Step 2 — confirm the persistent-IP CRD
+
+```bash
+kubectl get crd ipamclaims.k8s.cni.cncf.io
+# NAME                              CREATED AT
+# ipamclaims.k8s.cni.cncf.io        ...
+```
+
+If it is missing, install the NPWG network-attachment-definition-client CRDs (the
+same project that defines `network-attachment-definitions`). KubeSwift needs it to
+pin the guest's IP.
+
+---
+
+## Step 3 — create the layer2 segment (the NAD)
+
+A `layer2` NAD with **`allowPersistentIPs: true`** defines an overlay L2 segment
+spanning all nodes and enables the persistent-IP (IPAMClaim) mechanism KubeSwift
+relies on:
+
+```yaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ovn-l2
+  namespace: default                 # same ns as your SwiftGuests
+spec:
+  config: |
+    {
+      "cniVersion": "0.4.0",
+      "type": "ovn-k8s-cni-overlay",
+      "name": "ovn-l2",
+      "topology": "layer2",
+      "subnets": "10.20.0.0/16",
+      "allowPersistentIPs": true,
+      "netAttachDefName": "default/ovn-l2"
+    }
+```
+
+The runnable sample is
+[`config/samples/multi-node-l2/ovn-l2-nad.yaml`](../../config/samples/multi-node-l2/ovn-l2-nad.yaml).
+
+> **`allowPersistentIPs: true` is REQUIRED.** It is what lets OVN-Kubernetes persist
+> an allocated IP in an `IPAMClaim` (and lets KubeSwift's backend pin the guest's
+> primary IP). Without it, the IPAMClaim mechanism does not engage and the IP is
+> **not** preserved across a migration. `subnets` must be set (the claim mechanism
+> needs OVN-K IPAM on the segment).
+
+Verify the NAD exists:
+
+```bash
+kubectl get net-attach-def ovn-l2 -n default
+```
+
+---
+
+## Step 4 — run a guest on the segment
+
+Put the guest's **primary** interface on the NAD (and use RWX+Block storage to make
+it live-migratable):
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: ovnk-vm
+  namespace: default
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: default }
+  seedProfileRef: { name: default }
+  runPolicy: Running
+  # RWX+Block storage is required to LIVE-migrate (a migratable CSI):
+  storage: { accessMode: ReadWriteMany, volumeMode: Block, storageClassName: <migratable-sc> }
+  interfaces:
+    - name: app
+      primary: true                  # this NIC is the guest's primary (portable) IP
+      networkRef: { name: ovn-l2 }    # ...riding the OVN-K layer2 segment
+  migration:
+    enabled: true
+    preferredMode: live
+    drainPolicy: Migrate
+```
+
+This is the same shape as
+[`config/samples/migratable-guests/03-ip-preserving-live-migratable.yaml`](../../config/samples/migratable-guests/03-ip-preserving-live-migratable.yaml),
+which already references the `ovn-l2` NAD.
+
+The guest comes up `Running` with `status.network.primaryIP` from the `10.20.x`
+segment. **You do nothing manual** — the controller injects the guest MAC +
+`ipam-claim-reference` into the Multus annotation, creates+owns the per-guest
+`IPAMClaim`, and `network-init` re-MACs the pod NIC. The guest is reachable on the
+segment with **no `ovn-nbctl`**.
+
+---
+
+## Step 5 — verify (boot, cross-node reach, IP-preserving migration)
+
+This is the cluster-validated flow — a real RWX+Block disk-boot Ubuntu-Noble guest
+on a dedicated OVN-K-primary cluster.
+
+**Boot + cross-node reachability.**
+
+```bash
+# Guest Running with its NAD IP:
+kubectl get swiftguest -n default ovnk-vm \
+  -o jsonpath='{.status.phase} {.status.network.primaryIP}{"\n"}'
+# -> Running 10.20.0.1
+
+# The controller created+owns the per-guest IPAMClaim:
+kubectl get ipamclaim -n default ovnk-vm-net1 \
+  -o jsonpath='{.status.ips}{"\n"}'                # -> ["10.20.0.1/16"]
+
+# Reachable cross-node: ping the guest IP from a pod attached to ovn-l2 on ANOTHER node.
+# (annotate the prober pod with k8s.v1.cni.cncf.io/networks: default/ovn-l2 and pin
+#  it to a different node than the guest's) -> 0% packet loss
+```
+
+**IP-preserving live migration (the marquee).** Because the primary rides a
+multi-node NAD, `mode: live` is accepted **without `allowIPChange`**:
+
+```bash
+swiftctl migrate ovnk-vm -n default --to <other-node>   # mode auto -> live
+# or apply a SwiftMigration with spec.mode: live
+kubectl get swiftmigration -n default -w
+```
+
+Expect **`Completed`**, `observedDowntime` a few seconds, the guest on the target
+node with the **same** IP, and reachability from a **third** node afterward. In the
+P3 validation a `mode: live` migration ntx2→ntx1 with **no `allowIPChange`**
+Completed in **2.806 s** downtime with the IP **preserved (`10.20.0.1`) and
+reachable from a third node (ntx3) at 0% loss**.
+
+```bash
+# After migration: same IP, now on the target node:
+kubectl get swiftguest -n default ovnk-vm \
+  -o jsonpath='{.status.nodeName} {.status.network.primaryIP}{"\n"}'
+# -> <other-node> 10.20.0.1
+```
+
+---
+
+## UserDefinedNetwork (UDN) notes
+
+- **UDN *secondary* is handled transparently.** A `UserDefinedNetwork` (role
+  Secondary, topology Layer2) generates a `type: ovn-k8s-cni-overlay` `layer2` NAD,
+  which KubeSwift's OVN-Kubernetes backend detects exactly like the `ovn-l2` NAD
+  above. A guest just points `interfaces[].networkRef` at the generated NAD — **no
+  extra integration**. (Proven at the raw-pod level; rides the validated code
+  path.) See [UDN tenant isolation](ovn-kubernetes.md#4-tenant-isolation-with-userdefinednetwork).
+- **UDN *primary* (per-tenant primary networks / multi-tenancy) is a separate later
+  phase — NOT shipped here.** Guest-on-the-pod-PRIMARY-network is a different
+  datapath, requires the OVN-K `--enable-network-segmentation` gate, and
+  destabilized the node datapath on a small validation cluster. Do not treat
+  UDN-primary as available via this backend.
+
+---
+
+## Troubleshooting
+
+- **Guest gets an IP but is unreachable cross-node.** Confirm the launcher pod's
+  `k8s.v1.cni.cncf.io/networks` annotation carries the guest's `mac` on the NAD
+  entry (the OVN port identity) and that the per-guest `IPAMClaim` exists
+  (`kubectl get ipamclaim -n <ns> <guest>-net1`). If the annotation has no `mac`,
+  the controller is **older than the OVN-K backend (`#244`)**. If the claim is
+  missing, check that the NAD has **`allowPersistentIPs: true`** and that the
+  `ipamclaims.k8s.cni.cncf.io` CRD is installed. Also confirm the launcher image
+  carries the `network-init` re-MAC (`bridge fdb show br0` should **not** show a
+  permanent `<guest-mac> -> net1` entry).
+- **`mode: live` migration is rejected for `allowIPChange`.** The guest's
+  **primary** interface must set both `primary: true` **and** `networkRef`
+  (a secondary NAD does not make the primary IP portable). Confirm with
+  `kubectl get swiftguest <name> -o jsonpath='{.spec.interfaces}'`.
+- **dst can't keep the IP during migration.** Unlike kube-ovn, OVN-Kubernetes needs
+  no `migrationJobName` marker — the src and dst share the same `IPAMClaim` and the
+  overlap is allowed by default. If the dst fails to come up, confirm it inherited
+  the source's `k8s.v1.cni.cncf.io/networks` annotation (the `#235` carry-through)
+  and that `network-init` ran on the dst.
+- **`IPAMClaim.status.ownerPod` looks stale after a migration.** This is advisory
+  only — there is no kubevirt-ipam-claims controller updating it on an OVN-K-primary
+  cluster, and IP delivery follows the live pod regardless. The KubeSwift backend
+  owns the claim lifecycle (and GCs it with the guest via owner-ref).
+- **Controller crash-loops on a bare OVN-K cluster.** Historically caused by missing
+  CSI VolumeSnapshot CRDs (`snapshot.storage.k8s.io`). Install the snapshotter CRDs
+  if you want CSI snapshots; they are not needed for the VM runtime. (This hard
+  dependency is being removed in a separate change.)
+- **Cross-node L2 fails.** OVN-Kubernetes layer2 uses Geneve (UDP 6081) between
+  nodes; verify it is open in any firewall between nodes.
+
+---
+
+## See also
+
+- [OVN L2 install guide (kube-ovn non-primary)](ovn-l2-install.md) — the sibling
+  path for clusters on a different primary CNI.
+- [Multi-node L2 networking](multi-node-l2.md) — the feature/CRD reference and the
+  validation matrix.
+- [OVN-Kubernetes Integration Guide](ovn-kubernetes.md) — OVN-K secondary-network
+  use cases (storage, GPU data plane, VLAN/localnet, UDN).
+- [RFC: Pluggable OVN CNI backends](../design/ovn-cni-backends.md) — the
+  `ovnBackend` design and the P0/P3 validation evidence.

--- a/docs/networking/ovn-kubernetes.md
+++ b/docs/networking/ovn-kubernetes.md
@@ -4,6 +4,13 @@
 > OVN-Kubernetes (macvlan, bridge, vlan CNI), see the
 > [Networking Operations Guide](operations-guide.md).
 
+> **Want a portable *primary* IP + IP-preserving live migration?** This guide
+> covers OVN-Kubernetes **secondary** networks (a `networkRef` on a non-primary
+> NIC). To put a guest's **primary** NIC on an OVN-K `layer2` segment so its IP is
+> portable across nodes (cross-node `mode: live` migration with no `allowIPChange`),
+> see the **[OVN-Kubernetes-primary install guide](ovn-kubernetes-install.md)** —
+> cluster-validated.
+
 This guide covers how to use OVN-Kubernetes secondary networks with KubeSwift VMs.
 It assumes you have read [Multi-NIC Support](../multi-nic.md) for the general
 multi-interface architecture.


### PR DESCRIPTION
## What

**P4 of the OVN-Kubernetes arc** — the backend ([P1 #243](https://github.com/projectbeskar/kubeswift/pull/243) + [P2 #244](https://github.com/projectbeskar/kubeswift/pull/244)) is **cluster-validated** (P3), so this marks it shipped and gives operators a guide. **Docs-only**, plus a one-line sample fix.

## Changes

- **RFC `docs/design/ovn-cni-backends.md` → SHIPPED.** Status header flipped to SHIPPED; added a **P3 Validation** callout with the cluster evidence (real RWX+Block disk-boot guest on an OVN-K `layer2 allowPersistentIPs` NAD → booted reachable cross-node → `mode: live` IP-preserving migration in **2.806s**, no `allowIPChange`, reachable from a third node).
- **New `docs/networking/ovn-kubernetes-install.md`** — operator guide for running an IP-preserving guest on **OVN-Kubernetes-primary**: when to use it vs kube-ovn-non-primary; how KubeSwift stamps the guest identity + creates the `IPAMClaim` + re-MACs net1 (zero-touch); the `layer2 allowPersistentIPs` NAD; a primary-on-NAD SwiftGuest; and a boot → cross-node-reach → live-migrate **verify** section grounded in the P3 result. Plus UDN-secondary (transparent) vs UDN-primary (separate phase) notes and troubleshooting.
- **`config/samples/multi-node-l2/ovn-l2-nad.yaml`** — adds the **required** `allowPersistentIPs: true` (the OVN-K backend's IPAMClaim mechanism needs it; the stock sample omitted it — a P3 finding).
- **`docs/networking/multi-node-l2.md` + `ovn-kubernetes.md`** — OVN-Kubernetes-primary added as a validated IP-preserving-live path; cross-linked to the install guide.
- **CHANGELOG** — the P2 `[Unreleased]` entry now records the P3 cluster validation + the install guide.

## Notes

- **UDN-secondary** rides this backend transparently (a `UserDefinedNetwork` role=Secondary generates a `layer2` NAD the backend Detects like any other); **UDN-primary** multi-tenancy is a deliberate later phase (R6 / "P5").
- Pairs with [#245](https://github.com/projectbeskar/kubeswift/pull/245) (the VolumeSnapshot-CRD install-robustness fix surfaced during P3) — independent PRs.

With this, the OVN-Kubernetes backend arc (P1→P4) is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)