### PR TITLE
docs(networking): OVN-Kubernetes + UDN operator guides (kubeadm setup + Model B tenancy)

### DIFF
--- a/config/samples/multi-node-l2/udn-tenancy.yaml
+++ b/config/samples/multi-node-l2/udn-tenancy.yaml
@@ -1,0 +1,45 @@
+# Per-tenant isolated VM network via a SECONDARY OVN-Kubernetes UserDefinedNetwork.
+# The UDN auto-generates an `ovn-k8s-cni-overlay` layer2 NAD that KubeSwift's
+# shipped OVN-Kubernetes backend drives with NO extra config — the guest just
+# references it by `networkRef`. `ipam.lifecycle: Persistent` is what enables
+# IP-preserving LIVE migration (it puts `allowPersistentIPs: true` on the generated
+# NAD, engaging the IPAMClaim mechanism). Requires OVN-Kubernetes as the cluster CNI.
+# Full recipe + gotchas: docs/networking/udn-multi-tenancy.md
+#
+# Prereqs in the tenant namespace: a SwiftImage `ubuntu-noble`, a SwiftGuestClass
+# `default`, a SwiftSeedProfile `default`; cluster-wide: a migratable RWX+Block
+# StorageClass `longhorn-migratable`.
+apiVersion: k8s.ovn.org/v1
+kind: UserDefinedNetwork
+metadata:
+  name: tenant-a
+  namespace: tenant-a
+spec:
+  topology: Layer2
+  layer2:
+    role: Secondary
+    subnets: ["10.30.0.0/16"]
+    ipam:
+      lifecycle: Persistent       # REQUIRED for IP-preserving LIVE migration
+---
+# A guest whose primary IP rides the tenant's isolated UDN segment. Migrating it
+# (mode: live) keeps the IP with no allowIPChange — the IP follows the guest.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: tenant-a-vm
+  namespace: tenant-a
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: default }
+  seedProfileRef: { name: default }
+  runPolicy: Running
+  # RWX+Block is the live-migration storage requirement (Longhorn migratable shown).
+  storage:
+    accessMode: ReadWriteMany
+    volumeMode: Block
+    storageClassName: longhorn-migratable
+  interfaces:
+    - name: app
+      primary: true                 # the guest's primary (portable) IP
+      networkRef: { name: tenant-a }  # the UDN's metadata.name == the generated NAD

--- a/docs/networking/multi-node-l2.md
+++ b/docs/networking/multi-node-l2.md
@@ -126,6 +126,13 @@ issue of the hand-rolled mesh.
 > DHCP on the segment (OVN-K layer-2), the per-pod dnsmasq is redundant; a
 > "segment-DHCP" mode that skips it is a follow-up.
 
+> **Per-tenant isolation.** For *multiple isolated tenant networks*, create a
+> per-tenant OVN-Kubernetes **UserDefinedNetwork** (`role: Secondary`,
+> `ipam.lifecycle: Persistent`) instead of a hand-written NAD — OVN-K auto-generates
+> a NAD this same backend drives, so each tenant gets its own isolated L2 segment
+> with IP-preserving live migration and **no extra KubeSwift config**. Recipe:
+> [udn-multi-tenancy.md](udn-multi-tenancy.md).
+
 ## Recipe B (lab / on-prem): hand-rolled VXLAN-mesh + bridge NAD
 
 > The lightweight path that validated the datapath + offline migration here,

--- a/docs/networking/udn-multi-tenancy.md
+++ b/docs/networking/udn-multi-tenancy.md
@@ -1,0 +1,113 @@
+# Per-tenant isolated VM networks via OVN-Kubernetes UserDefinedNetworks
+
+Give each tenant its own **isolated layer-2 network** for SwiftGuest VMs — with
+**IP-preserving live migration** — using an OVN-Kubernetes **UserDefinedNetwork
+(UDN)**. This needs **no KubeSwift code or configuration beyond a `networkRef`**:
+a *secondary* UDN auto-generates a NAD that KubeSwift's shipped OVN-Kubernetes
+backend already drives (the same path as a hand-written `ovn-k8s-cni-overlay` NAD —
+see [`ovn-l2-install.md`](ovn-l2-install.md) and [`multi-node-l2.md`](multi-node-l2.md)).
+
+## When to use this
+
+- You run **OVN-Kubernetes as the cluster CNI** (primary) — or kube-ovn as a
+  secondary provider (use that project's NAD form instead; this guide is OVN-K).
+- You want **per-tenant L2 isolation**: each tenant's VMs share a flat L2 segment
+  (their own OVN logical switch), isolated from other tenants — and each VM keeps
+  its IP across a `mode: live` migration.
+
+This is **guest-level** tenancy: the VM's primary IP rides the tenant network; the
+launcher pod's `eth0` stays on the cluster-default network (control path). For
+*namespace-native* tenancy (the launcher pod's primary itself on the tenant
+network, for mixed pod+VM namespaces) — a **future enhancement**, not yet shipped.
+
+## The recipe
+
+### 1. Create a per-tenant secondary UDN
+
+```yaml
+apiVersion: k8s.ovn.org/v1
+kind: UserDefinedNetwork
+metadata:
+  name: tenant-a              # the NAD KubeSwift references has this same name
+  namespace: tenant-a
+spec:
+  topology: Layer2
+  layer2:
+    role: Secondary
+    subnets: ["10.30.0.0/16"]
+    ipam:
+      lifecycle: Persistent   # REQUIRED for IP-preserving LIVE migration (below)
+```
+
+OVN-K reconciles this to a NAD named `tenant-a` in namespace `tenant-a`. Its
+generated `spec.config` is `type: ovn-k8s-cni-overlay`, `topology: layer2`, and —
+because of `ipam.lifecycle: Persistent` — **`allowPersistentIPs: true`**. That
+annotation is what lets KubeSwift pin the VM's IP via an `IPAMClaim` and preserve
+it across a live migration; **without it you get the datapath + offline-migration
+IP-keep, but a *live* migration would require `allowIPChange`**.
+
+### 2. Reference the generated NAD from a SwiftGuest
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: tenant-a-vm
+  namespace: tenant-a
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: default }
+  seedProfileRef: { name: default }
+  # RWX+Block is the live-migration storage requirement (Longhorn migratable shown).
+  storage:
+    accessMode: ReadWriteMany
+    volumeMode: Block
+    storageClassName: longhorn-migratable
+  interfaces:
+    - name: app
+      primary: true                # this NIC is the guest's primary (portable) IP
+      networkRef: { name: tenant-a } # the UDN's metadata.name == the generated NAD
+```
+
+Reference the NAD by the **UDN's `metadata.name`** (`tenant-a`), *not* the
+generated `config.name` (which is namespace-prefixed, e.g. `tenant-a_tenant-a`).
+KubeSwift's `networkRef` resolves the NAD object by name and reads its config.
+
+That's it. The shipped controller detects the NAD, creates+owns the per-guest
+`IPAMClaim`, stamps the Multus annotation, and `network-init` bridges the VM onto
+the tenant segment. The VM boots with an IP from `10.30.0.0/16`, reachable from any
+pod/VM on the same tenant UDN, isolated from other tenants.
+
+### 3. Live-migrate with the IP preserved
+
+```bash
+swiftctl migrate tenant-a-vm -n tenant-a --to <other-node>   # mode auto -> live
+```
+
+The webhook accepts `mode: live` **without** `allowIPChange` because the primary
+rides a multi-node NAD; the VM keeps its tenant IP on the target node.
+
+## Validation status
+
+Cluster-validated end-to-end (OVN-K primary, 3-node cluster, 2026-06-18): a guest
+on a UDN-generated persistent NAD booted with its tenant IP, was reachable
+cross-node, and **live-migrated `mode: live` with no `allowIPChange`, IP preserved,
+~3.3 s downtime** — identical to the hand-written-NAD path.
+
+## Notes & gotchas
+
+- **`ipam.lifecycle: Persistent` is load-bearing** for *live* migration. Omit it
+  and live migration needs `allowIPChange` (the IP changes on the target).
+- **Generated NAD name** is `<namespace>_<udn-name>` in `config.name`, but the NAD
+  *object* is `<udn-name>` — use the latter in `networkRef`.
+- **OVN-K install prerequisites** (when OVN-K is your CNI) are in
+  [`ovn-l2-install.md`](ovn-l2-install.md). On OVN-K with `enableNetworkSegmentation`,
+  ensure the `NetworkAttachmentDefinition`, `MultiNetworkPolicy`, and `IPAMClaim`
+  CRDs are installed (OVN-K's control plane needs them at startup), and give the
+  thick-Multus daemonset enough memory (its 50Mi default OOMs — use ≥512Mi).
+- A plain (non-persistent) secondary UDN still gives you the **isolated datapath**
+  and **offline**-migration IP-keep; only *live* migration needs the persistent
+  IPAM.
+- This is multi-tenancy at the **VM/guest** layer. Whole-namespace primary tenancy
+  (the launcher pod's own primary on the tenant network) is a future enhancement,
+  not yet shipped.


### PR DESCRIPTION
## OVN-Kubernetes + UDN operator documentation

Two complementary operator docs for running KubeSwift VMs on OVN-Kubernetes with UDN multi-tenancy, grounded in the cluster-validated P5 build (kubeadm + OVN-K-primary).

### 1. kubeadm + OVN-Kubernetes cluster setup guide (new)
`docs/networking/kubeadm-ovn-kubernetes-setup.md` — end-to-end: build a kubeadm cluster with **OVN-Kubernetes as the primary CNI**, then Longhorn + KubeSwift + UDN. Every step is the validated one, including the real install gotchas: the 3 OVN-ecosystem CRDs (NAD / MultiNetworkPolicy / IPAMClaim) needed **at OVN-K startup** (else crash-loop), the thick-Multus **50Mi OOM** → 512Mi, the host-OVS conflict, the primary-UDN **identity-webhook** caveat on release-1.2, and the VolumeSnapshot-CRD tolerance (`#245`).

### 2. Per-tenant VM networks via secondary UDN (Model B)
`docs/networking/udn-multi-tenancy.md` + `config/samples/multi-node-l2/udn-tenancy.yaml` — a per-tenant **secondary** UDN with `ipam.lifecycle: Persistent` gives isolated per-tenant VM L2 + IP-preserving live migration through the **shipped** backend, **zero new code** (the guest just sets `networkRef`).

### Also
- Refreshes the stale UDN-primary note in `ovn-kubernetes-install.md` (the old "node instability" was a k0s cgroup quirk, overturned on kubeadm).
- Cross-references from the multi-node-L2 hub.

### Validation
Cluster-validated end-to-end on an OVN-K-primary kubeadm cluster: guests on (hand-written and UDN-generated) layer2 NADs booted with portable IPs, reachable cross-node, and `mode: live` migrated with no `allowIPChange`, IP preserved, ~3.2–3.3 s downtime. Docs/sample only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)