### PR TITLE
feat(gateway): client pool + GuestService read plane (UI backend P0, C2)

### DIFF
--- a/cmd/kubeswift-gateway/main.go
+++ b/cmd/kubeswift-gateway/main.go
@@ -10,6 +10,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,6 +34,7 @@ func main() {
 	corsOrigin := flag.String("cors-allow-origin", "*", "Access-Control-Allow-Origin for browser clients")
 	clustersNS := flag.String("clusters-namespace", clustersNamespace(), "Namespace the hub watches for fleet.kubeswift.io Cluster objects")
 	metricsAddr := flag.String("metrics-bind-address", "0", `controller-runtime metrics address ("0" disables)`)
+	authMode := flag.String("auth-mode", "insecure", `end-user auth: "token" (impersonate the user via TokenReview) or "insecure" (SA-trusted dev; no impersonation)`)
 	klog.InitFlags(nil)
 	flag.Parse()
 
@@ -58,6 +62,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// End-user authentication for member impersonation (decision D1).
+	auth, err := buildAuthenticator(*authMode, cfg, log)
+	if err != nil {
+		log.Error(err, "unable to build authenticator")
+		os.Exit(1)
+	}
+
 	// The shared informer broadcaster backing ClusterService.Watch.
 	watcher := gateway.NewClusterWatcher(mgr.GetCache())
 	if err := mgr.Add(watcher); err != nil {
@@ -65,14 +76,32 @@ func main() {
 		os.Exit(1)
 	}
 
+	// The per-member client pool backing the guest read plane.
+	pool := gateway.NewClientPool(mgr.GetCache(), mgr.GetClient(), *clustersNS)
+	if err := mgr.Add(pool); err != nil {
+		log.Error(err, "unable to add client pool")
+		os.Exit(1)
+	}
+
 	clusterSvc := gateway.NewClusterService(mgr.GetClient(), *clustersNS, watcher)
 	clusterPath, clusterHandler := kubeswiftv1connect.NewClusterServiceHandler(clusterSvc)
+
+	guestSvc := gateway.NewGuestService(pool, auth)
+	guestPath, guestHandler := kubeswiftv1connect.NewGuestServiceHandler(guestSvc)
+
+	// Telemetry + Console are P0 stubs (return CodeUnimplemented) so the UI can
+	// build its client against the full service set; they are implemented in P1.
+	telPath, telHandler := kubeswiftv1connect.NewTelemetryServiceHandler(kubeswiftv1connect.UnimplementedTelemetryServiceHandler{})
+	conPath, conHandler := kubeswiftv1connect.NewConsoleServiceHandler(kubeswiftv1connect.UnimplementedConsoleServiceHandler{})
 
 	srv := &gateway.Server{
 		Addr:          *listen,
 		AllowedOrigin: *corsOrigin,
 		Handlers: []gateway.ConnectHandler{
 			{Path: clusterPath, Handler: clusterHandler},
+			{Path: guestPath, Handler: guestHandler},
+			{Path: telPath, Handler: telHandler},
+			{Path: conPath, Handler: conHandler},
 		},
 		Log: log.WithName("server"),
 	}
@@ -94,4 +123,23 @@ func clustersNamespace() string {
 		return ns
 	}
 	return defaultClustersNamespace
+}
+
+// buildAuthenticator selects the end-user auth strategy (decision D1).
+// "token" impersonates the bearer-token user (validated via the hub's
+// TokenReview); "insecure" is the SA-trusted dev stub with no impersonation.
+func buildAuthenticator(mode string, cfg *rest.Config, log logr.Logger) (gateway.Authenticator, error) {
+	switch mode {
+	case "token":
+		cs, err := kubernetes.NewForConfig(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return gateway.NewTokenReviewAuthenticator(cs.AuthenticationV1().TokenReviews()), nil
+	case "insecure":
+		log.Info("auth-mode=insecure: member queries run as the gateway credential (no per-user impersonation)")
+		return gateway.NewInsecureAuthenticator(), nil
+	default:
+		return nil, fmt.Errorf("unknown auth-mode %q (want token|insecure)", mode)
+	}
 }

--- a/internal/gateway/auth.go
+++ b/internal/gateway/auth.go
@@ -1,0 +1,78 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	connect "connectrpc.com/connect"
+	authnv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	authnclient "k8s.io/client-go/kubernetes/typed/authentication/v1"
+)
+
+// Identity is the end user the gateway impersonates against member clusters
+// (decision D1). An empty Identity means "no impersonation" — member queries
+// run as the member's own credential (the SA-trusted dev mode).
+type Identity struct {
+	User   string
+	Groups []string
+}
+
+func (i Identity) empty() bool { return i.User == "" }
+
+// Authenticator resolves the end-user identity from a request's headers so the
+// gateway can impersonate it against member clusters.
+type Authenticator interface {
+	Authenticate(ctx context.Context, h http.Header) (Identity, error)
+}
+
+// insecureAuthenticator performs no authentication and returns an empty
+// identity, so member queries run as the gateway's own credential. This is the
+// SA-trusted dev stub the P0 cut allows; production uses TokenReview.
+type insecureAuthenticator struct{}
+
+// NewInsecureAuthenticator returns the no-impersonation dev authenticator.
+func NewInsecureAuthenticator() Authenticator { return insecureAuthenticator{} }
+
+func (insecureAuthenticator) Authenticate(context.Context, http.Header) (Identity, error) {
+	return Identity{}, nil
+}
+
+// tokenReviewAuthenticator validates the request's bearer token via the hub's
+// TokenReview API and impersonates the resulting user against members.
+type tokenReviewAuthenticator struct {
+	reviews authnclient.TokenReviewInterface
+}
+
+// NewTokenReviewAuthenticator builds a TokenReview-backed authenticator from a
+// client to the hub's authentication API.
+func NewTokenReviewAuthenticator(reviews authnclient.TokenReviewInterface) Authenticator {
+	return &tokenReviewAuthenticator{reviews: reviews}
+}
+
+func (a *tokenReviewAuthenticator) Authenticate(ctx context.Context, h http.Header) (Identity, error) {
+	tok := bearerToken(h)
+	if tok == "" {
+		return Identity{}, connect.NewError(connect.CodeUnauthenticated, errors.New("missing bearer token"))
+	}
+	res, err := a.reviews.Create(ctx, &authnv1.TokenReview{
+		Spec: authnv1.TokenReviewSpec{Token: tok},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return Identity{}, connect.NewError(connect.CodeInternal, err)
+	}
+	if !res.Status.Authenticated {
+		return Identity{}, connect.NewError(connect.CodeUnauthenticated, errors.New("token not authenticated"))
+	}
+	return Identity{User: res.Status.User.Username, Groups: res.Status.User.Groups}, nil
+}
+
+func bearerToken(h http.Header) string {
+	const prefix = "Bearer "
+	if v := h.Get("Authorization"); strings.HasPrefix(v, prefix) {
+		return strings.TrimPrefix(v, prefix)
+	}
+	return ""
+}

--- a/internal/gateway/guest_mapper.go
+++ b/internal/gateway/guest_mapper.go
@@ -1,0 +1,69 @@
+package gateway
+
+import (
+	"google.golang.org/protobuf/types/known/timestamppb"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	kubeswiftv1 "github.com/projectbeskar/kubeswift/gen/kubeswift/v1"
+)
+
+// guestRunningCondition is the SwiftGuest condition that reports the VM is
+// actually up. The operator writes it as a string literal (not a centralized
+// const), so the gateway mirrors the literal here.
+const guestRunningCondition = "GuestRunning"
+
+// guestToProto maps a SwiftGuest to the flat, UI-shaped inventory row, stamped
+// with its member cluster (the D2 dimension). It reads only the SwiftGuest
+// object itself — no cross-resource lookups — so a List stays one round-trip
+// per cluster; the expanded view (pod, events, gpu, storage) is GetGuestDetail
+// in P1. cpu/memory live on the resolved SwiftGuestClass, not the guest status,
+// so they are left zero here and enriched in P1.
+func guestToProto(cluster string, g *swiftv1alpha1.SwiftGuest) *kubeswiftv1.Guest {
+	out := &kubeswiftv1.Guest{
+		Ref: &kubeswiftv1.ObjectRef{
+			Cluster:   cluster,
+			Namespace: g.Namespace,
+			Name:      g.Name,
+		},
+		Phase:        string(g.Status.Phase),
+		NodeName:     g.Status.NodeName,
+		GuestClass:   g.Spec.GuestClassRef.Name,
+		BootSource:   bootSource(g),
+		GuestRunning: apimeta.IsStatusConditionTrue(g.Status.Conditions, guestRunningCondition),
+	}
+	if g.Status.Runtime != nil {
+		out.Hypervisor = g.Status.Runtime.Hypervisor
+	}
+	if g.Status.Network != nil {
+		out.PrimaryIp = g.Status.Network.PrimaryIP
+	}
+	if !g.CreationTimestamp.IsZero() {
+		out.CreatedAt = timestamppb.New(g.CreationTimestamp.Time)
+	}
+	for i := range g.Status.Conditions {
+		out.Conditions = append(out.Conditions, conditionToProto(&g.Status.Conditions[i]))
+	}
+	if len(g.Labels) > 0 {
+		out.Labels = make(map[string]string, len(g.Labels))
+		for k, v := range g.Labels {
+			out.Labels[k] = v
+		}
+	}
+	return out
+}
+
+// bootSource summarises the guest's boot origin into one human string for the
+// inventory row (the three boot sources are mutually exclusive).
+func bootSource(g *swiftv1alpha1.SwiftGuest) string {
+	switch {
+	case g.Spec.ImageRef != nil && g.Spec.ImageRef.Name != "":
+		return "image/" + g.Spec.ImageRef.Name
+	case g.Spec.KernelRef != nil && g.Spec.KernelRef.Name != "":
+		return "kernel/" + g.Spec.KernelRef.Name
+	case g.Spec.CloneFromSnapshot != nil && g.Spec.CloneFromSnapshot.SnapshotRef.Name != "":
+		return "clone/" + g.Spec.CloneFromSnapshot.SnapshotRef.Name
+	default:
+		return ""
+	}
+}

--- a/internal/gateway/guest_mapper_test.go
+++ b/internal/gateway/guest_mapper_test.go
@@ -1,0 +1,82 @@
+package gateway
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+func TestGuestToProto(t *testing.T) {
+	g := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vm-a",
+			Namespace: "default",
+			Labels:    map[string]string{"swift.kubeswift.io/pool": "web"},
+		},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef:      &corev1.LocalObjectReference{Name: "ubuntu-noble"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "default"},
+		},
+		Status: swiftv1alpha1.SwiftGuestStatus{
+			Phase:    swiftv1alpha1.SwiftGuestPhaseRunning,
+			NodeName: "miles",
+			Runtime:  &swiftv1alpha1.GuestRuntimeStatus{Hypervisor: "cloud-hypervisor"},
+			Network:  &swiftv1alpha1.GuestNetworkStatus{PrimaryIP: "192.168.99.11"},
+			Conditions: []metav1.Condition{
+				{Type: "GuestRunning", Status: metav1.ConditionTrue},
+			},
+		},
+	}
+	got := guestToProto("boba", g)
+	if got.GetRef().GetCluster() != "boba" || got.GetRef().GetNamespace() != "default" || got.GetRef().GetName() != "vm-a" {
+		t.Errorf("ref wrong: %+v", got.GetRef())
+	}
+	if got.Phase != "Running" {
+		t.Errorf("Phase = %q", got.Phase)
+	}
+	if got.NodeName != "miles" {
+		t.Errorf("NodeName = %q", got.NodeName)
+	}
+	if got.Hypervisor != "cloud-hypervisor" {
+		t.Errorf("Hypervisor = %q", got.Hypervisor)
+	}
+	if got.PrimaryIp != "192.168.99.11" {
+		t.Errorf("PrimaryIp = %q", got.PrimaryIp)
+	}
+	if got.GuestClass != "default" {
+		t.Errorf("GuestClass = %q", got.GuestClass)
+	}
+	if got.BootSource != "image/ubuntu-noble" {
+		t.Errorf("BootSource = %q", got.BootSource)
+	}
+	if !got.GuestRunning {
+		t.Error("GuestRunning = false, want true")
+	}
+	if got.Labels["swift.kubeswift.io/pool"] != "web" {
+		t.Errorf("labels not copied: %v", got.Labels)
+	}
+}
+
+func TestBootSource(t *testing.T) {
+	cases := []struct {
+		name string
+		spec swiftv1alpha1.SwiftGuestSpec
+		want string
+	}{
+		{"image", swiftv1alpha1.SwiftGuestSpec{ImageRef: &corev1.LocalObjectReference{Name: "img"}}, "image/img"},
+		{"kernel", swiftv1alpha1.SwiftGuestSpec{KernelRef: &corev1.LocalObjectReference{Name: "k"}}, "kernel/k"},
+		{"clone", swiftv1alpha1.SwiftGuestSpec{CloneFromSnapshot: &swiftv1alpha1.CloneFromSnapshotSource{SnapshotRef: corev1.LocalObjectReference{Name: "snap"}}}, "clone/snap"},
+		{"none", swiftv1alpha1.SwiftGuestSpec{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &swiftv1alpha1.SwiftGuest{Spec: tc.spec}
+			if got := bootSource(g); got != tc.want {
+				t.Errorf("bootSource = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/gateway/guest_service.go
+++ b/internal/gateway/guest_service.go
@@ -1,0 +1,279 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+
+	connect "connectrpc.com/connect"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+	kubeswiftv1 "github.com/projectbeskar/kubeswift/gen/kubeswift/v1"
+	"github.com/projectbeskar/kubeswift/gen/kubeswift/v1/kubeswiftv1connect"
+)
+
+// clientProvider is the subset of ClientPool the read plane needs: a per-member
+// impersonating dynamic client and the set of registered members. Narrowing to
+// an interface keeps GuestService unit-testable with a fake dynamic client.
+type clientProvider interface {
+	DynamicFor(cluster string, id Identity) (dynamic.Interface, error)
+	Members() []string
+}
+
+// GuestService is the read plane. ListGuests / WatchGuests fan out across the
+// selected member clusters, map each SwiftGuest to the flat proto row, and
+// merge — stamping the cluster dimension (D2) on every row and surfacing a
+// per-cluster error instead of failing the whole-fleet query (no silent
+// failures). Every call impersonates the end user against members (D1).
+type GuestService struct {
+	kubeswiftv1connect.UnimplementedGuestServiceHandler
+
+	pool clientProvider
+	auth Authenticator
+}
+
+var _ kubeswiftv1connect.GuestServiceHandler = (*GuestService)(nil)
+
+// NewGuestService wires the read plane to the client pool + the authenticator.
+func NewGuestService(pool clientProvider, auth Authenticator) *GuestService {
+	return &GuestService{pool: pool, auth: auth}
+}
+
+// ListGuests fans out to the selected clusters concurrently and merges the rows.
+func (s *GuestService) ListGuests(ctx context.Context, req *connect.Request[kubeswiftv1.ListGuestsRequest]) (*connect.Response[kubeswiftv1.ListGuestsResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	clusters := s.targetClusters(req.Msg.GetClusters())
+	resp := &kubeswiftv1.ListGuestsResponse{}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, cl := range clusters {
+		wg.Add(1)
+		go func(cl string) {
+			defer wg.Done()
+			guests, lerr := s.listOne(ctx, cl, id, req.Msg.GetNamespace(), req.Msg.GetPhase())
+			mu.Lock()
+			defer mu.Unlock()
+			if lerr != nil {
+				resp.Errors = append(resp.Errors, &kubeswiftv1.ClusterError{Cluster: cl, Message: lerr.Error()})
+				return
+			}
+			resp.Guests = append(resp.Guests, guests...)
+		}(cl)
+	}
+	wg.Wait()
+	sortGuests(resp.Guests)
+	return connect.NewResponse(resp), nil
+}
+
+func (s *GuestService) listOne(ctx context.Context, cluster string, id Identity, namespace, phase string) ([]*kubeswiftv1.Guest, error) {
+	dyn, err := s.pool.DynamicFor(cluster, id)
+	if err != nil {
+		return nil, err
+	}
+	ul, err := guestResource(dyn, namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*kubeswiftv1.Guest, 0, len(ul.Items))
+	for i := range ul.Items {
+		g, cerr := toSwiftGuest(&ul.Items[i])
+		if cerr != nil {
+			continue
+		}
+		if phase != "" && string(g.Status.Phase) != phase {
+			continue
+		}
+		out = append(out, guestToProto(cluster, g))
+	}
+	return out, nil
+}
+
+// WatchGuests multiplexes a per-cluster watch into one stream. A member whose
+// watch cannot start (or errors) yields a BOOKMARK event carrying a
+// ClusterError, so the UI shows a per-cluster problem rather than a dead stream.
+func (s *GuestService) WatchGuests(ctx context.Context, req *connect.Request[kubeswiftv1.WatchGuestsRequest], stream *connect.ServerStream[kubeswiftv1.GuestEvent]) error {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return err
+	}
+	clusters := s.targetClusters(req.Msg.GetClusters())
+	namespace := req.Msg.GetNamespace()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	events := make(chan *kubeswiftv1.GuestEvent, 256)
+	var wg sync.WaitGroup
+	for _, cl := range clusters {
+		wg.Add(1)
+		go func(cl string) {
+			defer wg.Done()
+			s.watchOne(ctx, cl, id, namespace, events)
+		}(cl)
+	}
+	go func() { wg.Wait(); close(events) }()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev, ok := <-events:
+			if !ok {
+				return nil
+			}
+			if err := stream.Send(ev); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (s *GuestService) watchOne(ctx context.Context, cluster string, id Identity, namespace string, out chan<- *kubeswiftv1.GuestEvent) {
+	dyn, err := s.pool.DynamicFor(cluster, id)
+	if err != nil {
+		sendClusterErr(ctx, out, cluster, err)
+		return
+	}
+	w, err := guestResource(dyn, namespace).Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		sendClusterErr(ctx, out, cluster, err)
+		return
+	}
+	defer w.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case e, ok := <-w.ResultChan():
+			if !ok {
+				return
+			}
+			if ev := watchEventToProto(cluster, e); ev != nil {
+				select {
+				case out <- ev:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}
+}
+
+// GetGuestDetail returns the flat guest in P0; P1 enriches it with the launcher
+// pod, recent Events, GPU, network, and storage in this one call.
+func (s *GuestService) GetGuestDetail(ctx context.Context, req *connect.Request[kubeswiftv1.GetGuestDetailRequest]) (*connect.Response[kubeswiftv1.GetGuestDetailResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	ref := req.Msg.GetRef()
+	if ref == nil || ref.GetCluster() == "" || ref.GetName() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("ref.cluster and ref.name are required"))
+	}
+	dyn, err := s.pool.DynamicFor(ref.GetCluster(), id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	u, err := dyn.Resource(swiftGuestGVR).Namespace(ref.GetNamespace()).Get(ctx, ref.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	g, err := toSwiftGuest(u)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&kubeswiftv1.GetGuestDetailResponse{Guest: guestToProto(ref.GetCluster(), g)}), nil
+}
+
+// targetClusters resolves the selector against the registered members. An empty
+// or all-clusters selector targets the whole fleet.
+func (s *GuestService) targetClusters(sel *kubeswiftv1.ClusterSelector) []string {
+	all := s.pool.Members()
+	sort.Strings(all)
+	if sel == nil || sel.GetAllClusters() || len(sel.GetClusters()) == 0 {
+		return all
+	}
+	registered := make(map[string]bool, len(all))
+	for _, m := range all {
+		registered[m] = true
+	}
+	var out []string
+	for _, c := range sel.GetClusters() {
+		if registered[c] {
+			out = append(out, c)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func guestResource(dyn dynamic.Interface, namespace string) dynamic.ResourceInterface {
+	if namespace == "" {
+		return dyn.Resource(swiftGuestGVR)
+	}
+	return dyn.Resource(swiftGuestGVR).Namespace(namespace)
+}
+
+func toSwiftGuest(u *unstructured.Unstructured) (*swiftv1alpha1.SwiftGuest, error) {
+	var g swiftv1alpha1.SwiftGuest
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &g); err != nil {
+		return nil, err
+	}
+	return &g, nil
+}
+
+func watchEventToProto(cluster string, e watch.Event) *kubeswiftv1.GuestEvent {
+	var t kubeswiftv1.EventType
+	switch e.Type {
+	case watch.Added:
+		t = kubeswiftv1.EventType_EVENT_TYPE_ADDED
+	case watch.Modified:
+		t = kubeswiftv1.EventType_EVENT_TYPE_MODIFIED
+	case watch.Deleted:
+		t = kubeswiftv1.EventType_EVENT_TYPE_DELETED
+	default: // Bookmark / Error from a member watch: not forwarded as a guest row
+		return nil
+	}
+	u, ok := e.Object.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+	g, err := toSwiftGuest(u)
+	if err != nil {
+		return nil
+	}
+	return &kubeswiftv1.GuestEvent{Type: t, Guest: guestToProto(cluster, g)}
+}
+
+func sendClusterErr(ctx context.Context, out chan<- *kubeswiftv1.GuestEvent, cluster string, err error) {
+	select {
+	case out <- &kubeswiftv1.GuestEvent{
+		Type:  kubeswiftv1.EventType_EVENT_TYPE_BOOKMARK,
+		Error: &kubeswiftv1.ClusterError{Cluster: cluster, Message: err.Error()},
+	}:
+	case <-ctx.Done():
+	}
+}
+
+func sortGuests(gs []*kubeswiftv1.Guest) {
+	sort.Slice(gs, func(i, j int) bool {
+		a, b := gs[i].GetRef(), gs[j].GetRef()
+		if a.GetCluster() != b.GetCluster() {
+			return a.GetCluster() < b.GetCluster()
+		}
+		if a.GetNamespace() != b.GetNamespace() {
+			return a.GetNamespace() < b.GetNamespace()
+		}
+		return a.GetName() < b.GetName()
+	})
+}

--- a/internal/gateway/guest_service_test.go
+++ b/internal/gateway/guest_service_test.go
@@ -1,0 +1,123 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	connect "connectrpc.com/connect"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	kubeswiftv1 "github.com/projectbeskar/kubeswift/gen/kubeswift/v1"
+)
+
+// fakeProvider stands in for the ClientPool: a fake dynamic client per member,
+// plus members whose client construction fails (the unreachable case).
+type fakeProvider struct {
+	clients map[string]dynamic.Interface
+	errs    map[string]error
+}
+
+func (f *fakeProvider) DynamicFor(cluster string, _ Identity) (dynamic.Interface, error) {
+	if e, ok := f.errs[cluster]; ok {
+		return nil, e
+	}
+	if c, ok := f.clients[cluster]; ok {
+		return c, nil
+	}
+	return nil, errors.New("no client for " + cluster)
+}
+
+func (f *fakeProvider) Members() []string {
+	var m []string
+	for k := range f.clients {
+		m = append(m, k)
+	}
+	for k := range f.errs {
+		m = append(m, k)
+	}
+	return m
+}
+
+func uGuest(ns, name, phase string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "swift.kubeswift.io/v1alpha1",
+		"kind":       "SwiftGuest",
+		"metadata":   map[string]interface{}{"namespace": ns, "name": name},
+		"spec": map[string]interface{}{
+			"guestClassRef": map[string]interface{}{"name": "default"},
+			"imageRef":      map[string]interface{}{"name": "ubuntu-noble"},
+		},
+		"status": map[string]interface{}{"phase": phase},
+	}}
+}
+
+func fakeDyn(objs ...*unstructured.Unstructured) dynamic.Interface {
+	ro := make([]runtime.Object, len(objs))
+	for i, o := range objs {
+		ro[i] = o
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{swiftGuestGVR: "SwiftGuestList"}, ro...)
+}
+
+func TestGuestService_ListGuests_FanOutMergeAndPartialError(t *testing.T) {
+	prov := &fakeProvider{
+		clients: map[string]dynamic.Interface{
+			"boba":  fakeDyn(uGuest("default", "vm-a", "Running"), uGuest("default", "vm-b", "Pending")),
+			"miles": fakeDyn(uGuest("default", "vm-c", "Running")),
+		},
+		errs: map[string]error{"down": errors.New("connection refused")},
+	}
+	svc := NewGuestService(prov, NewInsecureAuthenticator())
+
+	resp, err := svc.ListGuests(context.Background(), connect.NewRequest(&kubeswiftv1.ListGuestsRequest{}))
+	if err != nil {
+		t.Fatalf("ListGuests: %v", err)
+	}
+	if len(resp.Msg.Guests) != 3 {
+		t.Fatalf("got %d guests, want 3 (boba+miles)", len(resp.Msg.Guests))
+	}
+	// The unreachable member surfaces as a per-cluster error, not a fatal one.
+	if len(resp.Msg.Errors) != 1 || resp.Msg.Errors[0].Cluster != "down" {
+		t.Errorf("want one partial-fleet error for 'down', got %+v", resp.Msg.Errors)
+	}
+	// cluster dimension stamped; merged result sorted by (cluster, ns, name).
+	if resp.Msg.Guests[0].GetRef().GetCluster() != "boba" || resp.Msg.Guests[2].GetRef().GetCluster() != "miles" {
+		t.Errorf("not sorted by cluster: %v / %v", resp.Msg.Guests[0].GetRef(), resp.Msg.Guests[2].GetRef())
+	}
+}
+
+func TestGuestService_ListGuests_PhaseFilter(t *testing.T) {
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{
+		"boba": fakeDyn(uGuest("default", "vm-a", "Running"), uGuest("default", "vm-b", "Pending")),
+	}}
+	svc := NewGuestService(prov, NewInsecureAuthenticator())
+	resp, err := svc.ListGuests(context.Background(), connect.NewRequest(&kubeswiftv1.ListGuestsRequest{Phase: "Running"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Msg.Guests) != 1 || resp.Msg.Guests[0].GetRef().GetName() != "vm-a" {
+		t.Errorf("phase filter wrong: %+v", resp.Msg.Guests)
+	}
+}
+
+func TestGuestService_TargetClusters(t *testing.T) {
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{
+		"boba": fakeDyn(), "miles": fakeDyn(), "frida": fakeDyn(),
+	}}
+	svc := NewGuestService(prov, NewInsecureAuthenticator())
+
+	all := svc.targetClusters(nil) // nil selector = whole fleet, sorted
+	if len(all) != 3 || all[0] != "boba" {
+		t.Errorf("nil selector should return the sorted fleet: %v", all)
+	}
+	sub := svc.targetClusters(&kubeswiftv1.ClusterSelector{Clusters: []string{"miles", "ghost"}})
+	if len(sub) != 1 || sub[0] != "miles" { // unknown 'ghost' dropped
+		t.Errorf("subset should intersect registered members: %v", sub)
+	}
+}

--- a/internal/gateway/pool.go
+++ b/internal/gateway/pool.go
@@ -1,0 +1,226 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fleetv1alpha1 "github.com/projectbeskar/kubeswift/api/fleet/v1alpha1"
+)
+
+// swiftGuestGVR is the dynamic resource the read plane lists/watches per member.
+// Using the dynamic client keyed by a known GVR avoids per-request discovery /
+// RESTMapper construction; member clients are therefore cheap to create.
+var swiftGuestGVR = schema.GroupVersionResource{
+	Group:    "swift.kubeswift.io",
+	Version:  "v1alpha1",
+	Resource: "swiftguests",
+}
+
+// ClientPool watches the hub's fleet.Cluster registry and maintains a base REST
+// config per member cluster, built from the member's credential Secret. It
+// hands out per-request dynamic clients that impersonate the end user (D1). On
+// each member upsert it probes the member (server version) and writes the
+// Cluster status (Ready / Reachable / KubernetesVersion) so the UI's cluster
+// selector reflects real health. It is a manager.Runnable.
+type ClientPool struct {
+	cache     ctrlcache.Cache
+	hub       client.Client // reads credential Secrets, writes Cluster status
+	namespace string
+
+	mu      sync.RWMutex
+	members map[string]*member
+}
+
+type member struct {
+	name       string
+	config     *rest.Config
+	prometheus string
+}
+
+// NewClientPool builds the pool over the hub cache + a read/write hub client.
+func NewClientPool(c ctrlcache.Cache, hub client.Client, namespace string) *ClientPool {
+	return &ClientPool{cache: c, hub: hub, namespace: namespace, members: map[string]*member{}}
+}
+
+// NeedLeaderElection keeps the pool running on every replica.
+func (p *ClientPool) NeedLeaderElection() bool { return false }
+
+// Start registers the fleet.Cluster informer handler and blocks until ctx done.
+func (p *ClientPool) Start(ctx context.Context) error {
+	inf, err := p.cache.GetInformer(ctx, &fleetv1alpha1.Cluster{})
+	if err != nil {
+		return err
+	}
+	if _, err := inf.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { p.upsert(ctx, obj) },
+		UpdateFunc: func(_, obj any) { p.upsert(ctx, obj) },
+		DeleteFunc: func(obj any) { p.remove(obj) },
+	}); err != nil {
+		return err
+	}
+	<-ctx.Done()
+	return nil
+}
+
+func (p *ClientPool) upsert(ctx context.Context, obj any) {
+	c := extractCluster(obj)
+	if c == nil || c.Namespace != p.namespace {
+		return
+	}
+	cfg, err := p.buildConfig(ctx, c)
+	if err != nil {
+		p.mu.Lock()
+		delete(p.members, c.Name)
+		p.mu.Unlock()
+		p.setStatus(ctx, c, false, "", err.Error())
+		return
+	}
+	p.mu.Lock()
+	p.members[c.Name] = &member{name: c.Name, config: cfg, prometheus: c.Spec.PrometheusEndpoint}
+	p.mu.Unlock()
+
+	// Probe reachability + version off the informer goroutine so a slow or
+	// unreachable member never stalls the shared handler.
+	cl := c.DeepCopy()
+	go func() {
+		if ver, perr := serverVersion(cfg); perr != nil {
+			p.setStatus(ctx, cl, false, "", perr.Error())
+		} else {
+			p.setStatus(ctx, cl, true, ver, "")
+		}
+	}()
+}
+
+func (p *ClientPool) remove(obj any) {
+	if c := extractCluster(obj); c != nil {
+		p.mu.Lock()
+		delete(p.members, c.Name)
+		p.mu.Unlock()
+	}
+}
+
+// buildConfig builds the member's base REST config from its credential Secret:
+// a `kubeconfig` key (preferred) or a `token` (+ optional `ca.crt`) paired with
+// spec.server.
+func (p *ClientPool) buildConfig(ctx context.Context, c *fleetv1alpha1.Cluster) (*rest.Config, error) {
+	if c.Spec.CredentialSecretRef.Name == "" {
+		return nil, errors.New("spec.credentialSecretRef.name is empty")
+	}
+	var sec corev1.Secret
+	key := types.NamespacedName{Namespace: c.Namespace, Name: c.Spec.CredentialSecretRef.Name}
+	if err := p.hub.Get(ctx, key, &sec); err != nil {
+		return nil, fmt.Errorf("read credential secret: %w", err)
+	}
+	if kc := sec.Data["kubeconfig"]; len(kc) > 0 {
+		cfg, err := clientcmd.RESTConfigFromKubeConfig(kc)
+		if err != nil {
+			return nil, fmt.Errorf("parse kubeconfig: %w", err)
+		}
+		return cfg, nil
+	}
+	tok := sec.Data["token"]
+	if len(tok) == 0 {
+		return nil, errors.New("credential secret has neither a kubeconfig nor a token key")
+	}
+	if c.Spec.Server == "" {
+		return nil, errors.New("spec.server is required when using a token credential")
+	}
+	cfg := &rest.Config{Host: c.Spec.Server, BearerToken: string(tok)}
+	cfg.TLSClientConfig.Insecure = c.Spec.InsecureSkipTLSVerify
+	if ca := sec.Data["ca.crt"]; len(ca) > 0 {
+		cfg.TLSClientConfig.CAData = ca
+	}
+	return cfg, nil
+}
+
+// DynamicFor returns a dynamic client for the named member, impersonating the
+// given identity (an empty identity uses the member's own credential).
+func (p *ClientPool) DynamicFor(cluster string, id Identity) (dynamic.Interface, error) {
+	p.mu.RLock()
+	m, ok := p.members[cluster]
+	p.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("cluster %q is not registered or not reachable", cluster)
+	}
+	cfg := rest.CopyConfig(m.config)
+	if !id.empty() {
+		cfg.Impersonate = rest.ImpersonationConfig{UserName: id.User, Groups: id.Groups}
+	}
+	return dynamic.NewForConfig(cfg)
+}
+
+// Members returns the names of all currently registered member clusters.
+func (p *ClientPool) Members() []string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	names := make([]string, 0, len(p.members))
+	for n := range p.members {
+		names = append(names, n)
+	}
+	return names
+}
+
+func serverVersion(cfg *rest.Config) (string, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return "", err
+	}
+	v, err := dc.ServerVersion()
+	if err != nil {
+		return "", err
+	}
+	return v.GitVersion, nil
+}
+
+// setStatus best-effort patches the Cluster's Ready/Reachable conditions,
+// version, and lastConnected. It re-reads the object to avoid clobbering a
+// concurrent writer; failures are swallowed (status is advisory).
+func (p *ClientPool) setStatus(ctx context.Context, c *fleetv1alpha1.Cluster, reachable bool, version, msg string) {
+	var cur fleetv1alpha1.Cluster
+	if err := p.hub.Get(ctx, types.NamespacedName{Namespace: c.Namespace, Name: c.Name}, &cur); err != nil {
+		return
+	}
+	patch := client.MergeFrom(cur.DeepCopy())
+	now := metav1.Now()
+	setCondition(&cur.Status.Conditions, fleetv1alpha1.ClusterConditionReachable, reachable, "Reachable", "Unreachable", msg, now)
+	setCondition(&cur.Status.Conditions, fleetv1alpha1.ClusterConditionReady, reachable, "Ready", "NotReady", msg, now)
+	if version != "" {
+		cur.Status.KubernetesVersion = version
+	}
+	if reachable {
+		cur.Status.LastConnected = &now
+	}
+	cur.Status.ObservedGeneration = cur.Generation
+	_ = p.hub.Status().Patch(ctx, &cur, patch)
+}
+
+func setCondition(conds *[]metav1.Condition, condType string, ok bool, okReason, failReason, msg string, now metav1.Time) {
+	status := metav1.ConditionFalse
+	reason := failReason
+	if ok {
+		status = metav1.ConditionTrue
+		reason = okReason
+	}
+	apimeta.SetStatusCondition(conds, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            msg,
+		LastTransitionTime: now,
+	})
+}


### PR DESCRIPTION
Completes the gateway **read plane** (design: [`docs/design/ui-backend-enablement.md`](docs/design/ui-backend-enablement.md)) — the cross-cluster VM inventory the UI virtual-scrolls. **Stacked on #261 (C1)** — base is `feat/gateway-skeleton`; it retargets to `main` automatically when C1 merges.

## What

**`ClientPool`** (`manager.Runnable`) — the multi-cluster heart:
- watches the hub's `fleet.Cluster` registry; per member, builds a base REST config from its credential Secret (`kubeconfig`, or `token` + `ca.crt` + `spec.server`);
- hands out **per-request dynamic clients that impersonate the end user** (**D1**) — the dynamic client is keyed by the known SwiftGuest GVR, so there's no per-request discovery;
- probes each member (server version) off the informer goroutine and best-effort writes `Cluster` **status** (Ready/Reachable/version/lastConnected) so the UI selector shows real health.

**`GuestService.List/Watch/GetDetail`** — fans out across the selected members (`ClusterSelector`, **D2**), maps each SwiftGuest to the flat proto row, and merges. An unreachable member yields a **per-cluster `ClusterError`** (List) / `BOOKMARK` error event (Watch) instead of failing the whole-fleet query — **no silent failures**. Watch multiplexes per-cluster dynamic watches into one stream.

**`auth`** — `Authenticator` with a **TokenReview** impl (impersonate the bearer-token user) + an **insecure SA-trusted dev stub**; selected by `--auth-mode` (the P0 cut allows SA-trusted to bootstrap).

`main` wires the pool + `GuestService` + **Telemetry/Console stubs** (`CodeUnimplemented`, so the UI builds against the full service set).

## Validation

`GuestService` narrows to a `clientProvider` interface so it's unit-tested with a **fake dynamic client**: fan-out + merge + **partial-fleet error** + phase filter + cluster-selector intersection; plus the SwiftGuest→proto mapper (boot-source variants). `gofmt -s`/`go vet` clean; full `go test ./...` green.

## Scope / next

This finishes **C** (read plane). **PR D** adds the Helm `gateway.enabled` deployment, the gateway image, and the **hub RBAC** (impersonate, read Secrets, read SwiftGuests cross-cluster, patch Cluster status) — that's where this becomes deployable. End-to-end cluster validation lands with D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)