### PR TITLE
feat(gateway): write plane — StartGuest/StopGuest (UI backend P1)

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -6,9 +6,12 @@ lint:
     - STANDARD
   except:
     # Streaming RPCs return a shared event message (ClusterEvent / GuestEvent /
-    # VMMetricSample), which is idiomatic for Connect watch streams but trips
-    # the "<Method>Response" / unique-message rules. Intentionally relaxed.
+    # VMMetricSample), and the lifecycle actions share one GuestActionRequest /
+    # GuestActionResponse — both idiomatic for this hand-shaped API but trip the
+    # per-method "<Method>Request"/"<Method>Response"/unique-message rules.
+    # Intentionally relaxed.
     - RPC_REQUEST_RESPONSE_UNIQUE
+    - RPC_REQUEST_STANDARD_NAME
     - RPC_RESPONSE_STANDARD_NAME
 breaking:
   use:

--- a/config/samples/gateway/member-rbac.yaml
+++ b/config/samples/gateway/member-rbac.yaml
@@ -45,6 +45,12 @@ rules:
   - apiGroups: ["swift.kubeswift.io"]
     resources: ["swiftguests", "swiftguestclasses", "swiftguestpools"]
     verbs: ["get", "list", "watch"]
+  # Lifecycle write actions (UI Start/Stop) patch swiftguests.spec.runPolicy.
+  # Grant patch to the subjects you want to be able to act; drop this rule for
+  # a strictly read-only audience.
+  - apiGroups: ["swift.kubeswift.io"]
+    resources: ["swiftguests"]
+    verbs: ["update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/ui/gateway.md
+++ b/docs/ui/gateway.md
@@ -142,7 +142,13 @@ In `insecure` mode these work with no token; in `token` mode add
   highest-value target. Restrict who can read Secrets in the gateway namespace,
   scope each member credential to the least privilege the UI needs, and rotate.
 - **`insecure` mode is a footgun** — it bypasses per-user authorization. The
-  gateway logs a warning at startup when it is on.
+  gateway logs a warning at startup when it is on. Note the **write actions**
+  below make this sharper: in `insecure` mode every UI user can start/stop VMs.
+- **Write actions** — `GuestService.StartGuest`/`StopGuest` patch
+  `swiftguests.spec.runPolicy` on the target member, as the impersonated user.
+  The acting subject therefore needs `patch` on `swiftguests` there (see
+  `config/samples/gateway/member-rbac.yaml`); a read-only audience gets a clean
+  permission denial. In `token` mode the member's RBAC gates who can act.
 - **CORS** defaults to `*` (safe for a token-auth API with no cookies); pin
   `gateway.corsAllowOrigin` to the UI origin for a hardened install.
 

--- a/gen/kubeswift/v1/guest.pb.go
+++ b/gen/kubeswift/v1/guest.pb.go
@@ -511,6 +511,98 @@ func (x *GetGuestDetailResponse) GetGuest() *Guest {
 	return nil
 }
 
+// GuestActionRequest identifies the target VM for a lifecycle action.
+type GuestActionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ref           *ObjectRef             `protobuf:"bytes,1,opt,name=ref,proto3" json:"ref,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GuestActionRequest) Reset() {
+	*x = GuestActionRequest{}
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GuestActionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GuestActionRequest) ProtoMessage() {}
+
+func (x *GuestActionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GuestActionRequest.ProtoReflect.Descriptor instead.
+func (*GuestActionRequest) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_guest_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *GuestActionRequest) GetRef() *ObjectRef {
+	if x != nil {
+		return x.Ref
+	}
+	return nil
+}
+
+// GuestActionResponse returns the guest immediately after the action is
+// applied; its phase catches up asynchronously (the controller acts on the
+// runPolicy change), which the live Watch reflects.
+type GuestActionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Guest         *Guest                 `protobuf:"bytes,1,opt,name=guest,proto3" json:"guest,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GuestActionResponse) Reset() {
+	*x = GuestActionResponse{}
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GuestActionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GuestActionResponse) ProtoMessage() {}
+
+func (x *GuestActionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GuestActionResponse.ProtoReflect.Descriptor instead.
+func (*GuestActionResponse) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_guest_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *GuestActionResponse) GetGuest() *Guest {
+	if x != nil {
+		return x.Guest
+	}
+	return nil
+}
+
 var File_kubeswift_v1_guest_proto protoreflect.FileDescriptor
 
 const file_kubeswift_v1_guest_proto_rawDesc = "" +
@@ -563,12 +655,19 @@ const file_kubeswift_v1_guest_proto_rawDesc = "" +
 	"\x15GetGuestDetailRequest\x12)\n" +
 	"\x03ref\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\x03ref\"C\n" +
 	"\x16GetGuestDetailResponse\x12)\n" +
-	"\x05guest\x18\x01 \x01(\v2\x13.kubeswift.v1.GuestR\x05guest2\x89\x02\n" +
+	"\x05guest\x18\x01 \x01(\v2\x13.kubeswift.v1.GuestR\x05guest\"?\n" +
+	"\x12GuestActionRequest\x12)\n" +
+	"\x03ref\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\x03ref\"@\n" +
+	"\x13GuestActionResponse\x12)\n" +
+	"\x05guest\x18\x01 \x01(\v2\x13.kubeswift.v1.GuestR\x05guest2\xae\x03\n" +
 	"\fGuestService\x12O\n" +
 	"\n" +
 	"ListGuests\x12\x1f.kubeswift.v1.ListGuestsRequest\x1a .kubeswift.v1.ListGuestsResponse\x12K\n" +
 	"\vWatchGuests\x12 .kubeswift.v1.WatchGuestsRequest\x1a\x18.kubeswift.v1.GuestEvent0\x01\x12[\n" +
-	"\x0eGetGuestDetail\x12#.kubeswift.v1.GetGuestDetailRequest\x1a$.kubeswift.v1.GetGuestDetailResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
+	"\x0eGetGuestDetail\x12#.kubeswift.v1.GetGuestDetailRequest\x1a$.kubeswift.v1.GetGuestDetailResponse\x12Q\n" +
+	"\n" +
+	"StartGuest\x12 .kubeswift.v1.GuestActionRequest\x1a!.kubeswift.v1.GuestActionResponse\x12P\n" +
+	"\tStopGuest\x12 .kubeswift.v1.GuestActionRequest\x1a!.kubeswift.v1.GuestActionResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
 
 var (
 	file_kubeswift_v1_guest_proto_rawDescOnce sync.Once
@@ -582,7 +681,7 @@ func file_kubeswift_v1_guest_proto_rawDescGZIP() []byte {
 	return file_kubeswift_v1_guest_proto_rawDescData
 }
 
-var file_kubeswift_v1_guest_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_kubeswift_v1_guest_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_kubeswift_v1_guest_proto_goTypes = []any{
 	(*Guest)(nil),                  // 0: kubeswift.v1.Guest
 	(*ListGuestsRequest)(nil),      // 1: kubeswift.v1.ListGuestsRequest
@@ -591,43 +690,51 @@ var file_kubeswift_v1_guest_proto_goTypes = []any{
 	(*GuestEvent)(nil),             // 4: kubeswift.v1.GuestEvent
 	(*GetGuestDetailRequest)(nil),  // 5: kubeswift.v1.GetGuestDetailRequest
 	(*GetGuestDetailResponse)(nil), // 6: kubeswift.v1.GetGuestDetailResponse
-	nil,                            // 7: kubeswift.v1.Guest.LabelsEntry
-	(*ObjectRef)(nil),              // 8: kubeswift.v1.ObjectRef
-	(*timestamppb.Timestamp)(nil),  // 9: google.protobuf.Timestamp
-	(*Condition)(nil),              // 10: kubeswift.v1.Condition
-	(*ClusterSelector)(nil),        // 11: kubeswift.v1.ClusterSelector
-	(*PageRequest)(nil),            // 12: kubeswift.v1.PageRequest
-	(*PageResponse)(nil),           // 13: kubeswift.v1.PageResponse
-	(*ClusterError)(nil),           // 14: kubeswift.v1.ClusterError
-	(EventType)(0),                 // 15: kubeswift.v1.EventType
+	(*GuestActionRequest)(nil),     // 7: kubeswift.v1.GuestActionRequest
+	(*GuestActionResponse)(nil),    // 8: kubeswift.v1.GuestActionResponse
+	nil,                            // 9: kubeswift.v1.Guest.LabelsEntry
+	(*ObjectRef)(nil),              // 10: kubeswift.v1.ObjectRef
+	(*timestamppb.Timestamp)(nil),  // 11: google.protobuf.Timestamp
+	(*Condition)(nil),              // 12: kubeswift.v1.Condition
+	(*ClusterSelector)(nil),        // 13: kubeswift.v1.ClusterSelector
+	(*PageRequest)(nil),            // 14: kubeswift.v1.PageRequest
+	(*PageResponse)(nil),           // 15: kubeswift.v1.PageResponse
+	(*ClusterError)(nil),           // 16: kubeswift.v1.ClusterError
+	(EventType)(0),                 // 17: kubeswift.v1.EventType
 }
 var file_kubeswift_v1_guest_proto_depIdxs = []int32{
-	8,  // 0: kubeswift.v1.Guest.ref:type_name -> kubeswift.v1.ObjectRef
-	9,  // 1: kubeswift.v1.Guest.created_at:type_name -> google.protobuf.Timestamp
-	10, // 2: kubeswift.v1.Guest.conditions:type_name -> kubeswift.v1.Condition
-	7,  // 3: kubeswift.v1.Guest.labels:type_name -> kubeswift.v1.Guest.LabelsEntry
-	11, // 4: kubeswift.v1.ListGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
-	12, // 5: kubeswift.v1.ListGuestsRequest.page:type_name -> kubeswift.v1.PageRequest
+	10, // 0: kubeswift.v1.Guest.ref:type_name -> kubeswift.v1.ObjectRef
+	11, // 1: kubeswift.v1.Guest.created_at:type_name -> google.protobuf.Timestamp
+	12, // 2: kubeswift.v1.Guest.conditions:type_name -> kubeswift.v1.Condition
+	9,  // 3: kubeswift.v1.Guest.labels:type_name -> kubeswift.v1.Guest.LabelsEntry
+	13, // 4: kubeswift.v1.ListGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
+	14, // 5: kubeswift.v1.ListGuestsRequest.page:type_name -> kubeswift.v1.PageRequest
 	0,  // 6: kubeswift.v1.ListGuestsResponse.guests:type_name -> kubeswift.v1.Guest
-	13, // 7: kubeswift.v1.ListGuestsResponse.page:type_name -> kubeswift.v1.PageResponse
-	14, // 8: kubeswift.v1.ListGuestsResponse.errors:type_name -> kubeswift.v1.ClusterError
-	11, // 9: kubeswift.v1.WatchGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
-	15, // 10: kubeswift.v1.GuestEvent.type:type_name -> kubeswift.v1.EventType
+	15, // 7: kubeswift.v1.ListGuestsResponse.page:type_name -> kubeswift.v1.PageResponse
+	16, // 8: kubeswift.v1.ListGuestsResponse.errors:type_name -> kubeswift.v1.ClusterError
+	13, // 9: kubeswift.v1.WatchGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
+	17, // 10: kubeswift.v1.GuestEvent.type:type_name -> kubeswift.v1.EventType
 	0,  // 11: kubeswift.v1.GuestEvent.guest:type_name -> kubeswift.v1.Guest
-	14, // 12: kubeswift.v1.GuestEvent.error:type_name -> kubeswift.v1.ClusterError
-	8,  // 13: kubeswift.v1.GetGuestDetailRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	16, // 12: kubeswift.v1.GuestEvent.error:type_name -> kubeswift.v1.ClusterError
+	10, // 13: kubeswift.v1.GetGuestDetailRequest.ref:type_name -> kubeswift.v1.ObjectRef
 	0,  // 14: kubeswift.v1.GetGuestDetailResponse.guest:type_name -> kubeswift.v1.Guest
-	1,  // 15: kubeswift.v1.GuestService.ListGuests:input_type -> kubeswift.v1.ListGuestsRequest
-	3,  // 16: kubeswift.v1.GuestService.WatchGuests:input_type -> kubeswift.v1.WatchGuestsRequest
-	5,  // 17: kubeswift.v1.GuestService.GetGuestDetail:input_type -> kubeswift.v1.GetGuestDetailRequest
-	2,  // 18: kubeswift.v1.GuestService.ListGuests:output_type -> kubeswift.v1.ListGuestsResponse
-	4,  // 19: kubeswift.v1.GuestService.WatchGuests:output_type -> kubeswift.v1.GuestEvent
-	6,  // 20: kubeswift.v1.GuestService.GetGuestDetail:output_type -> kubeswift.v1.GetGuestDetailResponse
-	18, // [18:21] is the sub-list for method output_type
-	15, // [15:18] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	10, // 15: kubeswift.v1.GuestActionRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	0,  // 16: kubeswift.v1.GuestActionResponse.guest:type_name -> kubeswift.v1.Guest
+	1,  // 17: kubeswift.v1.GuestService.ListGuests:input_type -> kubeswift.v1.ListGuestsRequest
+	3,  // 18: kubeswift.v1.GuestService.WatchGuests:input_type -> kubeswift.v1.WatchGuestsRequest
+	5,  // 19: kubeswift.v1.GuestService.GetGuestDetail:input_type -> kubeswift.v1.GetGuestDetailRequest
+	7,  // 20: kubeswift.v1.GuestService.StartGuest:input_type -> kubeswift.v1.GuestActionRequest
+	7,  // 21: kubeswift.v1.GuestService.StopGuest:input_type -> kubeswift.v1.GuestActionRequest
+	2,  // 22: kubeswift.v1.GuestService.ListGuests:output_type -> kubeswift.v1.ListGuestsResponse
+	4,  // 23: kubeswift.v1.GuestService.WatchGuests:output_type -> kubeswift.v1.GuestEvent
+	6,  // 24: kubeswift.v1.GuestService.GetGuestDetail:output_type -> kubeswift.v1.GetGuestDetailResponse
+	8,  // 25: kubeswift.v1.GuestService.StartGuest:output_type -> kubeswift.v1.GuestActionResponse
+	8,  // 26: kubeswift.v1.GuestService.StopGuest:output_type -> kubeswift.v1.GuestActionResponse
+	22, // [22:27] is the sub-list for method output_type
+	17, // [17:22] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_kubeswift_v1_guest_proto_init() }
@@ -642,7 +749,7 @@ func file_kubeswift_v1_guest_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kubeswift_v1_guest_proto_rawDesc), len(file_kubeswift_v1_guest_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/kubeswift/v1/kubeswiftv1connect/guest.connect.go
+++ b/gen/kubeswift/v1/kubeswiftv1connect/guest.connect.go
@@ -41,6 +41,10 @@ const (
 	// GuestServiceGetGuestDetailProcedure is the fully-qualified name of the GuestService's
 	// GetGuestDetail RPC.
 	GuestServiceGetGuestDetailProcedure = "/kubeswift.v1.GuestService/GetGuestDetail"
+	// GuestServiceStartGuestProcedure is the fully-qualified name of the GuestService's StartGuest RPC.
+	GuestServiceStartGuestProcedure = "/kubeswift.v1.GuestService/StartGuest"
+	// GuestServiceStopGuestProcedure is the fully-qualified name of the GuestService's StopGuest RPC.
+	GuestServiceStopGuestProcedure = "/kubeswift.v1.GuestService/StopGuest"
 )
 
 // GuestServiceClient is a client for the kubeswift.v1.GuestService service.
@@ -48,6 +52,11 @@ type GuestServiceClient interface {
 	ListGuests(context.Context, *connect.Request[v1.ListGuestsRequest]) (*connect.Response[v1.ListGuestsResponse], error)
 	WatchGuests(context.Context, *connect.Request[v1.WatchGuestsRequest]) (*connect.ServerStreamForClient[v1.GuestEvent], error)
 	GetGuestDetail(context.Context, *connect.Request[v1.GetGuestDetailRequest]) (*connect.Response[v1.GetGuestDetailResponse], error)
+	// Lifecycle (write plane, P1): patch the guest's runPolicy — StartGuest sets
+	// Running, StopGuest sets Stopped. The impersonated user (decision D1) must
+	// be allowed to patch swiftguests on the target member cluster.
+	StartGuest(context.Context, *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error)
+	StopGuest(context.Context, *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error)
 }
 
 // NewGuestServiceClient constructs a client for the kubeswift.v1.GuestService service. By default,
@@ -79,6 +88,18 @@ func NewGuestServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 			connect.WithSchema(guestServiceMethods.ByName("GetGuestDetail")),
 			connect.WithClientOptions(opts...),
 		),
+		startGuest: connect.NewClient[v1.GuestActionRequest, v1.GuestActionResponse](
+			httpClient,
+			baseURL+GuestServiceStartGuestProcedure,
+			connect.WithSchema(guestServiceMethods.ByName("StartGuest")),
+			connect.WithClientOptions(opts...),
+		),
+		stopGuest: connect.NewClient[v1.GuestActionRequest, v1.GuestActionResponse](
+			httpClient,
+			baseURL+GuestServiceStopGuestProcedure,
+			connect.WithSchema(guestServiceMethods.ByName("StopGuest")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -87,6 +108,8 @@ type guestServiceClient struct {
 	listGuests     *connect.Client[v1.ListGuestsRequest, v1.ListGuestsResponse]
 	watchGuests    *connect.Client[v1.WatchGuestsRequest, v1.GuestEvent]
 	getGuestDetail *connect.Client[v1.GetGuestDetailRequest, v1.GetGuestDetailResponse]
+	startGuest     *connect.Client[v1.GuestActionRequest, v1.GuestActionResponse]
+	stopGuest      *connect.Client[v1.GuestActionRequest, v1.GuestActionResponse]
 }
 
 // ListGuests calls kubeswift.v1.GuestService.ListGuests.
@@ -104,11 +127,26 @@ func (c *guestServiceClient) GetGuestDetail(ctx context.Context, req *connect.Re
 	return c.getGuestDetail.CallUnary(ctx, req)
 }
 
+// StartGuest calls kubeswift.v1.GuestService.StartGuest.
+func (c *guestServiceClient) StartGuest(ctx context.Context, req *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error) {
+	return c.startGuest.CallUnary(ctx, req)
+}
+
+// StopGuest calls kubeswift.v1.GuestService.StopGuest.
+func (c *guestServiceClient) StopGuest(ctx context.Context, req *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error) {
+	return c.stopGuest.CallUnary(ctx, req)
+}
+
 // GuestServiceHandler is an implementation of the kubeswift.v1.GuestService service.
 type GuestServiceHandler interface {
 	ListGuests(context.Context, *connect.Request[v1.ListGuestsRequest]) (*connect.Response[v1.ListGuestsResponse], error)
 	WatchGuests(context.Context, *connect.Request[v1.WatchGuestsRequest], *connect.ServerStream[v1.GuestEvent]) error
 	GetGuestDetail(context.Context, *connect.Request[v1.GetGuestDetailRequest]) (*connect.Response[v1.GetGuestDetailResponse], error)
+	// Lifecycle (write plane, P1): patch the guest's runPolicy — StartGuest sets
+	// Running, StopGuest sets Stopped. The impersonated user (decision D1) must
+	// be allowed to patch swiftguests on the target member cluster.
+	StartGuest(context.Context, *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error)
+	StopGuest(context.Context, *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error)
 }
 
 // NewGuestServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -136,6 +174,18 @@ func NewGuestServiceHandler(svc GuestServiceHandler, opts ...connect.HandlerOpti
 		connect.WithSchema(guestServiceMethods.ByName("GetGuestDetail")),
 		connect.WithHandlerOptions(opts...),
 	)
+	guestServiceStartGuestHandler := connect.NewUnaryHandler(
+		GuestServiceStartGuestProcedure,
+		svc.StartGuest,
+		connect.WithSchema(guestServiceMethods.ByName("StartGuest")),
+		connect.WithHandlerOptions(opts...),
+	)
+	guestServiceStopGuestHandler := connect.NewUnaryHandler(
+		GuestServiceStopGuestProcedure,
+		svc.StopGuest,
+		connect.WithSchema(guestServiceMethods.ByName("StopGuest")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/kubeswift.v1.GuestService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case GuestServiceListGuestsProcedure:
@@ -144,6 +194,10 @@ func NewGuestServiceHandler(svc GuestServiceHandler, opts ...connect.HandlerOpti
 			guestServiceWatchGuestsHandler.ServeHTTP(w, r)
 		case GuestServiceGetGuestDetailProcedure:
 			guestServiceGetGuestDetailHandler.ServeHTTP(w, r)
+		case GuestServiceStartGuestProcedure:
+			guestServiceStartGuestHandler.ServeHTTP(w, r)
+		case GuestServiceStopGuestProcedure:
+			guestServiceStopGuestHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -163,4 +217,12 @@ func (UnimplementedGuestServiceHandler) WatchGuests(context.Context, *connect.Re
 
 func (UnimplementedGuestServiceHandler) GetGuestDetail(context.Context, *connect.Request[v1.GetGuestDetailRequest]) (*connect.Response[v1.GetGuestDetailResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.GuestService.GetGuestDetail is not implemented"))
+}
+
+func (UnimplementedGuestServiceHandler) StartGuest(context.Context, *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.GuestService.StartGuest is not implemented"))
+}
+
+func (UnimplementedGuestServiceHandler) StopGuest(context.Context, *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.GuestService.StopGuest is not implemented"))
 }

--- a/internal/gateway/guest_service.go
+++ b/internal/gateway/guest_service.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"sync"
 
@@ -10,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 
@@ -193,6 +195,44 @@ func (s *GuestService) GetGuestDetail(ctx context.Context, req *connect.Request[
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	return connect.NewResponse(&kubeswiftv1.GetGuestDetailResponse{Guest: guestToProto(ref.GetCluster(), g)}), nil
+}
+
+// StartGuest sets the guest's runPolicy to Running; StopGuest sets it to
+// Stopped. Both patch spec.runPolicy via the impersonating dynamic client, so
+// the member cluster's RBAC authorizes the end user (decision D1). The
+// controller acts on the change and the live Watch reflects the new phase.
+func (s *GuestService) StartGuest(ctx context.Context, req *connect.Request[kubeswiftv1.GuestActionRequest]) (*connect.Response[kubeswiftv1.GuestActionResponse], error) {
+	return s.setRunPolicy(ctx, req, "Running")
+}
+
+func (s *GuestService) StopGuest(ctx context.Context, req *connect.Request[kubeswiftv1.GuestActionRequest]) (*connect.Response[kubeswiftv1.GuestActionResponse], error) {
+	return s.setRunPolicy(ctx, req, "Stopped")
+}
+
+func (s *GuestService) setRunPolicy(ctx context.Context, req *connect.Request[kubeswiftv1.GuestActionRequest], policy string) (*connect.Response[kubeswiftv1.GuestActionResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	ref := req.Msg.GetRef()
+	if ref == nil || ref.GetCluster() == "" || ref.GetName() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("ref.cluster and ref.name are required"))
+	}
+	dyn, err := s.pool.DynamicFor(ref.GetCluster(), id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	patch := []byte(fmt.Sprintf(`{"spec":{"runPolicy":%q}}`, policy))
+	u, err := dyn.Resource(swiftGuestGVR).Namespace(ref.GetNamespace()).
+		Patch(ctx, ref.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	g, err := toSwiftGuest(u)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&kubeswiftv1.GuestActionResponse{Guest: guestToProto(ref.GetCluster(), g)}), nil
 }
 
 // targetClusters resolves the selector against the registered members. An empty

--- a/internal/gateway/guest_service_test.go
+++ b/internal/gateway/guest_service_test.go
@@ -121,3 +121,24 @@ func TestGuestService_TargetClusters(t *testing.T) {
 		t.Errorf("subset should intersect registered members: %v", sub)
 	}
 }
+
+func TestGuestService_StartStopGuest(t *testing.T) {
+	boba := fakeDyn(uGuest("default", "vm-a", "Running"))
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+	ref := &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"}
+
+	start, err := svc.StartGuest(context.Background(), connect.NewRequest(&kubeswiftv1.GuestActionRequest{Ref: ref}))
+	if err != nil {
+		t.Fatalf("StartGuest: %v", err)
+	}
+	if start.Msg.Guest.GetRef().GetName() != "vm-a" {
+		t.Errorf("StartGuest returned %+v", start.Msg.Guest)
+	}
+	if _, err := svc.StopGuest(context.Background(), connect.NewRequest(&kubeswiftv1.GuestActionRequest{Ref: ref})); err != nil {
+		t.Fatalf("StopGuest: %v", err)
+	}
+	// A missing ref is rejected, not silently a no-op.
+	if _, err := svc.StartGuest(context.Background(), connect.NewRequest(&kubeswiftv1.GuestActionRequest{})); err == nil {
+		t.Error("StartGuest with no ref should be InvalidArgument")
+	}
+}

--- a/proto/kubeswift/v1/guest.proto
+++ b/proto/kubeswift/v1/guest.proto
@@ -76,11 +76,30 @@ message GetGuestDetailResponse {
   Guest guest = 1;
 }
 
-// GuestService is the read plane for VM inventory. List/Watch fan out across
-// the selected member clusters and merge, stamping the cluster dimension on
-// every row; a per-cluster error surface preserves partial-fleet results.
+// GuestActionRequest identifies the target VM for a lifecycle action.
+message GuestActionRequest {
+  ObjectRef ref = 1;
+}
+
+// GuestActionResponse returns the guest immediately after the action is
+// applied; its phase catches up asynchronously (the controller acts on the
+// runPolicy change), which the live Watch reflects.
+message GuestActionResponse {
+  Guest guest = 1;
+}
+
+// GuestService is the read plane for VM inventory plus the P1 lifecycle write
+// actions. List/Watch fan out across the selected member clusters and merge,
+// stamping the cluster dimension on every row; a per-cluster error surface
+// preserves partial-fleet results.
 service GuestService {
   rpc ListGuests(ListGuestsRequest) returns (ListGuestsResponse);
   rpc WatchGuests(WatchGuestsRequest) returns (stream GuestEvent);
   rpc GetGuestDetail(GetGuestDetailRequest) returns (GetGuestDetailResponse);
+
+  // Lifecycle (write plane, P1): patch the guest's runPolicy — StartGuest sets
+  // Running, StopGuest sets Stopped. The impersonated user (decision D1) must
+  // be allowed to patch swiftguests on the target member cluster.
+  rpc StartGuest(GuestActionRequest) returns (GuestActionResponse);
+  rpc StopGuest(GuestActionRequest) returns (GuestActionResponse);
 }


### PR DESCRIPTION
First **write-plane** action for the UI (design: [`docs/design/ui-backend-enablement.md`](docs/design/ui-backend-enablement.md) Plane 4), so the console can *act* on VMs, not just view them.

## What

- **proto** — `GuestService.StartGuest` / `StopGuest` (`GuestActionRequest{ref}` → `GuestActionResponse{guest}`); buf-regenerated Go.
- **gateway** — both patch the target guest's `spec.runPolicy` (Running / Stopped) on its member cluster via the **impersonating** dynamic client (D1), so the member's RBAC authorizes the end user. Returns the guest immediately; the controller acts and the **live `WatchGuests` stream** reflects the new phase.
- **RBAC / docs** — the acting subject needs `patch` on `swiftguests` on the member (`config/samples/gateway/member-rbac.yaml` updated; a read-only audience gets a clean denial). Security note added: in `insecure` mode every UI user can start/stop VMs.

## Validation

Unit test (start / stop / missing-ref → `InvalidArgument`) against a fake dynamic client; `go build`, full `go test ./...`, `gofmt`, `buf` regen all green.

## After merge

`release-dev` rebuilds `kubeswift-gateway` → redeploy on the hub → the `kubeswift-ui` drawer gets Start/Stop buttons (separate UI commit) → cluster-validate (Stop a guest from the UI → its `runPolicy` flips → the live table updates).

**Restart** (pods RBAC) and **migrate** (SwiftMigration CR) are deliberate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)