### PR TITLE
feat(networking): Model A v1 — native-IP namespace tenancy via controller-derived status

### DIFF
--- a/internal/controller/swiftguest/constants.go
+++ b/internal/controller/swiftguest/constants.go
@@ -36,6 +36,19 @@ const PodAnnotationGuestHypervisor = "kubeswift.io/guest-hypervisor"
 // exposure §4). Mapped to status.network.egress + the EgressReady condition.
 const PodAnnotationEgress = "kubeswift.io/egress-cluster-reachable"
 
+// PodAnnotationPrimaryUDNIface marks a launcher pod whose guest rides the namespace
+// primary OVN-Kubernetes UDN (Model A); the value is the in-pod UDN interface name
+// (ovn-udn1). The pod-builder stamps it. swiftletd cannot reach the apiserver from a
+// primary-UDN pod (the UDN is bridged to the guest and eth0 is infrastructure-locked),
+// so the controller derives status for these guests from the OVN annotation + launcher
+// readiness instead of swiftletd's annotations. See docs/design/udn-primary-integration.md.
+const PodAnnotationPrimaryUDNIface = "kubeswift.io/primary-udn-interface"
+
+// OVNPodNetworksAnnotation is OVN-Kubernetes' status annotation carrying each attached
+// network's IP/MAC/routes. For a Model A pod the guest's IP is the entry that is NOT
+// the cluster default network ("default", role infrastructure-locked).
+const OVNPodNetworksAnnotation = "k8s.ovn.org/pod-networks"
+
 // Mount path constants. Must match internal/runtimeintent and rust/swiftletd.
 const (
 	DisksRootPath = "/var/lib/kubeswift/disks/root"

--- a/internal/controller/swiftguest/pod.go
+++ b/internal/controller/swiftguest/pod.go
@@ -44,7 +44,50 @@ func BuildPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGuest, seedC
 	applyFilesystems(pod, guest)
 	applyVhostUserSocketVolumes(pod, guest)
 	applyExposedPorts(pod, guest)
+	applyPrimaryUDN(pod, guest, rg)
 	return pod
+}
+
+// applyPrimaryUDN marks a Model A launcher pod (guest on the namespace primary OVN-K
+// UDN) and gives it a readiness probe so the controller can derive status without
+// swiftletd's apiserver access. swiftletd cannot reach the apiserver from a primary-UDN
+// pod (the UDN is bridged to the guest; eth0 is infrastructure-locked), so:
+//   - the marker tells the controller to derive primaryIP from the OVN annotation; and
+//   - the readiness probe (CH API socket present == CH up) drives GuestRunning via pod
+//     readiness. A service-port readiness probe (applyExposedPorts) is a stronger signal
+//     and takes precedence — the CH-socket probe is added only when none exists.
+//
+// No-op for every non-Model-A guest. Runs after applyExposedPorts so it sees that
+// probe. See docs/design/udn-primary-integration.md.
+func applyPrimaryUDN(pod *corev1.Pod, guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGuest) {
+	udnIface := rg.GetPrimaryUDNInterface()
+	if udnIface == "" {
+		return
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	pod.Annotations[PodAnnotationPrimaryUDNIface] = udnIface
+
+	chSock := fmt.Sprintf("%s/%s-%s/ch.sock", RunDirPath, guest.Namespace, guest.Name)
+	for i := range pod.Spec.Containers {
+		c := &pod.Spec.Containers[i]
+		if c.Name != "launcher" {
+			continue
+		}
+		if c.ReadinessProbe != nil {
+			return // service-port probe already set (stronger signal)
+		}
+		c.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{Command: []string{"sh", "-c", "test -S " + chSock}},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       5,
+			FailureThreshold:    3,
+		}
+		return
+	}
 }
 
 // applyExposedPorts declares launcher containerPorts for each spec.network.ports

--- a/internal/controller/swiftguest/status.go
+++ b/internal/controller/swiftguest/status.go
@@ -3,6 +3,7 @@ package swiftguest
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +30,24 @@ func MapPodToStatus(pod *corev1.Pod, status *swiftv1alpha1.SwiftGuestStatus) {
 		status.Network.PrimaryIP = ip
 		status.Network.Interface = "eth0"
 		status.Network.Ready = true
+	}
+
+	// Model A (primary OVN-K UDN): swiftletd cannot reach the apiserver from a
+	// primary-UDN pod (the UDN is bridged to the guest; eth0 is infrastructure-locked),
+	// so it never writes the guest-ip annotation. The guest's IP IS the pod's
+	// OVN-assigned UDN IP — derive it from the OVN pod-networks annotation when swiftletd
+	// has not (and cannot) provide one. See docs/design/udn-primary-integration.md.
+	if udn := pod.Annotations[PodAnnotationPrimaryUDNIface]; udn != "" {
+		if status.Network == nil || status.Network.PrimaryIP == "" {
+			if ip := primaryUDNIPFromPod(pod); ip != "" {
+				if status.Network == nil {
+					status.Network = &swiftv1alpha1.GuestNetworkStatus{}
+				}
+				status.Network.PrimaryIP = ip
+				status.Network.Interface = udn
+				status.Network.Ready = true
+			}
+		}
 	}
 
 	// Set network interfaces from pod annotation (set by swiftletd lease poller)
@@ -121,6 +140,57 @@ func MapPodToStatus(pod *corev1.Pod, status *swiftv1alpha1.SwiftGuestStatus) {
 		status.Phase = swiftv1alpha1.SwiftGuestPhaseScheduling
 		SetPodScheduledCondition(status, pod, false, "Scheduling")
 	}
+
+	// GuestRunning for a Model A guest: swiftletd can't patch it (no apiserver), so the
+	// controller derives it from launcher readiness (the CH-socket readiness probe the
+	// pod-builder adds). For non-Model-A guests this is untouched — swiftletd owns it.
+	if udn := pod.Annotations[PodAnnotationPrimaryUDNIface]; udn != "" {
+		if isLauncherReady(pod) {
+			setCondition(status, metav1.Condition{
+				Type:    "GuestRunning",
+				Status:  metav1.ConditionTrue,
+				Reason:  "GuestRunning",
+				Message: "Cloud Hypervisor running (derived from launcher readiness; primary-UDN guest)",
+			})
+		} else {
+			setCondition(status, metav1.Condition{
+				Type:    "GuestRunning",
+				Status:  metav1.ConditionFalse,
+				Reason:  "GuestStarting",
+				Message: "waiting for Cloud Hypervisor (launcher not ready; primary-UDN guest)",
+			})
+		}
+	}
+}
+
+// primaryUDNIPFromPod extracts the guest's UDN IP from the pod's OVN-Kubernetes
+// pod-networks annotation: the entry that is NOT the cluster default network ("default",
+// role infrastructure-locked on a primary-UDN pod). Returns "" when absent/unparseable.
+func primaryUDNIPFromPod(pod *corev1.Pod) string {
+	raw := pod.Annotations[OVNPodNetworksAnnotation]
+	if raw == "" {
+		return ""
+	}
+	var nets map[string]struct {
+		IPAddresses []string `json:"ip_addresses"`
+		Role        string   `json:"role"`
+	}
+	if err := json.Unmarshal([]byte(raw), &nets); err != nil {
+		return ""
+	}
+	for name, n := range nets {
+		if name == "default" || n.Role == "infrastructure-locked" {
+			continue
+		}
+		if len(n.IPAddresses) > 0 {
+			ip := n.IPAddresses[0]
+			if i := strings.IndexByte(ip, '/'); i >= 0 {
+				ip = ip[:i]
+			}
+			return ip
+		}
+	}
+	return ""
 }
 
 func podFailureReason(pod *corev1.Pod) (string, string) {

--- a/internal/controller/swiftguest/udn_status_test.go
+++ b/internal/controller/swiftguest/udn_status_test.go
@@ -1,0 +1,135 @@
+package swiftguest
+
+import (
+	"testing"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/resolved"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// A real OVN-K pod-networks annotation: the "default" entry is infrastructure-locked
+// (the cluster default, not the guest's IP); the UDN entry carries the guest's IP.
+const ovnPodNetworksFixture = `{"default":{"ip_addresses":["10.244.1.36/24"],"role":"infrastructure-locked"},` +
+	`"model-a/model-a-udn":{"ip_addresses":["10.50.0.26/16"],"role":"primary","gateway_ips":["10.50.0.1"]}}`
+
+// Model A: swiftletd writes no guest-ip annotation (no apiserver), so the controller
+// derives the guest IP from the OVN annotation (the non-default entry) and GuestRunning
+// from launcher readiness.
+func TestMapPodToStatus_ModelA_DerivesIPFromOVNAnnotation(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "g", Namespace: "model-a",
+			Annotations: map[string]string{
+				PodAnnotationPrimaryUDNIface: "ovn-udn1",
+				OVNPodNetworksAnnotation:     ovnPodNetworksFixture,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	status := &swiftv1alpha1.SwiftGuestStatus{}
+	MapPodToStatus(pod, status)
+
+	if status.Network == nil || status.Network.PrimaryIP != "10.50.0.26" {
+		t.Fatalf("primaryIP = %+v, want 10.50.0.26 (the UDN entry, not the infra-locked default)", status.Network)
+	}
+	if status.Network.Interface != "ovn-udn1" {
+		t.Errorf("interface = %q, want ovn-udn1", status.Network.Interface)
+	}
+	if gr := findCondition(status, "GuestRunning"); gr == nil || gr.Status != metav1.ConditionTrue {
+		t.Errorf("GuestRunning = %v, want True (launcher ready)", gr)
+	}
+}
+
+func TestMapPodToStatus_ModelA_GuestRunningFalseWhenNotReady(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "g", Namespace: "model-a",
+			Annotations: map[string]string{
+				PodAnnotationPrimaryUDNIface: "ovn-udn1",
+				OVNPodNetworksAnnotation:     ovnPodNetworksFixture,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},
+		},
+	}
+	status := &swiftv1alpha1.SwiftGuestStatus{}
+	MapPodToStatus(pod, status)
+	if gr := findCondition(status, "GuestRunning"); gr == nil || gr.Status != metav1.ConditionFalse {
+		t.Errorf("GuestRunning = %v, want False (launcher not ready)", gr)
+	}
+}
+
+// Regression: a non-Model-A guest (no marker) is untouched — the controller derives
+// neither the IP nor GuestRunning; swiftletd owns those via its annotations.
+func TestMapPodToStatus_NonModelA_NoDerivation(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "g", Namespace: "default",
+			Annotations: map[string]string{OVNPodNetworksAnnotation: ovnPodNetworksFixture},
+		},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	status := &swiftv1alpha1.SwiftGuestStatus{}
+	MapPodToStatus(pod, status)
+	if status.Network != nil && status.Network.PrimaryIP != "" {
+		t.Errorf("non-Model-A primaryIP = %q, want empty (no marker)", status.Network.PrimaryIP)
+	}
+	if gr := findCondition(status, "GuestRunning"); gr != nil {
+		t.Errorf("non-Model-A GuestRunning set by controller = %v, want nil (swiftletd owns it)", gr)
+	}
+}
+
+func TestApplyPrimaryUDN_StampsMarkerAndProbe(t *testing.T) {
+	rg := &resolved.ResolvedGuest{PrimaryUDNInterface: "ovn-udn1", Meta: resolved.Meta{Namespace: "model-a", Name: "g"}}
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Namespace: "model-a", Name: "g"}}
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "launcher"}}}}
+	applyPrimaryUDN(pod, guest, rg)
+
+	if pod.Annotations[PodAnnotationPrimaryUDNIface] != "ovn-udn1" {
+		t.Errorf("marker = %q, want ovn-udn1", pod.Annotations[PodAnnotationPrimaryUDNIface])
+	}
+	rp := pod.Spec.Containers[0].ReadinessProbe
+	if rp == nil || rp.Exec == nil {
+		t.Fatal("expected a CH-socket readiness probe on the launcher")
+	}
+	want := "test -S " + RunDirPath + "/model-a-g/ch.sock"
+	if got := rp.Exec.Command[len(rp.Exec.Command)-1]; got != want {
+		t.Errorf("probe cmd = %q, want %q", got, want)
+	}
+}
+
+// A Model A guest that already has a service-port readiness probe keeps it (stronger
+// signal); applyPrimaryUDN does not overwrite it.
+func TestApplyPrimaryUDN_KeepsServicePortProbe(t *testing.T) {
+	rg := &resolved.ResolvedGuest{PrimaryUDNInterface: "ovn-udn1", Meta: resolved.Meta{Namespace: "model-a", Name: "g"}}
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Namespace: "model-a", Name: "g"}}
+	existing := &corev1.Probe{ProbeHandler: corev1.ProbeHandler{TCPSocket: &corev1.TCPSocketAction{}}}
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "launcher", ReadinessProbe: existing}}}}
+	applyPrimaryUDN(pod, guest, rg)
+	if pod.Spec.Containers[0].ReadinessProbe != existing {
+		t.Error("service-port readiness probe was overwritten")
+	}
+}
+
+func TestApplyPrimaryUDN_NoopNonModelA(t *testing.T) {
+	rg := &resolved.ResolvedGuest{Meta: resolved.Meta{Namespace: "default", Name: "g"}}
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "g"}}
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "launcher"}}}}
+	applyPrimaryUDN(pod, guest, rg)
+	if _, ok := pod.Annotations[PodAnnotationPrimaryUDNIface]; ok {
+		t.Error("non-Model-A pod got the marker")
+	}
+	if pod.Spec.Containers[0].ReadinessProbe != nil {
+		t.Error("non-Model-A pod got a readiness probe")
+	}
+}

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -62,7 +62,12 @@ pub struct RuntimeIntent {
     /// br0/tap0 (setup_primary_udn_nic) and the guest adopts OVN's IP-derived MAC + IP
     /// (OVN port_security pins them); swiftletd uses that captured MAC for the primary
     /// NIC. eth0 stays on the cluster default for the control path.
-    #[serde(default)]
+    ///
+    /// Explicit rename: the struct's rename_all=camelCase would expect
+    /// `primaryUdnInterface`, but the Go controller emits `primaryUDNInterface`
+    /// (the UDN acronym is kept upper-case in the json tag). Without the rename the
+    /// field silently deserializes to None and the MAC override never fires.
+    #[serde(default, rename = "primaryUDNInterface")]
     pub primary_udn_interface: Option<String>,
     /// virtiofs shares. For each, swiftletd spawns a virtiofsd backend
     /// (shared-dir = source_path, listening on socket_path) before Cloud
@@ -622,6 +627,31 @@ mod tests {
             !lin.is_windows(),
             "absent osType should not be is_windows()"
         );
+    }
+
+    // Model A: the Go controller emits the top-level key `primaryUDNInterface`
+    // (UDN acronym upper-case). The struct's rename_all=camelCase would otherwise
+    // expect `primaryUdnInterface` and silently drop it to None — which on a real
+    // cluster skips the CH --net mac override and the guest never gets a UDN IP.
+    // This round-trips the EXACT Go-emitted key (the gap a cross-side test closes).
+    #[test]
+    fn test_intent_primary_udn_interface_go_key() {
+        let intent: RuntimeIntent = serde_json::from_str(
+            r#"{"rootDisk":{"path":"/d/i.raw","format":"raw"},"seedPath":"","cpu":2,"memory":2048,"lifecycle":"start","guestId":"model-a/g","network":true,"primaryUDNInterface":"ovn-udn1"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            intent.primary_udn_interface.as_deref(),
+            Some("ovn-udn1"),
+            "the Go-emitted `primaryUDNInterface` key must deserialize into primary_udn_interface"
+        );
+
+        // Absent (every non-Model-A guest) -> None.
+        let plain: RuntimeIntent = serde_json::from_str(
+            r#"{"rootDisk":{"path":"/d/i.raw","format":"raw"},"seedPath":"","cpu":2,"memory":2048,"lifecycle":"start","guestId":"default/g","network":true}"#,
+        )
+        .unwrap();
+        assert_eq!(plain.primary_udn_interface, None);
     }
 
     #[test]

--- a/rust/swiftletd/src/main.rs
+++ b/rust/swiftletd/src/main.rs
@@ -212,7 +212,24 @@ fn main() {
 
             let (namespace, name) = (env::var("POD_NAMESPACE").ok(), env::var("POD_NAME").ok());
 
+            // Model A (guest on the namespace primary OVN-K UDN): swiftletd CANNOT reach
+            // the apiserver from a primary-UDN pod — the UDN is bridged to the guest and
+            // eth0 is infrastructure-locked. So skip every apiserver interaction (lease
+            // poller, action loop, GuestRunning/runtime reports); the controller derives
+            // status from the OVN pod annotation + launcher readiness instead. Without
+            // this gate swiftletd would spam "client error (Connect)" forever.
+            // See docs/design/udn-primary-integration.md.
+            let is_primary_udn = intent.primary_udn_interface.is_some();
+            if is_primary_udn {
+                log::info!(
+                    "primary-UDN guest: skipping apiserver reporting (controller derives status)"
+                );
+            }
+
             let report_running = |running: bool, reason: Option<&str>| {
+                if is_primary_udn {
+                    return;
+                }
                 let (Some(ns), Some(n)) = (&namespace, &name) else {
                     return;
                 };
@@ -249,7 +266,7 @@ fn main() {
             // on-receive-completion lease report driven by the
             // action loop. See `docs/design/live-migration-phase-2.md`
             // §4.3.2 + §3.4 (poll-info-API).
-            if intent.has_network() && !intent.is_migration_receiver() {
+            if intent.has_network() && !intent.is_migration_receiver() && !is_primary_udn {
                 if let (Some(ref ns), Some(ref n)) = (&namespace, &name) {
                     let lease_path = runtime_dir.root().join("dnsmasq.leases");
                     let nics_for_poller = intent.nics.clone();
@@ -279,9 +296,11 @@ fn main() {
             // it here means it's running before launch::run blocks, so
             // the controller can drive it as soon as the launcher pod is
             // up (it does not require the VM to have already booted).
-            if let (Some(ref ns), Some(ref n)) = (&namespace, &name) {
-                let api_socket = runtime_dir.root().join("ch.sock");
-                action::spawn_action_loop(ns.clone(), n.clone(), api_socket);
+            if !is_primary_udn {
+                if let (Some(ref ns), Some(ref n)) = (&namespace, &name) {
+                    let api_socket = runtime_dir.root().join("ch.sock");
+                    action::spawn_action_loop(ns.clone(), n.clone(), api_socket);
+                }
             }
 
             // on_socket_ready: skipped in receiver mode. CH on a
@@ -295,7 +314,7 @@ fn main() {
             // operators verify destination success via the
             // migration-status: ready annotation OR via vm_info
             // directly.
-            let on_socket_ready = if intent.is_migration_receiver() {
+            let on_socket_ready = if intent.is_migration_receiver() || is_primary_udn {
                 None
             } else {
                 namespace.as_ref().zip(name.as_ref()).map(|_| {


### PR DESCRIPTION
## Model A v1 — namespace-native tenancy (toward v0.5.0)

A SwiftGuest in a namespace whose **primary** network is an OVN-Kubernetes UDN now boots
holding its **native UDN IP**, cross-node reachable and tenant-isolated. Completes the
Model A datapath started in PR1 (#253) + PR2 (#254).

### The journey
PR2's bridge-binding gives the VM the UDN IP — but cluster testing then exposed the real
problem: **swiftletd can't reach the apiserver from a primary-UDN pod**. OVN-K bridges the
UDN to the guest and **infrastructure-locks `eth0`** (cluster-confirmed: "No route to host"
to both the apiserver and kube-dns, even with a manual route; no 2nd pod IP and no eth0
unlock per OKEP-5233 + the UDN isolation ACLs). KubeVirt hits the identical wall and solves
it with the host-level `virt-handler`.

**This PR takes the KubeVirt insight without its DaemonSet:** the guest's IP *is* the pod's
OVN-assigned UDN IP, so the **controller** derives the status swiftletd can no longer report.

### Changes
- **serde fix** (`5c01301`): `primary_udn_interface` ← Go's `primaryUDNInterface` (UDN
  acronym); without the rename serde dropped it and the PR2 MAC override never fired.
- **Pod builder** `applyPrimaryUDN`: stamps `kubeswift.io/primary-udn-interface` + a
  CH-API-socket readiness probe (pod-Ready == CH up; a service-port probe takes precedence).
- **Controller** `MapPodToStatus`: for a marked pod, derive `status.network.primaryIP` from
  `k8s.ovn.org/pod-networks` (the non-default, non-infra-locked entry) and `GuestRunning`
  from launcher readiness. Non-Model-A status is untouched (swiftletd still owns it).
- **swiftletd**: gate the lease poller, action loop, and reports on
  `intent.primary_udn_interface` — skip all apiserver interaction (stops the connect-error
  spam; the controller reports instead).
- 8 new tests (status derivation, pod-builder, serde round-trip). No chart/CRD/RBAC change
  (reads an existing pod annotation).

### Cluster validation (ntx, OVN-K primary CNI)
| Check | Result |
|---|---|
| Native UDN IP (controller-derived) | **10.50.0.30** |
| `GuestRunning` (readiness-derived) | False → **True** |
| swiftletd connect-error spam | **0** lines (gated) |
| Cross-node ping on the UDN IP | ntx1 → ntx3 **3/3, 0% loss** |

### Scope
**v1 = namespace-native tenancy** (boot + native UDN IP + cross-node + isolated). **Live
migration + snapshot of Model A guests are v2** — they need a swiftletd↔swiftletd migration
channel the primary UDN doesn't give the pod (the dst `eth0` infra-lock drops pod-to-pod);
that's its own track. See [`docs/design/udn-primary-integration.md`](docs/design/udn-primary-integration.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)