### PR TITLE
feat(networking): Model A PR1 — primary-UDN namespace detection + intent plumbing

### DIFF
--- a/charts/kubeswift/templates/controller-manager/rbac.yaml
+++ b/charts/kubeswift/templates/controller-manager/rbac.yaml
@@ -40,6 +40,12 @@ rules:
   - apiGroups: ["k8s.cni.cncf.io"]
     resources: ["ipamclaims"]
     verbs: ["get", "list", "watch", "create"]
+  # Namespaces — read-only, to detect the OVN-Kubernetes primary-UDN label
+  # (Model A: guest rides its namespace primary UDN). list,watch alongside get —
+  # the cached client opens a Namespace informer (W7/W8).
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
   # Core resources
   - apiGroups: [""]
     resources: ["pods", "pods/status"]

--- a/config/manager/controller-manager-rbac.yaml
+++ b/config/manager/controller-manager-rbac.yaml
@@ -36,6 +36,13 @@ rules:
   - apiGroups: ["k8s.cni.cncf.io"]
     resources: ["ipamclaims"]
     verbs: ["get", "list", "watch", "create"]
+  # Namespaces — read-only, to detect the OVN-Kubernetes primary-UDN label
+  # (k8s.ovn.org/primary-user-defined-network) and decide whether a guest rides
+  # its namespace primary UDN (Model A). list,watch alongside get because the
+  # controller-runtime cached client opens a Namespace informer on Get (W7/W8).
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
   # SwiftKernel
   - apiGroups: ["kernel.kubeswift.io"]
     resources: ["swiftkernels", "swiftkernels/status"]

--- a/internal/resolved/resolver.go
+++ b/internal/resolved/resolver.go
@@ -78,6 +78,20 @@ func (r *resolver) Resolve(ctx context.Context, guest *swiftv1alpha1.SwiftGuest)
 	// fire pointlessly). See docs/design/clone-identity-vsock-agent.md.
 	rg.GuestAgentEnabled = guest.Spec.GuestAgent != nil && guest.Spec.GuestAgent.Enabled && !rg.IsWindows()
 
+	// Model A: a guest in a namespace carrying the OVN-Kubernetes primary-UDN
+	// label rides the namespace primary UDN (ovn-udn1) on its node-local primary
+	// NIC. GetNICs applies the interface only to a primary interface without a
+	// networkRef, so setting it here is a no-op for primary-on-NAD / secondary
+	// guests. No-op (and no Namespace read cost beyond one cached Get) for the
+	// vast majority of clusters that have no primary-UDN namespaces.
+	hasPrimaryUDN, err := NamespaceHasPrimaryUDN(ctx, r.client, guest.Namespace)
+	if err != nil {
+		return nil, &ResolutionError{Reason: "checking primary-UDN namespace: " + err.Error()}
+	}
+	if hasPrimaryUDN {
+		rg.PrimaryUDNInterface = OVNPrimaryUDNInterface
+	}
+
 	return rg, nil
 }
 

--- a/internal/resolved/types.go
+++ b/internal/resolved/types.go
@@ -51,6 +51,12 @@ type ResolvedGuest struct {
 	// Interfaces from SwiftGuest spec, used for multi-NIC support.
 	// Nil or empty means single default NIC (backward compatible).
 	Interfaces []swiftv1alpha1.GuestInterface `json:"interfaces,omitempty"`
+	// PrimaryUDNInterface names the pod's OVN-Kubernetes primary UDN interface
+	// (ovn-udn1) when the guest's namespace is a primary-UDN tenant namespace
+	// (Model A). Empty otherwise. GetNICs applies it to the primary node-local
+	// NIC (a primary interface without a networkRef). Set by the resolver from
+	// the namespace label.
+	PrimaryUDNInterface string `json:"primaryUDNInterface,omitempty"`
 	// NetworkSpec is the SwiftGuest spec.network block (binding + declarative
 	// service ports). Nil preserves today's behavior (nat, no exposure).
 	// See docs/design/service-exposure.md.
@@ -432,6 +438,13 @@ func (r *ResolvedGuest) GetNICs() []runtimeintent.NICIntent {
 		} else {
 			// Legacy rule (unchanged): node-local bridges are primary.
 			nic.Primary = iface.NetworkRef == nil
+		}
+		if nic.Primary && iface.NetworkRef == nil && r.PrimaryUDNInterface != "" {
+			// Model A: the primary rides the namespace primary OVN-K UDN
+			// (ovn-udn1), not the node-local bridge. swiftletd's
+			// setup_primary_udn_nic bridges it to br0/tap0; eth0 stays on the
+			// cluster default. Skipped for a primary that rides a NAD (net1).
+			nic.PrimaryUDNInterface = r.PrimaryUDNInterface
 		}
 		nics = append(nics, nic)
 		tapIdx++

--- a/internal/resolved/udn.go
+++ b/internal/resolved/udn.go
@@ -1,0 +1,43 @@
+package resolved
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// OVNPrimaryUDNNamespaceLabel marks a namespace whose pods ride a primary
+// OVN-Kubernetes UserDefinedNetwork. A cluster admin sets it at namespace
+// creation (immutable — OVN-K enforces it via a CEL webhook). KubeSwift reads it
+// to decide whether a guest rides the namespace primary UDN (Model A); the label
+// VALUE is ignored (presence is the signal), matching OVN-K.
+const OVNPrimaryUDNNamespaceLabel = "k8s.ovn.org/primary-user-defined-network"
+
+// OVNPrimaryUDNInterface is OVN-Kubernetes' deterministic in-pod interface name
+// for the namespace primary UDN — the guest's portable L2. eth0 stays on the
+// cluster default network for the swiftletd->apiserver control path and egress.
+const OVNPrimaryUDNInterface = "ovn-udn1"
+
+// NamespaceHasPrimaryUDN reports whether the namespace carries the
+// OVN-Kubernetes primary-UDN label. Read-only; used by the resolver (Model A
+// detection) and the SwiftMigration webhook (live-migration eligibility). The
+// controller-runtime cached client opens a Namespace informer for this Get, so
+// the manager needs `namespaces` get,list,watch RBAC (the W7/W8 lesson).
+func NamespaceHasPrimaryUDN(ctx context.Context, c client.Client, namespace string) (bool, error) {
+	ns := &corev1.Namespace{}
+	if err := c.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+		// A missing namespace is impossible for a real guest (it lives in the
+		// namespace), so NotFound means "no primary-UDN label" and resolution
+		// proceeds node-local. Transient errors propagate so a real primary-UDN
+		// guest is never silently downgraded (Principle #6).
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	_, ok := ns.Labels[OVNPrimaryUDNNamespaceLabel]
+	return ok, nil
+}

--- a/internal/resolved/udn_test.go
+++ b/internal/resolved/udn_test.go
@@ -1,0 +1,91 @@
+package resolved
+
+import (
+	"context"
+	"testing"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// Model A: a primary interface with no networkRef in a primary-UDN namespace
+// rides ovn-udn1. The resolver sets ResolvedGuest.PrimaryUDNInterface; GetNICs
+// applies it to that NIC (and not a Multus interface — the UDN is namespace-bound).
+func TestGetNICs_ModelA_PrimaryUDNAppliedToNodeLocalPrimary(t *testing.T) {
+	rg := &ResolvedGuest{
+		Interfaces:          []swiftv1alpha1.GuestInterface{{Name: "app", Primary: true}},
+		PrimaryUDNInterface: OVNPrimaryUDNInterface,
+		Meta:                Meta{Namespace: "model-a", Name: "vm", UID: types.UID("uid")},
+	}
+	nics := rg.GetNICs()
+	if len(nics) != 1 {
+		t.Fatalf("GetNICs = %d NICs, want 1", len(nics))
+	}
+	if !nics[0].Primary {
+		t.Error("primary NIC not marked primary")
+	}
+	if nics[0].PrimaryUDNInterface != OVNPrimaryUDNInterface {
+		t.Errorf("PrimaryUDNInterface = %q, want %q", nics[0].PrimaryUDNInterface, OVNPrimaryUDNInterface)
+	}
+	if nics[0].MultusInterface != "" {
+		t.Errorf("MultusInterface = %q, want empty (primary UDN is namespace-bound, not a NAD)", nics[0].MultusInterface)
+	}
+}
+
+// A primary that rides a secondary NAD keeps net1; the namespace UDN signal does
+// NOT override it (primary-on-NAD stays on its own path — Model B coexistence).
+func TestGetNICs_ModelA_NotAppliedToPrimaryOnNAD(t *testing.T) {
+	rg := &ResolvedGuest{
+		Interfaces: []swiftv1alpha1.GuestInterface{
+			{Name: "app", Primary: true, NetworkRef: &swiftv1alpha1.NetworkReference{Name: "ovn-l2"}},
+		},
+		PrimaryUDNInterface: OVNPrimaryUDNInterface,
+		Meta:                Meta{Namespace: "model-a", Name: "vm", UID: types.UID("uid")},
+	}
+	nics := rg.GetNICs()
+	if nics[0].PrimaryUDNInterface != "" {
+		t.Errorf("PrimaryUDNInterface = %q, want empty (primary rides the NAD)", nics[0].PrimaryUDNInterface)
+	}
+	if nics[0].MultusInterface != "net1" {
+		t.Errorf("MultusInterface = %q, want net1", nics[0].MultusInterface)
+	}
+}
+
+// Regression: outside a primary-UDN namespace (PrimaryUDNInterface unset), a
+// node-local primary stays node-local.
+func TestGetNICs_NoPrimaryUDN_Unset(t *testing.T) {
+	rg := &ResolvedGuest{
+		Interfaces: []swiftv1alpha1.GuestInterface{{Name: "app", Primary: true}},
+		Meta:       Meta{Namespace: "default", Name: "vm", UID: types.UID("uid")},
+	}
+	if nics := rg.GetNICs(); nics[0].PrimaryUDNInterface != "" {
+		t.Errorf("PrimaryUDNInterface = %q, want empty", nics[0].PrimaryUDNInterface)
+	}
+}
+
+func TestNamespaceHasPrimaryUDN(t *testing.T) {
+	s := testScheme()
+	labeled := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant", Labels: map[string]string{OVNPrimaryUDNNamespaceLabel: ""}}}
+	plain := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(labeled, plain).Build()
+
+	for _, tc := range []struct {
+		ns   string
+		want bool
+	}{
+		{"tenant", true},   // labeled → Model A
+		{"default", false}, // unlabeled
+		{"ghost", false},   // missing → NotFound → false, no error (resolution proceeds)
+	} {
+		ok, err := NamespaceHasPrimaryUDN(context.Background(), c, tc.ns)
+		if err != nil {
+			t.Errorf("ns %q: unexpected err %v", tc.ns, err)
+		}
+		if ok != tc.want {
+			t.Errorf("ns %q: ok = %v, want %v", tc.ns, ok, tc.want)
+		}
+	}
+}

--- a/internal/runtimeintent/types.go
+++ b/internal/runtimeintent/types.go
@@ -145,6 +145,13 @@ type NICIntent struct {
 	// MultusInterface is the name of the Multus-created interface (net1, net2, etc.)
 	// Empty for the primary NIC.
 	MultusInterface string `json:"multusInterface,omitempty"`
+	// PrimaryUDNInterface is the pod's OVN-Kubernetes primary UserDefinedNetwork
+	// interface (ovn-udn1) when the guest rides its namespace's primary UDN
+	// (Model A). Mutually exclusive with MultusInterface — the primary UDN is
+	// bound by the namespace label, not a Multus NAD. swiftletd bridges this
+	// interface to br0/tap0 (setup_primary_udn_nic); eth0 stays on the cluster
+	// default. Empty for every other networking mode.
+	PrimaryUDNInterface string `json:"primaryUDNInterface,omitempty"`
 	// Bridge is the bridge device name (br0, br1, etc.)
 	// Empty for SR-IOV interfaces.
 	Bridge string `json:"bridge,omitempty"`

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -329,6 +329,12 @@ pub struct NICIntent {
     /// Multus-created interface name (net1, net2, etc.). Empty for primary.
     #[serde(default)]
     pub multus_interface: Option<String>,
+    /// OVN-Kubernetes primary UDN interface (ovn-udn1) when the guest rides its
+    /// namespace's primary UserDefinedNetwork (Model A). None otherwise.
+    /// Mutually exclusive with multus_interface; network-init bridges it to
+    /// br0/tap0 via setup_primary_udn_nic.
+    #[serde(default)]
+    pub primary_udn_interface: Option<String>,
     /// Bridge device name (br0, br1, etc.). Empty for SR-IOV.
     #[serde(default)]
     pub bridge: String,


### PR DESCRIPTION
## Model A PR1 — primary-UDN namespace detection + intent plumbing

First implementation PR of the Model A arc (design: #252). Controller-side foundation; **no datapath yet** (PR2 adds the launcher path), so a guest in a primary-UDN namespace still boots node-local — this PR makes the controller *recognize* Model A and plumb the signal to the launcher.

### What it does
- **Detect** (`internal/resolved/`): `NamespaceHasPrimaryUDN` reads the `k8s.ovn.org/primary-user-defined-network` namespace label (NotFound → not-Model-A so resolution proceeds; transient errors propagate — no silent downgrade, Principle #6). The resolver stamps `ResolvedGuest.PrimaryUDNInterface = ovn-udn1`.
- **Plumb**: new `NICIntent.PrimaryUDNInterface` (Go + Rust serde-default). `GetNICs` applies it to a **primary interface with no `networkRef`** — a primary-on-NAD primary keeps `net1` (Model B coexistence stays on its own path).
- **RBAC**: `namespaces` get,list,watch (config/manager + chart; the cached-client informer lesson, W7/W8).

### Tests
Unit: `GetNICs` Model A application + primary-on-NAD non-override + no-UDN regression; `NamespaceHasPrimaryUDN` labeled/unlabeled/NotFound. `go test`/`vet`/`build` + `gofmt -s` + `cargo check` all green.

### Next
PR2 (`setup_primary_udn_nic`) makes the guest actually ride `ovn-udn1` — the marquee, validated end-to-end in the staged `model-a` namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)