### PR TITLE
fix(gateway): console exec must name the launcher container

### DIFF
--- a/internal/gateway/console_ws.go
+++ b/internal/gateway/console_ws.go
@@ -117,11 +117,12 @@ func (h *ConsoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	execReq := clientset.CoreV1().RESTClient().Post().
 		Resource("pods").Name(podName).Namespace(namespace).SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
-			Command: []string{"sh", "-c", bridge},
-			Stdin:   true,
-			Stdout:  true,
-			Stderr:  false,
-			TTY:     true,
+			Container: launcherContainer, // the launcher pod is multi-container; name the swiftletd one
+			Command:   []string{"sh", "-c", bridge},
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    false,
+			TTY:       true,
 		}, scheme.ParameterCodec)
 
 	executor, err := remotecommand.NewSPDYExecutor(cfg, "POST", execReq.URL())

--- a/internal/gateway/pool.go
+++ b/internal/gateway/pool.go
@@ -41,6 +41,10 @@ var podGVR = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
 // name) is the stable handle — a live-migrated guest's pod is <guest>-mig-<uid>.
 const guestPodLabel = "swift.kubeswift.io/guest"
 
+// launcherContainer is the swiftletd container in the (multi-container) launcher
+// pod — the one holding the serial socket. The console exec must name it.
+const launcherContainer = "launcher"
+
 // ClientPool watches the hub's fleet.Cluster registry and maintains a base REST
 // config per member cluster, built from the member's credential Secret. It
 // hands out per-request dynamic clients that impersonate the end user (D1). On


### PR DESCRIPTION
Follow-up to #269, caught by **cluster validation**.

The WebSocket upgrade + exec-pipe worked end-to-end (`WS OPEN` — h2c passes the HTTP/1.1 WS hijack through fine, the caveat I flagged is clear), but the exec failed:

> `[console closed: a container name must be specified for pod ft-vm, choose one of: [network-init launcher migration-stunnel]]`

The launcher pod is multi-container and `PodExecOptions` didn't set `Container`. Fix: `Container: "launcher"` (the swiftletd container holding the serial socket), mirroring `swiftctl console` (`cli.LauncherContainer`). The unit pre-flight test can't see this (no real apiserver) — the W5 pattern.

`go build`, `go test ./...`, `gofmt` green. Re-validated after merge+redeploy (expect the guest serial prompt back through the WS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)