### PR TITLE
feat(networking): Model A PR2 — primary-UDN launcher datapath (setup_primary_udn_nic)

### DIFF
--- a/internal/resolved/resolver.go
+++ b/internal/resolved/resolver.go
@@ -80,16 +80,22 @@ func (r *resolver) Resolve(ctx context.Context, guest *swiftv1alpha1.SwiftGuest)
 
 	// Model A: a guest in a namespace carrying the OVN-Kubernetes primary-UDN
 	// label rides the namespace primary UDN (ovn-udn1) on its node-local primary
-	// NIC. GetNICs applies the interface only to a primary interface without a
-	// networkRef, so setting it here is a no-op for primary-on-NAD / secondary
-	// guests. No-op (and no Namespace read cost beyond one cached Get) for the
-	// vast majority of clusters that have no primary-UDN namespaces.
+	// NIC. The eligibility gate (primary is node-local, not on a NAD) is computed
+	// HERE — not in GetNICs — because a default guest has no spec.interfaces (so
+	// GetNICs returns nil and emits no per-NIC field). PrimaryInterface()==nil for
+	// a default guest means a node-local primary -> Model A applies; a primary that
+	// rides a NAD (NetworkRef != nil) is Model B (primary-on-NAD) and is skipped.
+	// The signal is carried at the intent top level (RuntimeIntent.PrimaryUDNInterface).
+	// No-op (one cached Namespace Get) for the vast majority of clusters that have
+	// no primary-UDN namespaces.
 	hasPrimaryUDN, err := NamespaceHasPrimaryUDN(ctx, r.client, guest.Namespace)
 	if err != nil {
 		return nil, &ResolutionError{Reason: "checking primary-UDN namespace: " + err.Error()}
 	}
 	if hasPrimaryUDN {
-		rg.PrimaryUDNInterface = OVNPrimaryUDNInterface
+		if p := guest.PrimaryInterface(); p == nil || p.NetworkRef == nil {
+			rg.PrimaryUDNInterface = OVNPrimaryUDNInterface
+		}
 	}
 
 	return rg, nil

--- a/internal/resolved/types.go
+++ b/internal/resolved/types.go
@@ -439,18 +439,21 @@ func (r *ResolvedGuest) GetNICs() []runtimeintent.NICIntent {
 			// Legacy rule (unchanged): node-local bridges are primary.
 			nic.Primary = iface.NetworkRef == nil
 		}
-		if nic.Primary && iface.NetworkRef == nil && r.PrimaryUDNInterface != "" {
-			// Model A: the primary rides the namespace primary OVN-K UDN
-			// (ovn-udn1), not the node-local bridge. swiftletd's
-			// setup_primary_udn_nic bridges it to br0/tap0; eth0 stays on the
-			// cluster default. Skipped for a primary that rides a NAD (net1).
-			nic.PrimaryUDNInterface = r.PrimaryUDNInterface
-		}
 		nics = append(nics, nic)
 		tapIdx++
 		bridgeIdx++
 	}
 	return nics
+}
+
+// GetPrimaryUDNInterface returns the OVN-Kubernetes primary-UDN interface name
+// (ovn-udn1) when the guest rides its namespace primary UDN (Model A), else "".
+// The resolver has already gated PrimaryUDNInterface on the primary being
+// node-local (a primary-on-NAD guest is Model B and never sets it), so this is a
+// plain accessor. It is read at the intent TOP LEVEL (RuntimeIntent.PrimaryUDNInterface)
+// rather than per-NIC so it covers the default guest, whose intent has no nics array.
+func (r *ResolvedGuest) GetPrimaryUDNInterface() string {
+	return r.PrimaryUDNInterface
 }
 
 // GetExposedPorts builds the PortIntent list from spec.network.ports for a

--- a/internal/resolved/udn_test.go
+++ b/internal/resolved/udn_test.go
@@ -4,65 +4,94 @@ import (
 	"context"
 	"testing"
 
+	imagev1alpha1 "github.com/projectbeskar/kubeswift/api/image/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// Model A: a primary interface with no networkRef in a primary-UDN namespace
-// rides ovn-udn1. The resolver sets ResolvedGuest.PrimaryUDNInterface; GetNICs
-// applies it to that NIC (and not a Multus interface — the UDN is namespace-bound).
-func TestGetNICs_ModelA_PrimaryUDNAppliedToNodeLocalPrimary(t *testing.T) {
-	rg := &ResolvedGuest{
-		Interfaces:          []swiftv1alpha1.GuestInterface{{Name: "app", Primary: true}},
-		PrimaryUDNInterface: OVNPrimaryUDNInterface,
-		Meta:                Meta{Namespace: "model-a", Name: "vm", UID: types.UID("uid")},
-	}
-	nics := rg.GetNICs()
-	if len(nics) != 1 {
-		t.Fatalf("GetNICs = %d NICs, want 1", len(nics))
-	}
-	if !nics[0].Primary {
-		t.Error("primary NIC not marked primary")
-	}
-	if nics[0].PrimaryUDNInterface != OVNPrimaryUDNInterface {
-		t.Errorf("PrimaryUDNInterface = %q, want %q", nics[0].PrimaryUDNInterface, OVNPrimaryUDNInterface)
-	}
-	if nics[0].MultusInterface != "" {
-		t.Errorf("MultusInterface = %q, want empty (primary UDN is namespace-bound, not a NAD)", nics[0].MultusInterface)
-	}
-}
-
-// A primary that rides a secondary NAD keeps net1; the namespace UDN signal does
-// NOT override it (primary-on-NAD stays on its own path — Model B coexistence).
-func TestGetNICs_ModelA_NotAppliedToPrimaryOnNAD(t *testing.T) {
-	rg := &ResolvedGuest{
-		Interfaces: []swiftv1alpha1.GuestInterface{
-			{Name: "app", Primary: true, NetworkRef: &swiftv1alpha1.NetworkReference{Name: "ovn-l2"}},
+// resolveModelA resolves a disk-boot guest in namespace "ns", optionally carrying
+// the OVN-K primary-UDN label, with the given interfaces, and returns the
+// ResolvedGuest. Model A eligibility is computed in the resolver (not GetNICs) so
+// it covers the DEFAULT guest (no spec.interfaces) — the case the PR1 per-NIC
+// plumbing missed and the cluster check caught.
+func resolveModelA(t *testing.T, nsLabeled bool, ifaces []swiftv1alpha1.GuestInterface) *ResolvedGuest {
+	t.Helper()
+	scheme := testScheme()
+	guestClass := &swiftv1alpha1.SwiftGuestClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "gc"},
+		Spec: swiftv1alpha1.SwiftGuestClassSpec{
+			CPU: resource.MustParse("2"), Memory: resource.MustParse("2Gi"),
+			RootDisk: swiftv1alpha1.RootDiskSpec{Size: resource.MustParse("10Gi"), Format: swiftv1alpha1.DiskFormatRaw},
 		},
-		PrimaryUDNInterface: OVNPrimaryUDNInterface,
-		Meta:                Meta{Namespace: "model-a", Name: "vm", UID: types.UID("uid")},
 	}
-	nics := rg.GetNICs()
-	if nics[0].PrimaryUDNInterface != "" {
-		t.Errorf("PrimaryUDNInterface = %q, want empty (primary rides the NAD)", nics[0].PrimaryUDNInterface)
+	image := &imagev1alpha1.SwiftImage{
+		ObjectMeta: metav1.ObjectMeta{Name: "img", Namespace: "ns"},
+		Status:     imagev1alpha1.SwiftImageStatus{Phase: imagev1alpha1.SwiftImagePhaseReady, PreparedArtifact: &imagev1alpha1.PreparedArtifactRef{Format: imagev1alpha1.DiskFormatRaw}},
 	}
-	if nics[0].MultusInterface != "net1" {
-		t.Errorf("MultusInterface = %q, want net1", nics[0].MultusInterface)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}}
+	if nsLabeled {
+		ns.Labels = map[string]string{OVNPrimaryUDNNamespaceLabel: ""}
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guestClass, image, ns).Build()
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "ns", UID: "uid-123"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef:      &corev1.LocalObjectReference{Name: "img"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "gc"},
+			Interfaces:    ifaces,
+		},
+	}
+	rg, err := NewResolver(client).Resolve(context.Background(), guest)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	return rg
+}
+
+// A DEFAULT guest (no spec.interfaces) in a primary-UDN namespace rides ovn-udn1.
+// GetNICs returns nil for such a guest, so the signal MUST be top-level — this is
+// exactly the gap the PR1 cluster check found.
+func TestResolve_ModelA_DefaultGuest(t *testing.T) {
+	rg := resolveModelA(t, true, nil)
+	if rg.PrimaryUDNInterface != OVNPrimaryUDNInterface {
+		t.Errorf("PrimaryUDNInterface = %q, want %q", rg.PrimaryUDNInterface, OVNPrimaryUDNInterface)
+	}
+	if got := rg.GetPrimaryUDNInterface(); got != OVNPrimaryUDNInterface {
+		t.Errorf("GetPrimaryUDNInterface() = %q, want %q", got, OVNPrimaryUDNInterface)
 	}
 }
 
-// Regression: outside a primary-UDN namespace (PrimaryUDNInterface unset), a
-// node-local primary stays node-local.
-func TestGetNICs_NoPrimaryUDN_Unset(t *testing.T) {
-	rg := &ResolvedGuest{
-		Interfaces: []swiftv1alpha1.GuestInterface{{Name: "app", Primary: true}},
-		Meta:       Meta{Namespace: "default", Name: "vm", UID: types.UID("uid")},
+// An explicit node-local primary (no networkRef) in a primary-UDN namespace also
+// rides ovn-udn1.
+func TestResolve_ModelA_ExplicitNodeLocalPrimary(t *testing.T) {
+	rg := resolveModelA(t, true, []swiftv1alpha1.GuestInterface{{Name: "app", Primary: true}})
+	if rg.PrimaryUDNInterface != OVNPrimaryUDNInterface {
+		t.Errorf("PrimaryUDNInterface = %q, want %q", rg.PrimaryUDNInterface, OVNPrimaryUDNInterface)
 	}
-	if nics := rg.GetNICs(); nics[0].PrimaryUDNInterface != "" {
-		t.Errorf("PrimaryUDNInterface = %q, want empty", nics[0].PrimaryUDNInterface)
+}
+
+// A primary that rides a NAD is Model B (primary-on-NAD), NOT Model A — even in a
+// primary-UDN namespace. The resolver's node-local gate skips it.
+func TestResolve_ModelA_PrimaryOnNADSkipped(t *testing.T) {
+	rg := resolveModelA(t, true, []swiftv1alpha1.GuestInterface{
+		{Name: "app", Primary: true, NetworkRef: &swiftv1alpha1.NetworkReference{Name: "ovn-l2"}},
+	})
+	if rg.PrimaryUDNInterface != "" {
+		t.Errorf("PrimaryUDNInterface = %q, want empty (primary rides a NAD = Model B)", rg.PrimaryUDNInterface)
+	}
+}
+
+// Outside a primary-UDN namespace, the signal is never set.
+func TestResolve_ModelA_NonUDNNamespace(t *testing.T) {
+	rg := resolveModelA(t, false, nil)
+	if rg.PrimaryUDNInterface != "" {
+		t.Errorf("PrimaryUDNInterface = %q, want empty (namespace not labelled)", rg.PrimaryUDNInterface)
+	}
+	if got := rg.GetPrimaryUDNInterface(); got != "" {
+		t.Errorf("GetPrimaryUDNInterface() = %q, want empty", got)
 	}
 }
 

--- a/internal/runtimeintent/build.go
+++ b/internal/runtimeintent/build.go
@@ -25,6 +25,9 @@ type ResolvedGuest interface {
 	GetHypervisor() string
 	GetOSType() string
 	GetNICs() []NICIntent
+	// GetPrimaryUDNInterface returns the OVN-Kubernetes primary-UDN interface
+	// (ovn-udn1) when the guest rides its namespace primary UDN (Model A), else "".
+	GetPrimaryUDNInterface() string
 	GetExposedPorts() []PortIntent
 	GetFilesystems() []FilesystemIntent
 	GetVhostUserDevices() []VhostUserDeviceIntent
@@ -40,6 +43,7 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 	dataDisks := rg.GetDataDisks()
 
 	nics := rg.GetNICs()
+	primaryUDN := rg.GetPrimaryUDNInterface()
 	ports := rg.GetExposedPorts()
 	filesystems := rg.GetFilesystems()
 	vhostUserDevices := rg.GetVhostUserDevices()
@@ -56,22 +60,23 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 			lifecycle = "start"
 		}
 		return &RuntimeIntent{
-			RootDisk:         RootDiskSpec{Path: "", Format: ""},
-			SeedPath:         "",
-			CPU:              rg.GetCPU(),
-			Memory:           rg.GetMemoryMiB(),
-			Lifecycle:        lifecycle,
-			GuestID:          rg.GetGuestID(),
-			Network:          rg.HasNetwork(),
-			Hypervisor:       rg.GetHypervisor(),
-			OSType:           rg.GetOSType(),
-			DataDisks:        dataDisks,
-			NICs:             nics,
-			Ports:            ports,
-			Filesystems:      filesystems,
-			VhostUserDevices: vhostUserDevices,
-			CoreScheduling:   coreScheduling,
-			Vsock:            vsock,
+			RootDisk:            RootDiskSpec{Path: "", Format: ""},
+			SeedPath:            "",
+			CPU:                 rg.GetCPU(),
+			Memory:              rg.GetMemoryMiB(),
+			Lifecycle:           lifecycle,
+			GuestID:             rg.GetGuestID(),
+			Network:             rg.HasNetwork(),
+			Hypervisor:          rg.GetHypervisor(),
+			OSType:              rg.GetOSType(),
+			DataDisks:           dataDisks,
+			NICs:                nics,
+			PrimaryUDNInterface: primaryUDN,
+			Ports:               ports,
+			Filesystems:         filesystems,
+			VhostUserDevices:    vhostUserDevices,
+			CoreScheduling:      coreScheduling,
+			Vsock:               vsock,
 			KernelBoot: &KernelBootSpec{
 				KernelPath:    rg.GetKernelPath(),
 				InitramfsPath: rg.GetInitramfsPath(),
@@ -102,20 +107,21 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 			Path:   rootDiskPath,
 			Format: rg.GetRootDiskFormat(),
 		},
-		SeedPath:         seedPath,
-		CPU:              rg.GetCPU(),
-		Memory:           rg.GetMemoryMiB(),
-		Lifecycle:        lifecycle,
-		GuestID:          rg.GetGuestID(),
-		Network:          rg.HasNetwork(),
-		Hypervisor:       rg.GetHypervisor(),
-		OSType:           rg.GetOSType(),
-		DataDisks:        dataDisks,
-		NICs:             nics,
-		Ports:            ports,
-		Filesystems:      filesystems,
-		VhostUserDevices: vhostUserDevices,
-		CoreScheduling:   coreScheduling,
-		Vsock:            vsock,
+		SeedPath:            seedPath,
+		CPU:                 rg.GetCPU(),
+		Memory:              rg.GetMemoryMiB(),
+		Lifecycle:           lifecycle,
+		GuestID:             rg.GetGuestID(),
+		Network:             rg.HasNetwork(),
+		Hypervisor:          rg.GetHypervisor(),
+		OSType:              rg.GetOSType(),
+		DataDisks:           dataDisks,
+		NICs:                nics,
+		PrimaryUDNInterface: primaryUDN,
+		Ports:               ports,
+		Filesystems:         filesystems,
+		VhostUserDevices:    vhostUserDevices,
+		CoreScheduling:      coreScheduling,
+		Vsock:               vsock,
 	}
 }

--- a/internal/runtimeintent/build_test.go
+++ b/internal/runtimeintent/build_test.go
@@ -6,25 +6,26 @@ import (
 )
 
 type mockResolvedGuest struct {
-	hasSeed          bool
-	hasKernel        bool
-	hasNetwork       bool
-	dataDisks        []DataDiskSpec
-	format           string
-	rootVolumeMode   string // W9: "Filesystem" (default) or "Block"
-	cpu              int
-	memory           int
-	lifecycle        string
-	guestID          string
-	kernelPath       string
-	initramfsPath    string
-	kernelCmdline    string
-	hypervisor       string
-	osType           string
-	filesystems      []FilesystemIntent
-	vhostUserDevices []VhostUserDeviceIntent
-	coreScheduling   string
-	vsockCID         uint32
+	hasSeed             bool
+	hasKernel           bool
+	hasNetwork          bool
+	dataDisks           []DataDiskSpec
+	format              string
+	rootVolumeMode      string // W9: "Filesystem" (default) or "Block"
+	cpu                 int
+	memory              int
+	lifecycle           string
+	guestID             string
+	kernelPath          string
+	initramfsPath       string
+	kernelCmdline       string
+	hypervisor          string
+	osType              string
+	filesystems         []FilesystemIntent
+	vhostUserDevices    []VhostUserDeviceIntent
+	coreScheduling      string
+	vsockCID            uint32
+	primaryUDNInterface string
 }
 
 func (m *mockResolvedGuest) HasSeed() bool                 { return m.hasSeed }
@@ -48,6 +49,7 @@ func (m *mockResolvedGuest) GetOSType() string {
 	return m.osType
 }
 func (m *mockResolvedGuest) GetNICs() []NICIntent               { return nil }
+func (m *mockResolvedGuest) GetPrimaryUDNInterface() string     { return m.primaryUDNInterface }
 func (m *mockResolvedGuest) GetExposedPorts() []PortIntent      { return nil }
 func (m *mockResolvedGuest) GetFilesystems() []FilesystemIntent { return m.filesystems }
 func (m *mockResolvedGuest) GetVhostUserDevices() []VhostUserDeviceIntent {
@@ -83,6 +85,29 @@ func TestBuild_VsockSetWhenCIDNonZero(t *testing.T) {
 // this string to Cloud Hypervisor's --disk path=<value> opaquely; the
 // kubelet attaches the Block PVC at this device path via VolumeDevices
 // in the launcher pod (controller-side, see pod.go::rootDiskMount).
+// TestBuild_PrimaryUDNInterface is the Model A wiring gate: the top-level
+// PrimaryUDNInterface flows from the resolver getter into the intent on BOTH boot
+// paths (a default guest's intent has no nics, so this MUST be top-level). Empty
+// when not Model A.
+func TestBuild_PrimaryUDNInterface(t *testing.T) {
+	// disk boot
+	rg := &mockResolvedGuest{hasSeed: true, hasNetwork: true, format: "raw", cpu: 2, memory: 2048, lifecycle: "start", guestID: "default/udn", primaryUDNInterface: "ovn-udn1"}
+	if got := Build(rg).PrimaryUDNInterface; got != "ovn-udn1" {
+		t.Errorf("disk-boot PrimaryUDNInterface = %q, want ovn-udn1", got)
+	}
+	// kernel boot honors it too
+	rg.hasSeed = false
+	rg.hasKernel = true
+	if got := Build(rg).PrimaryUDNInterface; got != "ovn-udn1" {
+		t.Errorf("kernel-boot PrimaryUDNInterface = %q, want ovn-udn1", got)
+	}
+	// not Model A -> empty
+	rg2 := &mockResolvedGuest{hasSeed: true, hasNetwork: true, format: "raw", cpu: 2, memory: 2048, lifecycle: "start", guestID: "default/plain"}
+	if got := Build(rg2).PrimaryUDNInterface; got != "" {
+		t.Errorf("non-Model-A PrimaryUDNInterface = %q, want empty", got)
+	}
+}
+
 func TestBuild_DiskBootBlockMode(t *testing.T) {
 	rg := &mockResolvedGuest{
 		hasSeed:        true,

--- a/internal/runtimeintent/types.go
+++ b/internal/runtimeintent/types.go
@@ -26,6 +26,16 @@ type RuntimeIntent struct {
 	// NICs is the list of network interfaces for the VM.
 	// If empty and Network is true, a single default NIC is created (backward compat).
 	NICs []NICIntent `json:"nics,omitempty"`
+	// PrimaryUDNInterface is the pod's OVN-Kubernetes primary UserDefinedNetwork
+	// interface (ovn-udn1) when the guest rides its namespace's primary UDN
+	// (Model A). It is a TOP-LEVEL attribute of the primary NIC because the
+	// primary is singular and a default guest (no spec.interfaces -> empty NICs)
+	// is the common Model A case — a per-NIC field would never be emitted for it.
+	// When set, network-init.sh bridges this interface to br0/tap0
+	// (setup_primary_udn_nic): the guest adopts the OVN-assigned, IP-derived MAC +
+	// IP (OVN port_security pins them), and eth0 stays on the cluster default for
+	// the swiftletd->apiserver control path. Empty for every other networking mode.
+	PrimaryUDNInterface string `json:"primaryUDNInterface,omitempty"`
 	// Ports declares service ports to expose from the guest's primary NIC
 	// (service exposure — docs/design/service-exposure.md). When non-empty,
 	// network-init.sh pins the primary VM IP and installs an in-pod DNAT
@@ -145,13 +155,6 @@ type NICIntent struct {
 	// MultusInterface is the name of the Multus-created interface (net1, net2, etc.)
 	// Empty for the primary NIC.
 	MultusInterface string `json:"multusInterface,omitempty"`
-	// PrimaryUDNInterface is the pod's OVN-Kubernetes primary UserDefinedNetwork
-	// interface (ovn-udn1) when the guest rides its namespace's primary UDN
-	// (Model A). Mutually exclusive with MultusInterface — the primary UDN is
-	// bound by the namespace label, not a Multus NAD. swiftletd bridges this
-	// interface to br0/tap0 (setup_primary_udn_nic); eth0 stays on the cluster
-	// default. Empty for every other networking mode.
-	PrimaryUDNInterface string `json:"primaryUDNInterface,omitempty"`
 	// Bridge is the bridge device name (br0, br1, etc.)
 	// Empty for SR-IOV interfaces.
 	Bridge string `json:"bridge,omitempty"`

--- a/rust/swiftletd/scripts/launcher-entrypoint.sh
+++ b/rust/swiftletd/scripts/launcher-entrypoint.sh
@@ -51,6 +51,36 @@ if network_enabled; then
     lease_dir="$RUN_DIR/$safe_id"
     mkdir -p "$lease_dir"
 
+    # Model A (docs/design/udn-primary-integration.md): network-init persisted the
+    # OVN-K primary-UDN-assigned IP + the OVN-derived MAC the guest MUST adopt (the LSP
+    # port_security pins MAC+IP). Hand exactly that IP to the guest (matched by MAC) via
+    # a fixed dnsmasq lease, and export the MAC so swiftletd uses it for the CH
+    # --net mac= (the guest cannot use its own 52:54:.. MAC -- OVN would drop it).
+    udn_env="$lease_dir/primary-udn.env"
+    if [ -f "$udn_env" ]; then
+        # shellcheck disable=SC1090
+        . "$udn_env"   # UDN_IP, UDN_PREFIX, UDN_GW, UDN_MAC, UDN_BRIDGE, UDN_MTU
+        dns=$(grep '^nameserver ' /etc/resolv.conf 2>/dev/null | head -1 | awk '{print $2}')
+        [ -z "$dns" ] && dns="10.96.0.10"
+        # swiftletd reads this for the primary NIC's CH --net mac= so the guest sources
+        # frames with OVN's expected MAC (passes port_security).
+        export KUBESWIFT_PRIMARY_UDN_MAC="$UDN_MAC"
+        echo "Primary UDN dnsmasq: handing $UDN_IP to $UDN_MAC on $UDN_BRIDGE (gw $UDN_GW, mtu ${UDN_MTU:-default})"
+        # Same shared-L2 guards as the NAD path (answer only this guest's MAC, infinite
+        # lease, carry the overlay MTU) -- a primary UDN is a flat L2 too.
+        dnsmasq --no-daemon --bind-interfaces --interface="$UDN_BRIDGE" \
+            --dhcp-range="$UDN_IP,$UDN_IP,infinite" \
+            ${UDN_MAC:+--dhcp-host="$UDN_MAC,$UDN_IP"} \
+            ${UDN_MAC:+--dhcp-ignore=tag:!known} \
+            ${UDN_GW:+--dhcp-option=option:router,"$UDN_GW"} \
+            --dhcp-option=option:dns-server,"$dns" \
+            ${UDN_MTU:+--dhcp-option=option:mtu,"$UDN_MTU"} \
+            --dhcp-leasefile="$lease_dir/dnsmasq.leases" \
+            --dhcp-authoritative &
+        sleep 1
+        exec /usr/local/bin/swiftletd "$@"
+    fi
+
     # Primary-on-NAD (multi-node L2): network-init persisted the NAD-assigned
     # primary IP. Hand exactly that IP to the guest (matched by MAC) via a fixed
     # dnsmasq lease, so the guest's primary IP is the NAD's portable IP. lease.rs

--- a/rust/swiftletd/scripts/network-init.sh
+++ b/rust/swiftletd/scripts/network-init.sh
@@ -253,6 +253,107 @@ setup_primary_nad_nic() {
     echo "Primary NIC on NAD: $bridge bridges $multus_iface to $tap; guest IP=$nad_ip/$nad_prefix gw=$nad_gw (helper $helper)"
 }
 
+# setup_primary_udn_nic -- multi-node L2, guest on the namespace PRIMARY OVN-K UDN
+# (Model A; docs/design/udn-primary-integration.md). OVN-Kubernetes attaches the pod
+# to its namespace primary UserDefinedNetwork as `ovn-udn1` (e.g. 10.50.0.10/16)
+# automatically, driven by the namespace label; eth0 stays on the cluster default
+# (role infrastructure-locked) for the swiftletd->apiserver control path + egress.
+#
+# Same KubeVirt bridge-binding as setup_primary_nad_nic, with ONE Model-A specific:
+# the OVN logical-switch-port PINS MAC+IP in port_security, and that MAC is IP-DERIVED
+# and immutable (0a:58:<ip-octets-hex>). The guest CANNOT present its own 52:54:.. MAC
+# -- OVN drops it. So the guest ADOPTS OVN's MAC: capture it here, hand it to swiftletd
+# (UDN_MAC -> KUBESWIFT_PRIMARY_UDN_MAC via the entrypoint) for CH `--net mac=`, and the
+# launcher's fixed-lease dnsmasq hands the captured IP to that MAC. (Controller-side
+# MAC stamping -- the kube-ovn primary-NAD trick -- is impossible: a primary UDN has no
+# Multus selection element to carry a requested MAC.)
+#
+#   1. wait for ovn-udn1; read its OVN-assigned MAC + IP + gw + MTU
+#   2. persist them (primary-udn.env) for the launcher entrypoint (dnsmasq fixed lease
+#      + the guest-MAC override)
+#   3. flush the IP off ovn-udn1 (the GUEST owns it; avoids a duplicate-address ARP
+#      conflict on the UDN)
+#   4. re-MAC ovn-udn1 to a DISTINCT dummy BEFORE enslaving -- the guest uses the SAME
+#      0a:58:.. MAC, which would otherwise add a permanent fdb entry shadowing the tap.
+#      The 0a:fe:<rest> dummy differs from the 0a:58:<rest> guest MAC (the #240
+#      0a:<rest> derivation is a no-op for a 0a:.. MAC).
+#   5. bridge ovn-udn1 to the guest's tap; give br a helper IP for dnsmasq to bind
+setup_primary_udn_nic() {
+    bridge="$1"; tap="$2"; udn_iface="$3"
+
+    attempts=0
+    while [ $attempts -lt 30 ]; do
+        ip link show "$udn_iface" >/dev/null 2>&1 && break
+        sleep 1; attempts=$((attempts + 1))
+    done
+    if ! ip link show "$udn_iface" >/dev/null 2>&1; then
+        echo "ERROR: primary UDN interface $udn_iface not found after 30s (is the namespace primary-UDN label set?)" >&2
+        exit 1
+    fi
+
+    udn_cidr=$(ip -4 addr show "$udn_iface" 2>/dev/null | awk '/inet /{print $2; exit}')
+    if [ -z "$udn_cidr" ]; then
+        echo "ERROR: primary UDN interface $udn_iface has no IPv4 address (OVN-K IPAM did not assign one)" >&2
+        exit 1
+    fi
+    udn_ip="${udn_cidr%/*}"
+    udn_prefix="${udn_cidr#*/}"
+    udn_mac=$(cat "/sys/class/net/$udn_iface/address" 2>/dev/null)
+    if [ -z "$udn_mac" ]; then
+        echo "ERROR: primary UDN interface $udn_iface has no MAC" >&2
+        exit 1
+    fi
+    udn_gw=$(ip route show default 2>/dev/null | awk -v d="$udn_iface" '$0 ~ ("dev "d){print $3; exit}')
+    [ -z "$udn_gw" ] && udn_gw=$(ip route show dev "$udn_iface" 2>/dev/null | awk '/default/{print $3; exit}')
+    udn_mtu=$(ip -o link show "$udn_iface" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="mtu"){print $(i+1); exit}}')
+
+    # Persist for the launcher entrypoint (shared run dir). The guest must adopt
+    # UDN_MAC (OVN port_security), so the entrypoint exports it as
+    # KUBESWIFT_PRIMARY_UDN_MAC for swiftletd's CH --net mac=.
+    rd=$(guest_run_dir); mkdir -p "$rd"
+    {
+        echo "UDN_IP=$udn_ip"
+        echo "UDN_PREFIX=$udn_prefix"
+        echo "UDN_GW=$udn_gw"
+        echo "UDN_MAC=$udn_mac"
+        echo "UDN_BRIDGE=$bridge"
+        echo "UDN_MTU=$udn_mtu"
+    } > "$rd/primary-udn.env"
+
+    # The guest claims udn_ip; the host must not also hold it on the UDN.
+    ip addr flush dev "$udn_iface" 2>/dev/null || true
+
+    ip link add "$bridge" type bridge stp_state 0 2>/dev/null || true
+    ip link set "$bridge" up
+    ip tuntap add dev "$tap" mode tap 2>/dev/null || true
+    ip link set "$tap" up
+    ip link set "$tap" master "$bridge"
+
+    # The guest adopts OVN's MAC (udn_mac), so the pod NIC's kernel MAC (== udn_mac)
+    # would add a permanent fdb entry <udn_mac> -> ovn-udn1 that SHADOWS the guest's
+    # tap (return traffic + unicast DHCP go to the NIC, not the guest). Re-MAC the NIC
+    # to a DISTINCT dummy before enslaving (KubeVirt bridge-binding). The OVN LSP keeps
+    # udn_mac, so OVN still delivers the guest's frames NIC -> bridge -> tap. Per-pod
+    # netns, so the dummy need only differ from udn_mac within this pod.
+    dummy="0a:fe:${udn_mac#*:*:}"
+    ip link set "$udn_iface" down 2>/dev/null || true
+    ip link set "$udn_iface" address "$dummy" 2>/dev/null || true
+    ip link set "$udn_iface" up 2>/dev/null || true
+    echo "Primary UDN: re-MAC'd $udn_iface $udn_mac -> $dummy (it would shadow the tap on $bridge); guest adopts $udn_mac"
+
+    ip link set "$udn_iface" master "$bridge"
+    ip link set "$udn_iface" up
+
+    # Best-effort helper IP in the UDN subnet for dnsmasq to bind (same .254 heuristic
+    # as the NAD path; the guest talks via its UDN IP + gateway, never the helper).
+    net_base=$(echo "$udn_ip" | sed 's/\.[0-9]*$//')
+    helper="${net_base}.254"
+    [ "$helper" = "$udn_ip" ] && helper="${net_base}.253"
+    ip addr add "$helper/$udn_prefix" dev "$bridge" 2>/dev/null || true
+
+    echo "Primary NIC on UDN: $bridge bridges $udn_iface to $tap; guest IP=$udn_ip/$udn_prefix mac=$udn_mac gw=$udn_gw (helper $helper)"
+}
+
 # --- Main ---
 
 # Check if intent has "nics" array (multi-NIC mode)
@@ -261,6 +362,12 @@ has_nics() {
     grep -q '"nics"' "$INTENT_PATH" || return 1
     return 0
 }
+
+# Model A (docs/design/udn-primary-integration.md): the top-level primaryUDNInterface
+# signal (ovn-udn1) applies to the PRIMARY NIC -- whether the guest has explicit
+# interfaces or the default single NIC -- so it is read once here, not per-NIC. Empty
+# for every other networking mode.
+PRIMARY_UDN_IFACE=$(sed -n 's/.*"primaryUDNInterface"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$INTENT_PATH" 2>/dev/null | head -1)
 
 if has_nics; then
     # Multi-NIC mode: parse NIC list from intent JSON with python3.
@@ -314,6 +421,11 @@ for nic in nics:
             # Primary-on-NAD (multi-node L2): the primary rides a Multus NAD
             # instead of the node-local bridge.
             setup_primary_nad_nic "$bridge" "$tap" "$multus" "$mac"
+        elif [ "$primary" = "1" ] && [ -n "$PRIMARY_UDN_IFACE" ]; then
+            # Model A: the primary rides the namespace primary OVN-K UDN (ovn-udn1).
+            # The resolver only sets the signal for a node-local primary, so a
+            # primary-on-NAD guest takes the branch above, never this one.
+            setup_primary_udn_nic "$bridge" "$tap" "$PRIMARY_UDN_IFACE"
         elif [ "$primary" = "1" ]; then
             setup_primary_nic "$bridge" "$tap"
             setup_exposed_ports "$bridge"
@@ -327,7 +439,15 @@ else
     # Legacy mode: single NIC (backward compatible)
     BRIDGE="${BRIDGE_NAME:-br0}"
     TAP="${TAP_NAME:-tap0}"
-    setup_primary_nic "$BRIDGE" "$TAP"
-    setup_exposed_ports "$BRIDGE"
-    echo "Network init done: $BRIDGE (internal) with $TAP"
+    if [ -n "$PRIMARY_UDN_IFACE" ]; then
+        # Model A: the default single NIC rides the namespace primary OVN-K UDN
+        # (ovn-udn1). This is the common Model A case -- a plain SwiftGuest with no
+        # spec.interfaces in a primary-UDN namespace.
+        setup_primary_udn_nic "$BRIDGE" "$TAP" "$PRIMARY_UDN_IFACE"
+        echo "Network init done: $BRIDGE bridges $PRIMARY_UDN_IFACE (primary UDN) to $TAP"
+    else
+        setup_primary_nic "$BRIDGE" "$TAP"
+        setup_exposed_ports "$BRIDGE"
+        echo "Network init done: $BRIDGE (internal) with $TAP"
+    fi
 fi

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -55,6 +55,15 @@ pub struct RuntimeIntent {
     /// If empty/absent and network=true, a single default NIC is used (backward compat).
     #[serde(default)]
     pub nics: Option<Vec<NICIntent>>,
+    /// OVN-Kubernetes primary UDN interface (ovn-udn1) when the guest rides its
+    /// namespace's primary UserDefinedNetwork (Model A). None otherwise. A TOP-LEVEL
+    /// attribute (not per-NIC) because the primary is singular and the common case is
+    /// a default guest with no nics. When set, network-init bridges this interface to
+    /// br0/tap0 (setup_primary_udn_nic) and the guest adopts OVN's IP-derived MAC + IP
+    /// (OVN port_security pins them); swiftletd uses that captured MAC for the primary
+    /// NIC. eth0 stays on the cluster default for the control path.
+    #[serde(default)]
+    pub primary_udn_interface: Option<String>,
     /// virtiofs shares. For each, swiftletd spawns a virtiofsd backend
     /// (shared-dir = source_path, listening on socket_path) before Cloud
     /// Hypervisor, then passes CH `--fs tag=<tag>,socket=<socket_path>`.
@@ -329,12 +338,6 @@ pub struct NICIntent {
     /// Multus-created interface name (net1, net2, etc.). Empty for primary.
     #[serde(default)]
     pub multus_interface: Option<String>,
-    /// OVN-Kubernetes primary UDN interface (ovn-udn1) when the guest rides its
-    /// namespace's primary UserDefinedNetwork (Model A). None otherwise.
-    /// Mutually exclusive with multus_interface; network-init bridges it to
-    /// br0/tap0 via setup_primary_udn_nic.
-    #[serde(default)]
-    pub primary_udn_interface: Option<String>,
     /// Bridge device name (br0, br1, etc.). Empty for SR-IOV.
     #[serde(default)]
     pub bridge: String,

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -548,6 +548,19 @@ where
 fn build_ch_nics(
     intent: &RuntimeIntent,
 ) -> (Option<String>, Vec<NICConfig>, Vec<VFIODeviceConfig>) {
+    // Model A: the guest rides its namespace primary OVN-K UDN (ovn-udn1). network-init
+    // captured OVN's IP-derived MAC (the LSP port_security pins MAC+IP) and the launcher
+    // entrypoint exported it here. The PRIMARY NIC must source frames with this MAC or
+    // OVN drops them. Gated on the intent's primary_udn_interface signal so a stray env
+    // var never rewrites a non-Model-A guest's MAC. See docs/design/udn-primary-integration.md.
+    let primary_udn_mac = if intent.primary_udn_interface.is_some() {
+        std::env::var("KUBESWIFT_PRIMARY_UDN_MAC")
+            .ok()
+            .filter(|m| !m.is_empty())
+    } else {
+        None
+    };
+
     if let Some(nics) = intent.nics() {
         let mut ch_nics = vec![];
         let mut vfio_devs = vec![];
@@ -585,16 +598,38 @@ fn build_ch_nics(
                     }
                 }
             } else {
+                // Model A: the primary NIC adopts OVN's captured MAC; others keep
+                // their intent MAC.
+                let mac = if n.primary {
+                    primary_udn_mac.clone().unwrap_or_else(|| n.mac.clone())
+                } else {
+                    n.mac.clone()
+                };
                 ch_nics.push(NICConfig {
                     tap_name: n.tap_device.clone(),
-                    mac: n.mac.clone(),
+                    mac,
                     vhost_user_socket: None,
                 });
             }
         }
         (None, ch_nics, vfio_devs)
     } else if intent.has_network() {
-        (Some("tap0".to_string()), vec![], vec![])
+        // Legacy single default NIC. For a Model A default guest (no explicit
+        // interfaces), emit an explicit NICConfig carrying OVN's captured MAC instead
+        // of the auto-MAC tap0 path, so the guest passes the UDN's port_security.
+        if let Some(mac) = primary_udn_mac {
+            (
+                None,
+                vec![NICConfig {
+                    tap_name: "tap0".to_string(),
+                    mac,
+                    vhost_user_socket: None,
+                }],
+                vec![],
+            )
+        } else {
+            (Some("tap0".to_string()), vec![], vec![])
+        }
     } else {
         (None, vec![], vec![])
     }


### PR DESCRIPTION
## Model A PR2 — the marquee datapath (toward v0.5.0)

Makes a SwiftGuest in an **OVN-Kubernetes primary-UDN namespace** boot with its
primary NIC on `ovn-udn1` and be reachable cross-node on the UDN IP. Builds on
PR1 (#253, detection + intent plumbing) and the design doc
([`docs/design/udn-primary-integration.md`](docs/design/udn-primary-integration.md), #252).

### Two findings from the PR1 cluster check drove the shape

1. **Default-guest gap → top-level signal.** PR1 put `PrimaryUDNInterface` on
   `NICIntent`, set in `GetNICs()` — but `GetNICs()` returns `nil` for a guest
   with no `spec.interfaces` (the *common* Model A case). The signal now rides at
   the intent **top level** (`RuntimeIntent.PrimaryUDNInterface`), gated in the
   resolver on the primary being node-local (a primary-on-NAD guest is Model B and
   is skipped). The PR1 unit test passed because it used an explicit primary
   interface; only the cluster check with a default guest caught it.

2. **OVN port_security forces the MAC model.** The `ovn-udn1` LSP `port_security`
   pins an **IP-derived, immutable** MAC (`0a:58:<ip-hex>`) and drops any other
   source MAC. The kube-ovn #239 controller-MAC-stamp is **impossible** for a
   primary UDN (no Multus selection element to carry a requested MAC). So the
   guest **adopts OVN's MAC**: `network-init` captures it (`primary-udn.env`), the
   entrypoint exports it (`KUBESWIFT_PRIMARY_UDN_MAC`) + serves a fixed-lease
   dnsmasq, and swiftletd uses it for the primary NIC's CH `--net mac=`.

`setup_primary_udn_nic` mirrors the cluster-validated #240 NAD bridge-binding
(capture → persist → flush → re-MAC the pod NIC to a **distinct** dummy before
enslaving → bridge to tap0), with the Model-A specifics above (the `0a:<rest>`
NAD dummy is a no-op for a `0a:..` MAC, so it uses `0a:fe:<rest>`).

### Changes
- **Go (signal):** top-level `RuntimeIntent.PrimaryUDNInterface` (per-NIC field
  removed); resolver node-local gate via `guest.PrimaryInterface()`;
  `ResolvedGuest.GetPrimaryUDNInterface()`; `Build` wiring on both boot paths.
- **Rust:** top-level intent field; swiftletd primary-NIC MAC override (gated on
  the intent signal so a stray env var never rewrites a non-Model-A guest).
- **Datapath:** `network-init.sh` `setup_primary_udn_nic` + dispatch (legacy +
  per-NIC); `launcher-entrypoint.sh` UDN fixed-lease dnsmasq + MAC export.
- **Tests:** resolver tests (incl. the default-guest case PR1 missed) + a Build
  wiring test on both boot paths. `go test`/`cargo test` green.

### Validation
Fully isolated to Model A (everything gates on the namespace label / signal) — no
effect on any existing guest. Cluster validation (default guest boots on
`ovn-udn1`, cross-node reachable on the ntx OVN-K cluster) lands **after merge**:
the launcher image only builds via `release-dev` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)