### PR TITLE
fix(gateway): StopGuest deletes the launcher pod (UI backend P1)

### DIFF
--- a/config/samples/gateway/member-rbac.yaml
+++ b/config/samples/gateway/member-rbac.yaml
@@ -46,11 +46,17 @@ rules:
     resources: ["swiftguests", "swiftguestclasses", "swiftguestpools"]
     verbs: ["get", "list", "watch"]
   # Lifecycle write actions (UI Start/Stop) patch swiftguests.spec.runPolicy.
-  # Grant patch to the subjects you want to be able to act; drop this rule for
+  # Grant these to the subjects you want to be able to act; drop both rules for
   # a strictly read-only audience.
   - apiGroups: ["swift.kubeswift.io"]
     resources: ["swiftguests"]
     verbs: ["update", "patch"]
+  # StopGuest also DELETES the launcher pod — the SwiftGuest stop guard is
+  # reactive (it blocks recreation, it does not stop a running VM), so a
+  # runPolicy patch alone would leave the guest running.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/ui/gateway.md
+++ b/docs/ui/gateway.md
@@ -146,9 +146,12 @@ In `insecure` mode these work with no token; in `token` mode add
   below make this sharper: in `insecure` mode every UI user can start/stop VMs.
 - **Write actions** — `GuestService.StartGuest`/`StopGuest` patch
   `swiftguests.spec.runPolicy` on the target member, as the impersonated user.
-  The acting subject therefore needs `patch` on `swiftguests` there (see
-  `config/samples/gateway/member-rbac.yaml`); a read-only audience gets a clean
-  permission denial. In `token` mode the member's RBAC gates who can act.
+  `StopGuest` additionally **deletes the launcher pod** (the SwiftGuest stop
+  guard is reactive — a runPolicy patch alone does not stop a running VM). So
+  the acting subject needs `patch` on `swiftguests` **and** `delete` on `pods`
+  there (see `config/samples/gateway/member-rbac.yaml`); a read-only audience
+  gets a clean permission denial. In `token` mode the member's RBAC gates who
+  can act.
 - **CORS** defaults to `*` (safe for a token-auth API with no cookies); pin
   `gateway.corsAllowOrigin` to the UI origin for a hardened install.
 

--- a/internal/gateway/guest_service.go
+++ b/internal/gateway/guest_service.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	connect "connectrpc.com/connect"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -199,17 +200,23 @@ func (s *GuestService) GetGuestDetail(ctx context.Context, req *connect.Request[
 
 // StartGuest sets the guest's runPolicy to Running; StopGuest sets it to
 // Stopped. Both patch spec.runPolicy via the impersonating dynamic client, so
-// the member cluster's RBAC authorizes the end user (decision D1). The
-// controller acts on the change and the live Watch reflects the new phase.
+// the member cluster's RBAC authorizes the end user (decision D1).
+//
+// StopGuest ALSO deletes the launcher pod: the SwiftGuest stop guard is
+// reactive — it prevents pod *recreation*, it does not stop a running VM — so a
+// runPolicy patch alone leaves the guest running (verified on-cluster). Deleting
+// the pod triggers swiftletd's graceful SIGTERM shutdown; the guard then keeps
+// it stopped. StartGuest needs no pod action — the controller recreates the pod
+// once runPolicy is Running. The live Watch reflects the resulting phase.
 func (s *GuestService) StartGuest(ctx context.Context, req *connect.Request[kubeswiftv1.GuestActionRequest]) (*connect.Response[kubeswiftv1.GuestActionResponse], error) {
-	return s.setRunPolicy(ctx, req, "Running")
+	return s.setRunPolicy(ctx, req, "Running", false)
 }
 
 func (s *GuestService) StopGuest(ctx context.Context, req *connect.Request[kubeswiftv1.GuestActionRequest]) (*connect.Response[kubeswiftv1.GuestActionResponse], error) {
-	return s.setRunPolicy(ctx, req, "Stopped")
+	return s.setRunPolicy(ctx, req, "Stopped", true)
 }
 
-func (s *GuestService) setRunPolicy(ctx context.Context, req *connect.Request[kubeswiftv1.GuestActionRequest], policy string) (*connect.Response[kubeswiftv1.GuestActionResponse], error) {
+func (s *GuestService) setRunPolicy(ctx context.Context, req *connect.Request[kubeswiftv1.GuestActionRequest], policy string, deleteLauncher bool) (*connect.Response[kubeswiftv1.GuestActionResponse], error) {
 	id, err := s.auth.Authenticate(ctx, req.Header())
 	if err != nil {
 		return nil, err
@@ -228,11 +235,35 @@ func (s *GuestService) setRunPolicy(ctx context.Context, req *connect.Request[ku
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
+	if deleteLauncher {
+		if err := s.deleteLauncherPods(ctx, dyn, ref); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("runPolicy patched but stopping the VM (pod delete) failed: %w", err))
+		}
+	}
 	g, err := toSwiftGuest(u)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	return connect.NewResponse(&kubeswiftv1.GuestActionResponse{Guest: guestToProto(ref.GetCluster(), g)}), nil
+}
+
+// deleteLauncherPods deletes the guest's launcher pod(s), selected by the guest
+// label (robust to the <guest>-mig-<uid> rename after a live migration). A
+// pod that is already gone is success — the VM is already stopped.
+func (s *GuestService) deleteLauncherPods(ctx context.Context, dyn dynamic.Interface, ref *kubeswiftv1.ObjectRef) error {
+	pods, err := dyn.Resource(podGVR).Namespace(ref.GetNamespace()).
+		List(ctx, metav1.ListOptions{LabelSelector: guestPodLabel + "=" + ref.GetName()})
+	if err != nil {
+		return err
+	}
+	for i := range pods.Items {
+		name := pods.Items[i].GetName()
+		if err := dyn.Resource(podGVR).Namespace(ref.GetNamespace()).
+			Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 // targetClusters resolves the selector against the registered members. An empty

--- a/internal/gateway/guest_service_test.go
+++ b/internal/gateway/guest_service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	connect "connectrpc.com/connect"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -56,13 +57,27 @@ func uGuest(ns, name, phase string) *unstructured.Unstructured {
 	}}
 }
 
+func uPod(ns, name, guest string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"namespace": ns, "name": name,
+			"labels": map[string]interface{}{guestPodLabel: guest},
+		},
+	}}
+}
+
 func fakeDyn(objs ...*unstructured.Unstructured) dynamic.Interface {
 	ro := make([]runtime.Object, len(objs))
 	for i, o := range objs {
 		ro[i] = o
 	}
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
-		map[schema.GroupVersionResource]string{swiftGuestGVR: "SwiftGuestList"}, ro...)
+		map[schema.GroupVersionResource]string{
+			swiftGuestGVR: "SwiftGuestList",
+			podGVR:        "PodList",
+		}, ro...)
 }
 
 func TestGuestService_ListGuests_FanOutMergeAndPartialError(t *testing.T) {
@@ -123,9 +138,13 @@ func TestGuestService_TargetClusters(t *testing.T) {
 }
 
 func TestGuestService_StartStopGuest(t *testing.T) {
-	boba := fakeDyn(uGuest("default", "vm-a", "Running"))
+	boba := fakeDyn(uGuest("default", "vm-a", "Running"), uPod("default", "vm-a", "vm-a"))
 	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
 	ref := &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"}
+	podCount := func() int {
+		l, _ := boba.Resource(podGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
+		return len(l.Items)
+	}
 
 	start, err := svc.StartGuest(context.Background(), connect.NewRequest(&kubeswiftv1.GuestActionRequest{Ref: ref}))
 	if err != nil {
@@ -134,9 +153,21 @@ func TestGuestService_StartStopGuest(t *testing.T) {
 	if start.Msg.Guest.GetRef().GetName() != "vm-a" {
 		t.Errorf("StartGuest returned %+v", start.Msg.Guest)
 	}
+	// StartGuest must NOT delete the launcher pod (the controller recreates a
+	// stopped one; a running one keeps running).
+	if got := podCount(); got != 1 {
+		t.Errorf("StartGuest left %d launcher pods, want 1", got)
+	}
+
 	if _, err := svc.StopGuest(context.Background(), connect.NewRequest(&kubeswiftv1.GuestActionRequest{Ref: ref})); err != nil {
 		t.Fatalf("StopGuest: %v", err)
 	}
+	// StopGuest must delete the launcher pod — the stop guard is reactive only,
+	// so a runPolicy patch alone would leave the VM running.
+	if got := podCount(); got != 0 {
+		t.Errorf("StopGuest left %d launcher pods, want 0", got)
+	}
+
 	// A missing ref is rejected, not silently a no-op.
 	if _, err := svc.StartGuest(context.Background(), connect.NewRequest(&kubeswiftv1.GuestActionRequest{})); err == nil {
 		t.Error("StartGuest with no ref should be InvalidArgument")

--- a/internal/gateway/pool.go
+++ b/internal/gateway/pool.go
@@ -31,6 +31,16 @@ var swiftGuestGVR = schema.GroupVersionResource{
 	Resource: "swiftguests",
 }
 
+// podGVR is the launcher-pod resource. StopGuest deletes the launcher pod (by
+// the guest label below) after patching runPolicy, because the SwiftGuest stop
+// guard is reactive only — it prevents pod recreation, it does not stop a
+// running VM.
+var podGVR = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+
+// guestPodLabel ties a launcher pod to its SwiftGuest. The label (not the pod
+// name) is the stable handle — a live-migrated guest's pod is <guest>-mig-<uid>.
+const guestPodLabel = "swift.kubeswift.io/guest"
+
 // ClientPool watches the hub's fleet.Cluster registry and maintains a base REST
 // config per member cluster, built from the member's credential Secret. It
 // hands out per-request dynamic clients that impersonate the end user (D1). On


### PR DESCRIPTION
Follow-up to #266, caught by **cluster validation** on `ft-vm`.

## The bug

`StopGuest` patched `swiftguests.spec.runPolicy: Stopped` and returned — but the VM **kept running** (phase=Running, launcher pod up, 60s+). The SwiftGuest **stop guard is reactive**: it blocks pod *recreation*, it does not delete a running launcher pod. A runPolicy patch alone never stops a running VM — the same lesson as Live Migration Phase 1's Preparing phase, and exactly what `swiftctl stop` does (patch **+** pod delete).

The fake-client unit test only saw the patch land (the recurring **W5 pattern** — unit tests verify control flow, the cluster verifies behavior).

## Fix

`StopGuest` now deletes the launcher pod(s) — selected by the `swift.kubeswift.io/guest` label (robust to the `<guest>-mig-<uid>` rename) — after patching runPolicy. The delete triggers swiftletd's graceful SIGTERM shutdown; the guard then keeps it stopped. `StartGuest` is unchanged (controller recreates the pod once runPolicy is Running; a missing pod on delete is success).

- **RBAC**: acting subjects now also need `delete` on `pods` (member-rbac sample + gateway.md security note updated).
- **Test**: seeds a launcher pod, asserts `StopGuest` deletes it and `StartGuest` keeps it.

`go test ./...`, `buf lint`, `gofmt` green. StartGuest + StopGuest's runPolicy patch were already cluster-validated on `ft-vm` (Running→runPolicy=Stopped, and back); this PR makes Stop actually stop the VM, re-validated after merge+redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)