### PR TITLE
refactor(actions): extract shared VM lifecycle primitives (gateway + swiftctl)

### DIFF
--- a/cmd/swiftctl/migration.go
+++ b/cmd/swiftctl/migration.go
@@ -10,10 +10,10 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/actions"
 	"github.com/projectbeskar/kubeswift/internal/scheme"
 )
 
@@ -165,57 +165,40 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	c, err := newMigrationClient()
+	if migrateCheck {
+		// Preflight only — the typed client drives the read-only checks; it
+		// creates nothing.
+		c, err := newMigrationClient()
+		if err != nil {
+			return err
+		}
+		return runMigratePreflight(cmd, c, guestName, ns, mode)
+	}
+
+	dyn, err := newDynamicClient()
 	if err != nil {
 		return err
 	}
-	if migrateCheck {
-		return runMigratePreflight(cmd, c, guestName, ns, mode)
-	}
-	name := migrateName
-	if name == "" {
-		// Use the apiserver's GenerateName so the resource gets a
-		// unique suffix even if the operator runs `swiftctl migrate`
-		// twice in quick succession.
-		name = ""
-	}
-	mig := &migrationv1alpha1.SwiftMigration{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns,
-		},
-		Spec: migrationv1alpha1.SwiftMigrationSpec{
-			GuestRef:      migrationv1alpha1.SwiftMigrationGuestRef{Name: guestName},
-			Target:        migrationv1alpha1.SwiftMigrationTarget{NodeName: migrateTargetNode},
-			Mode:          mode,
-			AllowIPChange: migrateAllowIPChange,
-		},
-	}
-	// Only set spec.timeout when the operator passed --timeout; leaving it nil
-	// lets the apiserver apply the CRD default (30m).
-	mig.Spec.Timeout = migrationTimeoutPtr(migrateTimeout)
-	// --ttl (opt-in): auto-delete the migration record this long after it
-	// finishes. nil when unset (kept until deleted by hand).
-	mig.Spec.TTL = migrationTimeoutPtr(migrateTTL)
-	if name == "" {
-		mig.GenerateName = guestName + "-migrate-"
-	} else {
-		mig.Name = name
-	}
-	if err := c.Create(context.Background(), mig); err != nil {
+	// migrateName is "" by default, so actions.Migrate falls back to the
+	// "<guest>-migrate-" generateName prefix (the apiserver assigns a unique
+	// suffix even if the operator runs `swiftctl migrate` twice in quick
+	// succession). --timeout/--ttl of 0 are omitted so the CRD defaults apply
+	// (spec.timeout defaults to 30m; spec.ttl unset = keep).
+	created, err := actions.Migrate(context.Background(), dyn, actions.MigrateParams{
+		Namespace:     ns,
+		GuestName:     guestName,
+		TargetNode:    migrateTargetNode,
+		Mode:          string(mode),
+		AllowIPChange: migrateAllowIPChange,
+		Name:          migrateName,
+		Timeout:       migrateTimeout,
+		TTL:           migrateTTL,
+	})
+	if err != nil {
 		return fmt.Errorf("create SwiftMigration: %w", err)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "swiftmigration.migration.kubeswift.io/%s created\n", mig.Name)
+	fmt.Fprintf(cmd.OutOrStdout(), "swiftmigration.migration.kubeswift.io/%s created\n", created.GetName())
 	return nil
-}
-
-// migrationTimeoutPtr maps the --timeout flag to spec.timeout: a positive
-// duration becomes an explicit override; zero (the flag default) returns nil so
-// the apiserver applies the CRD default (30m).
-func migrationTimeoutPtr(d time.Duration) *metav1.Duration {
-	if d <= 0 {
-		return nil
-	}
-	return &metav1.Duration{Duration: d}
 }
 
 func runMigrationList(cmd *cobra.Command, _ []string) error {

--- a/cmd/swiftctl/migration_test.go
+++ b/cmd/swiftctl/migration_test.go
@@ -132,15 +132,7 @@ func TestRenderMigrationDescribe_LiveProgress(t *testing.T) {
 	}
 }
 
-func TestMigrationTimeoutPtr(t *testing.T) {
-	if got := migrationTimeoutPtr(0); got != nil {
-		t.Errorf("0 (flag default) must return nil so the CRD default applies; got %v", got)
-	}
-	if got := migrationTimeoutPtr(-5 * time.Second); got != nil {
-		t.Errorf("negative must return nil; got %v", got)
-	}
-	got := migrationTimeoutPtr(10 * time.Minute)
-	if got == nil || got.Duration != 10*time.Minute {
-		t.Errorf("positive must return an explicit override; got %v", got)
-	}
-}
+// The --timeout/--ttl flag-to-spec mapping moved into internal/actions
+// (actions.Migrate omits a zero duration so the CRD default applies, and
+// serializes a positive one). It is covered by the actions package tests
+// (TestMigrate_CreatesSwiftMigration / TestMigrate_DefaultsModeAndName).

--- a/cmd/swiftctl/root.go
+++ b/cmd/swiftctl/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/projectbeskar/kubeswift/internal/cli"
 	"github.com/projectbeskar/kubeswift/internal/version"
@@ -46,6 +47,18 @@ func init() {
 	rootCmd.AddCommand(scheduleCmd)
 	rootCmd.AddCommand(migrateCmd)
 	rootCmd.AddCommand(migrationCmd)
+}
+
+// newDynamicClient builds a dynamic client from the resolved kubeconfig. The
+// shared lifecycle actions (start/stop/migrate, internal/actions) operate over a
+// dynamic.Interface — the same model the gateway uses — so swiftctl builds one
+// here instead of a typed controller-runtime client for those commands.
+func newDynamicClient() (dynamic.Interface, error) {
+	cfg, err := kubeConfig.ToRESTConfig()
+	if err != nil {
+		return nil, fmt.Errorf("kubeconfig: %w", err)
+	}
+	return dynamic.NewForConfig(cfg)
 }
 
 func getNamespace() string {

--- a/cmd/swiftctl/start.go
+++ b/cmd/swiftctl/start.go
@@ -5,19 +5,16 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
-	"github.com/projectbeskar/kubeswift/internal/cli"
-	"github.com/projectbeskar/kubeswift/internal/scheme"
+	"github.com/projectbeskar/kubeswift/internal/actions"
 )
 
 var startCmd = &cobra.Command{
 	Use:          "start [guest-name]",
 	Short:        "Start a SwiftGuest",
 	SilenceUsage: true,
-	Long: `Start a SwiftGuest by setting spec.runPolicy=Running and recreating the pod.
-The controller will create a new pod with lifecycle=start; swiftletd will launch the VM.`,
+	Long: `Start a SwiftGuest by setting spec.runPolicy=Running.
+The controller creates a new launcher pod; swiftletd launches the VM.`,
 	Example: `  swiftctl start sample
   swiftctl -n myns start my-guest`,
 	Args: cobra.ExactArgs(1),
@@ -28,39 +25,17 @@ func runStart(cmd *cobra.Command, args []string) error {
 	guestName := args[0]
 	ns := getNamespace()
 
-	config, err := kubeConfig.ToRESTConfig()
-	if err != nil {
-		return fmt.Errorf("kubeconfig: %w", err)
-	}
-
-	c, err := client.New(config, client.Options{Scheme: scheme.Scheme})
-	if err != nil {
-		return fmt.Errorf("create client: %w", err)
-	}
-
-	resolver := &cli.GuestResolver{Client: c}
-	ctx := context.Background()
-
-	guest, err := resolver.ResolveGuest(ctx, ns, guestName)
+	dyn, err := newDynamicClient()
 	if err != nil {
 		return err
 	}
 
-	// Patch runPolicy to Running
-	if err := resolver.PatchRunPolicy(ctx, guest, swiftv1alpha1.RunPolicyRunning); err != nil {
+	// Start patches runPolicy=Running; the controller recreates the launcher
+	// pod. (To recreate the pod of an already-running guest, use `restart`.)
+	if _, err := actions.Start(context.Background(), dyn, ns, guestName); err != nil {
 		return fmt.Errorf("failed to start guest: %w", err)
 	}
 
-	// Delete pod if it exists so controller recreates with lifecycle=start
-	pod, err := resolver.ResolvePod(ctx, guest)
-	if err == nil {
-		if err := resolver.DeletePod(ctx, pod); err != nil {
-			return fmt.Errorf("failed to delete pod: %w", err)
-		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Started %s/%s (pod deleted, controller will recreate)\n", ns, guestName)
-	} else {
-		fmt.Fprintf(cmd.OutOrStdout(), "Started %s/%s (runPolicy=Running)\n", ns, guestName)
-	}
-
+	fmt.Fprintf(cmd.OutOrStdout(), "Started %s/%s (runPolicy=Running; controller will recreate the pod)\n", ns, guestName)
 	return nil
 }

--- a/cmd/swiftctl/stop.go
+++ b/cmd/swiftctl/stop.go
@@ -3,29 +3,23 @@ package main
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/remotecommand"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
-	"github.com/projectbeskar/kubeswift/internal/cli"
-	"github.com/projectbeskar/kubeswift/internal/scheme"
-
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"github.com/projectbeskar/kubeswift/internal/actions"
 )
 
 var stopCmd = &cobra.Command{
 	Use:          "stop [guest-name]",
 	Short:        "Stop a SwiftGuest",
 	SilenceUsage: true,
-	Long: `Stop a SwiftGuest by setting spec.runPolicy=Stopped and deleting the pod.
-The controller will create a new pod with lifecycle=stop; swiftletd will exit without launching.`,
+	Long: `Stop a SwiftGuest by setting spec.runPolicy=Stopped and deleting the launcher pod.
+
+Both steps are required: the SwiftGuest stop guard is reactive — it prevents
+the pod from being recreated, it does not stop a running VM — so a runPolicy
+patch alone leaves the guest running. Deleting the launcher pod triggers
+swiftletd's graceful SIGTERM shutdown within the pod's termination grace
+period; the guard then keeps it stopped.`,
 	Example: `  swiftctl stop sample
   swiftctl -n myns stop my-guest`,
 	Args: cobra.ExactArgs(1),
@@ -36,91 +30,13 @@ func runStop(cmd *cobra.Command, args []string) error {
 	guestName := args[0]
 	ns := getNamespace()
 
-	config, err := kubeConfig.ToRESTConfig()
-	if err != nil {
-		return fmt.Errorf("kubeconfig: %w", err)
-	}
-
-	c, err := client.New(config, client.Options{Scheme: scheme.Scheme})
-	if err != nil {
-		return fmt.Errorf("create client: %w", err)
-	}
-
-	resolver := &cli.GuestResolver{Client: c}
-	ctx := context.Background()
-
-	guest, err := resolver.ResolveGuest(ctx, ns, guestName)
+	dyn, err := newDynamicClient()
 	if err != nil {
 		return err
 	}
 
-	if err := resolver.PatchRunPolicy(ctx, guest, swiftv1alpha1.RunPolicyStopped); err != nil {
+	if _, err := actions.Stop(context.Background(), dyn, ns, guestName); err != nil {
 		return fmt.Errorf("failed to stop guest: %w", err)
-	}
-
-	if guest.Status.Phase != swiftv1alpha1.SwiftGuestPhaseRunning {
-		fmt.Fprintf(cmd.OutOrStdout(), "Stopped %s/%s\n", ns, guestName)
-		return nil
-	}
-
-	pod, err := resolver.ResolvePod(ctx, guest)
-	if err != nil {
-		fmt.Fprintf(cmd.OutOrStdout(), "Stopped %s/%s\n", ns, guestName)
-		return nil
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return fmt.Errorf("create clientset: %w", err)
-	}
-
-	pid := int64(0)
-	if guest.Status.Runtime != nil {
-		pid = guest.Status.Runtime.PID
-	}
-
-	if pid != 0 {
-		req := clientset.CoreV1().RESTClient().Post().
-			Resource("pods").
-			Namespace(pod.Namespace).
-			Name(pod.Name).
-			SubResource("exec").
-			VersionedParams(&corev1.PodExecOptions{
-				Container: cli.LauncherContainer,
-				Command:   []string{"kill", "-TERM", fmt.Sprintf("%d", pid)},
-				Stdin:     false,
-				Stdout:    true,
-				Stderr:    true,
-				TTY:       false,
-			}, clientgoscheme.ParameterCodec)
-
-		executor, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
-		if err != nil {
-			return fmt.Errorf("failed to create executor: %w", err)
-		}
-
-		_ = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
-			Stdout: cmd.OutOrStdout(),
-			Stderr: cmd.ErrOrStderr(),
-		})
-	}
-
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
-		_, err := clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) {
-				fmt.Fprintf(cmd.OutOrStdout(), "Stopped %s/%s\n", ns, guestName)
-				return nil
-			}
-			return fmt.Errorf("failed to check pod: %w", err)
-		}
-		time.Sleep(2 * time.Second)
-	}
-
-	fmt.Fprintln(cmd.ErrOrStderr(), "graceful shutdown timed out, forcing pod deletion")
-	if err := clientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("failed to delete pod: %w", err)
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Stopped %s/%s\n", ns, guestName)

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -1,0 +1,185 @@
+// Package actions implements the shared SwiftGuest lifecycle primitives —
+// start, stop, migrate — used by BOTH swiftctl and the kubeswift-gateway.
+//
+// These actions were implemented twice and drifted: the gateway's StopGuest
+// once patched runPolicy=Stopped but forgot to delete the launcher pod, so a
+// running VM never stopped (fixed in PR #267, caught only by cluster
+// validation). Centralizing the logic here gives the two surfaces a single
+// code path, so the next such divergence cannot happen.
+//
+// The primitives operate over a dynamic.Interface. swiftctl historically used a
+// typed controller-runtime client and the gateway a dynamic (per-member,
+// impersonating) client; the dynamic client is the common denominator (the
+// gateway needs impersonation, swiftctl builds one cheaply from its REST
+// config), so it is the single model here. Callers keep their own input
+// validation and error mapping (connect codes for the gateway, cobra errors for
+// swiftctl) — this package returns plain errors and the patched/created object.
+package actions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+
+	migrationv1alpha1 "github.com/projectbeskar/kubeswift/api/migration/v1alpha1"
+	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
+)
+
+const (
+	// GuestLabel ties a launcher pod to its SwiftGuest. The label — not the pod
+	// name — is the stable handle: a live-migrated guest's pod is renamed to
+	// <guest>-mig-<uid>, but this label still selects it.
+	GuestLabel = "swift.kubeswift.io/guest"
+
+	// LauncherContainer is the swiftletd container in the (multi-container)
+	// launcher pod — the one holding the serial socket and the VM process.
+	LauncherContainer = "launcher"
+)
+
+// RunPolicy spec values the start/stop primitives patch. Derived from the API
+// enum so there is a single source of truth for the strings.
+const (
+	RunPolicyRunning = string(swiftv1alpha1.RunPolicyRunning)
+	RunPolicyStopped = string(swiftv1alpha1.RunPolicyStopped)
+)
+
+// Resource GVRs the primitives act on. Centralized here so the gateway and any
+// other dynamic-client caller reference one definition.
+var (
+	SwiftGuestGVR     = schema.GroupVersionResource{Group: "swift.kubeswift.io", Version: "v1alpha1", Resource: "swiftguests"}
+	SwiftMigrationGVR = schema.GroupVersionResource{Group: "migration.kubeswift.io", Version: "v1alpha1", Resource: "swiftmigrations"}
+	PodGVR            = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+)
+
+// SetRunPolicy patches spec.runPolicy on the named SwiftGuest via a merge patch
+// and returns the patched object.
+func SetRunPolicy(ctx context.Context, dyn dynamic.Interface, namespace, name, policy string) (*unstructured.Unstructured, error) {
+	patch := []byte(fmt.Sprintf(`{"spec":{"runPolicy":%q}}`, policy))
+	return dyn.Resource(SwiftGuestGVR).Namespace(namespace).
+		Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+}
+
+// Start sets runPolicy=Running. The SwiftGuest controller recreates the launcher
+// pod once the policy is Running, so no pod action is needed here. (To force a
+// running guest's pod to be recreated, delete the pod — that is "restart", a
+// distinct operation, not "start".)
+func Start(ctx context.Context, dyn dynamic.Interface, namespace, name string) (*unstructured.Unstructured, error) {
+	return SetRunPolicy(ctx, dyn, namespace, name, RunPolicyRunning)
+}
+
+// Stop sets runPolicy=Stopped AND deletes the launcher pod(s). Both steps are
+// required: the SwiftGuest stop guard is reactive — it prevents pod
+// *recreation*, it does not stop a running VM — so a runPolicy patch alone
+// leaves the guest running (verified on-cluster; the bug PR #267 fixed in the
+// gateway was exactly a Stop that patched but forgot the pod delete). Deleting
+// the launcher pod triggers swiftletd's graceful SIGTERM shutdown (within the
+// pod's termination grace period); the guard then keeps it stopped.
+//
+// The returned object is the runPolicy=Stopped patch result.
+func Stop(ctx context.Context, dyn dynamic.Interface, namespace, name string) (*unstructured.Unstructured, error) {
+	u, err := SetRunPolicy(ctx, dyn, namespace, name, RunPolicyStopped)
+	if err != nil {
+		return nil, err
+	}
+	if err := DeleteLauncherPods(ctx, dyn, namespace, name); err != nil {
+		return nil, fmt.Errorf("runPolicy patched to Stopped but stopping the VM (pod delete) failed: %w", err)
+	}
+	return u, nil
+}
+
+// DeleteLauncherPods deletes the guest's launcher pod(s), selected by GuestLabel
+// (robust to the <guest>-mig-<uid> rename after a live migration). A pod that is
+// already gone is success — the VM is already stopped.
+func DeleteLauncherPods(ctx context.Context, dyn dynamic.Interface, namespace, guestName string) error {
+	pods, err := dyn.Resource(PodGVR).Namespace(namespace).
+		List(ctx, metav1.ListOptions{LabelSelector: GuestLabel + "=" + guestName})
+	if err != nil {
+		return err
+	}
+	for i := range pods.Items {
+		name := pods.Items[i].GetName()
+		if err := dyn.Resource(PodGVR).Namespace(namespace).
+			Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// MigrateParams describes a SwiftMigration to create. The variable bits — the
+// resource name, optional timeout/ttl, the reason string — let swiftctl and the
+// UI shape the record while sharing the spec construction.
+type MigrateParams struct {
+	Namespace     string
+	GuestName     string
+	TargetNode    string
+	Mode          string // auto | live | offline; empty resolves to auto
+	AllowIPChange bool
+	Reason        string // free-text spec.reason; omitted when empty
+
+	// Name vs GenerateName: set at most one. If both are empty, GenerateName
+	// defaults to "<guest>-migrate-".
+	Name         string
+	GenerateName string
+
+	// Optional spec.timeout / spec.ttl. Zero omits the field, letting the CRD
+	// defaults apply (spec.timeout defaults to 30m; spec.ttl unset = keep).
+	Timeout time.Duration
+	TTL     time.Duration
+}
+
+// Migrate creates a SwiftMigration for the guest named in p and returns the
+// created object (its generated name is on metadata.name). Callers validate
+// inputs (e.g. a required target node) and map errors to their own surface — a
+// webhook admission denial (allowIPChange required for a cross-node move, or
+// live+VFIO) propagates here, never a silent failure.
+func Migrate(ctx context.Context, dyn dynamic.Interface, p MigrateParams) (*unstructured.Unstructured, error) {
+	mode := p.Mode
+	if mode == "" {
+		mode = string(migrationv1alpha1.SwiftMigrationModeAuto)
+	}
+
+	meta := map[string]interface{}{"namespace": p.Namespace}
+	switch {
+	case p.Name != "":
+		meta["name"] = p.Name
+	case p.GenerateName != "":
+		meta["generateName"] = p.GenerateName
+	default:
+		meta["generateName"] = p.GuestName + "-migrate-"
+	}
+
+	spec := map[string]interface{}{
+		"guestRef":      map[string]interface{}{"name": p.GuestName},
+		"target":        map[string]interface{}{"nodeName": p.TargetNode},
+		"mode":          mode,
+		"allowIPChange": p.AllowIPChange,
+	}
+	if p.Reason != "" {
+		spec["reason"] = p.Reason
+	}
+	// metav1.Duration marshals as a Go duration string (e.g. "10m0s"); the
+	// apiserver parses it back into the CRD's *metav1.Duration field.
+	if p.Timeout > 0 {
+		spec["timeout"] = p.Timeout.String()
+	}
+	if p.TTL > 0 {
+		spec["ttl"] = p.TTL.String()
+	}
+
+	mig := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "migration.kubeswift.io/v1alpha1",
+		"kind":       "SwiftMigration",
+		"metadata":   meta,
+		"spec":       spec,
+	}}
+	return dyn.Resource(SwiftMigrationGVR).Namespace(p.Namespace).
+		Create(ctx, mig, metav1.CreateOptions{})
+}

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -1,0 +1,225 @@
+package actions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func uGuest(ns, name, policy string) *unstructured.Unstructured {
+	spec := map[string]interface{}{
+		"guestClassRef": map[string]interface{}{"name": "default"},
+		"imageRef":      map[string]interface{}{"name": "ubuntu-noble"},
+	}
+	if policy != "" {
+		spec["runPolicy"] = policy
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "swift.kubeswift.io/v1alpha1",
+		"kind":       "SwiftGuest",
+		"metadata":   map[string]interface{}{"namespace": ns, "name": name},
+		"spec":       spec,
+	}}
+}
+
+func uPod(ns, name, guest string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"namespace": ns, "name": name,
+			"labels": map[string]interface{}{GuestLabel: guest},
+		},
+	}}
+}
+
+func fakeDyn(objs ...*unstructured.Unstructured) dynamic.Interface {
+	ro := make([]runtime.Object, len(objs))
+	for i, o := range objs {
+		ro[i] = o
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			SwiftGuestGVR:     "SwiftGuestList",
+			PodGVR:            "PodList",
+			SwiftMigrationGVR: "SwiftMigrationList",
+		}, ro...)
+}
+
+func runPolicyOf(t *testing.T, dyn dynamic.Interface, ns, name string) string {
+	t.Helper()
+	u, err := dyn.Resource(SwiftGuestGVR).Namespace(ns).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get guest: %v", err)
+	}
+	p, _, _ := unstructured.NestedString(u.Object, "spec", "runPolicy")
+	return p
+}
+
+func podCount(t *testing.T, dyn dynamic.Interface, ns string) int {
+	t.Helper()
+	l, err := dyn.Resource(PodGVR).Namespace(ns).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	return len(l.Items)
+}
+
+// Start patches runPolicy=Running and leaves the launcher pod alone (the
+// controller recreates a stopped one; a running one keeps running).
+func TestStart_PatchesRunningKeepsPod(t *testing.T) {
+	dyn := fakeDyn(uGuest("default", "vm-a", "Stopped"), uPod("default", "vm-a", "vm-a"))
+
+	u, err := Start(context.Background(), dyn, "default", "vm-a")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if u.GetName() != "vm-a" {
+		t.Errorf("Start returned %q, want vm-a", u.GetName())
+	}
+	if got := runPolicyOf(t, dyn, "default", "vm-a"); got != RunPolicyRunning {
+		t.Errorf("runPolicy=%q, want Running", got)
+	}
+	if got := podCount(t, dyn, "default"); got != 1 {
+		t.Errorf("Start deleted the launcher pod: %d pods, want 1", got)
+	}
+}
+
+// Stop patches runPolicy=Stopped AND deletes the launcher pod — both halves are
+// load-bearing (the stop guard is reactive; PR #267).
+func TestStop_PatchesStoppedAndDeletesPod(t *testing.T) {
+	dyn := fakeDyn(uGuest("default", "vm-a", "Running"), uPod("default", "vm-a", "vm-a"))
+
+	if _, err := Stop(context.Background(), dyn, "default", "vm-a"); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if got := runPolicyOf(t, dyn, "default", "vm-a"); got != RunPolicyStopped {
+		t.Errorf("runPolicy=%q, want Stopped", got)
+	}
+	if got := podCount(t, dyn, "default"); got != 0 {
+		t.Errorf("Stop left %d launcher pods, want 0", got)
+	}
+}
+
+// Stop selects the pod by the guest label, so it stops a live-migrated guest
+// whose pod was renamed <guest>-mig-<uid>.
+func TestStop_DeletesRenamedMigrationPod(t *testing.T) {
+	dyn := fakeDyn(uGuest("default", "vm-a", "Running"), uPod("default", "vm-a-mig-abcd", "vm-a"))
+
+	if _, err := Stop(context.Background(), dyn, "default", "vm-a"); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if got := podCount(t, dyn, "default"); got != 0 {
+		t.Errorf("Stop left %d launcher pods, want 0 (renamed pod not selected by label)", got)
+	}
+}
+
+// Stop with no launcher pod is success — the VM is already stopped.
+func TestStop_NoPodIsSuccess(t *testing.T) {
+	dyn := fakeDyn(uGuest("default", "vm-a", "Running"))
+	if _, err := Stop(context.Background(), dyn, "default", "vm-a"); err != nil {
+		t.Fatalf("Stop with no pod should succeed: %v", err)
+	}
+	if got := runPolicyOf(t, dyn, "default", "vm-a"); got != RunPolicyStopped {
+		t.Errorf("runPolicy=%q, want Stopped", got)
+	}
+}
+
+func TestMigrate_CreatesSwiftMigration(t *testing.T) {
+	dyn := fakeDyn(uGuest("default", "vm-a", "Running"))
+
+	created, err := Migrate(context.Background(), dyn, MigrateParams{
+		Namespace:     "default",
+		GuestName:     "vm-a",
+		TargetNode:    "miles",
+		Mode:          "offline",
+		AllowIPChange: true,
+		Reason:        "test",
+		Timeout:       10 * time.Minute,
+		TTL:           time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	migs, err := dyn.Resource(SwiftMigrationGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list migrations: %v", err)
+	}
+	if len(migs.Items) != 1 {
+		t.Fatalf("want 1 SwiftMigration, got %d", len(migs.Items))
+	}
+	m := migs.Items[0]
+	if m.GetName() != created.GetName() {
+		t.Errorf("created name %q != listed %q", created.GetName(), m.GetName())
+	}
+	guestName, _, _ := unstructured.NestedString(m.Object, "spec", "guestRef", "name")
+	node, _, _ := unstructured.NestedString(m.Object, "spec", "target", "nodeName")
+	mode, _, _ := unstructured.NestedString(m.Object, "spec", "mode")
+	allowIP, _, _ := unstructured.NestedBool(m.Object, "spec", "allowIPChange")
+	reason, _, _ := unstructured.NestedString(m.Object, "spec", "reason")
+	timeout, _, _ := unstructured.NestedString(m.Object, "spec", "timeout")
+	ttl, _, _ := unstructured.NestedString(m.Object, "spec", "ttl")
+	if guestName != "vm-a" || node != "miles" || mode != "offline" || !allowIP || reason != "test" {
+		t.Errorf("spec wrong: guest=%q node=%q mode=%q allowIP=%v reason=%q", guestName, node, mode, allowIP, reason)
+	}
+	if timeout != "10m0s" || ttl != "1h0m0s" {
+		t.Errorf("duration spec wrong: timeout=%q ttl=%q", timeout, ttl)
+	}
+}
+
+// An empty mode resolves to auto; an empty Name+GenerateName defaults the
+// generateName prefix; timeout/ttl are omitted (so the CRD default applies).
+func TestMigrate_DefaultsModeAndName(t *testing.T) {
+	dyn := fakeDyn(uGuest("default", "vm-a", "Running"))
+
+	if _, err := Migrate(context.Background(), dyn, MigrateParams{
+		Namespace:  "default",
+		GuestName:  "vm-a",
+		TargetNode: "miles",
+	}); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	migs, _ := dyn.Resource(SwiftMigrationGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
+	if len(migs.Items) != 1 {
+		t.Fatalf("want 1 SwiftMigration, got %d", len(migs.Items))
+	}
+	m := migs.Items[0]
+	mode, _, _ := unstructured.NestedString(m.Object, "spec", "mode")
+	if mode != "auto" {
+		t.Errorf("empty mode should default to auto, got %q", mode)
+	}
+	if gn := m.GetGenerateName(); gn != "vm-a-migrate-" {
+		t.Errorf("generateName=%q, want vm-a-migrate-", gn)
+	}
+	if _, found, _ := unstructured.NestedString(m.Object, "spec", "timeout"); found {
+		t.Error("timeout should be omitted when zero (CRD default applies)")
+	}
+	if _, found, _ := unstructured.NestedString(m.Object, "spec", "ttl"); found {
+		t.Error("ttl should be omitted when zero")
+	}
+}
+
+// An explicit Name wins over the generateName default.
+func TestMigrate_ExplicitName(t *testing.T) {
+	dyn := fakeDyn(uGuest("default", "vm-a", "Running"))
+	created, err := Migrate(context.Background(), dyn, MigrateParams{
+		Namespace:  "default",
+		GuestName:  "vm-a",
+		TargetNode: "miles",
+		Name:       "vm-a-rebalance",
+	})
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if created.GetName() != "vm-a-rebalance" {
+		t.Errorf("explicit name not used: %q", created.GetName())
+	}
+}

--- a/internal/cli/guest.go
+++ b/internal/cli/guest.go
@@ -181,8 +181,6 @@ func (r *GuestResolver) DeletePod(ctx context.Context, pod *corev1.Pod) error {
 	return r.Delete(ctx, pod)
 }
 
-// PatchRunPolicy patches the SwiftGuest spec.runPolicy.
-func (r *GuestResolver) PatchRunPolicy(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, runPolicy swiftv1alpha1.RunPolicy) error {
-	guest.Spec.RunPolicy = runPolicy
-	return r.Update(ctx, guest)
-}
+// NOTE: run-policy patching (start/stop) now lives in internal/actions
+// (shared with the kubeswift-gateway over a dynamic client). The former
+// GuestResolver.PatchRunPolicy was removed to keep a single implementation.

--- a/internal/gateway/guest_service.go
+++ b/internal/gateway/guest_service.go
@@ -3,7 +3,6 @@ package gateway
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 	"sync"
 
@@ -12,13 +11,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 
 	swiftv1alpha1 "github.com/projectbeskar/kubeswift/api/swift/v1alpha1"
 	kubeswiftv1 "github.com/projectbeskar/kubeswift/gen/kubeswift/v1"
 	"github.com/projectbeskar/kubeswift/gen/kubeswift/v1/kubeswiftv1connect"
+	"github.com/projectbeskar/kubeswift/internal/actions"
 )
 
 // clientProvider is the subset of ClientPool the read plane needs: a per-member
@@ -199,24 +198,25 @@ func (s *GuestService) GetGuestDetail(ctx context.Context, req *connect.Request[
 }
 
 // StartGuest sets the guest's runPolicy to Running; StopGuest sets it to
-// Stopped. Both patch spec.runPolicy via the impersonating dynamic client, so
-// the member cluster's RBAC authorizes the end user (decision D1).
-//
-// StopGuest ALSO deletes the launcher pod: the SwiftGuest stop guard is
-// reactive — it prevents pod *recreation*, it does not stop a running VM — so a
-// runPolicy patch alone leaves the guest running (verified on-cluster). Deleting
-// the pod triggers swiftletd's graceful SIGTERM shutdown; the guard then keeps
-// it stopped. StartGuest needs no pod action — the controller recreates the pod
-// once runPolicy is Running. The live Watch reflects the resulting phase.
+// Stopped and deletes the launcher pod. Both run as the impersonated user
+// against the member cluster (decision D1) and delegate to internal/actions,
+// the single implementation shared with swiftctl — so a stop that forgets the
+// pod delete (PR #267) cannot diverge between the two surfaces again. The live
+// Watch reflects the resulting phase.
 func (s *GuestService) StartGuest(ctx context.Context, req *connect.Request[kubeswiftv1.GuestActionRequest]) (*connect.Response[kubeswiftv1.GuestActionResponse], error) {
-	return s.setRunPolicy(ctx, req, "Running", false)
+	return s.guestAction(ctx, req, actions.Start)
 }
 
 func (s *GuestService) StopGuest(ctx context.Context, req *connect.Request[kubeswiftv1.GuestActionRequest]) (*connect.Response[kubeswiftv1.GuestActionResponse], error) {
-	return s.setRunPolicy(ctx, req, "Stopped", true)
+	return s.guestAction(ctx, req, actions.Stop)
 }
 
-func (s *GuestService) setRunPolicy(ctx context.Context, req *connect.Request[kubeswiftv1.GuestActionRequest], policy string, deleteLauncher bool) (*connect.Response[kubeswiftv1.GuestActionResponse], error) {
+// guestAction authenticates, validates the ref, resolves the impersonating
+// dynamic client, runs the shared action, and maps the patched guest to proto.
+// action is actions.Start or actions.Stop (same signature).
+func (s *GuestService) guestAction(ctx context.Context, req *connect.Request[kubeswiftv1.GuestActionRequest],
+	action func(context.Context, dynamic.Interface, string, string) (*unstructured.Unstructured, error),
+) (*connect.Response[kubeswiftv1.GuestActionResponse], error) {
 	id, err := s.auth.Authenticate(ctx, req.Header())
 	if err != nil {
 		return nil, err
@@ -229,41 +229,15 @@ func (s *GuestService) setRunPolicy(ctx context.Context, req *connect.Request[ku
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
-	patch := []byte(fmt.Sprintf(`{"spec":{"runPolicy":%q}}`, policy))
-	u, err := dyn.Resource(swiftGuestGVR).Namespace(ref.GetNamespace()).
-		Patch(ctx, ref.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
+	u, err := action(ctx, dyn, ref.GetNamespace(), ref.GetName())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	if deleteLauncher {
-		if err := s.deleteLauncherPods(ctx, dyn, ref); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("runPolicy patched but stopping the VM (pod delete) failed: %w", err))
-		}
 	}
 	g, err := toSwiftGuest(u)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	return connect.NewResponse(&kubeswiftv1.GuestActionResponse{Guest: guestToProto(ref.GetCluster(), g)}), nil
-}
-
-// deleteLauncherPods deletes the guest's launcher pod(s), selected by the guest
-// label (robust to the <guest>-mig-<uid> rename after a live migration). A
-// pod that is already gone is success — the VM is already stopped.
-func (s *GuestService) deleteLauncherPods(ctx context.Context, dyn dynamic.Interface, ref *kubeswiftv1.ObjectRef) error {
-	pods, err := dyn.Resource(podGVR).Namespace(ref.GetNamespace()).
-		List(ctx, metav1.ListOptions{LabelSelector: guestPodLabel + "=" + ref.GetName()})
-	if err != nil {
-		return err
-	}
-	for i := range pods.Items {
-		name := pods.Items[i].GetName()
-		if err := dyn.Resource(podGVR).Namespace(ref.GetNamespace()).
-			Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
 }
 
 // MigrateGuest creates a SwiftMigration to move the guest to targetNode, as the
@@ -281,31 +255,19 @@ func (s *GuestService) MigrateGuest(ctx context.Context, req *connect.Request[ku
 	if req.Msg.GetTargetNode() == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("target_node is required"))
 	}
-	mode := req.Msg.GetMode()
-	if mode == "" {
-		mode = "auto"
-	}
 	dyn, err := s.pool.DynamicFor(ref.GetCluster(), id)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
-	mig := &unstructured.Unstructured{Object: map[string]interface{}{
-		"apiVersion": "migration.kubeswift.io/v1alpha1",
-		"kind":       "SwiftMigration",
-		"metadata": map[string]interface{}{
-			"generateName": ref.GetName() + "-mig-",
-			"namespace":    ref.GetNamespace(),
-		},
-		"spec": map[string]interface{}{
-			"guestRef":      map[string]interface{}{"name": ref.GetName()},
-			"target":        map[string]interface{}{"nodeName": req.Msg.GetTargetNode()},
-			"mode":          mode,
-			"allowIPChange": req.Msg.GetAllowIpChange(),
-			"reason":        "initiated from the KubeSwift UI",
-		},
-	}}
-	created, err := dyn.Resource(swiftMigrationGVR).Namespace(ref.GetNamespace()).
-		Create(ctx, mig, metav1.CreateOptions{})
+	created, err := actions.Migrate(ctx, dyn, actions.MigrateParams{
+		Namespace:     ref.GetNamespace(),
+		GuestName:     ref.GetName(),
+		TargetNode:    req.Msg.GetTargetNode(),
+		Mode:          req.Msg.GetMode(), // empty resolves to auto in actions.Migrate
+		AllowIPChange: req.Msg.GetAllowIpChange(),
+		Reason:        "initiated from the KubeSwift UI",
+		GenerateName:  ref.GetName() + "-mig-",
+	})
 	if err != nil {
 		// A webhook admission denial (e.g. allowIPChange required for a
 		// cross-node move, or live+VFIO) surfaces here with its reason — never

--- a/internal/gateway/pool.go
+++ b/internal/gateway/pool.go
@@ -20,36 +20,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fleetv1alpha1 "github.com/projectbeskar/kubeswift/api/fleet/v1alpha1"
+	"github.com/projectbeskar/kubeswift/internal/actions"
 )
 
-// swiftGuestGVR is the dynamic resource the read plane lists/watches per member.
-// Using the dynamic client keyed by a known GVR avoids per-request discovery /
-// RESTMapper construction; member clients are therefore cheap to create.
-var swiftGuestGVR = schema.GroupVersionResource{
-	Group:    "swift.kubeswift.io",
-	Version:  "v1alpha1",
-	Resource: "swiftguests",
-}
-
-// podGVR is the launcher-pod resource. StopGuest deletes the launcher pod (by
-// the guest label below) after patching runPolicy, because the SwiftGuest stop
-// guard is reactive only — it prevents pod recreation, it does not stop a
-// running VM.
-var podGVR = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
-
-// swiftMigrationGVR is the SwiftMigration resource — MigrateGuest creates one.
-var swiftMigrationGVR = schema.GroupVersionResource{Group: "migration.kubeswift.io", Version: "v1alpha1", Resource: "swiftmigrations"}
+// swiftGuestGVR, podGVR, swiftMigrationGVR, guestPodLabel, and launcherContainer
+// are sourced from internal/actions — the single definition shared with
+// swiftctl and the write-action primitives. The read plane (ListGuests /
+// WatchGuests), console, and telemetry reference these gateway-local names; the
+// values live in one place.
+var (
+	swiftGuestGVR     = actions.SwiftGuestGVR
+	podGVR            = actions.PodGVR
+	swiftMigrationGVR = actions.SwiftMigrationGVR
+)
 
 // nodeGVR is the core node resource — ListNodes lists it for the migrate picker.
+// It is gateway-only (no write action touches nodes), so it stays local.
 var nodeGVR = schema.GroupVersionResource{Version: "v1", Resource: "nodes"}
 
 // guestPodLabel ties a launcher pod to its SwiftGuest. The label (not the pod
 // name) is the stable handle — a live-migrated guest's pod is <guest>-mig-<uid>.
-const guestPodLabel = "swift.kubeswift.io/guest"
+const guestPodLabel = actions.GuestLabel
 
 // launcherContainer is the swiftletd container in the (multi-container) launcher
 // pod — the one holding the serial socket. The console exec must name it.
-const launcherContainer = "launcher"
+const launcherContainer = actions.LauncherContainer
 
 // ClientPool watches the hub's fleet.Cluster registry and maintains a base REST
 // config per member cluster, built from the member's credential Secret. It


### PR DESCRIPTION
## Why

VM lifecycle actions (start/stop/migrate) were implemented **twice**:

- **swiftctl** — `cmd/swiftctl/{start,stop,migrate}.go`, over a typed controller-runtime `client.Client` (via `internal/cli.GuestResolver`).
- **gateway** — `internal/gateway/guest_service.go` (`StartGuest`/`StopGuest`/`MigrateGuest`), over an impersonating `dynamic.Interface`.

They drifted once already: the gateway's `StopGuest` patched `runPolicy: Stopped` but **forgot to delete the launcher pod**, so a running VM never stopped (the stop guard is reactive). Fixed in [#267](https://github.com/projectbeskar/kubeswift/pull/267) — caught only by cluster validation. One implementation prevents the next such divergence.

## What

New **`internal/actions`** package — the single implementation, over a `dynamic.Interface` (the common denominator: the gateway already needs impersonation, swiftctl builds one cheaply from its REST config):

- `SetRunPolicy` / `Start` (patch `runPolicy=Running`) / `Stop` (patch `runPolicy=Stopped` **and** delete the launcher pod by the `swift.kubeswift.io/guest` label) / `DeleteLauncherPods` / `Migrate(MigrateParams)`.
- Centralized constants: `GuestLabel`, `LauncherContainer`, the `RunPolicy` values (derived from the API enum), and the SwiftGuest/SwiftMigration/Pod GVRs.

**Both surfaces now call it, duplicated logic deleted:**

- **gateway**: `StartGuest`/`StopGuest` → a `guestAction` helper over `actions.Start`/`actions.Stop`; `MigrateGuest` → `actions.Migrate`. `setRunPolicy`/`deleteLauncherPods` removed. `pool.go` aliases its GVRs/label/container to `actions` (one source of truth); the read/console/telemetry planes are untouched. Connect validation + error mapping stay at the gateway.
- **swiftctl**: `start` → `actions.Start`; `stop` → `actions.Stop`; `migrate` create path → `actions.Migrate`. New `newDynamicClient()` helper in `root.go`. Dead `migrationTimeoutPtr` and the now-unused `GuestResolver.PatchRunPolicy` removed.

## Behavior notes (behavior-preserving in outcome)

- swiftctl `start` no longer deletes a lingering pod — it matches the shared `Start`/gateway (a clean `stop` already removes the pod; `restart` remains the explicit pod-recreate command).
- swiftctl `stop` drops its bespoke `exec kill -TERM` + wait for the shared delete-pod model — pod deletion triggers swiftletd's graceful SIGTERM shutdown within the pod's termination grace period (the gateway's cluster-validated model from #267).
- The gateway's write-action unit tests (`internal/gateway/guest_service_test.go`) stay green unchanged.

## Validation

`go build ./...`, `go test ./...` (37 pkgs, 0 fail), `gofmt -s` clean. New `internal/actions` unit tests; existing gateway write-action tests unchanged.

**Dev cluster — swiftctl** (`field-testing/ft-vm`): `stop` → runPolicy=Stopped + launcher pod gracefully terminated (~27s) → Stopped; `start` → runPolicy=Running → controller recreated pod → Running with IP; `migrate --check` preflight OK; `migrate` created an admitted SwiftMigration (correct spec, `timeout=30m0s` CRD default applied), cancelled cleanly.

**Dev cluster — gateway** (rebuilt image, `kubectl set image`, auth-mode=insecure): `ListGuests` OK; `StopGuest` → runPolicy=Stopped + pod deleted by label → Stopped; `StartGuest` → Running with IP; `MigrateGuest` → created `ft-vm-mig-*` with the gateway shape (mode defaulted to `auto`, reason "initiated from the KubeSwift UI"), admitted, cancelled.

> Note: the dev-cluster gateway is running a locally-built validation image (`sha-c202ef4`). Redeploy the CI-built main image after merge via the normal flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)