### PR TITLE
fix(docs,config): bump stale v0.4.2 version pins to v0.4.6

### DIFF
--- a/config/dra-driver/dra-driver.yaml
+++ b/config/dra-driver/dra-driver.yaml
@@ -83,7 +83,7 @@ spec:
         - name: dra-driver
           # Pinned to the release (no :latest tag is published). Bump on release;
           # or use the Helm chart (dra.enabled=true), which manages this version.
-          image: ghcr.io/projectbeskar/kubeswift/kubeswift-dra-driver:v0.4.2
+          image: ghcr.io/projectbeskar/kubeswift/kubeswift-dra-driver:v0.4.6
           args:
             - --v=2
           env:

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -100,7 +100,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/projectbeskar/charts/kubeswift \
-  --version 0.4.2 -n kubeswift-system --create-namespace \
+  --version 0.4.6 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/projectbeskar/charts/kubeswift \
-  --version 0.4.2 \
+  --version 0.4.6 \
   -n kubeswift-system \
   --create-namespace
 ```


### PR DESCRIPTION
## Stale version pins → v0.4.6

While verifying that everything reflects the just-cut **v0.4.6** release, found three repo files still pinning **v0.4.2** (stale since 0.4.2 — the per-release manual bump was missed across 0.4.3–0.4.5):

- `config/dra-driver/dra-driver.yaml` — standalone DRA-driver image tag (`:v0.4.2` → `:v0.4.6`); its own comment says "Bump on release".
- `docs/quickstart.md` — `helm install … --version 0.4.2` → `0.4.6`.
- `docs/gpu/dra-allocation.md` — `helm install … --version 0.4.2` → `0.4.6`.

Operators following the quickstart/DRA docs would have installed the **old 0.4.2** chart/driver. The Helm **chart itself was already correct** for v0.4.6 (`appVersion: "0.4.6"` resolves all images to `v0.4.6` via the `kubeswift.imageTag` helper) — this is just the hardcoded auxiliary pins.

**Recurrence note:** these are manually-bumped pins that go stale every release; worth adding to the release checklist (or de-pinning the docs to "latest").

Docs/config only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)