### PR TITLE
feat(networking): Model A v1 — migration guard (offline-only) + docs + sample

### DIFF
--- a/config/samples/model-a/00-namespace-and-udn.yaml
+++ b/config/samples/model-a/00-namespace-and-udn.yaml
@@ -1,0 +1,25 @@
+# Model A — namespace-native VM tenancy on the primary OVN-Kubernetes UDN.
+# See docs/networking/udn-primary-tenancy.md.
+#
+# 1. The namespace carries the OVN-K primary-UDN label (presence is the signal; the
+#    value is ignored). It MUST be set at namespace creation — OVN-K enforces immutability.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tenant-a
+  labels:
+    k8s.ovn.org/primary-user-defined-network: ""
+---
+# 2. The namespace primary UDN. Every pod and VM in tenant-a gets an `ovn-udn1`
+#    interface on this network as its primary (eth0 stays on the cluster default,
+#    locked to kubelet health checks).
+apiVersion: k8s.ovn.org/v1
+kind: UserDefinedNetwork
+metadata:
+  name: tenant-a-udn
+  namespace: tenant-a
+spec:
+  topology: Layer2
+  layer2:
+    role: Primary
+    subnets: ["10.50.0.0/16"]

--- a/config/samples/model-a/10-class-and-seed.yaml
+++ b/config/samples/model-a/10-class-and-seed.yaml
@@ -1,0 +1,33 @@
+# SwiftGuestClass (cluster-scoped) + SwiftSeedProfile for the Model A sample guest.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestClass
+metadata:
+  name: model-a-small
+spec:
+  cpu: 2
+  memory: "2Gi"
+  rootDisk:
+    size: "10Gi"
+    format: raw
+---
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftSeedProfile
+metadata:
+  name: model-a-seed
+  namespace: tenant-a
+spec:
+  datasource: NoCloud
+  userData: |
+    #cloud-config
+    hostname: tenant-vm
+    users:
+      - name: kubeswift
+        # password: kubeswift (change for any real use)
+        passwd: $6$kubeswift$/2TeJTNbX7JcApzW0gTbSFzCAN4eFcOdnQsI0lVANFpXhHmjqLy7npyhHxvT65kpUd0YKVMBAbRt3MUfV6eCJ.
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        lock_passwd: false
+    runcmd:
+      - systemctl enable --now getty@ttyS0.service
+  metaData: |
+    instance-id: tenant-vm-001
+    local-hostname: tenant-vm

--- a/config/samples/model-a/20-guest.yaml
+++ b/config/samples/model-a/20-guest.yaml
@@ -1,0 +1,19 @@
+# A plain SwiftGuest in the primary-UDN namespace — automatically Model A (KubeSwift
+# detects the namespace label). No Model-A-specific spec is needed.
+#
+# Requires a Ready SwiftImage named `ubuntu-noble` in `tenant-a` (provide your own;
+# any modern cloud image works). The guest boots holding a native UDN IP (10.50.0.x),
+# reported in status.network.primaryIP, reachable cross-node from the same namespace.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: tenant-vm
+  namespace: tenant-a
+spec:
+  imageRef:
+    name: ubuntu-noble
+  guestClassRef:
+    name: model-a-small
+  seedProfileRef:
+    name: model-a-seed
+  runPolicy: Running

--- a/config/samples/model-a/README.md
+++ b/config/samples/model-a/README.md
@@ -1,0 +1,41 @@
+# Model A — namespace-native VM tenancy (primary OVN-K UDN)
+
+A SwiftGuest on its namespace's **primary** OVN-Kubernetes UserDefinedNetwork: every pod
+and VM in the namespace shares one isolated tenant network, and the VM holds a **native
+UDN IP**, reachable cross-node. Full guide: [`docs/networking/udn-primary-tenancy.md`](../../../docs/networking/udn-primary-tenancy.md).
+
+## Prerequisites
+
+- **OVN-Kubernetes as the cluster CNI**, network-segmentation enabled. On OVN-K
+  release-1.2 disable the identity webhook (`global.enableOvnKubeIdentity=false`) or
+  primary-UDN pods fall back to the default network.
+- KubeSwift **≥ v0.5.0**.
+- A Ready `SwiftImage` named `ubuntu-noble` in `tenant-a` (provide your own).
+
+## Apply
+
+```bash
+kubectl apply -f 00-namespace-and-udn.yaml   # namespace + primary-UDN label + UDN
+kubectl apply -f 10-class-and-seed.yaml      # SwiftGuestClass + SwiftSeedProfile
+# (create your SwiftImage `ubuntu-noble` in tenant-a here)
+kubectl apply -f 20-guest.yaml               # the guest — no Model-A-specific spec
+```
+
+## Verify
+
+```bash
+kubectl -n tenant-a get swiftguest tenant-vm -o wide
+# status.network.primaryIP is a 10.50.0.x (the UDN), GuestRunning=True.
+
+# Cross-node reachability (a pod in tenant-a on another node reaches the VM's UDN IP):
+kubectl -n tenant-a run probe --image=nicolaka/netshoot --restart=Never -- sleep 3600
+kubectl -n tenant-a exec probe -- ping -c2 <the primaryIP>
+```
+
+## Scope (v1)
+
+Boot + native UDN IP + cross-node + tenant isolation. **Offline** migration / drain
+evacuation works (the target gets a fresh UDN IP). **Live** migration and snapshot of a
+Model A guest are **v2** — `mode: live` is rejected at admission; `auto` resolves to
+offline. For IP-preserving live migration today, use the secondary-UDN path
+([Model B](../../../docs/networking/udn-multi-tenancy.md)).

--- a/docs/design/udn-primary-integration.md
+++ b/docs/design/udn-primary-integration.md
@@ -1,9 +1,30 @@
 # Design: Model A — guest on the pod's primary OVN-Kubernetes UserDefinedNetwork
 
-> Staff-architect design doc. Status: **APPROVED — implementation arc, target v0.5.0.**
-> Builds on the spike `docs/design/udn-primary-spike.md` (gitignored) and the shipped
-> OVN-Kubernetes backend (v0.4.6, PRs #242–#249). Cluster: ntx (kubeadm + OVN-K
-> primary, identity webhook off), staged namespace `model-a`.
+> Staff-architect design doc. Status: **v1 SHIPPED in v0.5.0** (PRs #253 detect, #254
+> datapath, #255 controller-derived status, + the migration guard). Builds on the spike
+> `docs/design/udn-primary-spike.md` (gitignored) and the shipped OVN-Kubernetes backend
+> (v0.4.6, PRs #242–#249). Cluster: ntx (kubeadm + OVN-K primary, identity webhook off).
+> Operator how-to: [`docs/networking/udn-primary-tenancy.md`](../networking/udn-primary-tenancy.md).
+>
+> **v1 implementation outcome (what changed from the sections below — cluster-driven):**
+> 1. **Datapath = bridge-binding** (the VM adopts the pod's OVN-assigned IP-derived MAC +
+>    IP; `setup_primary_udn_nic`). This part matches the design. The signal moved to the
+>    intent **top level** (`primaryUDNInterface`) because `GetNICs()` emits nothing for a
+>    default guest (the common case).
+> 2. **The hard finding:** bridge-binding severs swiftletd's **apiserver access** — OVN-K
+>    infrastructure-locks `eth0` (no route to services) and the UDN is the guest's. No 2nd
+>    pod IP (OKEP-5233 is single-address) and no eth0 unlock. KubeVirt hits this too and
+>    uses a host-level `virt-handler`.
+> 3. **v1 resolution (lighter than the host-reporter sketched below):** the **controller
+>    derives status** — `primaryIP` from the pod's `k8s.ovn.org/pod-networks` annotation,
+>    `GuestRunning` from a launcher CH-socket readiness probe; swiftletd skips all apiserver
+>    calls for these guests. No host DaemonSet needed for v1.
+> 4. **Migration:** Model A guests are **offline-only** in v1 (the webhook rejects
+>    `mode: live`; `auto`→offline). Live migration + snapshot of Model A guests = **v2**
+>    (they need the swiftletd↔swiftletd channel the primary UDN withholds from the pod —
+>    the host-reporter/action-relay track).
+>
+> The numbered sections below are the ORIGINAL design; read them through the outcome above.
 
 ## 1. Goal
 

--- a/docs/networking/udn-multi-tenancy.md
+++ b/docs/networking/udn-multi-tenancy.md
@@ -15,10 +15,13 @@ see [`ovn-l2-install.md`](ovn-l2-install.md) and [`multi-node-l2.md`](multi-node
   (their own OVN logical switch), isolated from other tenants — and each VM keeps
   its IP across a `mode: live` migration.
 
-This is **guest-level** tenancy: the VM's primary IP rides the tenant network; the
-launcher pod's `eth0` stays on the cluster-default network (control path). For
-*namespace-native* tenancy (the launcher pod's primary itself on the tenant
-network, for mixed pod+VM namespaces) — a **future enhancement**, not yet shipped.
+This is **guest-level** tenancy: the VM's primary IP rides a *secondary* tenant
+network; the launcher pod's `eth0` stays on the cluster-default network (control
+path). For *namespace-native* tenancy — the VM on the namespace's **primary** UDN, so
+every pod *and* VM in the namespace shares one tenant network — use **Model A**
+([`udn-primary-tenancy.md`](udn-primary-tenancy.md), shipped in v0.5.0). Model A gives a
+native UDN IP + cross-node reachability today; IP-preserving **live** migration is the
+Model B (secondary-UDN) path's advantage for now (Model A live migration is a v2 item).
 
 ## The recipe
 

--- a/docs/networking/udn-primary-tenancy.md
+++ b/docs/networking/udn-primary-tenancy.md
@@ -1,0 +1,126 @@
+# Namespace-native VM tenancy — guest on the primary OVN-Kubernetes UDN (Model A)
+
+Put a SwiftGuest VM **directly on its namespace's primary network** when that primary
+is an OVN-Kubernetes **UserDefinedNetwork (UDN)**. Every pod *and* VM in the namespace
+shares one isolated tenant network — **namespace-native tenancy** — and each VM holds a
+**native UDN IP**, reachable cross-node, isolated from other tenants.
+
+This is the **Model A** path. Compare with the **Model B** path
+([`udn-multi-tenancy.md`](udn-multi-tenancy.md)), where the VM rides a *secondary* UDN
+via a per-guest `networkRef` and the launcher pod's `eth0` stays on the cluster-default
+network. Pick Model A when the *namespace itself* is the tenant boundary (mixed pod+VM
+workloads on one primary network, no per-workload `networkRef`); pick Model B when you
+want per-guest opt-in on top of a normal namespace.
+
+## Scope (v1)
+
+| Capability | Model A v1 |
+|---|---|
+| Boot with a native UDN IP | ✅ |
+| Cross-node reachability on the UDN IP | ✅ |
+| Tenant L2 isolation | ✅ (OVN-K UDN) |
+| **Offline** migration / drain evacuation | ✅ (target acquires a fresh UDN IP) |
+| **Live** migration (IP-preserving) | ❌ **v2** — rejected at admission (see below) |
+| Snapshot / clone of a Model A guest | ❌ **v2** |
+
+Live migration of a Model A guest is **not supported in v1** and is rejected with a clear
+message: the primary UDN withholds the swiftletd↔swiftletd migration channel from the
+launcher pod (the destination pod's `eth0` is infrastructure-locked, so the migration TCP
+has no pod-to-pod path). `mode: auto` resolves to **offline** for these guests, so
+`kubectl drain` still evacuates them (with a fresh IP on the target). If you need
+IP-preserving live migration today, use **Model B** (a secondary UDN —
+[`udn-multi-tenancy.md`](udn-multi-tenancy.md)).
+
+## Prerequisites
+
+- **OVN-Kubernetes as the cluster (primary) CNI**, with network-segmentation /
+  UserDefinedNetworks enabled. Install: [`ovn-kubernetes-install.md`](ovn-kubernetes-install.md)
+  and [`kubeadm-ovn-kubernetes-setup.md`](kubeadm-ovn-kubernetes-setup.md).
+- **OVN-K release-1.2 caveat:** its pod-admission identity webhook rejects a primary-UDN
+  pod annotation. Disable it (`--set global.enableOvnKubeIdentity=false` on the OVN-K
+  Helm release) or use a newer OVN-K. Without this, primary-UDN pods silently fall back to
+  the cluster-default network.
+- KubeSwift **≥ v0.5.0**.
+
+## Recipe
+
+### 1. Create the tenant namespace with the primary-UDN label
+
+OVN-K binds a namespace's primary UDN by the **presence** of this label (the value is
+ignored):
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tenant-a
+  labels:
+    k8s.ovn.org/primary-user-defined-network: ""
+```
+
+The label is immutable and must be set **at namespace creation** (OVN-K enforces this).
+
+### 2. Create the primary UserDefinedNetwork
+
+```yaml
+apiVersion: k8s.ovn.org/v1
+kind: UserDefinedNetwork
+metadata:
+  name: tenant-a-udn
+  namespace: tenant-a
+spec:
+  topology: Layer2
+  layer2:
+    role: Primary
+    subnets: ["10.50.0.0/16"]
+```
+
+Every pod created in `tenant-a` now gets an `ovn-udn1` interface on this network as its
+primary, plus an `eth0` on the cluster-default network locked to kubelet health checks.
+
+### 3. Deploy a guest — no special spec
+
+A plain SwiftGuest in the namespace is automatically Model A (KubeSwift detects the
+namespace label):
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: tenant-vm
+  namespace: tenant-a
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: small }
+  seedProfileRef: { name: default-seed }
+  runPolicy: Running
+```
+
+The VM boots holding a `10.50.0.x` address from the tenant UDN. `status.network.primaryIP`
+reports it; `GuestRunning` flips True when Cloud Hypervisor is up. A pod (or VM) in the
+same namespace on **any node** can reach it on that IP.
+
+Full sample set: [`config/samples/model-a/`](../../config/samples/model-a/).
+
+## How it works (brief)
+
+- **Datapath (bridge-binding):** OVN-K assigns the launcher pod a UDN IP + an IP-derived
+  MAC (`0a:58:<ip-hex>`); `network-init` bridges `ovn-udn1` to the VM's tap so the **VM
+  adopts that exact IP+MAC** (OVN `port_security` pins them). This is the KubeVirt
+  bridge-binding pattern.
+- **Status (controller-derived):** because the UDN is bridged to the VM and `eth0` is
+  infrastructure-locked, swiftletd **cannot reach the apiserver** from the pod. So the
+  **controller** derives status: `primaryIP` from the pod's `k8s.ovn.org/pod-networks`
+  annotation, `GuestRunning` from a launcher CH-socket readiness probe. swiftletd skips
+  all apiserver calls for these guests.
+
+Design detail: [`docs/design/udn-primary-integration.md`](../design/udn-primary-integration.md).
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| Guest stuck `Scheduling`, no IP | The pod has no `ovn-udn1` (OVN-K identity webhook rejected the primary-UDN annotation) — set `global.enableOvnKubeIdentity=false`. Check `kubectl get pod <g> -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/pod-networks}'`. |
+| IP is `192.168.99.x` (node-local), not the UDN subnet | The namespace lacks the primary-UDN label, or the controller is < v0.5.0. Confirm the label and the controller image. |
+| `swiftctl migrate … --mode live` rejected | Expected in v1 — Model A guests are offline-only. Use `--mode offline` (or `auto`). |
+| `kubectl drain` of a Model A node | Works (offline migration, fresh IP). Remember `--delete-emptydir-data` (the launcher pod uses emptyDir). |

--- a/internal/controller/swiftmigration/auto_mode.go
+++ b/internal/controller/swiftmigration/auto_mode.go
@@ -9,6 +9,7 @@ import (
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/resolved"
 )
 
 // resolveAutoMode resolves spec.Mode=auto into a concrete status.Mode
@@ -95,6 +96,18 @@ func (r *SwiftMigrationReconciler) resolveAutoMode(
 		// offline; offline migration on default networking also
 		// produces a fresh IP, but offline's "stop, move, start"
 		// semantics make the IP change explicit (the guest reboots).
+		return nil
+	}
+
+	// Model A: a guest on the namespace primary OVN-K UDN cannot live-migrate in v1
+	// (the primary UDN withholds the swiftletd<->swiftletd migration channel from the
+	// pod — the dst eth0 is infrastructure-locked, dropping pod-to-pod traffic). Auto
+	// resolves to offline, which works: the target acquires a fresh UDN IP. The webhook
+	// rejects explicit mode=live for these guests. Mirrors the VFIO rule above.
+	// See docs/design/udn-primary-integration.md.
+	if modelA, err := resolved.NamespaceHasPrimaryUDN(ctx, r.Client, mig.Namespace); err != nil {
+		return phaseTransient(fmt.Errorf("checking primary-UDN namespace for auto-resolution: %w", err))
+	} else if modelA {
 		return nil
 	}
 

--- a/internal/controller/swiftmigration/auto_mode_test.go
+++ b/internal/controller/swiftmigration/auto_mode_test.go
@@ -53,6 +53,32 @@ func TestResolveAutoMode_VFIO_ResolvesToOffline(t *testing.T) {
 	}
 }
 
+// A guest that would otherwise resolve to live (no VFIO, allowIPChange) but rides its
+// namespace's primary OVN-K UDN (Model A) MUST resolve to offline — live migration of a
+// primary-UDN guest is unsupported in v1 (no swiftletd<->swiftletd channel).
+func TestResolveAutoMode_ModelA_ResolvesToOffline(t *testing.T) {
+	scheme := testScheme(t)
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "model-a"},
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   "model-a",
+		Labels: map[string]string{"k8s.ovn.org/primary-user-defined-network": ""},
+	}}
+	mig := newMigration("m", "model-a")
+	mig.Spec.AllowIPChange = true
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, ns).Build()
+	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme}
+
+	if res := r.resolveAutoMode(context.Background(), mig, &mig.Status); res != nil {
+		t.Fatalf("expected nil result; got %+v", res)
+	}
+	if mig.Status.Mode != migrationv1alpha1.SwiftMigrationModeOffline {
+		t.Errorf("Model A must resolve auto→offline; got %q", mig.Status.Mode)
+	}
+}
+
 func TestResolveAutoMode_DefaultNetworking_NoAllowIPChange_ResolvesToOffline(t *testing.T) {
 	scheme := testScheme(t)
 	guest := &swiftv1alpha1.SwiftGuest{

--- a/internal/webhook/swiftmigration/validator.go
+++ b/internal/webhook/swiftmigration/validator.go
@@ -453,6 +453,23 @@ func (v *Validator) validateClusterState(ctx context.Context, mig *migrationv1al
 			guest.Name)
 	}
 
+	// Model A (primary OVN-K UDN) live-migration gate. A guest on its namespace's
+	// primary OVN-Kubernetes UDN cannot live-migrate in v1: the primary UDN withholds
+	// the swiftletd<->swiftletd migration channel from the pod (the destination pod's
+	// eth0 is infrastructure-locked, dropping pod-to-pod traffic). Offline migration
+	// works (the target acquires a fresh UDN IP); auto resolves to offline
+	// (auto_mode.go), mirroring VFIO. See docs/design/udn-primary-integration.md.
+	if mig.Spec.Mode == migrationv1alpha1.SwiftMigrationModeLive {
+		modelA, err := resolved.NamespaceHasPrimaryUDN(ctx, v.Client, mig.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("checking primary-UDN namespace for SwiftGuest %q: %w", guest.Name, err)
+		}
+		if modelA {
+			return nil, fmt.Errorf("SwiftGuest %q is on the namespace primary OVN-K UDN (Model A); live migration is not supported in v1 — the primary UDN withholds the migration channel from the pod. Use mode=offline (or auto, which resolves to offline).",
+				guest.Name)
+		}
+	}
+
 	// Live-mode storage gate (W6 follow-up; Phase 3a kernel-boot
 	// adjustment).
 	//

--- a/internal/webhook/swiftmigration/validator_test.go
+++ b/internal/webhook/swiftmigration/validator_test.go
@@ -412,6 +412,29 @@ func TestValidateClusterState_MigrationDisabled(t *testing.T) {
 	}
 }
 
+// A guest on its namespace primary OVN-K UDN (Model A) cannot live-migrate in v1; an
+// explicit mode=live SwiftMigration is rejected with a clear message (auto resolves to
+// offline in auto_mode.go). The primary UDN withholds the migration channel from the pod.
+func TestValidateClusterState_ModelA_LiveRejected(t *testing.T) {
+	scheme := migrationScheme(t)
+	guest := newSwiftGuest("guest", "model-a") // status.NodeName = boba
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   "model-a",
+		Labels: map[string]string{"k8s.ovn.org/primary-user-defined-network": ""},
+	}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, ns, newReadyNode("miles")).Build()
+	v := &Validator{Client: c}
+
+	mig := newSwiftMigration("m", "model-a")
+	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
+	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.AllowIPChange = true
+	_, err := v.validate(context.Background(), mig)
+	if err == nil || !strings.Contains(err.Error(), "primary OVN-K UDN") {
+		t.Fatalf("Model A mode=live must be rejected with the primary-UDN message; got %v", err)
+	}
+}
+
 func TestValidateClusterState_SameNodeRejected(t *testing.T) {
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default") // status.NodeName = boba


### PR DESCRIPTION
## Finishes Model A v1 for v0.5.0 — the safety gate + operator surface

Builds on #255 (controller-derived status). Two parts:

### Migration guard — Model A guests are offline-only in v1
Live migration of a primary-UDN guest is impossible (the primary UDN withholds the
swiftletd↔swiftletd channel from the pod — the destination pod's `eth0` is
infrastructure-locked, dropping pod-to-pod traffic). Without a guard, draining a Model A
node would attempt **live** and stall confusingly (no-silent-failure, Principle #6).
Mirrors the existing VFIO offline-only handling:
- **webhook** (`validateClusterState`): reject explicit `mode: live` for a Model A guest,
  parallel to the VFIO/SR-IOV/virtio gates.
- **controller** (`resolveAutoMode`): a Model A guest resolves `auto`→**offline** (which
  works — the target acquires a fresh UDN IP), so `kubectl drain` still evacuates them.

Both detect Model A caller-side via `resolved.NamespaceHasPrimaryUDN`. 2 new tests.

### Docs + sample
- `docs/networking/udn-primary-tenancy.md` — operator how-to (prerequisites incl. the
  OVN-K release-1.2 identity-webhook caveat, recipe, how-it-works, **v1/v2 scope**,
  troubleshooting).
- `docs/networking/udn-multi-tenancy.md` — the "namespace-native tenancy is a future
  enhancement" note now points to the shipped Model A doc.
- `docs/design/udn-primary-integration.md` — a v1-outcome callout so the original
  bridge-binding/host-reporter sections are read against what shipped (controller-derived
  status; offline-only migration).
- `config/samples/model-a/` — namespace+label, primary UserDefinedNetwork, class+seed,
  guest, README.

The guard is pure admission/resolution logic (fake-client unit-tested); the runtime
datapath it complements was cluster-validated in #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)