### PR TITLE
feat(gateway): migrate action — MigrateGuest + ListNodes (UI backend P2)

### DIFF
--- a/cmd/kubeswift-gateway/main.go
+++ b/cmd/kubeswift-gateway/main.go
@@ -83,7 +83,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	clusterSvc := gateway.NewClusterService(mgr.GetClient(), *clustersNS, watcher)
+	clusterSvc := gateway.NewClusterService(mgr.GetClient(), *clustersNS, watcher, pool, auth)
 	clusterPath, clusterHandler := kubeswiftv1connect.NewClusterServiceHandler(clusterSvc)
 
 	guestSvc := gateway.NewGuestService(pool, auth)

--- a/config/samples/gateway/member-rbac.yaml
+++ b/config/samples/gateway/member-rbac.yaml
@@ -63,6 +63,14 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]
+  # The migrate action creates a SwiftMigration; ListNodes (the migrate target
+  # picker) lists nodes.
+  - apiGroups: ["migration.kubeswift.io"]
+    resources: ["swiftmigrations"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/gen/kubeswift/v1/cluster.pb.go
+++ b/gen/kubeswift/v1/cluster.pb.go
@@ -346,6 +346,174 @@ func (x *ClusterEvent) GetError() *ClusterError {
 	return nil
 }
 
+// Node is a member cluster's node, for the migrate target picker.
+type Node struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Cluster       string                 `protobuf:"bytes,1,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Ready         bool                   `protobuf:"varint,3,opt,name=ready,proto3" json:"ready,omitempty"`
+	Schedulable   bool                   `protobuf:"varint,4,opt,name=schedulable,proto3" json:"schedulable,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Node) Reset() {
+	*x = Node{}
+	mi := &file_kubeswift_v1_cluster_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Node) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Node) ProtoMessage() {}
+
+func (x *Node) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_cluster_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Node.ProtoReflect.Descriptor instead.
+func (*Node) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_cluster_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *Node) GetCluster() string {
+	if x != nil {
+		return x.Cluster
+	}
+	return ""
+}
+
+func (x *Node) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Node) GetReady() bool {
+	if x != nil {
+		return x.Ready
+	}
+	return false
+}
+
+func (x *Node) GetSchedulable() bool {
+	if x != nil {
+		return x.Schedulable
+	}
+	return false
+}
+
+type ListNodesRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// cluster is required — nodes are per-member (the migrate dialog asks for one
+	// cluster's nodes).
+	Cluster       string `protobuf:"bytes,1,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListNodesRequest) Reset() {
+	*x = ListNodesRequest{}
+	mi := &file_kubeswift_v1_cluster_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListNodesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListNodesRequest) ProtoMessage() {}
+
+func (x *ListNodesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_cluster_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListNodesRequest.ProtoReflect.Descriptor instead.
+func (*ListNodesRequest) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_cluster_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ListNodesRequest) GetCluster() string {
+	if x != nil {
+		return x.Cluster
+	}
+	return ""
+}
+
+type ListNodesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Nodes []*Node                `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes,omitempty"`
+	// error is set (nodes empty) when the cluster is unknown or unreachable.
+	Error         *ClusterError `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListNodesResponse) Reset() {
+	*x = ListNodesResponse{}
+	mi := &file_kubeswift_v1_cluster_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListNodesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListNodesResponse) ProtoMessage() {}
+
+func (x *ListNodesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_cluster_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListNodesResponse.ProtoReflect.Descriptor instead.
+func (*ListNodesResponse) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_cluster_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ListNodesResponse) GetNodes() []*Node {
+	if x != nil {
+		return x.Nodes
+	}
+	return nil
+}
+
+func (x *ListNodesResponse) GetError() *ClusterError {
+	if x != nil {
+		return x.Error
+	}
+	return nil
+}
+
 var File_kubeswift_v1_cluster_proto protoreflect.FileDescriptor
 
 const file_kubeswift_v1_cluster_proto_rawDesc = "" +
@@ -376,10 +544,21 @@ const file_kubeswift_v1_cluster_proto_rawDesc = "" +
 	"\fClusterEvent\x12+\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x17.kubeswift.v1.EventTypeR\x04type\x12/\n" +
 	"\acluster\x18\x02 \x01(\v2\x15.kubeswift.v1.ClusterR\acluster\x120\n" +
-	"\x05error\x18\x03 \x01(\v2\x1a.kubeswift.v1.ClusterErrorR\x05error2\xba\x01\n" +
+	"\x05error\x18\x03 \x01(\v2\x1a.kubeswift.v1.ClusterErrorR\x05error\"l\n" +
+	"\x04Node\x12\x18\n" +
+	"\acluster\x18\x01 \x01(\tR\acluster\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
+	"\x05ready\x18\x03 \x01(\bR\x05ready\x12 \n" +
+	"\vschedulable\x18\x04 \x01(\bR\vschedulable\",\n" +
+	"\x10ListNodesRequest\x12\x18\n" +
+	"\acluster\x18\x01 \x01(\tR\acluster\"o\n" +
+	"\x11ListNodesResponse\x12(\n" +
+	"\x05nodes\x18\x01 \x03(\v2\x12.kubeswift.v1.NodeR\x05nodes\x120\n" +
+	"\x05error\x18\x02 \x01(\v2\x1a.kubeswift.v1.ClusterErrorR\x05error2\x88\x02\n" +
 	"\x0eClusterService\x12U\n" +
 	"\fListClusters\x12!.kubeswift.v1.ListClustersRequest\x1a\".kubeswift.v1.ListClustersResponse\x12Q\n" +
-	"\rWatchClusters\x12\".kubeswift.v1.WatchClustersRequest\x1a\x1a.kubeswift.v1.ClusterEvent0\x01BAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
+	"\rWatchClusters\x12\".kubeswift.v1.WatchClustersRequest\x1a\x1a.kubeswift.v1.ClusterEvent0\x01\x12L\n" +
+	"\tListNodes\x12\x1e.kubeswift.v1.ListNodesRequest\x1a\x1f.kubeswift.v1.ListNodesResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
 
 var (
 	file_kubeswift_v1_cluster_proto_rawDescOnce sync.Once
@@ -393,39 +572,46 @@ func file_kubeswift_v1_cluster_proto_rawDescGZIP() []byte {
 	return file_kubeswift_v1_cluster_proto_rawDescData
 }
 
-var file_kubeswift_v1_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_kubeswift_v1_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_kubeswift_v1_cluster_proto_goTypes = []any{
 	(*Cluster)(nil),               // 0: kubeswift.v1.Cluster
 	(*ListClustersRequest)(nil),   // 1: kubeswift.v1.ListClustersRequest
 	(*ListClustersResponse)(nil),  // 2: kubeswift.v1.ListClustersResponse
 	(*WatchClustersRequest)(nil),  // 3: kubeswift.v1.WatchClustersRequest
 	(*ClusterEvent)(nil),          // 4: kubeswift.v1.ClusterEvent
-	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
-	(*Condition)(nil),             // 6: kubeswift.v1.Condition
-	(*PageRequest)(nil),           // 7: kubeswift.v1.PageRequest
-	(*PageResponse)(nil),          // 8: kubeswift.v1.PageResponse
-	(*ClusterError)(nil),          // 9: kubeswift.v1.ClusterError
-	(EventType)(0),                // 10: kubeswift.v1.EventType
+	(*Node)(nil),                  // 5: kubeswift.v1.Node
+	(*ListNodesRequest)(nil),      // 6: kubeswift.v1.ListNodesRequest
+	(*ListNodesResponse)(nil),     // 7: kubeswift.v1.ListNodesResponse
+	(*timestamppb.Timestamp)(nil), // 8: google.protobuf.Timestamp
+	(*Condition)(nil),             // 9: kubeswift.v1.Condition
+	(*PageRequest)(nil),           // 10: kubeswift.v1.PageRequest
+	(*PageResponse)(nil),          // 11: kubeswift.v1.PageResponse
+	(*ClusterError)(nil),          // 12: kubeswift.v1.ClusterError
+	(EventType)(0),                // 13: kubeswift.v1.EventType
 }
 var file_kubeswift_v1_cluster_proto_depIdxs = []int32{
-	5,  // 0: kubeswift.v1.Cluster.last_connected:type_name -> google.protobuf.Timestamp
-	6,  // 1: kubeswift.v1.Cluster.conditions:type_name -> kubeswift.v1.Condition
-	7,  // 2: kubeswift.v1.ListClustersRequest.page:type_name -> kubeswift.v1.PageRequest
+	8,  // 0: kubeswift.v1.Cluster.last_connected:type_name -> google.protobuf.Timestamp
+	9,  // 1: kubeswift.v1.Cluster.conditions:type_name -> kubeswift.v1.Condition
+	10, // 2: kubeswift.v1.ListClustersRequest.page:type_name -> kubeswift.v1.PageRequest
 	0,  // 3: kubeswift.v1.ListClustersResponse.clusters:type_name -> kubeswift.v1.Cluster
-	8,  // 4: kubeswift.v1.ListClustersResponse.page:type_name -> kubeswift.v1.PageResponse
-	9,  // 5: kubeswift.v1.ListClustersResponse.errors:type_name -> kubeswift.v1.ClusterError
-	10, // 6: kubeswift.v1.ClusterEvent.type:type_name -> kubeswift.v1.EventType
+	11, // 4: kubeswift.v1.ListClustersResponse.page:type_name -> kubeswift.v1.PageResponse
+	12, // 5: kubeswift.v1.ListClustersResponse.errors:type_name -> kubeswift.v1.ClusterError
+	13, // 6: kubeswift.v1.ClusterEvent.type:type_name -> kubeswift.v1.EventType
 	0,  // 7: kubeswift.v1.ClusterEvent.cluster:type_name -> kubeswift.v1.Cluster
-	9,  // 8: kubeswift.v1.ClusterEvent.error:type_name -> kubeswift.v1.ClusterError
-	1,  // 9: kubeswift.v1.ClusterService.ListClusters:input_type -> kubeswift.v1.ListClustersRequest
-	3,  // 10: kubeswift.v1.ClusterService.WatchClusters:input_type -> kubeswift.v1.WatchClustersRequest
-	2,  // 11: kubeswift.v1.ClusterService.ListClusters:output_type -> kubeswift.v1.ListClustersResponse
-	4,  // 12: kubeswift.v1.ClusterService.WatchClusters:output_type -> kubeswift.v1.ClusterEvent
-	11, // [11:13] is the sub-list for method output_type
-	9,  // [9:11] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	12, // 8: kubeswift.v1.ClusterEvent.error:type_name -> kubeswift.v1.ClusterError
+	5,  // 9: kubeswift.v1.ListNodesResponse.nodes:type_name -> kubeswift.v1.Node
+	12, // 10: kubeswift.v1.ListNodesResponse.error:type_name -> kubeswift.v1.ClusterError
+	1,  // 11: kubeswift.v1.ClusterService.ListClusters:input_type -> kubeswift.v1.ListClustersRequest
+	3,  // 12: kubeswift.v1.ClusterService.WatchClusters:input_type -> kubeswift.v1.WatchClustersRequest
+	6,  // 13: kubeswift.v1.ClusterService.ListNodes:input_type -> kubeswift.v1.ListNodesRequest
+	2,  // 14: kubeswift.v1.ClusterService.ListClusters:output_type -> kubeswift.v1.ListClustersResponse
+	4,  // 15: kubeswift.v1.ClusterService.WatchClusters:output_type -> kubeswift.v1.ClusterEvent
+	7,  // 16: kubeswift.v1.ClusterService.ListNodes:output_type -> kubeswift.v1.ListNodesResponse
+	14, // [14:17] is the sub-list for method output_type
+	11, // [11:14] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_kubeswift_v1_cluster_proto_init() }
@@ -440,7 +626,7 @@ func file_kubeswift_v1_cluster_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kubeswift_v1_cluster_proto_rawDesc), len(file_kubeswift_v1_cluster_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/kubeswift/v1/guest.pb.go
+++ b/gen/kubeswift/v1/guest.pb.go
@@ -603,6 +603,126 @@ func (x *GuestActionResponse) GetGuest() *Guest {
 	return nil
 }
 
+// MigrateGuestRequest moves a guest to another node by creating a
+// SwiftMigration on its member cluster. targetNode is required; mode defaults
+// to auto. A cross-node move on default node-local networking changes the
+// guest IP, so allowIpChange is required there (the webhook rejects it
+// otherwise).
+type MigrateGuestRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ref           *ObjectRef             `protobuf:"bytes,1,opt,name=ref,proto3" json:"ref,omitempty"`
+	TargetNode    string                 `protobuf:"bytes,2,opt,name=target_node,json=targetNode,proto3" json:"target_node,omitempty"`
+	Mode          string                 `protobuf:"bytes,3,opt,name=mode,proto3" json:"mode,omitempty"` // auto | live | offline
+	AllowIpChange bool                   `protobuf:"varint,4,opt,name=allow_ip_change,json=allowIpChange,proto3" json:"allow_ip_change,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MigrateGuestRequest) Reset() {
+	*x = MigrateGuestRequest{}
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MigrateGuestRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MigrateGuestRequest) ProtoMessage() {}
+
+func (x *MigrateGuestRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MigrateGuestRequest.ProtoReflect.Descriptor instead.
+func (*MigrateGuestRequest) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_guest_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *MigrateGuestRequest) GetRef() *ObjectRef {
+	if x != nil {
+		return x.Ref
+	}
+	return nil
+}
+
+func (x *MigrateGuestRequest) GetTargetNode() string {
+	if x != nil {
+		return x.TargetNode
+	}
+	return ""
+}
+
+func (x *MigrateGuestRequest) GetMode() string {
+	if x != nil {
+		return x.Mode
+	}
+	return ""
+}
+
+func (x *MigrateGuestRequest) GetAllowIpChange() bool {
+	if x != nil {
+		return x.AllowIpChange
+	}
+	return false
+}
+
+// MigrateGuestResponse returns the created SwiftMigration's ref; the migration
+// then progresses on the member (watch the guest's phase, or a future
+// migrations view).
+type MigrateGuestResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Migration     *ObjectRef             `protobuf:"bytes,1,opt,name=migration,proto3" json:"migration,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MigrateGuestResponse) Reset() {
+	*x = MigrateGuestResponse{}
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MigrateGuestResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MigrateGuestResponse) ProtoMessage() {}
+
+func (x *MigrateGuestResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MigrateGuestResponse.ProtoReflect.Descriptor instead.
+func (*MigrateGuestResponse) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_guest_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *MigrateGuestResponse) GetMigration() *ObjectRef {
+	if x != nil {
+		return x.Migration
+	}
+	return nil
+}
+
 var File_kubeswift_v1_guest_proto protoreflect.FileDescriptor
 
 const file_kubeswift_v1_guest_proto_rawDesc = "" +
@@ -659,7 +779,15 @@ const file_kubeswift_v1_guest_proto_rawDesc = "" +
 	"\x12GuestActionRequest\x12)\n" +
 	"\x03ref\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\x03ref\"@\n" +
 	"\x13GuestActionResponse\x12)\n" +
-	"\x05guest\x18\x01 \x01(\v2\x13.kubeswift.v1.GuestR\x05guest2\xae\x03\n" +
+	"\x05guest\x18\x01 \x01(\v2\x13.kubeswift.v1.GuestR\x05guest\"\x9d\x01\n" +
+	"\x13MigrateGuestRequest\x12)\n" +
+	"\x03ref\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\x03ref\x12\x1f\n" +
+	"\vtarget_node\x18\x02 \x01(\tR\n" +
+	"targetNode\x12\x12\n" +
+	"\x04mode\x18\x03 \x01(\tR\x04mode\x12&\n" +
+	"\x0fallow_ip_change\x18\x04 \x01(\bR\rallowIpChange\"M\n" +
+	"\x14MigrateGuestResponse\x125\n" +
+	"\tmigration\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\tmigration2\x85\x04\n" +
 	"\fGuestService\x12O\n" +
 	"\n" +
 	"ListGuests\x12\x1f.kubeswift.v1.ListGuestsRequest\x1a .kubeswift.v1.ListGuestsResponse\x12K\n" +
@@ -667,7 +795,8 @@ const file_kubeswift_v1_guest_proto_rawDesc = "" +
 	"\x0eGetGuestDetail\x12#.kubeswift.v1.GetGuestDetailRequest\x1a$.kubeswift.v1.GetGuestDetailResponse\x12Q\n" +
 	"\n" +
 	"StartGuest\x12 .kubeswift.v1.GuestActionRequest\x1a!.kubeswift.v1.GuestActionResponse\x12P\n" +
-	"\tStopGuest\x12 .kubeswift.v1.GuestActionRequest\x1a!.kubeswift.v1.GuestActionResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
+	"\tStopGuest\x12 .kubeswift.v1.GuestActionRequest\x1a!.kubeswift.v1.GuestActionResponse\x12U\n" +
+	"\fMigrateGuest\x12!.kubeswift.v1.MigrateGuestRequest\x1a\".kubeswift.v1.MigrateGuestResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
 
 var (
 	file_kubeswift_v1_guest_proto_rawDescOnce sync.Once
@@ -681,7 +810,7 @@ func file_kubeswift_v1_guest_proto_rawDescGZIP() []byte {
 	return file_kubeswift_v1_guest_proto_rawDescData
 }
 
-var file_kubeswift_v1_guest_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_kubeswift_v1_guest_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_kubeswift_v1_guest_proto_goTypes = []any{
 	(*Guest)(nil),                  // 0: kubeswift.v1.Guest
 	(*ListGuestsRequest)(nil),      // 1: kubeswift.v1.ListGuestsRequest
@@ -692,49 +821,55 @@ var file_kubeswift_v1_guest_proto_goTypes = []any{
 	(*GetGuestDetailResponse)(nil), // 6: kubeswift.v1.GetGuestDetailResponse
 	(*GuestActionRequest)(nil),     // 7: kubeswift.v1.GuestActionRequest
 	(*GuestActionResponse)(nil),    // 8: kubeswift.v1.GuestActionResponse
-	nil,                            // 9: kubeswift.v1.Guest.LabelsEntry
-	(*ObjectRef)(nil),              // 10: kubeswift.v1.ObjectRef
-	(*timestamppb.Timestamp)(nil),  // 11: google.protobuf.Timestamp
-	(*Condition)(nil),              // 12: kubeswift.v1.Condition
-	(*ClusterSelector)(nil),        // 13: kubeswift.v1.ClusterSelector
-	(*PageRequest)(nil),            // 14: kubeswift.v1.PageRequest
-	(*PageResponse)(nil),           // 15: kubeswift.v1.PageResponse
-	(*ClusterError)(nil),           // 16: kubeswift.v1.ClusterError
-	(EventType)(0),                 // 17: kubeswift.v1.EventType
+	(*MigrateGuestRequest)(nil),    // 9: kubeswift.v1.MigrateGuestRequest
+	(*MigrateGuestResponse)(nil),   // 10: kubeswift.v1.MigrateGuestResponse
+	nil,                            // 11: kubeswift.v1.Guest.LabelsEntry
+	(*ObjectRef)(nil),              // 12: kubeswift.v1.ObjectRef
+	(*timestamppb.Timestamp)(nil),  // 13: google.protobuf.Timestamp
+	(*Condition)(nil),              // 14: kubeswift.v1.Condition
+	(*ClusterSelector)(nil),        // 15: kubeswift.v1.ClusterSelector
+	(*PageRequest)(nil),            // 16: kubeswift.v1.PageRequest
+	(*PageResponse)(nil),           // 17: kubeswift.v1.PageResponse
+	(*ClusterError)(nil),           // 18: kubeswift.v1.ClusterError
+	(EventType)(0),                 // 19: kubeswift.v1.EventType
 }
 var file_kubeswift_v1_guest_proto_depIdxs = []int32{
-	10, // 0: kubeswift.v1.Guest.ref:type_name -> kubeswift.v1.ObjectRef
-	11, // 1: kubeswift.v1.Guest.created_at:type_name -> google.protobuf.Timestamp
-	12, // 2: kubeswift.v1.Guest.conditions:type_name -> kubeswift.v1.Condition
-	9,  // 3: kubeswift.v1.Guest.labels:type_name -> kubeswift.v1.Guest.LabelsEntry
-	13, // 4: kubeswift.v1.ListGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
-	14, // 5: kubeswift.v1.ListGuestsRequest.page:type_name -> kubeswift.v1.PageRequest
+	12, // 0: kubeswift.v1.Guest.ref:type_name -> kubeswift.v1.ObjectRef
+	13, // 1: kubeswift.v1.Guest.created_at:type_name -> google.protobuf.Timestamp
+	14, // 2: kubeswift.v1.Guest.conditions:type_name -> kubeswift.v1.Condition
+	11, // 3: kubeswift.v1.Guest.labels:type_name -> kubeswift.v1.Guest.LabelsEntry
+	15, // 4: kubeswift.v1.ListGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
+	16, // 5: kubeswift.v1.ListGuestsRequest.page:type_name -> kubeswift.v1.PageRequest
 	0,  // 6: kubeswift.v1.ListGuestsResponse.guests:type_name -> kubeswift.v1.Guest
-	15, // 7: kubeswift.v1.ListGuestsResponse.page:type_name -> kubeswift.v1.PageResponse
-	16, // 8: kubeswift.v1.ListGuestsResponse.errors:type_name -> kubeswift.v1.ClusterError
-	13, // 9: kubeswift.v1.WatchGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
-	17, // 10: kubeswift.v1.GuestEvent.type:type_name -> kubeswift.v1.EventType
+	17, // 7: kubeswift.v1.ListGuestsResponse.page:type_name -> kubeswift.v1.PageResponse
+	18, // 8: kubeswift.v1.ListGuestsResponse.errors:type_name -> kubeswift.v1.ClusterError
+	15, // 9: kubeswift.v1.WatchGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
+	19, // 10: kubeswift.v1.GuestEvent.type:type_name -> kubeswift.v1.EventType
 	0,  // 11: kubeswift.v1.GuestEvent.guest:type_name -> kubeswift.v1.Guest
-	16, // 12: kubeswift.v1.GuestEvent.error:type_name -> kubeswift.v1.ClusterError
-	10, // 13: kubeswift.v1.GetGuestDetailRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	18, // 12: kubeswift.v1.GuestEvent.error:type_name -> kubeswift.v1.ClusterError
+	12, // 13: kubeswift.v1.GetGuestDetailRequest.ref:type_name -> kubeswift.v1.ObjectRef
 	0,  // 14: kubeswift.v1.GetGuestDetailResponse.guest:type_name -> kubeswift.v1.Guest
-	10, // 15: kubeswift.v1.GuestActionRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	12, // 15: kubeswift.v1.GuestActionRequest.ref:type_name -> kubeswift.v1.ObjectRef
 	0,  // 16: kubeswift.v1.GuestActionResponse.guest:type_name -> kubeswift.v1.Guest
-	1,  // 17: kubeswift.v1.GuestService.ListGuests:input_type -> kubeswift.v1.ListGuestsRequest
-	3,  // 18: kubeswift.v1.GuestService.WatchGuests:input_type -> kubeswift.v1.WatchGuestsRequest
-	5,  // 19: kubeswift.v1.GuestService.GetGuestDetail:input_type -> kubeswift.v1.GetGuestDetailRequest
-	7,  // 20: kubeswift.v1.GuestService.StartGuest:input_type -> kubeswift.v1.GuestActionRequest
-	7,  // 21: kubeswift.v1.GuestService.StopGuest:input_type -> kubeswift.v1.GuestActionRequest
-	2,  // 22: kubeswift.v1.GuestService.ListGuests:output_type -> kubeswift.v1.ListGuestsResponse
-	4,  // 23: kubeswift.v1.GuestService.WatchGuests:output_type -> kubeswift.v1.GuestEvent
-	6,  // 24: kubeswift.v1.GuestService.GetGuestDetail:output_type -> kubeswift.v1.GetGuestDetailResponse
-	8,  // 25: kubeswift.v1.GuestService.StartGuest:output_type -> kubeswift.v1.GuestActionResponse
-	8,  // 26: kubeswift.v1.GuestService.StopGuest:output_type -> kubeswift.v1.GuestActionResponse
-	22, // [22:27] is the sub-list for method output_type
-	17, // [17:22] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	12, // 17: kubeswift.v1.MigrateGuestRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	12, // 18: kubeswift.v1.MigrateGuestResponse.migration:type_name -> kubeswift.v1.ObjectRef
+	1,  // 19: kubeswift.v1.GuestService.ListGuests:input_type -> kubeswift.v1.ListGuestsRequest
+	3,  // 20: kubeswift.v1.GuestService.WatchGuests:input_type -> kubeswift.v1.WatchGuestsRequest
+	5,  // 21: kubeswift.v1.GuestService.GetGuestDetail:input_type -> kubeswift.v1.GetGuestDetailRequest
+	7,  // 22: kubeswift.v1.GuestService.StartGuest:input_type -> kubeswift.v1.GuestActionRequest
+	7,  // 23: kubeswift.v1.GuestService.StopGuest:input_type -> kubeswift.v1.GuestActionRequest
+	9,  // 24: kubeswift.v1.GuestService.MigrateGuest:input_type -> kubeswift.v1.MigrateGuestRequest
+	2,  // 25: kubeswift.v1.GuestService.ListGuests:output_type -> kubeswift.v1.ListGuestsResponse
+	4,  // 26: kubeswift.v1.GuestService.WatchGuests:output_type -> kubeswift.v1.GuestEvent
+	6,  // 27: kubeswift.v1.GuestService.GetGuestDetail:output_type -> kubeswift.v1.GetGuestDetailResponse
+	8,  // 28: kubeswift.v1.GuestService.StartGuest:output_type -> kubeswift.v1.GuestActionResponse
+	8,  // 29: kubeswift.v1.GuestService.StopGuest:output_type -> kubeswift.v1.GuestActionResponse
+	10, // 30: kubeswift.v1.GuestService.MigrateGuest:output_type -> kubeswift.v1.MigrateGuestResponse
+	25, // [25:31] is the sub-list for method output_type
+	19, // [19:25] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_kubeswift_v1_guest_proto_init() }
@@ -749,7 +884,7 @@ func file_kubeswift_v1_guest_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kubeswift_v1_guest_proto_rawDesc), len(file_kubeswift_v1_guest_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/kubeswift/v1/kubeswiftv1connect/cluster.connect.go
+++ b/gen/kubeswift/v1/kubeswiftv1connect/cluster.connect.go
@@ -39,12 +39,16 @@ const (
 	// ClusterServiceWatchClustersProcedure is the fully-qualified name of the ClusterService's
 	// WatchClusters RPC.
 	ClusterServiceWatchClustersProcedure = "/kubeswift.v1.ClusterService/WatchClusters"
+	// ClusterServiceListNodesProcedure is the fully-qualified name of the ClusterService's ListNodes
+	// RPC.
+	ClusterServiceListNodesProcedure = "/kubeswift.v1.ClusterService/ListNodes"
 )
 
 // ClusterServiceClient is a client for the kubeswift.v1.ClusterService service.
 type ClusterServiceClient interface {
 	ListClusters(context.Context, *connect.Request[v1.ListClustersRequest]) (*connect.Response[v1.ListClustersResponse], error)
 	WatchClusters(context.Context, *connect.Request[v1.WatchClustersRequest]) (*connect.ServerStreamForClient[v1.ClusterEvent], error)
+	ListNodes(context.Context, *connect.Request[v1.ListNodesRequest]) (*connect.Response[v1.ListNodesResponse], error)
 }
 
 // NewClusterServiceClient constructs a client for the kubeswift.v1.ClusterService service. By
@@ -70,6 +74,12 @@ func NewClusterServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			connect.WithSchema(clusterServiceMethods.ByName("WatchClusters")),
 			connect.WithClientOptions(opts...),
 		),
+		listNodes: connect.NewClient[v1.ListNodesRequest, v1.ListNodesResponse](
+			httpClient,
+			baseURL+ClusterServiceListNodesProcedure,
+			connect.WithSchema(clusterServiceMethods.ByName("ListNodes")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -77,6 +87,7 @@ func NewClusterServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 type clusterServiceClient struct {
 	listClusters  *connect.Client[v1.ListClustersRequest, v1.ListClustersResponse]
 	watchClusters *connect.Client[v1.WatchClustersRequest, v1.ClusterEvent]
+	listNodes     *connect.Client[v1.ListNodesRequest, v1.ListNodesResponse]
 }
 
 // ListClusters calls kubeswift.v1.ClusterService.ListClusters.
@@ -89,10 +100,16 @@ func (c *clusterServiceClient) WatchClusters(ctx context.Context, req *connect.R
 	return c.watchClusters.CallServerStream(ctx, req)
 }
 
+// ListNodes calls kubeswift.v1.ClusterService.ListNodes.
+func (c *clusterServiceClient) ListNodes(ctx context.Context, req *connect.Request[v1.ListNodesRequest]) (*connect.Response[v1.ListNodesResponse], error) {
+	return c.listNodes.CallUnary(ctx, req)
+}
+
 // ClusterServiceHandler is an implementation of the kubeswift.v1.ClusterService service.
 type ClusterServiceHandler interface {
 	ListClusters(context.Context, *connect.Request[v1.ListClustersRequest]) (*connect.Response[v1.ListClustersResponse], error)
 	WatchClusters(context.Context, *connect.Request[v1.WatchClustersRequest], *connect.ServerStream[v1.ClusterEvent]) error
+	ListNodes(context.Context, *connect.Request[v1.ListNodesRequest]) (*connect.Response[v1.ListNodesResponse], error)
 }
 
 // NewClusterServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -114,12 +131,20 @@ func NewClusterServiceHandler(svc ClusterServiceHandler, opts ...connect.Handler
 		connect.WithSchema(clusterServiceMethods.ByName("WatchClusters")),
 		connect.WithHandlerOptions(opts...),
 	)
+	clusterServiceListNodesHandler := connect.NewUnaryHandler(
+		ClusterServiceListNodesProcedure,
+		svc.ListNodes,
+		connect.WithSchema(clusterServiceMethods.ByName("ListNodes")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/kubeswift.v1.ClusterService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case ClusterServiceListClustersProcedure:
 			clusterServiceListClustersHandler.ServeHTTP(w, r)
 		case ClusterServiceWatchClustersProcedure:
 			clusterServiceWatchClustersHandler.ServeHTTP(w, r)
+		case ClusterServiceListNodesProcedure:
+			clusterServiceListNodesHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -135,4 +160,8 @@ func (UnimplementedClusterServiceHandler) ListClusters(context.Context, *connect
 
 func (UnimplementedClusterServiceHandler) WatchClusters(context.Context, *connect.Request[v1.WatchClustersRequest], *connect.ServerStream[v1.ClusterEvent]) error {
 	return connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.ClusterService.WatchClusters is not implemented"))
+}
+
+func (UnimplementedClusterServiceHandler) ListNodes(context.Context, *connect.Request[v1.ListNodesRequest]) (*connect.Response[v1.ListNodesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.ClusterService.ListNodes is not implemented"))
 }

--- a/gen/kubeswift/v1/kubeswiftv1connect/guest.connect.go
+++ b/gen/kubeswift/v1/kubeswiftv1connect/guest.connect.go
@@ -45,6 +45,9 @@ const (
 	GuestServiceStartGuestProcedure = "/kubeswift.v1.GuestService/StartGuest"
 	// GuestServiceStopGuestProcedure is the fully-qualified name of the GuestService's StopGuest RPC.
 	GuestServiceStopGuestProcedure = "/kubeswift.v1.GuestService/StopGuest"
+	// GuestServiceMigrateGuestProcedure is the fully-qualified name of the GuestService's MigrateGuest
+	// RPC.
+	GuestServiceMigrateGuestProcedure = "/kubeswift.v1.GuestService/MigrateGuest"
 )
 
 // GuestServiceClient is a client for the kubeswift.v1.GuestService service.
@@ -57,6 +60,9 @@ type GuestServiceClient interface {
 	// be allowed to patch swiftguests on the target member cluster.
 	StartGuest(context.Context, *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error)
 	StopGuest(context.Context, *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error)
+	// Migrate (write plane, P2): create a SwiftMigration to move the guest. The
+	// impersonated user must be allowed to create swiftmigrations on the member.
+	MigrateGuest(context.Context, *connect.Request[v1.MigrateGuestRequest]) (*connect.Response[v1.MigrateGuestResponse], error)
 }
 
 // NewGuestServiceClient constructs a client for the kubeswift.v1.GuestService service. By default,
@@ -100,6 +106,12 @@ func NewGuestServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 			connect.WithSchema(guestServiceMethods.ByName("StopGuest")),
 			connect.WithClientOptions(opts...),
 		),
+		migrateGuest: connect.NewClient[v1.MigrateGuestRequest, v1.MigrateGuestResponse](
+			httpClient,
+			baseURL+GuestServiceMigrateGuestProcedure,
+			connect.WithSchema(guestServiceMethods.ByName("MigrateGuest")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -110,6 +122,7 @@ type guestServiceClient struct {
 	getGuestDetail *connect.Client[v1.GetGuestDetailRequest, v1.GetGuestDetailResponse]
 	startGuest     *connect.Client[v1.GuestActionRequest, v1.GuestActionResponse]
 	stopGuest      *connect.Client[v1.GuestActionRequest, v1.GuestActionResponse]
+	migrateGuest   *connect.Client[v1.MigrateGuestRequest, v1.MigrateGuestResponse]
 }
 
 // ListGuests calls kubeswift.v1.GuestService.ListGuests.
@@ -137,6 +150,11 @@ func (c *guestServiceClient) StopGuest(ctx context.Context, req *connect.Request
 	return c.stopGuest.CallUnary(ctx, req)
 }
 
+// MigrateGuest calls kubeswift.v1.GuestService.MigrateGuest.
+func (c *guestServiceClient) MigrateGuest(ctx context.Context, req *connect.Request[v1.MigrateGuestRequest]) (*connect.Response[v1.MigrateGuestResponse], error) {
+	return c.migrateGuest.CallUnary(ctx, req)
+}
+
 // GuestServiceHandler is an implementation of the kubeswift.v1.GuestService service.
 type GuestServiceHandler interface {
 	ListGuests(context.Context, *connect.Request[v1.ListGuestsRequest]) (*connect.Response[v1.ListGuestsResponse], error)
@@ -147,6 +165,9 @@ type GuestServiceHandler interface {
 	// be allowed to patch swiftguests on the target member cluster.
 	StartGuest(context.Context, *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error)
 	StopGuest(context.Context, *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error)
+	// Migrate (write plane, P2): create a SwiftMigration to move the guest. The
+	// impersonated user must be allowed to create swiftmigrations on the member.
+	MigrateGuest(context.Context, *connect.Request[v1.MigrateGuestRequest]) (*connect.Response[v1.MigrateGuestResponse], error)
 }
 
 // NewGuestServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -186,6 +207,12 @@ func NewGuestServiceHandler(svc GuestServiceHandler, opts ...connect.HandlerOpti
 		connect.WithSchema(guestServiceMethods.ByName("StopGuest")),
 		connect.WithHandlerOptions(opts...),
 	)
+	guestServiceMigrateGuestHandler := connect.NewUnaryHandler(
+		GuestServiceMigrateGuestProcedure,
+		svc.MigrateGuest,
+		connect.WithSchema(guestServiceMethods.ByName("MigrateGuest")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/kubeswift.v1.GuestService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case GuestServiceListGuestsProcedure:
@@ -198,6 +225,8 @@ func NewGuestServiceHandler(svc GuestServiceHandler, opts ...connect.HandlerOpti
 			guestServiceStartGuestHandler.ServeHTTP(w, r)
 		case GuestServiceStopGuestProcedure:
 			guestServiceStopGuestHandler.ServeHTTP(w, r)
+		case GuestServiceMigrateGuestProcedure:
+			guestServiceMigrateGuestHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -225,4 +254,8 @@ func (UnimplementedGuestServiceHandler) StartGuest(context.Context, *connect.Req
 
 func (UnimplementedGuestServiceHandler) StopGuest(context.Context, *connect.Request[v1.GuestActionRequest]) (*connect.Response[v1.GuestActionResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.GuestService.StopGuest is not implemented"))
+}
+
+func (UnimplementedGuestServiceHandler) MigrateGuest(context.Context, *connect.Request[v1.MigrateGuestRequest]) (*connect.Response[v1.MigrateGuestResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.GuestService.MigrateGuest is not implemented"))
 }

--- a/internal/gateway/cluster_nodes.go
+++ b/internal/gateway/cluster_nodes.go
@@ -1,0 +1,70 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+
+	connect "connectrpc.com/connect"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	kubeswiftv1 "github.com/projectbeskar/kubeswift/gen/kubeswift/v1"
+)
+
+// ListNodes lists a member cluster's nodes for the migrate target picker. It
+// fans out to the one named cluster as the impersonated user; an unknown or
+// unreachable cluster surfaces as a ClusterError, not a silent empty list.
+func (s *ClusterService) ListNodes(ctx context.Context, req *connect.Request[kubeswiftv1.ListNodesRequest]) (*connect.Response[kubeswiftv1.ListNodesResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	cluster := req.Msg.GetCluster()
+	if cluster == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cluster is required"))
+	}
+	dyn, err := s.pool.DynamicFor(cluster, id)
+	if err != nil {
+		return nodesErr(cluster, err.Error()), nil
+	}
+	list, err := dyn.Resource(nodeGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nodesErr(cluster, err.Error()), nil
+	}
+	out := &kubeswiftv1.ListNodesResponse{}
+	for i := range list.Items {
+		n := &list.Items[i]
+		out.Nodes = append(out.Nodes, &kubeswiftv1.Node{
+			Cluster:     cluster,
+			Name:        n.GetName(),
+			Ready:       nodeReady(n),
+			Schedulable: !nestedBool(n, "spec", "unschedulable"),
+		})
+	}
+	return connect.NewResponse(out), nil
+}
+
+func nodeReady(n *unstructured.Unstructured) bool {
+	conds, _, _ := unstructured.NestedSlice(n.Object, "status", "conditions")
+	for _, c := range conds {
+		m, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if m["type"] == "Ready" {
+			return m["status"] == "True"
+		}
+	}
+	return false
+}
+
+func nestedBool(n *unstructured.Unstructured, fields ...string) bool {
+	b, _, _ := unstructured.NestedBool(n.Object, fields...)
+	return b
+}
+
+func nodesErr(cluster, msg string) *connect.Response[kubeswiftv1.ListNodesResponse] {
+	return connect.NewResponse(&kubeswiftv1.ListNodesResponse{
+		Error: &kubeswiftv1.ClusterError{Cluster: cluster, Message: msg},
+	})
+}

--- a/internal/gateway/cluster_nodes_test.go
+++ b/internal/gateway/cluster_nodes_test.go
@@ -1,0 +1,41 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	connect "connectrpc.com/connect"
+	"k8s.io/client-go/dynamic"
+
+	kubeswiftv1 "github.com/projectbeskar/kubeswift/gen/kubeswift/v1"
+)
+
+func TestClusterService_ListNodes(t *testing.T) {
+	boba := fakeDyn(uNode("worker-1", true, true), uNode("worker-2", true, false)) // worker-2 cordoned
+	svc := NewClusterService(nil, "kubeswift-system", nil,
+		&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+
+	resp, err := svc.ListNodes(context.Background(), connect.NewRequest(&kubeswiftv1.ListNodesRequest{Cluster: "boba"}))
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if resp.Msg.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Msg.Error)
+	}
+	if len(resp.Msg.Nodes) != 2 {
+		t.Fatalf("want 2 nodes, got %d", len(resp.Msg.Nodes))
+	}
+	sched := map[string]bool{}
+	for _, n := range resp.Msg.Nodes {
+		sched[n.Name] = n.Schedulable
+	}
+	if !sched["worker-1"] || sched["worker-2"] {
+		t.Errorf("schedulable wrong (worker-2 is cordoned): %v", sched)
+	}
+
+	// An unknown cluster surfaces a ClusterError, not a fatal.
+	bad, _ := svc.ListNodes(context.Background(), connect.NewRequest(&kubeswiftv1.ListNodesRequest{Cluster: "ghost"}))
+	if bad.Msg.Error == nil {
+		t.Error("unknown cluster should surface a ClusterError")
+	}
+}

--- a/internal/gateway/cluster_service.go
+++ b/internal/gateway/cluster_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	connect "connectrpc.com/connect"
+	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fleetv1alpha1 "github.com/projectbeskar/kubeswift/api/fleet/v1alpha1"
@@ -22,13 +23,23 @@ type ClusterService struct {
 	hub       client.Reader
 	namespace string
 	watcher   *ClusterWatcher
+	// pool + auth power ListNodes, which fans out to a member (the migrate
+	// target picker); ListClusters/WatchClusters use only the hub cache above.
+	pool nodeProvider
+	auth Authenticator
+}
+
+// nodeProvider is the slice of ClientPool ListNodes needs.
+type nodeProvider interface {
+	DynamicFor(cluster string, id Identity) (dynamic.Interface, error)
 }
 
 var _ kubeswiftv1connect.ClusterServiceHandler = (*ClusterService)(nil)
 
-// NewClusterService wires the service to the hub cache + the shared watcher.
-func NewClusterService(hub client.Reader, namespace string, watcher *ClusterWatcher) *ClusterService {
-	return &ClusterService{hub: hub, namespace: namespace, watcher: watcher}
+// NewClusterService wires the service to the hub cache + the shared watcher,
+// plus the client pool + authenticator for ListNodes.
+func NewClusterService(hub client.Reader, namespace string, watcher *ClusterWatcher, pool nodeProvider, auth Authenticator) *ClusterService {
+	return &ClusterService{hub: hub, namespace: namespace, watcher: watcher, pool: pool, auth: auth}
 }
 
 // ListClusters returns every registered member cluster. The fleet is small, so

--- a/internal/gateway/cluster_service_test.go
+++ b/internal/gateway/cluster_service_test.go
@@ -20,7 +20,7 @@ func TestClusterService_ListClusters_NamespaceScoped(t *testing.T) {
 		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "elsewhere", Namespace: "other"}},
 	).Build()
 
-	svc := NewClusterService(hub, "kubeswift-system", nil)
+	svc := NewClusterService(hub, "kubeswift-system", nil, nil, nil) // ListClusters uses only the hub cache
 	resp, err := svc.ListClusters(context.Background(), connect.NewRequest(&kubeswiftv1.ListClustersRequest{}))
 	if err != nil {
 		t.Fatalf("ListClusters: %v", err)

--- a/internal/gateway/guest_service.go
+++ b/internal/gateway/guest_service.go
@@ -266,6 +266,65 @@ func (s *GuestService) deleteLauncherPods(ctx context.Context, dyn dynamic.Inter
 	return nil
 }
 
+// MigrateGuest creates a SwiftMigration to move the guest to targetNode, as the
+// impersonated user. The migration then progresses on the member; the UI
+// watches the guest's phase (a dedicated migrations view is a later add).
+func (s *GuestService) MigrateGuest(ctx context.Context, req *connect.Request[kubeswiftv1.MigrateGuestRequest]) (*connect.Response[kubeswiftv1.MigrateGuestResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	ref := req.Msg.GetRef()
+	if ref == nil || ref.GetCluster() == "" || ref.GetName() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("ref.cluster and ref.name are required"))
+	}
+	if req.Msg.GetTargetNode() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("target_node is required"))
+	}
+	mode := req.Msg.GetMode()
+	if mode == "" {
+		mode = "auto"
+	}
+	dyn, err := s.pool.DynamicFor(ref.GetCluster(), id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	mig := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "migration.kubeswift.io/v1alpha1",
+		"kind":       "SwiftMigration",
+		"metadata": map[string]interface{}{
+			"generateName": ref.GetName() + "-mig-",
+			"namespace":    ref.GetNamespace(),
+		},
+		"spec": map[string]interface{}{
+			"guestRef":      map[string]interface{}{"name": ref.GetName()},
+			"target":        map[string]interface{}{"nodeName": req.Msg.GetTargetNode()},
+			"mode":          mode,
+			"allowIPChange": req.Msg.GetAllowIpChange(),
+			"reason":        "initiated from the KubeSwift UI",
+		},
+	}}
+	created, err := dyn.Resource(swiftMigrationGVR).Namespace(ref.GetNamespace()).
+		Create(ctx, mig, metav1.CreateOptions{})
+	if err != nil {
+		// A webhook admission denial (e.g. allowIPChange required for a
+		// cross-node move, or live+VFIO) surfaces here with its reason — never
+		// a silent failure.
+		code := connect.CodeInternal
+		if apierrors.IsForbidden(err) || apierrors.IsInvalid(err) {
+			code = connect.CodeFailedPrecondition
+		}
+		return nil, connect.NewError(code, err)
+	}
+	return connect.NewResponse(&kubeswiftv1.MigrateGuestResponse{
+		Migration: &kubeswiftv1.ObjectRef{
+			Cluster:   ref.GetCluster(),
+			Namespace: ref.GetNamespace(),
+			Name:      created.GetName(),
+		},
+	}), nil
+}
+
 // targetClusters resolves the selector against the registered members. An empty
 // or all-clusters selector targets the whole fleet.
 func (s *GuestService) targetClusters(sel *kubeswiftv1.ClusterSelector) []string {

--- a/internal/gateway/guest_service_test.go
+++ b/internal/gateway/guest_service_test.go
@@ -82,6 +82,22 @@ func uPod(ns, name, guest string) *unstructured.Unstructured {
 	}}
 }
 
+func uNode(name string, ready, schedulable bool) *unstructured.Unstructured {
+	status := "False"
+	if ready {
+		status = "True"
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Node",
+		"metadata":   map[string]interface{}{"name": name},
+		"spec":       map[string]interface{}{"unschedulable": !schedulable},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{map[string]interface{}{"type": "Ready", "status": status}},
+		},
+	}}
+}
+
 func fakeDyn(objs ...*unstructured.Unstructured) dynamic.Interface {
 	ro := make([]runtime.Object, len(objs))
 	for i, o := range objs {
@@ -89,8 +105,10 @@ func fakeDyn(objs ...*unstructured.Unstructured) dynamic.Interface {
 	}
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
 		map[schema.GroupVersionResource]string{
-			swiftGuestGVR: "SwiftGuestList",
-			podGVR:        "PodList",
+			swiftGuestGVR:     "SwiftGuestList",
+			podGVR:            "PodList",
+			nodeGVR:           "NodeList",
+			swiftMigrationGVR: "SwiftMigrationList",
 		}, ro...)
 }
 
@@ -185,5 +203,34 @@ func TestGuestService_StartStopGuest(t *testing.T) {
 	// A missing ref is rejected, not silently a no-op.
 	if _, err := svc.StartGuest(context.Background(), connect.NewRequest(&kubeswiftv1.GuestActionRequest{})); err == nil {
 		t.Error("StartGuest with no ref should be InvalidArgument")
+	}
+}
+
+func TestGuestService_MigrateGuest(t *testing.T) {
+	boba := fakeDyn(uGuest("default", "vm-a", "Running"))
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+
+	resp, err := svc.MigrateGuest(context.Background(), connect.NewRequest(&kubeswiftv1.MigrateGuestRequest{
+		Ref:        &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+		TargetNode: "miles",
+		Mode:       "offline",
+	}))
+	if err != nil {
+		t.Fatalf("MigrateGuest: %v", err)
+	}
+	if resp.Msg.Migration.GetCluster() != "boba" || resp.Msg.Migration.GetNamespace() != "default" {
+		t.Errorf("unexpected migration ref: %+v", resp.Msg.Migration)
+	}
+	// A SwiftMigration was actually created in the namespace.
+	migs, _ := boba.Resource(swiftMigrationGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
+	if len(migs.Items) != 1 {
+		t.Errorf("want 1 SwiftMigration created, got %d", len(migs.Items))
+	}
+
+	// target_node is required, not silently defaulted.
+	if _, err := svc.MigrateGuest(context.Background(), connect.NewRequest(&kubeswiftv1.MigrateGuestRequest{
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+	})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("missing target_node should be InvalidArgument, got %v", err)
 	}
 }

--- a/internal/gateway/pool.go
+++ b/internal/gateway/pool.go
@@ -37,6 +37,12 @@ var swiftGuestGVR = schema.GroupVersionResource{
 // running VM.
 var podGVR = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
 
+// swiftMigrationGVR is the SwiftMigration resource — MigrateGuest creates one.
+var swiftMigrationGVR = schema.GroupVersionResource{Group: "migration.kubeswift.io", Version: "v1alpha1", Resource: "swiftmigrations"}
+
+// nodeGVR is the core node resource — ListNodes lists it for the migrate picker.
+var nodeGVR = schema.GroupVersionResource{Version: "v1", Resource: "nodes"}
+
 // guestPodLabel ties a launcher pod to its SwiftGuest. The label (not the pod
 // name) is the stable handle — a live-migrated guest's pod is <guest>-mig-<uid>.
 const guestPodLabel = "swift.kubeswift.io/guest"

--- a/proto/kubeswift/v1/cluster.proto
+++ b/proto/kubeswift/v1/cluster.proto
@@ -46,9 +46,31 @@ message ClusterEvent {
   ClusterError error = 3;
 }
 
+// Node is a member cluster's node, for the migrate target picker.
+message Node {
+  string cluster = 1;
+  string name = 2;
+  bool ready = 3;
+  bool schedulable = 4;
+}
+
+message ListNodesRequest {
+  // cluster is required — nodes are per-member (the migrate dialog asks for one
+  // cluster's nodes).
+  string cluster = 1;
+}
+
+message ListNodesResponse {
+  repeated Node nodes = 1;
+  // error is set (nodes empty) when the cluster is unknown or unreachable.
+  ClusterError error = 2;
+}
+
 // ClusterService exposes the hub's fleet registry to the UI: the cluster
-// selector lists members, and a watch keeps per-cluster health live.
+// selector lists members, a watch keeps per-cluster health live, and ListNodes
+// feeds the migrate target picker.
 service ClusterService {
   rpc ListClusters(ListClustersRequest) returns (ListClustersResponse);
   rpc WatchClusters(WatchClustersRequest) returns (stream ClusterEvent);
+  rpc ListNodes(ListNodesRequest) returns (ListNodesResponse);
 }

--- a/proto/kubeswift/v1/guest.proto
+++ b/proto/kubeswift/v1/guest.proto
@@ -88,10 +88,29 @@ message GuestActionResponse {
   Guest guest = 1;
 }
 
-// GuestService is the read plane for VM inventory plus the P1 lifecycle write
-// actions. List/Watch fan out across the selected member clusters and merge,
-// stamping the cluster dimension on every row; a per-cluster error surface
-// preserves partial-fleet results.
+// MigrateGuestRequest moves a guest to another node by creating a
+// SwiftMigration on its member cluster. targetNode is required; mode defaults
+// to auto. A cross-node move on default node-local networking changes the
+// guest IP, so allowIpChange is required there (the webhook rejects it
+// otherwise).
+message MigrateGuestRequest {
+  ObjectRef ref = 1;
+  string target_node = 2;
+  string mode = 3; // auto | live | offline
+  bool allow_ip_change = 4;
+}
+
+// MigrateGuestResponse returns the created SwiftMigration's ref; the migration
+// then progresses on the member (watch the guest's phase, or a future
+// migrations view).
+message MigrateGuestResponse {
+  ObjectRef migration = 1;
+}
+
+// GuestService is the read plane for VM inventory plus the P1/P2 write actions.
+// List/Watch fan out across the selected member clusters and merge, stamping
+// the cluster dimension on every row; a per-cluster error surface preserves
+// partial-fleet results.
 service GuestService {
   rpc ListGuests(ListGuestsRequest) returns (ListGuestsResponse);
   rpc WatchGuests(WatchGuestsRequest) returns (stream GuestEvent);
@@ -102,4 +121,8 @@ service GuestService {
   // be allowed to patch swiftguests on the target member cluster.
   rpc StartGuest(GuestActionRequest) returns (GuestActionResponse);
   rpc StopGuest(GuestActionRequest) returns (GuestActionResponse);
+
+  // Migrate (write plane, P2): create a SwiftMigration to move the guest. The
+  // impersonated user must be allowed to create swiftmigrations on the member.
+  rpc MigrateGuest(MigrateGuestRequest) returns (MigrateGuestResponse);
 }


### PR DESCRIPTION
The marquee write action — move a guest to another node from the UI.

## What

- **`GuestService.MigrateGuest(ref, targetNode, mode, allowIpChange)`** creates a `SwiftMigration` (`migration.kubeswift.io/v1alpha1`, `generateName`) on the guest's member, as the **impersonated user**. `mode` defaults to `auto`. A webhook admission denial (e.g. `allowIPChange` required for a cross-node move on default node-local networking, or live+VFIO) surfaces as `FailedPrecondition` **with its reason** — never a silent failure.
- **`ClusterService.ListNodes(cluster)`** lists a member's nodes (name / ready / schedulable) for the migrate **target picker**. ClusterService gains pool+auth (ListClusters/WatchClusters still use only the hub cache). Unknown/unreachable cluster → `ClusterError`, not an empty list.
- **RBAC**: acting subject needs `create` on `swiftmigrations` + `list` on `nodes` (member-rbac sample updated).
- **Tests**: MigrateGuest creates a SwiftMigration + rejects a missing `target_node`; ListNodes maps ready/schedulable (a cordoned node) + surfaces unknown-cluster errors.

`go build`, full `go test ./...`, `buf lint`, `gofmt` green.

## After merge

rebuild → redeploy → grant `create swiftmigrations` + `list nodes` → the UI drawer gets a **Migrate** dialog (target node dropdown from ListNodes + mode + allowIPChange) (separate UI commit) → cluster-validate by migrating `ft-vm`.

A dedicated **migrations view** (List/Watch SwiftMigrations + live progress) is a deliberate later add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)