### PR TITLE
feat(gateway): console plane (D5) — serial console over WebSocket

### DIFF
--- a/cmd/kubeswift-gateway/main.go
+++ b/cmd/kubeswift-gateway/main.go
@@ -95,6 +95,11 @@ func main() {
 	// Console stays a P0 stub (CodeUnimplemented) until the console plane lands.
 	conPath, conHandler := kubeswiftv1connect.NewConsoleServiceHandler(kubeswiftv1connect.UnimplementedConsoleServiceHandler{})
 
+	// Console plane (D5 bootstrap): a raw WebSocket at /console that exec-bridges
+	// the guest's serial socket. Not a Connect RPC — browsers can't do bidi
+	// Connect — so it rides RawHandlers, not the generated ConsoleService stub.
+	consoleWS := gateway.NewConsoleHandler(pool, auth)
+
 	srv := &gateway.Server{
 		Addr:          *listen,
 		AllowedOrigin: *corsOrigin,
@@ -103,6 +108,9 @@ func main() {
 			{Path: guestPath, Handler: guestHandler},
 			{Path: telPath, Handler: telHandler},
 			{Path: conPath, Handler: conHandler},
+		},
+		RawHandlers: []gateway.ConnectHandler{
+			{Path: "/console", Handler: consoleWS},
 		},
 		Log: log.WithName("server"),
 	}

--- a/config/samples/gateway/member-rbac.yaml
+++ b/config/samples/gateway/member-rbac.yaml
@@ -57,6 +57,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "delete"]
+  # The console plane execs `socat` in the launcher pod to bridge the serial
+  # socket. pods/exec is powerful (arbitrary in-pod commands) — grant it only to
+  # subjects allowed to open VM consoles; drop it to disable the console.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/ui/gateway.md
+++ b/docs/ui/gateway.md
@@ -152,6 +152,15 @@ In `insecure` mode these work with no token; in `token` mode add
   there (see `config/samples/gateway/member-rbac.yaml`); a read-only audience
   gets a clean permission denial. In `token` mode the member's RBAC gates who
   can act.
+- **Console** — a raw WebSocket at `/console?cluster=&namespace=&name=&token=`
+  exec-bridges the guest's serial socket (the D5 bootstrap; swiftletd
+  serial-on-a-port is the later transport). It execs `socat` in the launcher
+  pod, so the acting subject needs `create` on `pods/exec` — **powerful**
+  (arbitrary in-pod commands); grant it only to console users. Because browsers
+  can't set a WebSocket `Authorization` header, the bearer token rides the
+  `?token=` query param — which **can land in proxy/access logs**; prefer a
+  short-lived token, and a TLS-terminating ingress so the URL isn't on the wire.
+  `insecure` mode needs no token (and then anyone can open any console).
 - **CORS** defaults to `*` (safe for a token-auth API with no cookies); pin
   `gateway.corsAllowOrigin` to the UI origin for a hardened install.
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	connectrpc.com/connect v1.20.0
 	github.com/go-logr/logr v1.4.3
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/klauspost/compress v1.18.6
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0
 	github.com/minio/minio-go/v7 v7.2.0
@@ -41,7 +42,6 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/internal/gateway/console_ws.go
+++ b/internal/gateway/console_ws.go
@@ -1,0 +1,180 @@
+package gateway
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/gorilla/websocket"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// consoleProvider is the subset of ClientPool the console plane needs: the
+// impersonating dynamic client (to resolve + authorize the guest's pod) and the
+// raw REST config (client-go's remotecommand exec needs it).
+type consoleProvider interface {
+	DynamicFor(cluster string, id Identity) (dynamic.Interface, error)
+	RestConfigFor(cluster string, id Identity) (*rest.Config, error)
+}
+
+// ConsoleHandler bridges a guest's serial console to a browser WebSocket. It is
+// the D5 bootstrap path: exec `socat ... UNIX-CONNECT:<serial.sock>` inside the
+// launcher pod (as the impersonated user) and pump bytes both ways. The
+// swiftletd serial-on-a-port transport is the later upgrade.
+type ConsoleHandler struct {
+	pool consoleProvider
+	auth Authenticator
+	up   websocket.Upgrader
+}
+
+func NewConsoleHandler(pool consoleProvider, auth Authenticator) *ConsoleHandler {
+	return &ConsoleHandler{
+		pool: pool,
+		auth: auth,
+		// The bearer token (not a cookie) is the auth, so a cross-origin upgrade
+		// is safe to accept — mirrors the Connect CORS=* posture.
+		up: websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+	}
+}
+
+func (h *ConsoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	cluster, namespace, name := q.Get("cluster"), q.Get("namespace"), q.Get("name")
+	if cluster == "" || namespace == "" || name == "" {
+		http.Error(w, "cluster, namespace and name are required", http.StatusBadRequest)
+		return
+	}
+
+	// Browsers cannot set headers on a WebSocket, so the token rides a query
+	// param (?token=); insecure mode ignores it. (URL-borne tokens can land in
+	// logs — acceptable for the bootstrap path, noted in the operator docs.)
+	hdr := http.Header{}
+	if tok := q.Get("token"); tok != "" {
+		hdr.Set("Authorization", "Bearer "+tok)
+	} else if a := r.Header.Get("Authorization"); a != "" {
+		hdr.Set("Authorization", a)
+	}
+	id, err := h.auth.Authenticate(r.Context(), hdr)
+	if err != nil {
+		http.Error(w, "unauthorized: "+err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	// Resolve the guest's current launcher pod (authz via the impersonating client).
+	dyn, err := h.pool.DynamicFor(cluster, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	pods, err := dyn.Resource(podGVR).Namespace(namespace).
+		List(r.Context(), metav1.ListOptions{LabelSelector: guestPodLabel + "=" + name})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	podName := ""
+	for i := range pods.Items {
+		phase, _, _ := unstructured.NestedString(pods.Items[i].Object, "status", "phase")
+		if phase == "Running" { // prefer a Running pod; fall back to the first
+			podName = pods.Items[i].GetName()
+			break
+		}
+		if podName == "" {
+			podName = pods.Items[i].GetName()
+		}
+	}
+	if podName == "" {
+		http.Error(w, "no launcher pod for guest (is it running?)", http.StatusConflict)
+		return
+	}
+
+	cfg, err := h.pool.RestConfigFor(cluster, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// The serial socket is keyed by the GUEST id (ns-name), stable across the
+	// <guest>-mig-<uid> pod rename. Mirrors swiftctl console exactly.
+	serialSocket := fmt.Sprintf("/var/lib/kubeswift/run/%s-%s/serial.sock", namespace, name)
+	bridge := fmt.Sprintf("for i in $(seq 1 15); do test -S %q && break; sleep 1; done; "+
+		"test -S %q || { echo 'serial socket not found at %s'; exit 1; }; "+
+		"exec socat -,raw,echo=0 UNIX-CONNECT:%s", serialSocket, serialSocket, serialSocket, serialSocket)
+
+	execReq := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").Name(podName).Namespace(namespace).SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Command: []string{"sh", "-c", bridge},
+			Stdin:   true,
+			Stdout:  true,
+			Stderr:  false,
+			TTY:     true,
+		}, scheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(cfg, "POST", execReq.URL())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Upgrade only after the pre-flight passes, so a failure is a plain HTTP
+	// error the browser can read (not a closed socket).
+	conn, err := h.up.Upgrade(w, r, nil)
+	if err != nil {
+		return // Upgrade already wrote the response
+	}
+	defer conn.Close()
+
+	wc := &wsConn{conn: conn}
+	if streamErr := executor.StreamWithContext(r.Context(), remotecommand.StreamOptions{
+		Stdin:  wc,
+		Stdout: wc,
+		Tty:    true,
+	}); streamErr != nil {
+		_ = conn.WriteMessage(websocket.TextMessage, []byte("\r\n[console closed: "+streamErr.Error()+"]\r\n"))
+	}
+}
+
+// wsConn adapts a WebSocket to io.Reader (browser keystrokes → exec stdin) and
+// io.Writer (serial output → browser). gorilla allows one concurrent reader and
+// one concurrent writer — exactly remotecommand's stdin/stdout access pattern.
+type wsConn struct {
+	conn *websocket.Conn
+	rbuf []byte
+	wmu  sync.Mutex
+}
+
+func (c *wsConn) Read(p []byte) (int, error) {
+	for len(c.rbuf) == 0 {
+		_, data, err := c.conn.ReadMessage()
+		if err != nil {
+			return 0, io.EOF
+		}
+		c.rbuf = data
+	}
+	n := copy(p, c.rbuf)
+	c.rbuf = c.rbuf[n:]
+	return n, nil
+}
+
+func (c *wsConn) Write(p []byte) (int, error) {
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	if err := c.conn.WriteMessage(websocket.BinaryMessage, p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/internal/gateway/console_ws_test.go
+++ b/internal/gateway/console_ws_test.go
@@ -1,0 +1,35 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/client-go/dynamic"
+)
+
+// TestConsoleHandler_Preflight covers the HTTP pre-flight that runs before the
+// WebSocket upgrade — so failures are readable HTTP errors, not a dropped
+// socket. The exec bridge itself is validated on-cluster.
+func TestConsoleHandler_Preflight(t *testing.T) {
+	boba := fakeDyn(uGuest("default", "vm-a", "Running")) // a guest, but no launcher pod
+	h := NewConsoleHandler(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+
+	cases := []struct {
+		name, target string
+		want         int
+	}{
+		{"missing params", "/console?cluster=boba", http.StatusBadRequest},
+		{"unknown cluster", "/console?cluster=ghost&namespace=default&name=vm-a", http.StatusNotFound},
+		{"no launcher pod", "/console?cluster=boba&namespace=default&name=vm-a", http.StatusConflict},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, tc.target, nil))
+			if w.Code != tc.want {
+				t.Errorf("want %d, got %d (%s)", tc.want, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/gateway/guest_service_test.go
+++ b/internal/gateway/guest_service_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
 
 	kubeswiftv1 "github.com/projectbeskar/kubeswift/gen/kubeswift/v1"
 )
@@ -27,6 +28,13 @@ type fakeProvider struct {
 
 func (f *fakeProvider) PrometheusEndpoint(cluster string) string {
 	return f.prom[cluster]
+}
+
+func (f *fakeProvider) RestConfigFor(cluster string, _ Identity) (*rest.Config, error) {
+	if _, ok := f.clients[cluster]; ok {
+		return &rest.Config{Host: "http://fake"}, nil
+	}
+	return nil, errors.New("no config for " + cluster)
 }
 
 func (f *fakeProvider) DynamicFor(cluster string, _ Identity) (dynamic.Interface, error) {

--- a/internal/gateway/pool.go
+++ b/internal/gateway/pool.go
@@ -161,6 +161,17 @@ func (p *ClientPool) buildConfig(ctx context.Context, c *fleetv1alpha1.Cluster) 
 // DynamicFor returns a dynamic client for the named member, impersonating the
 // given identity (an empty identity uses the member's own credential).
 func (p *ClientPool) DynamicFor(cluster string, id Identity) (dynamic.Interface, error) {
+	cfg, err := p.RestConfigFor(cluster, id)
+	if err != nil {
+		return nil, err
+	}
+	return dynamic.NewForConfig(cfg)
+}
+
+// RestConfigFor returns the member's REST config, impersonating the identity
+// (unless empty). The console plane needs the raw config for client-go's
+// remotecommand exec; DynamicFor builds on it.
+func (p *ClientPool) RestConfigFor(cluster string, id Identity) (*rest.Config, error) {
 	p.mu.RLock()
 	m, ok := p.members[cluster]
 	p.mu.RUnlock()
@@ -171,7 +182,7 @@ func (p *ClientPool) DynamicFor(cluster string, id Identity) (dynamic.Interface,
 	if !id.empty() {
 		cfg.Impersonate = rest.ImpersonationConfig{UserName: id.User, Groups: id.Groups}
 	}
-	return dynamic.NewForConfig(cfg)
+	return cfg, nil
 }
 
 // Members returns the names of all currently registered member clusters.

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -27,7 +27,10 @@ type Server struct {
 	Addr          string
 	AllowedOrigin string
 	Handlers      []ConnectHandler
-	Log           logr.Logger
+	// RawHandlers are non-Connect routes (e.g. the WebSocket console plane),
+	// mounted on the same mux. They handle their own protocol upgrade.
+	RawHandlers []ConnectHandler
+	Log         logr.Logger
 }
 
 // NeedLeaderElection keeps the server running on every replica.
@@ -37,6 +40,9 @@ func (s *Server) NeedLeaderElection() bool { return false }
 func (s *Server) Start(ctx context.Context) error {
 	mux := http.NewServeMux()
 	for _, h := range s.Handlers {
+		mux.Handle(h.Path, h.Handler)
+	}
+	for _, h := range s.RawHandlers {
 		mux.Handle(h.Path, h.Handler)
 	}
 	mux.HandleFunc("/healthz", okHandler)


### PR DESCRIPTION
The console plane (decision **D5**) — the **bootstrap** path: a raw WebSocket that exec-bridges a guest's serial console to an xterm.js terminal in the UI. (The swiftletd serial-on-a-port transport is the later upgrade.)

## What

`GET /console?cluster=&namespace=&name=&token=` (a raw WS, **not** a Connect RPC — browsers can't do bidi Connect, so it rides the Server's new `RawHandlers`). The gateway:
1. pre-flights (params / unknown-cluster / **no launcher pod** → readable HTTP errors *before* the upgrade);
2. resolves the guest's launcher pod by the `swift.kubeswift.io/guest` label (prefer Running);
3. as the **impersonated user**, execs `socat -,raw,echo=0 UNIX-CONNECT:/var/lib/kubeswift/run/<ns>-<name>/serial.sock` (mirrors `swiftctl console`; the socket is keyed by the **guest id**, stable across the `-mig-` rename) and pumps bytes both ways via `remotecommand`.

- `pool.RestConfigFor` factored out (remotecommand needs the raw `*rest.Config`); `wsConn` adapts the socket to `io.Reader`/`io.Writer` (gorilla's one-reader-one-writer == remotecommand's stdin/stdout).
- **RBAC**: the acting subject needs `create` on `pods/exec` — **powerful** (arbitrary in-pod commands); member-rbac sample + gateway.md security note updated. Token rides `?token=` (no WS `Authorization` header); logged-URL caveat documented; `insecure` mode needs none.
- `gorilla/websocket` promoted to a direct dep.

`go build`, full `go test ./...` (incl. the pre-flight test), `gofmt`, `go vet` green.

## After merge

rebuild → redeploy → grant `pods/exec` → the UI drawer gets a **Console** button → xterm.js terminal over the WS (separate UI commit) → cluster-validate against `ft-vm` (type, see the guest prompt). Known caveat to validate: h2c + WebSocket hijack on the same listener (WS arrives as HTTP/1.1; h2c should pass it through hijackable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)