### PR TITLE
feat(gateway): Helm gateway.enabled + image + hub RBAC + release (UI backend P0, D)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -225,3 +225,21 @@ jobs:
           file: ./images/migration-stunnel/Containerfile
           push: false
           load: true
+
+  gateway-image:
+    name: kubeswift-gateway image
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build kubeswift-gateway image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./images/kubeswift-gateway/Containerfile
+          push: false
+          load: true

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -149,6 +149,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push kubeswift-gateway
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./images/kubeswift-gateway/Containerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/kubeswift-gateway:${{ steps.version.outputs.image_tag }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            GIT_COMMIT=${{ steps.version.outputs.git_commit }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -172,6 +172,24 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push kubeswift-gateway
+        id: build-gateway
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./images/kubeswift-gateway/Containerfile
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/kubeswift-gateway:${{ steps.version.outputs.tag }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            GIT_COMMIT=${{ steps.version.outputs.git_commit }}
+            BUILD_DATE=${{ steps.version.outputs.build_date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
@@ -192,6 +210,7 @@ jobs:
           cosign sign "${{ env.IMAGE_PREFIX }}/kubeswift-dra-driver@${{ steps.build-dra-driver.outputs.digest }}"
           cosign sign "${{ env.IMAGE_PREFIX }}/swiftletd@${{ steps.build-swiftletd.outputs.digest }}"
           cosign sign "${{ env.IMAGE_PREFIX }}/migration-stunnel@${{ steps.build-migration-stunnel.outputs.digest }}"
+          cosign sign "${{ env.IMAGE_PREFIX }}/kubeswift-gateway@${{ steps.build-gateway.outputs.digest }}"
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ GPU_DISCOVERY_IMAGE ?= ghcr.io/projectbeskar/kubeswift/gpu-discovery:$(IMAGE_TAG
 DRA_DRIVER_IMAGE ?= ghcr.io/projectbeskar/kubeswift/kubeswift-dra-driver:$(IMAGE_TAG)
 MIGRATION_STUNNEL_IMAGE ?= ghcr.io/projectbeskar/kubeswift/migration-stunnel:$(IMAGE_TAG)
 SNAPSHOT_S3_IMAGE ?= ghcr.io/projectbeskar/kubeswift/snapshot-s3:$(IMAGE_TAG)
+GATEWAY_IMAGE ?= ghcr.io/projectbeskar/kubeswift/kubeswift-gateway:$(IMAGE_TAG)
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/kubeswift
 # Push destination: parent OCI repo only (Helm appends chart name from Chart.yaml)
 CHART_OCI_PUSH ?= oci://ghcr.io/projectbeskar/charts
@@ -43,7 +44,7 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
 
 .PHONY: build build-go build-rust build-images build-controller-image build-swiftletd-image \
-	build-gpu-discovery-image build-migration-stunnel-image build-snapshot-s3-image build-dra-driver-image generate deploy deploy-with-webhook deploy-with-mtls deploy-with-webhook-and-mtls undeploy load-images smoke-test smoke-test-cleanup \
+	build-gpu-discovery-image build-migration-stunnel-image build-snapshot-s3-image build-dra-driver-image build-gateway-image generate deploy deploy-with-webhook deploy-with-mtls deploy-with-webhook-and-mtls undeploy load-images smoke-test smoke-test-cleanup \
 	clonestrategy-test snapshot-test local-roundtrip-test local-clone-identity-test \
 	b0-cross-node-tcp-test e2e-tests \
 	verify-e2e-scripts \
@@ -92,7 +93,7 @@ build-go:
 build-rust:
 	cd rust && KUBESWIFT_VERSION="$(VERSION)" KUBESWIFT_GIT_COMMIT="$(GIT_COMMIT)" KUBESWIFT_BUILD_DATE="$(BUILD_DATE)" cargo build
 
-build-images: build-controller-image build-swiftletd-image build-gpu-discovery-image build-migration-stunnel-image build-snapshot-s3-image build-dra-driver-image
+build-images: build-controller-image build-swiftletd-image build-gpu-discovery-image build-migration-stunnel-image build-snapshot-s3-image build-dra-driver-image build-gateway-image
 
 build-controller-image:
 	docker build -f images/controller-manager/Containerfile . -t $(CONTROLLER_IMAGE) \
@@ -118,6 +119,10 @@ build-migration-stunnel-image:
 	docker build -f images/migration-stunnel/Containerfile . -t $(MIGRATION_STUNNEL_IMAGE) \
 		--build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT)
 
+build-gateway-image:
+	docker build -f images/kubeswift-gateway/Containerfile . -t $(GATEWAY_IMAGE) \
+		--build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_DATE=$(BUILD_DATE)
+
 push-images: build-images
 	docker push $(CONTROLLER_IMAGE)
 	docker push $(SWIFTLETD_IMAGE)
@@ -125,6 +130,7 @@ push-images: build-images
 	docker push $(MIGRATION_STUNNEL_IMAGE)
 	docker push $(SNAPSHOT_S3_IMAGE)
 	docker push $(DRA_DRIVER_IMAGE)
+	docker push $(GATEWAY_IMAGE)
 
 package-chart:
 	@CHART_VER="$${CHART_VERSION:-$$(./hack/chart-version.sh dev 2>/dev/null || echo "0.0.0-dev.unknown")}"; \

--- a/charts/kubeswift/templates/gateway/deployment.yaml
+++ b/charts/kubeswift/templates/gateway/deployment.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.gateway.enabled }}
+# kubeswift-gateway: the browser-facing Connect hub for the KubeSwift UI. Runs
+# in this (hub) cluster, watches fleet.kubeswift.io Cluster objects, and fans
+# the read plane out across the registered member clusters. See
+# docs/ui/gateway.md and docs/design/ui-backend-enablement.md.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubeswift-gateway
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: gateway
+spec:
+  replicas: {{ .Values.gateway.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubeswift
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubeswift
+        app.kubernetes.io/component: gateway
+    spec:
+      serviceAccountName: kubeswift-gateway
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gateway
+          image: {{ .Values.gateway.image.registry }}/kubeswift-gateway:{{ include "kubeswift.imageTag" (dict "tag" .Values.gateway.image.tag "appVersion" .Chart.AppVersion) }}
+          args:
+            - --listen=:{{ .Values.gateway.port }}
+            - --clusters-namespace={{ .Values.namespace }}
+            - --auth-mode={{ .Values.gateway.authMode }}
+            - --cors-allow-origin={{ .Values.gateway.corsAllowOrigin }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http
+              containerPort: {{ .Values.gateway.port }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            # /readyz answers only once the manager's cache has synced and the
+            # server is listening, so readiness reflects "able to serve".
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+{{- end }}

--- a/charts/kubeswift/templates/gateway/ingress.yaml
+++ b/charts/kubeswift/templates/gateway/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.gateway.enabled .Values.gateway.ingress.enabled }}
+# Optional Ingress. The gateway serves Connect/gRPC-Web over h2c (cleartext
+# HTTP/2); terminate TLS at the ingress. For gRPC-Web streaming, the ingress
+# controller must allow HTTP/2 to the backend (e.g. nginx:
+# nginx.ingress.kubernetes.io/backend-protocol: "GRPC", or GCE/Contour
+# equivalents) — set via gateway.ingress.annotations.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kubeswift-gateway
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: gateway
+  {{- with .Values.gateway.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.gateway.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.gateway.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kubeswift-gateway
+                port:
+                  name: http
+  {{- with .Values.gateway.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kubeswift/templates/gateway/rbac.yaml
+++ b/charts/kubeswift/templates/gateway/rbac.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeswift-gateway
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: gateway
+---
+# Hub-namespace permissions: read the fleet registry + its credential Secrets,
+# and write Cluster status. Namespaced because a Cluster and its credential
+# Secret live in the gateway's namespace (the Cluster API model).
+#
+# NOTE: the hub does NOT need the `impersonate` verb. Impersonation happens
+# against MEMBER clusters using each member's own credential; that credential
+# (in the Secret) must carry impersonate rights on its member cluster. See
+# docs/ui/gateway.md.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubeswift-gateway
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: gateway
+rules:
+  - apiGroups: ["fleet.kubeswift.io"]
+    resources: ["clusters"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["fleet.kubeswift.io"]
+    resources: ["clusters/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubeswift-gateway
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubeswift-gateway
+subjects:
+  - kind: ServiceAccount
+    name: kubeswift-gateway
+    namespace: {{ .Values.namespace }}
+---
+# Cluster-scoped: validate end-user bearer tokens (auth-mode=token).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeswift-gateway
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: gateway
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeswift-gateway
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeswift-gateway
+subjects:
+  - kind: ServiceAccount
+    name: kubeswift-gateway
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/charts/kubeswift/templates/gateway/service.yaml
+++ b/charts/kubeswift/templates/gateway/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubeswift-gateway
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: gateway
+spec:
+  type: {{ .Values.gateway.service.type }}
+  selector:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: gateway
+  ports:
+    - name: http
+      port: {{ .Values.gateway.service.port }}
+      targetPort: http
+{{- end }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -102,6 +102,47 @@ dra:
       cpu: 100m
       memory: 128Mi
 
+# UI backend gateway (the browser-facing Connect hub for a separate kubeswift-ui
+# app). Opt-in. Runs in a hub cluster, watches fleet.kubeswift.io Cluster
+# objects, and fans the read plane across the registered member clusters.
+# See docs/ui/gateway.md and docs/design/ui-backend-enablement.md.
+gateway:
+  enabled: false
+  image:
+    registry: ghcr.io/projectbeskar/kubeswift
+    # Same as controllerManager; use tag: latest for local build+load.
+    tag: latest
+  replicas: 1
+  port: 8080
+  # End-user auth (decision D1):
+  #   token    - impersonate the bearer-token user via the hub's TokenReview
+  #              (production). The fleet should share an OIDC identity provider
+  #              so the impersonated subject authorizes uniformly on each member.
+  #   insecure - member queries run as the gateway's own credential, with NO
+  #              per-user impersonation. DEV/LAB ONLY: every UI user inherits
+  #              whatever the member credentials grant. Do not use in production.
+  authMode: insecure
+  # Browser origin allowed to call the Connect/gRPC-Web surface (the kubeswift-ui
+  # app's origin). "*" is acceptable for a token-auth API (no cookies); pin it
+  # for a hardened install.
+  corsAllowOrigin: "*"
+  service:
+    type: ClusterIP
+    port: 8080
+  ingress:
+    enabled: false
+    className: ""
+    host: kubeswift-gateway.example.com
+    annotations: {}
+    tls: []
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
 # Admission webhooks (optional). Requires cert-manager. When enabled, controller-manager runs with --webhook-enabled=true.
 webhook:
   enabled: false

--- a/config/samples/gateway/README.md
+++ b/config/samples/gateway/README.md
@@ -1,0 +1,30 @@
+# kubeswift-gateway samples
+
+Register member clusters with the [kubeswift-gateway](../../../docs/ui/gateway.md)
+hub.
+
+1. **Enable the gateway on the hub** (Helm):
+
+   ```bash
+   helm upgrade --install kubeswift oci://ghcr.io/projectbeskar/charts/kubeswift \
+     -n kubeswift-system --create-namespace \
+     --set gateway.enabled=true --set gateway.authMode=token
+   ```
+
+2. **On each member cluster**, apply [`member-rbac.yaml`](member-rbac.yaml) (lets
+   the gateway's member credential impersonate end users + read VMs as them), and
+   mint a credential (e.g. a ServiceAccount token) for the gateway.
+
+3. **On the hub**, apply [`cluster.yaml`](cluster.yaml) — a credential Secret + a
+   `fleet.kubeswift.io/v1alpha1` Cluster — once per member (edit names/endpoints
+   and paste the member credential).
+
+4. **Verify**:
+
+   ```bash
+   kubectl -n kubeswift-system get clusters
+   ```
+
+   Each member should reach `READY=True` with its Kubernetes version + guest
+   count. See the [operator guide](../../../docs/ui/gateway.md) for the full flow
+   and the auth/security notes.

--- a/config/samples/gateway/cluster.yaml
+++ b/config/samples/gateway/cluster.yaml
@@ -1,0 +1,46 @@
+# Register a member cluster with the kubeswift-gateway hub. Apply BOTH objects
+# in the gateway's namespace (default: kubeswift-system). Replace the kubeconfig
+# with one for your member whose user is impersonation-capable (see
+# member-rbac.yaml) for auth-mode=token.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: boba-kubeconfig
+  namespace: kubeswift-system
+type: Opaque
+stringData:
+  # A full kubeconfig for the member cluster. The gateway uses its
+  # current-context. (Alternatively, drop `kubeconfig` and provide `token` +
+  # optional `ca.crt`, paired with spec.server on the Cluster below.)
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: boba
+        cluster:
+          server: https://boba.example.com:6443
+          # certificate-authority-data: <base64 CA>
+    users:
+      - name: kubeswift-gateway
+        user:
+          token: <member service-account token>
+    contexts:
+      - name: boba
+        context:
+          cluster: boba
+          user: kubeswift-gateway
+    current-context: boba
+---
+apiVersion: fleet.kubeswift.io/v1alpha1
+kind: Cluster
+metadata:
+  name: boba
+  namespace: kubeswift-system
+spec:
+  # Optional when the kubeconfig already names the server.
+  server: https://boba.example.com:6443
+  credentialSecretRef:
+    name: boba-kubeconfig
+  # Optional: per-member Prometheus for VM telemetry (P1).
+  # prometheusEndpoint: http://prometheus.monitoring.svc:9090
+  displayName: Boba (lab)

--- a/config/samples/gateway/member-rbac.yaml
+++ b/config/samples/gateway/member-rbac.yaml
@@ -1,0 +1,62 @@
+# Apply on each MEMBER cluster (NOT the hub). Grants the gateway's member
+# credential the rights it needs for auth-mode=token: impersonate end users +
+# read the fleet's VMs as them. Bind your real users/groups (from your IdP) to
+# the reader role separately.
+#
+# Assumes the member credential authenticates as the ServiceAccount
+# `kubeswift-gateway` in `kubeswift-system` — adjust to match your kubeconfig.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeswift-gateway
+  namespace: kubeswift-system
+---
+# 1) Let the member credential impersonate end users + groups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeswift-gateway-impersonator
+rules:
+  - apiGroups: [""]
+    resources: ["users", "groups"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeswift-gateway-impersonator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeswift-gateway-impersonator
+subjects:
+  - kind: ServiceAccount
+    name: kubeswift-gateway
+    namespace: kubeswift-system
+---
+# 2) A read-only VM role to bind your IMPERSONATED users/groups to (so the UI
+#    can list their VMs). Bind real subjects from your IdP — this sample binds
+#    an example group.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeswift-vm-reader
+rules:
+  - apiGroups: ["swift.kubeswift.io"]
+    resources: ["swiftguests", "swiftguestclasses", "swiftguestpools"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeswift-vm-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeswift-vm-reader
+subjects:
+  # Replace with the real users/groups your IdP issues (the subjects the
+  # gateway impersonates). Example:
+  - kind: Group
+    name: kubeswift-operators
+    apiGroup: rbac.authorization.k8s.io

--- a/docs/ui/gateway.md
+++ b/docs/ui/gateway.md
@@ -1,0 +1,152 @@
+# kubeswift-gateway (UI backend)
+
+`kubeswift-gateway` is the browser-facing backend for the separate **kubeswift-ui**
+app. It is a [Connect](https://connectrpc.com/) (gRPC-Web–compatible) server that
+runs in a **hub** cluster, discovers **member** clusters from a registry CRD, and
+fans the read plane out across the fleet — so the UI talks to one endpoint and
+sees every cluster's VMs.
+
+> Status: **v1alpha1**, opt-in. P0 ships the read plane (cluster selector + a
+> cross-cluster SwiftGuest inventory). Write, telemetry, and consoles follow.
+> Design: [`docs/design/ui-backend-enablement.md`](../design/ui-backend-enablement.md).
+
+## Architecture
+
+```
+Browser (kubeswift-ui)
+   │ Connect / gRPC-Web
+   ▼
+kubeswift-gateway  (HUB cluster)
+   ├─ watches fleet.kubeswift.io Cluster objects (the registry)
+   ├─ per member: a client built from the member's credential Secret,
+   │   impersonating the end user (auth-mode=token)
+   └─ ClusterService.List/Watch + GuestService.List/Watch (fan-out + merge)
+   ▼
+Member cluster A · Member cluster B · …   (each runs the KubeSwift operator)
+```
+
+The hub is just where the gateway runs; it may also be one of the member
+clusters, or a dedicated management cluster.
+
+## Install (on the hub)
+
+The gateway ships with the KubeSwift chart, gated off by default:
+
+```bash
+helm upgrade --install kubeswift oci://ghcr.io/projectbeskar/charts/kubeswift \
+  -n kubeswift-system --create-namespace \
+  --set gateway.enabled=true \
+  --set gateway.authMode=token        # see "Authentication" below
+```
+
+This deploys the gateway Deployment + Service + its hub RBAC. Expose it to the
+UI with `gateway.ingress.enabled=true` (+ `gateway.ingress.host`/`annotations`),
+or a Service of `type: LoadBalancer`. The gateway serves Connect/gRPC-Web over
+**h2c** — terminate TLS at the ingress and allow HTTP/2 to the backend.
+
+## Register a member cluster
+
+For each member, create — **in the gateway's namespace** — a credential Secret
+and a `Cluster` object. The simplest credential is a kubeconfig:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: boba-kubeconfig
+  namespace: kubeswift-system
+type: Opaque
+stringData:
+  kubeconfig: |
+    # a kubeconfig for the member, whose user is impersonation-capable (below)
+---
+apiVersion: fleet.kubeswift.io/v1alpha1
+kind: Cluster
+metadata:
+  name: boba
+  namespace: kubeswift-system
+spec:
+  server: https://boba.example.com:6443       # optional if the kubeconfig has it
+  credentialSecretRef:
+    name: boba-kubeconfig
+  prometheusEndpoint: http://prometheus.monitoring.svc:9090   # optional (telemetry)
+  displayName: Boba (lab)
+```
+
+Alternatively the Secret may carry a `token` (+ optional `ca.crt`) instead of a
+`kubeconfig`, paired with `spec.server`.
+
+The gateway picks the member up immediately, probes it, and writes status:
+
+```bash
+kubectl -n kubeswift-system get clusters
+# NAME   SERVER                          READY   K8S       GUESTS   AGE
+# boba   https://boba.example.com:6443   True    v1.34.3   7        1m
+```
+
+## Authentication (decision D1)
+
+| `gateway.authMode` | Behaviour |
+|---|---|
+| `token` (**production**) | The UI sends the end user's bearer token; the gateway validates it via the hub's **TokenReview**, then **impersonates** that user against each member. Existing Kubernetes RBAC (and Model-A namespace tenancy) applies per user. |
+| `insecure` (**dev/lab only**) | No impersonation — member queries run as the member's own credential. **Every UI user inherits whatever that credential grants.** Do not use in production. |
+
+For `token` mode to authorize uniformly, the fleet should share an **identity
+provider** (OIDC), so the impersonated subject is bound in every member's RBAC.
+Where members don't federate, impersonation is only valid where the subject is
+bound.
+
+### Member-side permissions
+
+Impersonation happens **on the member**, using the member credential — so that
+credential must be allowed to impersonate, and the impersonated users must be
+able to read SwiftGuests. On each member:
+
+```yaml
+# Let the gateway's member credential impersonate end users + groups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeswift-gateway-impersonator
+rules:
+  - apiGroups: [""]
+    resources: ["users", "groups"]
+    verbs: ["impersonate"]
+---
+# And let the (impersonated) users read VMs — bind the real users/groups to a
+# role granting get/list/watch on swiftguests, scoped to their namespaces.
+```
+
+The **hub** SA needs no `impersonate` verb; the chart grants it only what it
+needs on the hub (read `clusters` + credential Secrets, write `clusters/status`,
+create `tokenreviews`).
+
+## Verify
+
+```bash
+kubectl -n kubeswift-system port-forward svc/kubeswift-gateway 8080:8080 &
+# List clusters (Connect over HTTP/1.1 JSON):
+curl -s http://localhost:8080/kubeswift.v1.ClusterService/ListClusters \
+  -H 'Content-Type: application/json' -d '{}'
+# List guests across the fleet:
+curl -s http://localhost:8080/kubeswift.v1.GuestService/ListGuests \
+  -H 'Content-Type: application/json' -d '{}'
+```
+
+In `insecure` mode these work with no token; in `token` mode add
+`-H "Authorization: Bearer <user-token>"`.
+
+## Security notes
+
+- **The hub holds credentials to every member** — it is the fleet's
+  highest-value target. Restrict who can read Secrets in the gateway namespace,
+  scope each member credential to the least privilege the UI needs, and rotate.
+- **`insecure` mode is a footgun** — it bypasses per-user authorization. The
+  gateway logs a warning at startup when it is on.
+- **CORS** defaults to `*` (safe for a token-auth API with no cookies); pin
+  `gateway.corsAllowOrigin` to the UI origin for a hardened install.
+
+## See also
+
+- [`docs/design/ui-backend-enablement.md`](../design/ui-backend-enablement.md) — the design + the resolved decisions.
+- `config/samples/gateway/` — runnable Secret + Cluster samples.

--- a/images/kubeswift-gateway/Containerfile
+++ b/images/kubeswift-gateway/Containerfile
@@ -1,0 +1,28 @@
+# Multi-stage build for kubeswift-gateway (the UI backend Connect hub).
+FROM golang:1.25-bookworm AS builder
+WORKDIR /build
+
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags "-X github.com/projectbeskar/kubeswift/internal/version.Version=${VERSION} -X github.com/projectbeskar/kubeswift/internal/version.GitCommit=${GIT_COMMIT} -X github.com/projectbeskar/kubeswift/internal/version.BuildDate=${BUILD_DATE}" \
+    -o kubeswift-gateway ./cmd/kubeswift-gateway
+
+# distroless static + nonroot: the gateway is a pure network service (no host
+# access). ca-certificates are bundled so it can dial member API servers /
+# Prometheus over TLS via the system trust store (per-member CAs still come
+# from the credential Secret's ca.crt).
+FROM gcr.io/distroless/static:nonroot
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+COPY --from=builder /build/kubeswift-gateway /kubeswift-gateway
+USER 65532:65532
+ENTRYPOINT ["/kubeswift-gateway"]


### PR DESCRIPTION
Final P0 increment (design: [`docs/design/ui-backend-enablement.md`](docs/design/ui-backend-enablement.md)) — makes the gateway **deployable**. Builds on the merged C1 (#261) + C2 (#263).

## What

- **`images/kubeswift-gateway/Containerfile`** — distroless-static + nonroot, version-stamped (mirrors kubeswift-dra-driver).
- **`charts/kubeswift/templates/gateway/`** — opt-in (`gateway.enabled`, default off):
  - **Deployment** — hardened (runAsNonRoot, drop ALL, readOnlyRootFilesystem, RuntimeDefault seccomp), h2c `/healthz`+`/readyz` probes.
  - **Service** + optional **Ingress** (h2c/gRPC-Web notes).
  - **hub RBAC** — the hub SA gets only what it needs on the hub: read `clusters` + credential `secrets`, write `clusters/status`, create `tokenreviews`. It deliberately does **NOT** get `impersonate` (that's a member-side grant on the member credential — documented).
- **`values.yaml`** `gateway` block: image, replicas, port, **`authMode`** (`token`|`insecure`, D1), `corsAllowOrigin`, service, ingress, resources.
- **Makefile** `build-gateway-image` + build/push/.PHONY wiring.
- **Workflows** — `release-stable` (build+push+cosign), `release-dev` (build+push on main), and a CI image-build smoke job (continue-on-error).
- **Docs + samples** — [`docs/ui/gateway.md`](docs/ui/gateway.md) (install, register a member, auth modes, **member-side impersonation RBAC**, verify, security notes) + `config/samples/gateway/`.

## Validation

`helm lint` + full template render (incl. ingress) green; workflow YAML parses; the full gateway (C1+C2) builds. The hub SA RBAC, the member-side impersonation model, and the insecure-mode footgun are all documented.

## After merge

`release-dev` publishes `kubeswift-gateway:sha-<commit>` on merge to main. Then the **end-to-end cluster validation** (deploy the gateway on a hub, register the ntx + Hetzner clusters as fleet members, list guests across both) is the closing step — the first real multi-cluster exercise of the read plane.

**This completes the P0 backend** (A→B→C1→C2→D): the seam + a runnable, deployable, impersonating multi-cluster read gateway. The separate `kubeswift-ui` repo can now build its shell + cluster/namespace selectors + a live fleet inventory against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)