### PR TITLE
feat(gateway): telemetry plane — GetGuestMetrics CPU/mem/net (UI backend P1)

### DIFF
--- a/cmd/kubeswift-gateway/main.go
+++ b/cmd/kubeswift-gateway/main.go
@@ -89,9 +89,10 @@ func main() {
 	guestSvc := gateway.NewGuestService(pool, auth)
 	guestPath, guestHandler := kubeswiftv1connect.NewGuestServiceHandler(guestSvc)
 
-	// Telemetry + Console are P0 stubs (return CodeUnimplemented) so the UI can
-	// build its client against the full service set; they are implemented in P1.
-	telPath, telHandler := kubeswiftv1connect.NewTelemetryServiceHandler(kubeswiftv1connect.UnimplementedTelemetryServiceHandler{})
+	// Telemetry (P1): per-VM range metrics from each member's Prometheus.
+	telSvc := gateway.NewTelemetryService(pool, auth)
+	telPath, telHandler := kubeswiftv1connect.NewTelemetryServiceHandler(telSvc)
+	// Console stays a P0 stub (CodeUnimplemented) until the console plane lands.
 	conPath, conHandler := kubeswiftv1connect.NewConsoleServiceHandler(kubeswiftv1connect.UnimplementedConsoleServiceHandler{})
 
 	srv := &gateway.Server{

--- a/gen/kubeswift/v1/kubeswiftv1connect/telemetry.connect.go
+++ b/gen/kubeswift/v1/kubeswiftv1connect/telemetry.connect.go
@@ -33,14 +33,14 @@ const (
 // reflection-formatted method names, remove the leading slash and convert the remaining slash to a
 // period.
 const (
-	// TelemetryServiceStreamVMMetricsProcedure is the fully-qualified name of the TelemetryService's
-	// StreamVMMetrics RPC.
-	TelemetryServiceStreamVMMetricsProcedure = "/kubeswift.v1.TelemetryService/StreamVMMetrics"
+	// TelemetryServiceGetGuestMetricsProcedure is the fully-qualified name of the TelemetryService's
+	// GetGuestMetrics RPC.
+	TelemetryServiceGetGuestMetricsProcedure = "/kubeswift.v1.TelemetryService/GetGuestMetrics"
 )
 
 // TelemetryServiceClient is a client for the kubeswift.v1.TelemetryService service.
 type TelemetryServiceClient interface {
-	StreamVMMetrics(context.Context, *connect.Request[v1.StreamVMMetricsRequest]) (*connect.ServerStreamForClient[v1.VMMetricSample], error)
+	GetGuestMetrics(context.Context, *connect.Request[v1.GetGuestMetricsRequest]) (*connect.Response[v1.GetGuestMetricsResponse], error)
 }
 
 // NewTelemetryServiceClient constructs a client for the kubeswift.v1.TelemetryService service. By
@@ -54,10 +54,10 @@ func NewTelemetryServiceClient(httpClient connect.HTTPClient, baseURL string, op
 	baseURL = strings.TrimRight(baseURL, "/")
 	telemetryServiceMethods := v1.File_kubeswift_v1_telemetry_proto.Services().ByName("TelemetryService").Methods()
 	return &telemetryServiceClient{
-		streamVMMetrics: connect.NewClient[v1.StreamVMMetricsRequest, v1.VMMetricSample](
+		getGuestMetrics: connect.NewClient[v1.GetGuestMetricsRequest, v1.GetGuestMetricsResponse](
 			httpClient,
-			baseURL+TelemetryServiceStreamVMMetricsProcedure,
-			connect.WithSchema(telemetryServiceMethods.ByName("StreamVMMetrics")),
+			baseURL+TelemetryServiceGetGuestMetricsProcedure,
+			connect.WithSchema(telemetryServiceMethods.ByName("GetGuestMetrics")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -65,17 +65,17 @@ func NewTelemetryServiceClient(httpClient connect.HTTPClient, baseURL string, op
 
 // telemetryServiceClient implements TelemetryServiceClient.
 type telemetryServiceClient struct {
-	streamVMMetrics *connect.Client[v1.StreamVMMetricsRequest, v1.VMMetricSample]
+	getGuestMetrics *connect.Client[v1.GetGuestMetricsRequest, v1.GetGuestMetricsResponse]
 }
 
-// StreamVMMetrics calls kubeswift.v1.TelemetryService.StreamVMMetrics.
-func (c *telemetryServiceClient) StreamVMMetrics(ctx context.Context, req *connect.Request[v1.StreamVMMetricsRequest]) (*connect.ServerStreamForClient[v1.VMMetricSample], error) {
-	return c.streamVMMetrics.CallServerStream(ctx, req)
+// GetGuestMetrics calls kubeswift.v1.TelemetryService.GetGuestMetrics.
+func (c *telemetryServiceClient) GetGuestMetrics(ctx context.Context, req *connect.Request[v1.GetGuestMetricsRequest]) (*connect.Response[v1.GetGuestMetricsResponse], error) {
+	return c.getGuestMetrics.CallUnary(ctx, req)
 }
 
 // TelemetryServiceHandler is an implementation of the kubeswift.v1.TelemetryService service.
 type TelemetryServiceHandler interface {
-	StreamVMMetrics(context.Context, *connect.Request[v1.StreamVMMetricsRequest], *connect.ServerStream[v1.VMMetricSample]) error
+	GetGuestMetrics(context.Context, *connect.Request[v1.GetGuestMetricsRequest]) (*connect.Response[v1.GetGuestMetricsResponse], error)
 }
 
 // NewTelemetryServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -85,16 +85,16 @@ type TelemetryServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewTelemetryServiceHandler(svc TelemetryServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	telemetryServiceMethods := v1.File_kubeswift_v1_telemetry_proto.Services().ByName("TelemetryService").Methods()
-	telemetryServiceStreamVMMetricsHandler := connect.NewServerStreamHandler(
-		TelemetryServiceStreamVMMetricsProcedure,
-		svc.StreamVMMetrics,
-		connect.WithSchema(telemetryServiceMethods.ByName("StreamVMMetrics")),
+	telemetryServiceGetGuestMetricsHandler := connect.NewUnaryHandler(
+		TelemetryServiceGetGuestMetricsProcedure,
+		svc.GetGuestMetrics,
+		connect.WithSchema(telemetryServiceMethods.ByName("GetGuestMetrics")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/kubeswift.v1.TelemetryService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case TelemetryServiceStreamVMMetricsProcedure:
-			telemetryServiceStreamVMMetricsHandler.ServeHTTP(w, r)
+		case TelemetryServiceGetGuestMetricsProcedure:
+			telemetryServiceGetGuestMetricsHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -104,6 +104,6 @@ func NewTelemetryServiceHandler(svc TelemetryServiceHandler, opts ...connect.Han
 // UnimplementedTelemetryServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedTelemetryServiceHandler struct{}
 
-func (UnimplementedTelemetryServiceHandler) StreamVMMetrics(context.Context, *connect.Request[v1.StreamVMMetricsRequest], *connect.ServerStream[v1.VMMetricSample]) error {
-	return connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.TelemetryService.StreamVMMetrics is not implemented"))
+func (UnimplementedTelemetryServiceHandler) GetGuestMetrics(context.Context, *connect.Request[v1.GetGuestMetricsRequest]) (*connect.Response[v1.GetGuestMetricsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.TelemetryService.GetGuestMetrics is not implemented"))
 }

--- a/gen/kubeswift/v1/telemetry.pb.go
+++ b/gen/kubeswift/v1/telemetry.pb.go
@@ -22,34 +22,36 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// StreamVMMetricsRequest asks for a live metric stream for one guest. The
-// gateway resolves the guest's member cluster (ref.cluster), queries that
-// member's Prometheus, and joins on the swift.kubeswift.io/guest label
-// (decision D4). Stubbed in P0; implemented in P1.
-type StreamVMMetricsRequest struct {
+// GetGuestMetricsRequest asks for one guest's recent resource usage as range
+// series for charting. The gateway resolves the guest's current launcher pod
+// on its member cluster (ref.cluster) and range-queries that member's
+// Prometheus (cAdvisor; O5 swiftletd vm.counters in v2 — decision D4). The
+// launcher cgroup is the VM (Cloud Hypervisor runs in it).
+type GetGuestMetricsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	Guest *ObjectRef             `protobuf:"bytes,1,opt,name=guest,proto3" json:"guest,omitempty"`
-	// metrics names the series the UI charts (e.g. "cpu", "mem", "disk_io",
-	// "net"); empty requests a default set.
-	Metrics       []string `protobuf:"bytes,2,rep,name=metrics,proto3" json:"metrics,omitempty"`
+	Ref   *ObjectRef             `protobuf:"bytes,1,opt,name=ref,proto3" json:"ref,omitempty"`
+	// WindowSeconds is the look-back duration; default 900 (15m).
+	WindowSeconds int32 `protobuf:"varint,2,opt,name=window_seconds,json=windowSeconds,proto3" json:"window_seconds,omitempty"`
+	// StepSeconds is the sample interval; default 30.
+	StepSeconds   int32 `protobuf:"varint,3,opt,name=step_seconds,json=stepSeconds,proto3" json:"step_seconds,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *StreamVMMetricsRequest) Reset() {
-	*x = StreamVMMetricsRequest{}
+func (x *GetGuestMetricsRequest) Reset() {
+	*x = GetGuestMetricsRequest{}
 	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *StreamVMMetricsRequest) String() string {
+func (x *GetGuestMetricsRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*StreamVMMetricsRequest) ProtoMessage() {}
+func (*GetGuestMetricsRequest) ProtoMessage() {}
 
-func (x *StreamVMMetricsRequest) ProtoReflect() protoreflect.Message {
+func (x *GetGuestMetricsRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -61,50 +63,55 @@ func (x *StreamVMMetricsRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use StreamVMMetricsRequest.ProtoReflect.Descriptor instead.
-func (*StreamVMMetricsRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use GetGuestMetricsRequest.ProtoReflect.Descriptor instead.
+func (*GetGuestMetricsRequest) Descriptor() ([]byte, []int) {
 	return file_kubeswift_v1_telemetry_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *StreamVMMetricsRequest) GetGuest() *ObjectRef {
+func (x *GetGuestMetricsRequest) GetRef() *ObjectRef {
 	if x != nil {
-		return x.Guest
+		return x.Ref
 	}
 	return nil
 }
 
-func (x *StreamVMMetricsRequest) GetMetrics() []string {
+func (x *GetGuestMetricsRequest) GetWindowSeconds() int32 {
 	if x != nil {
-		return x.Metrics
+		return x.WindowSeconds
 	}
-	return nil
+	return 0
 }
 
-// VMMetricSample is one point on one series, tagged with its cluster.
-type VMMetricSample struct {
+func (x *GetGuestMetricsRequest) GetStepSeconds() int32 {
+	if x != nil {
+		return x.StepSeconds
+	}
+	return 0
+}
+
+// MetricPoint is one sample on one series.
+type MetricPoint struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Cluster       string                 `protobuf:"bytes,1,opt,name=cluster,proto3" json:"cluster,omitempty"`
-	Metric        string                 `protobuf:"bytes,2,opt,name=metric,proto3" json:"metric,omitempty"`
-	Value         float64                `protobuf:"fixed64,3,opt,name=value,proto3" json:"value,omitempty"`
-	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Ts            *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=ts,proto3" json:"ts,omitempty"`
+	Value         float64                `protobuf:"fixed64,2,opt,name=value,proto3" json:"value,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *VMMetricSample) Reset() {
-	*x = VMMetricSample{}
+func (x *MetricPoint) Reset() {
+	*x = MetricPoint{}
 	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *VMMetricSample) String() string {
+func (x *MetricPoint) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*VMMetricSample) ProtoMessage() {}
+func (*MetricPoint) ProtoMessage() {}
 
-func (x *VMMetricSample) ProtoReflect() protoreflect.Message {
+func (x *MetricPoint) ProtoReflect() protoreflect.Message {
 	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -116,35 +123,141 @@ func (x *VMMetricSample) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use VMMetricSample.ProtoReflect.Descriptor instead.
-func (*VMMetricSample) Descriptor() ([]byte, []int) {
+// Deprecated: Use MetricPoint.ProtoReflect.Descriptor instead.
+func (*MetricPoint) Descriptor() ([]byte, []int) {
 	return file_kubeswift_v1_telemetry_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *VMMetricSample) GetCluster() string {
+func (x *MetricPoint) GetTs() *timestamppb.Timestamp {
 	if x != nil {
-		return x.Cluster
+		return x.Ts
 	}
-	return ""
+	return nil
 }
 
-func (x *VMMetricSample) GetMetric() string {
-	if x != nil {
-		return x.Metric
-	}
-	return ""
-}
-
-func (x *VMMetricSample) GetValue() float64 {
+func (x *MetricPoint) GetValue() float64 {
 	if x != nil {
 		return x.Value
 	}
 	return 0
 }
 
-func (x *VMMetricSample) GetTimestamp() *timestamppb.Timestamp {
+// MetricSeries is one named series over the window.
+type MetricSeries struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Kind: cpu_cores | memory_bytes | net_rx_bps | net_tx_bps.
+	Kind string `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
+	// Unit: cores | bytes | bytes/sec — a UI formatting hint.
+	Unit          string         `protobuf:"bytes,2,opt,name=unit,proto3" json:"unit,omitempty"`
+	Points        []*MetricPoint `protobuf:"bytes,3,rep,name=points,proto3" json:"points,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MetricSeries) Reset() {
+	*x = MetricSeries{}
+	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MetricSeries) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MetricSeries) ProtoMessage() {}
+
+func (x *MetricSeries) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[2]
 	if x != nil {
-		return x.Timestamp
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MetricSeries.ProtoReflect.Descriptor instead.
+func (*MetricSeries) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_telemetry_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *MetricSeries) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *MetricSeries) GetUnit() string {
+	if x != nil {
+		return x.Unit
+	}
+	return ""
+}
+
+func (x *MetricSeries) GetPoints() []*MetricPoint {
+	if x != nil {
+		return x.Points
+	}
+	return nil
+}
+
+// GetGuestMetricsResponse carries the series, or an error when the member's
+// Prometheus is unconfigured/unreachable (never a silent empty chart).
+type GetGuestMetricsResponse struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Series []*MetricSeries        `protobuf:"bytes,1,rep,name=series,proto3" json:"series,omitempty"`
+	// Error is set (and series empty) when telemetry could not be sourced —
+	// e.g. no prometheusEndpoint registered for the cluster, or it was
+	// unreachable. The cluster field carries ref.cluster.
+	Error         *ClusterError `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetGuestMetricsResponse) Reset() {
+	*x = GetGuestMetricsResponse{}
+	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetGuestMetricsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetGuestMetricsResponse) ProtoMessage() {}
+
+func (x *GetGuestMetricsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetGuestMetricsResponse.ProtoReflect.Descriptor instead.
+func (*GetGuestMetricsResponse) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_telemetry_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *GetGuestMetricsResponse) GetSeries() []*MetricSeries {
+	if x != nil {
+		return x.Series
+	}
+	return nil
+}
+
+func (x *GetGuestMetricsResponse) GetError() *ClusterError {
+	if x != nil {
+		return x.Error
 	}
 	return nil
 }
@@ -153,17 +266,23 @@ var File_kubeswift_v1_telemetry_proto protoreflect.FileDescriptor
 
 const file_kubeswift_v1_telemetry_proto_rawDesc = "" +
 	"\n" +
-	"\x1ckubeswift/v1/telemetry.proto\x12\fkubeswift.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x19kubeswift/v1/common.proto\"a\n" +
-	"\x16StreamVMMetricsRequest\x12-\n" +
-	"\x05guest\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\x05guest\x12\x18\n" +
-	"\ametrics\x18\x02 \x03(\tR\ametrics\"\x92\x01\n" +
-	"\x0eVMMetricSample\x12\x18\n" +
-	"\acluster\x18\x01 \x01(\tR\acluster\x12\x16\n" +
-	"\x06metric\x18\x02 \x01(\tR\x06metric\x12\x14\n" +
-	"\x05value\x18\x03 \x01(\x01R\x05value\x128\n" +
-	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp2k\n" +
-	"\x10TelemetryService\x12W\n" +
-	"\x0fStreamVMMetrics\x12$.kubeswift.v1.StreamVMMetricsRequest\x1a\x1c.kubeswift.v1.VMMetricSample0\x01BAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
+	"\x1ckubeswift/v1/telemetry.proto\x12\fkubeswift.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x19kubeswift/v1/common.proto\"\x8d\x01\n" +
+	"\x16GetGuestMetricsRequest\x12)\n" +
+	"\x03ref\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\x03ref\x12%\n" +
+	"\x0ewindow_seconds\x18\x02 \x01(\x05R\rwindowSeconds\x12!\n" +
+	"\fstep_seconds\x18\x03 \x01(\x05R\vstepSeconds\"O\n" +
+	"\vMetricPoint\x12*\n" +
+	"\x02ts\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x02ts\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\x01R\x05value\"i\n" +
+	"\fMetricSeries\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x12\n" +
+	"\x04unit\x18\x02 \x01(\tR\x04unit\x121\n" +
+	"\x06points\x18\x03 \x03(\v2\x19.kubeswift.v1.MetricPointR\x06points\"\x7f\n" +
+	"\x17GetGuestMetricsResponse\x122\n" +
+	"\x06series\x18\x01 \x03(\v2\x1a.kubeswift.v1.MetricSeriesR\x06series\x120\n" +
+	"\x05error\x18\x02 \x01(\v2\x1a.kubeswift.v1.ClusterErrorR\x05error2r\n" +
+	"\x10TelemetryService\x12^\n" +
+	"\x0fGetGuestMetrics\x12$.kubeswift.v1.GetGuestMetricsRequest\x1a%.kubeswift.v1.GetGuestMetricsResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
 
 var (
 	file_kubeswift_v1_telemetry_proto_rawDescOnce sync.Once
@@ -177,23 +296,29 @@ func file_kubeswift_v1_telemetry_proto_rawDescGZIP() []byte {
 	return file_kubeswift_v1_telemetry_proto_rawDescData
 }
 
-var file_kubeswift_v1_telemetry_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_kubeswift_v1_telemetry_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_kubeswift_v1_telemetry_proto_goTypes = []any{
-	(*StreamVMMetricsRequest)(nil), // 0: kubeswift.v1.StreamVMMetricsRequest
-	(*VMMetricSample)(nil),         // 1: kubeswift.v1.VMMetricSample
-	(*ObjectRef)(nil),              // 2: kubeswift.v1.ObjectRef
-	(*timestamppb.Timestamp)(nil),  // 3: google.protobuf.Timestamp
+	(*GetGuestMetricsRequest)(nil),  // 0: kubeswift.v1.GetGuestMetricsRequest
+	(*MetricPoint)(nil),             // 1: kubeswift.v1.MetricPoint
+	(*MetricSeries)(nil),            // 2: kubeswift.v1.MetricSeries
+	(*GetGuestMetricsResponse)(nil), // 3: kubeswift.v1.GetGuestMetricsResponse
+	(*ObjectRef)(nil),               // 4: kubeswift.v1.ObjectRef
+	(*timestamppb.Timestamp)(nil),   // 5: google.protobuf.Timestamp
+	(*ClusterError)(nil),            // 6: kubeswift.v1.ClusterError
 }
 var file_kubeswift_v1_telemetry_proto_depIdxs = []int32{
-	2, // 0: kubeswift.v1.StreamVMMetricsRequest.guest:type_name -> kubeswift.v1.ObjectRef
-	3, // 1: kubeswift.v1.VMMetricSample.timestamp:type_name -> google.protobuf.Timestamp
-	0, // 2: kubeswift.v1.TelemetryService.StreamVMMetrics:input_type -> kubeswift.v1.StreamVMMetricsRequest
-	1, // 3: kubeswift.v1.TelemetryService.StreamVMMetrics:output_type -> kubeswift.v1.VMMetricSample
-	3, // [3:4] is the sub-list for method output_type
-	2, // [2:3] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	4, // 0: kubeswift.v1.GetGuestMetricsRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	5, // 1: kubeswift.v1.MetricPoint.ts:type_name -> google.protobuf.Timestamp
+	1, // 2: kubeswift.v1.MetricSeries.points:type_name -> kubeswift.v1.MetricPoint
+	2, // 3: kubeswift.v1.GetGuestMetricsResponse.series:type_name -> kubeswift.v1.MetricSeries
+	6, // 4: kubeswift.v1.GetGuestMetricsResponse.error:type_name -> kubeswift.v1.ClusterError
+	0, // 5: kubeswift.v1.TelemetryService.GetGuestMetrics:input_type -> kubeswift.v1.GetGuestMetricsRequest
+	3, // 6: kubeswift.v1.TelemetryService.GetGuestMetrics:output_type -> kubeswift.v1.GetGuestMetricsResponse
+	6, // [6:7] is the sub-list for method output_type
+	5, // [5:6] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_kubeswift_v1_telemetry_proto_init() }
@@ -208,7 +333,7 @@ func file_kubeswift_v1_telemetry_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kubeswift_v1_telemetry_proto_rawDesc), len(file_kubeswift_v1_telemetry_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/gateway/guest_service_test.go
+++ b/internal/gateway/guest_service_test.go
@@ -17,10 +17,16 @@ import (
 )
 
 // fakeProvider stands in for the ClientPool: a fake dynamic client per member,
-// plus members whose client construction fails (the unreachable case).
+// plus members whose client construction fails (the unreachable case), and an
+// optional per-member Prometheus endpoint (telemetry plane).
 type fakeProvider struct {
 	clients map[string]dynamic.Interface
 	errs    map[string]error
+	prom    map[string]string
+}
+
+func (f *fakeProvider) PrometheusEndpoint(cluster string) string {
+	return f.prom[cluster]
 }
 
 func (f *fakeProvider) DynamicFor(cluster string, _ Identity) (dynamic.Interface, error) {

--- a/internal/gateway/pool.go
+++ b/internal/gateway/pool.go
@@ -185,6 +185,17 @@ func (p *ClientPool) Members() []string {
 	return names
 }
 
+// PrometheusEndpoint returns the member's registered Prometheus base URL, or ""
+// if the cluster is unknown or has no prometheusEndpoint configured.
+func (p *ClientPool) PrometheusEndpoint(cluster string) string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if m, ok := p.members[cluster]; ok {
+		return m.prometheus
+	}
+	return ""
+}
+
 func serverVersion(cfg *rest.Config) (string, error) {
 	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {

--- a/internal/gateway/telemetry_service.go
+++ b/internal/gateway/telemetry_service.go
@@ -1,0 +1,193 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	connect "connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+
+	kubeswiftv1 "github.com/projectbeskar/kubeswift/gen/kubeswift/v1"
+	"github.com/projectbeskar/kubeswift/gen/kubeswift/v1/kubeswiftv1connect"
+)
+
+// metricsProvider is the subset of ClientPool the telemetry plane needs: the
+// member's impersonating client (to resolve the guest's launcher pod, which
+// also authorizes the caller) and the member's Prometheus base URL.
+type metricsProvider interface {
+	DynamicFor(cluster string, id Identity) (dynamic.Interface, error)
+	PrometheusEndpoint(cluster string) string
+}
+
+// TelemetryService serves per-VM range metrics. It resolves the guest's current
+// launcher pod (by the swift.kubeswift.io/guest label — robust to the
+// <guest>-mig-<uid> rename) and range-queries the member cluster's Prometheus
+// (cAdvisor). The launcher cgroup IS the VM — Cloud Hypervisor runs in it.
+//
+// It queries by the resolved pod name rather than joining kube-state-metrics on
+// the guest label, so it needs no KSM metric-labels allowlist. The trade-off is
+// that history does not span a live migration's pod rename; that continuity is a
+// v2 upgrade (KSM allowlist + label join).
+type TelemetryService struct {
+	kubeswiftv1connect.UnimplementedTelemetryServiceHandler
+	pool metricsProvider
+	auth Authenticator
+	http *http.Client
+}
+
+func NewTelemetryService(pool metricsProvider, auth Authenticator) *TelemetryService {
+	return &TelemetryService{pool: pool, auth: auth, http: &http.Client{Timeout: 15 * time.Second}}
+}
+
+// promSeries pairs a metric kind/unit with the PromQL that computes it.
+type promSeries struct {
+	kind, unit, query string
+}
+
+func (s *TelemetryService) GetGuestMetrics(ctx context.Context, req *connect.Request[kubeswiftv1.GetGuestMetricsRequest]) (*connect.Response[kubeswiftv1.GetGuestMetricsResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	ref := req.Msg.GetRef()
+	if ref == nil || ref.GetCluster() == "" || ref.GetName() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("ref.cluster and ref.name are required"))
+	}
+
+	endpoint := strings.TrimRight(s.pool.PrometheusEndpoint(ref.GetCluster()), "/")
+	if endpoint == "" {
+		// No silent empty chart — say why telemetry is unavailable.
+		return clusterMetricsErr(ref.GetCluster(), "no prometheusEndpoint registered for this cluster"), nil
+	}
+
+	// Resolve the guest's current launcher pod(s) by label (authz via the
+	// impersonating client — the caller can only chart pods it may list).
+	dyn, err := s.pool.DynamicFor(ref.GetCluster(), id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	pods, err := dyn.Resource(podGVR).Namespace(ref.GetNamespace()).
+		List(ctx, metav1.ListOptions{LabelSelector: guestPodLabel + "=" + ref.GetName()})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	if len(pods.Items) == 0 {
+		// Stopped guest — no pod, no series. Not an error.
+		return connect.NewResponse(&kubeswiftv1.GetGuestMetricsResponse{}), nil
+	}
+	names := make([]string, 0, len(pods.Items))
+	for i := range pods.Items {
+		names = append(names, pods.Items[i].GetName())
+	}
+	podRe := strings.Join(names, "|")
+	ns := ref.GetNamespace()
+	const rateWin = "2m"
+
+	window := time.Duration(orDefaultInt32(req.Msg.GetWindowSeconds(), 900)) * time.Second
+	step := time.Duration(orDefaultInt32(req.Msg.GetStepSeconds(), 30)) * time.Second
+	end := time.Now()
+	start := end.Add(-window)
+
+	defs := []promSeries{
+		{"cpu_cores", "cores", fmt.Sprintf(`sum(rate(container_cpu_usage_seconds_total{namespace="%s",pod=~"%s",container!=""}[%s]))`, ns, podRe, rateWin)},
+		{"memory_bytes", "bytes", fmt.Sprintf(`sum(container_memory_working_set_bytes{namespace="%s",pod=~"%s",container!=""})`, ns, podRe)},
+		{"net_rx_bps", "bytes/sec", fmt.Sprintf(`sum(rate(container_network_receive_bytes_total{namespace="%s",pod=~"%s"}[%s]))`, ns, podRe, rateWin)},
+		{"net_tx_bps", "bytes/sec", fmt.Sprintf(`sum(rate(container_network_transmit_bytes_total{namespace="%s",pod=~"%s"}[%s]))`, ns, podRe, rateWin)},
+	}
+
+	out := &kubeswiftv1.GetGuestMetricsResponse{}
+	for _, d := range defs {
+		pts, err := s.queryRange(ctx, endpoint, d.query, start, end, step)
+		if err != nil {
+			return clusterMetricsErr(ref.GetCluster(), fmt.Sprintf("prometheus query failed: %v", err)), nil
+		}
+		out.Series = append(out.Series, &kubeswiftv1.MetricSeries{Kind: d.kind, Unit: d.unit, Points: pts})
+	}
+	return connect.NewResponse(out), nil
+}
+
+// queryRange runs one Prometheus query_range and flattens the (single,
+// aggregated) result series into points.
+func (s *TelemetryService) queryRange(ctx context.Context, endpoint, query string, start, end time.Time, step time.Duration) ([]*kubeswiftv1.MetricPoint, error) {
+	q := url.Values{}
+	q.Set("query", query)
+	q.Set("start", strconv.FormatInt(start.Unix(), 10))
+	q.Set("end", strconv.FormatInt(end.Unix(), 10))
+	q.Set("step", strconv.Itoa(int(step.Seconds())))
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/api/v1/query_range?"+q.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.http.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("prometheus returned %s", resp.Status)
+	}
+	var pr promRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return nil, err
+	}
+	if pr.Status != "success" {
+		return nil, fmt.Errorf("prometheus status %q", pr.Status)
+	}
+	var pts []*kubeswiftv1.MetricPoint
+	for _, res := range pr.Data.Result {
+		for _, v := range res.Values {
+			if len(v) != 2 {
+				continue
+			}
+			tsF, ok := v[0].(float64)
+			if !ok {
+				continue
+			}
+			valS, ok := v[1].(string)
+			if !ok {
+				continue
+			}
+			f, err := strconv.ParseFloat(valS, 64)
+			if err != nil {
+				continue // NaN / Inf — skip the point, don't fail the chart
+			}
+			pts = append(pts, &kubeswiftv1.MetricPoint{Ts: timestamppb.New(time.Unix(int64(tsF), 0)), Value: f})
+		}
+	}
+	return pts, nil
+}
+
+// promRangeResponse is the subset of Prometheus' query_range JSON we consume.
+type promRangeResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string `json:"resultType"`
+		Result     []struct {
+			Metric map[string]string `json:"metric"`
+			Values [][]interface{}   `json:"values"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+func orDefaultInt32(v, def int32) int32 {
+	if v <= 0 {
+		return def
+	}
+	return v
+}
+
+func clusterMetricsErr(cluster, msg string) *connect.Response[kubeswiftv1.GetGuestMetricsResponse] {
+	return connect.NewResponse(&kubeswiftv1.GetGuestMetricsResponse{
+		Error: &kubeswiftv1.ClusterError{Cluster: cluster, Message: msg},
+	})
+}

--- a/internal/gateway/telemetry_service_test.go
+++ b/internal/gateway/telemetry_service_test.go
@@ -1,0 +1,99 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	connect "connectrpc.com/connect"
+	"k8s.io/client-go/dynamic"
+
+	kubeswiftv1 "github.com/projectbeskar/kubeswift/gen/kubeswift/v1"
+)
+
+// fakeProm serves a Prometheus query_range matrix with two points.
+func fakeProm() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/query_range" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[{"metric":{},"values":[[1700000000,"0.5"],[1700000030,"0.7"]]}]}}`))
+	}))
+}
+
+func TestTelemetryService_GetGuestMetrics(t *testing.T) {
+	prom := fakeProm()
+	defer prom.Close()
+	boba := fakeDyn(uGuest("default", "vm-a", "Running"), uPod("default", "vm-a", "vm-a"))
+	prov := &fakeProvider{
+		clients: map[string]dynamic.Interface{"boba": boba},
+		prom:    map[string]string{"boba": prom.URL},
+	}
+	svc := NewTelemetryService(prov, NewInsecureAuthenticator())
+
+	resp, err := svc.GetGuestMetrics(context.Background(), connect.NewRequest(&kubeswiftv1.GetGuestMetricsRequest{
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+	}))
+	if err != nil {
+		t.Fatalf("GetGuestMetrics: %v", err)
+	}
+	if resp.Msg.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Msg.Error)
+	}
+	if len(resp.Msg.Series) != 4 {
+		t.Fatalf("want 4 series (cpu/mem/rx/tx), got %d", len(resp.Msg.Series))
+	}
+	kinds := map[string]bool{}
+	for _, s := range resp.Msg.Series {
+		kinds[s.Kind] = true
+		if len(s.Points) != 2 {
+			t.Errorf("series %q: want 2 points, got %d", s.Kind, len(s.Points))
+		}
+	}
+	for _, k := range []string{"cpu_cores", "memory_bytes", "net_rx_bps", "net_tx_bps"} {
+		if !kinds[k] {
+			t.Errorf("missing series %q", k)
+		}
+	}
+}
+
+func TestTelemetryService_NoEndpoint(t *testing.T) {
+	boba := fakeDyn(uGuest("default", "vm-a", "Running"), uPod("default", "vm-a", "vm-a"))
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}} // no prom endpoint
+	svc := NewTelemetryService(prov, NewInsecureAuthenticator())
+
+	resp, err := svc.GetGuestMetrics(context.Background(), connect.NewRequest(&kubeswiftv1.GetGuestMetricsRequest{
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+	}))
+	if err != nil {
+		t.Fatalf("GetGuestMetrics: %v", err)
+	}
+	// No silent empty chart: an unconfigured endpoint surfaces as a cluster error.
+	if resp.Msg.Error == nil || resp.Msg.Error.Cluster != "boba" {
+		t.Errorf("want a cluster error for the missing endpoint, got %+v", resp.Msg.Error)
+	}
+}
+
+func TestTelemetryService_StoppedGuestNoPod(t *testing.T) {
+	prom := fakeProm()
+	defer prom.Close()
+	boba := fakeDyn(uGuest("default", "vm-a", "Stopped")) // no launcher pod
+	prov := &fakeProvider{
+		clients: map[string]dynamic.Interface{"boba": boba},
+		prom:    map[string]string{"boba": prom.URL},
+	}
+	svc := NewTelemetryService(prov, NewInsecureAuthenticator())
+
+	resp, err := svc.GetGuestMetrics(context.Background(), connect.NewRequest(&kubeswiftv1.GetGuestMetricsRequest{
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+	}))
+	if err != nil {
+		t.Fatalf("GetGuestMetrics: %v", err)
+	}
+	if len(resp.Msg.Series) != 0 || resp.Msg.Error != nil {
+		t.Errorf("stopped guest should yield empty series + no error, got series=%d err=%v", len(resp.Msg.Series), resp.Msg.Error)
+	}
+}

--- a/proto/kubeswift/v1/telemetry.proto
+++ b/proto/kubeswift/v1/telemetry.proto
@@ -7,27 +7,46 @@ import "kubeswift/v1/common.proto";
 
 option go_package = "github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1";
 
-// StreamVMMetricsRequest asks for a live metric stream for one guest. The
-// gateway resolves the guest's member cluster (ref.cluster), queries that
-// member's Prometheus, and joins on the swift.kubeswift.io/guest label
-// (decision D4). Stubbed in P0; implemented in P1.
-message StreamVMMetricsRequest {
-  ObjectRef guest = 1;
-  // metrics names the series the UI charts (e.g. "cpu", "mem", "disk_io",
-  // "net"); empty requests a default set.
-  repeated string metrics = 2;
+// GetGuestMetricsRequest asks for one guest's recent resource usage as range
+// series for charting. The gateway resolves the guest's current launcher pod
+// on its member cluster (ref.cluster) and range-queries that member's
+// Prometheus (cAdvisor; O5 swiftletd vm.counters in v2 — decision D4). The
+// launcher cgroup is the VM (Cloud Hypervisor runs in it).
+message GetGuestMetricsRequest {
+  ObjectRef ref = 1;
+  // WindowSeconds is the look-back duration; default 900 (15m).
+  int32 window_seconds = 2;
+  // StepSeconds is the sample interval; default 30.
+  int32 step_seconds = 3;
 }
 
-// VMMetricSample is one point on one series, tagged with its cluster.
-message VMMetricSample {
-  string cluster = 1;
-  string metric = 2;
-  double value = 3;
-  google.protobuf.Timestamp timestamp = 4;
+// MetricPoint is one sample on one series.
+message MetricPoint {
+  google.protobuf.Timestamp ts = 1;
+  double value = 2;
 }
 
-// TelemetryService streams per-VM telemetry sourced from each member's
+// MetricSeries is one named series over the window.
+message MetricSeries {
+  // Kind: cpu_cores | memory_bytes | net_rx_bps | net_tx_bps.
+  string kind = 1;
+  // Unit: cores | bytes | bytes/sec — a UI formatting hint.
+  string unit = 2;
+  repeated MetricPoint points = 3;
+}
+
+// GetGuestMetricsResponse carries the series, or an error when the member's
+// Prometheus is unconfigured/unreachable (never a silent empty chart).
+message GetGuestMetricsResponse {
+  repeated MetricSeries series = 1;
+  // Error is set (and series empty) when telemetry could not be sourced —
+  // e.g. no prometheusEndpoint registered for the cluster, or it was
+  // unreachable. The cluster field carries ref.cluster.
+  ClusterError error = 2;
+}
+
+// TelemetryService serves per-VM telemetry sourced from each member's
 // Prometheus (cAdvisor today, O5 swiftletd vm.counters in v2 — decision D4).
 service TelemetryService {
-  rpc StreamVMMetrics(StreamVMMetricsRequest) returns (stream VMMetricSample);
+  rpc GetGuestMetrics(GetGuestMetricsRequest) returns (GetGuestMetricsResponse);
 }


### PR DESCRIPTION
The telemetry plane (design [`docs/design/ui-backend-enablement.md`](docs/design/ui-backend-enablement.md) D4) — per-VM CPU/memory/network for the UI's drawer charts.

## What

`TelemetryService.GetGuestMetrics(ref, windowSeconds, stepSeconds)` → `repeated MetricSeries{kind, unit, points}` for `cpu_cores`, `memory_bytes`, `net_rx_bps`, `net_tx_bps`. The gateway:
1. resolves the guest's **current launcher pod** by the `swift.kubeswift.io/guest` label (robust to the `<guest>-mig-<uid>` rename), via the impersonating client (which authorizes the caller);
2. range-queries the **member cluster's Prometheus** (`spec.prometheusEndpoint`) over cAdvisor — the launcher cgroup *is* the VM (CH runs in it).

Querying by resolved pod name needs **no kube-state-metrics allowlist**; cross-migration history continuity is a v2 upgrade (label join), noted in code. A missing/unreachable endpoint returns a `ClusterError` — **no silent empty chart**.

- proto: replaced the `StreamVMMetrics` stub with unary `GetGuestMetrics`; `pool.PrometheusEndpoint(cluster)` accessor; `query_range` over `net/http` (no new dep); `main.go` wires the real service.
- tests: httptest fake Prometheus (4 series, points parsed); missing-endpoint → error; stopped guest (no pod) → empty series.
- No new RBAC (pod resolution reuses the impersonating client's `pods` list).

`go build`, full `go test ./...`, `buf lint`, `gofmt` green.

## After merge

rebuild → redeploy → register each member's `prometheusEndpoint` (hub's is `monitoring-kube-prometheus-prometheus.monitoring:9090`) → the UI drawer gets CPU/mem/net sparklines (separate UI commit) → cluster-validate against `ft-vm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)