### PR TITLE
feat(gateway): node metrics + GetResource (UI Phase 3 node-insights backend)

### DIFF
--- a/gen/kubeswift/v1/kubeswiftv1connect/resource.connect.go
+++ b/gen/kubeswift/v1/kubeswiftv1connect/resource.connect.go
@@ -39,12 +39,16 @@ const (
 	// ResourceServiceListResourcesProcedure is the fully-qualified name of the ResourceService's
 	// ListResources RPC.
 	ResourceServiceListResourcesProcedure = "/kubeswift.v1.ResourceService/ListResources"
+	// ResourceServiceGetResourceProcedure is the fully-qualified name of the ResourceService's
+	// GetResource RPC.
+	ResourceServiceGetResourceProcedure = "/kubeswift.v1.ResourceService/GetResource"
 )
 
 // ResourceServiceClient is a client for the kubeswift.v1.ResourceService service.
 type ResourceServiceClient interface {
 	ListResourceKinds(context.Context, *connect.Request[v1.ListResourceKindsRequest]) (*connect.Response[v1.ListResourceKindsResponse], error)
 	ListResources(context.Context, *connect.Request[v1.ListResourcesRequest]) (*connect.Response[v1.ListResourcesResponse], error)
+	GetResource(context.Context, *connect.Request[v1.GetResourceRequest]) (*connect.Response[v1.GetResourceResponse], error)
 }
 
 // NewResourceServiceClient constructs a client for the kubeswift.v1.ResourceService service. By
@@ -70,6 +74,12 @@ func NewResourceServiceClient(httpClient connect.HTTPClient, baseURL string, opt
 			connect.WithSchema(resourceServiceMethods.ByName("ListResources")),
 			connect.WithClientOptions(opts...),
 		),
+		getResource: connect.NewClient[v1.GetResourceRequest, v1.GetResourceResponse](
+			httpClient,
+			baseURL+ResourceServiceGetResourceProcedure,
+			connect.WithSchema(resourceServiceMethods.ByName("GetResource")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -77,6 +87,7 @@ func NewResourceServiceClient(httpClient connect.HTTPClient, baseURL string, opt
 type resourceServiceClient struct {
 	listResourceKinds *connect.Client[v1.ListResourceKindsRequest, v1.ListResourceKindsResponse]
 	listResources     *connect.Client[v1.ListResourcesRequest, v1.ListResourcesResponse]
+	getResource       *connect.Client[v1.GetResourceRequest, v1.GetResourceResponse]
 }
 
 // ListResourceKinds calls kubeswift.v1.ResourceService.ListResourceKinds.
@@ -89,10 +100,16 @@ func (c *resourceServiceClient) ListResources(ctx context.Context, req *connect.
 	return c.listResources.CallUnary(ctx, req)
 }
 
+// GetResource calls kubeswift.v1.ResourceService.GetResource.
+func (c *resourceServiceClient) GetResource(ctx context.Context, req *connect.Request[v1.GetResourceRequest]) (*connect.Response[v1.GetResourceResponse], error) {
+	return c.getResource.CallUnary(ctx, req)
+}
+
 // ResourceServiceHandler is an implementation of the kubeswift.v1.ResourceService service.
 type ResourceServiceHandler interface {
 	ListResourceKinds(context.Context, *connect.Request[v1.ListResourceKindsRequest]) (*connect.Response[v1.ListResourceKindsResponse], error)
 	ListResources(context.Context, *connect.Request[v1.ListResourcesRequest]) (*connect.Response[v1.ListResourcesResponse], error)
+	GetResource(context.Context, *connect.Request[v1.GetResourceRequest]) (*connect.Response[v1.GetResourceResponse], error)
 }
 
 // NewResourceServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -114,12 +131,20 @@ func NewResourceServiceHandler(svc ResourceServiceHandler, opts ...connect.Handl
 		connect.WithSchema(resourceServiceMethods.ByName("ListResources")),
 		connect.WithHandlerOptions(opts...),
 	)
+	resourceServiceGetResourceHandler := connect.NewUnaryHandler(
+		ResourceServiceGetResourceProcedure,
+		svc.GetResource,
+		connect.WithSchema(resourceServiceMethods.ByName("GetResource")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/kubeswift.v1.ResourceService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case ResourceServiceListResourceKindsProcedure:
 			resourceServiceListResourceKindsHandler.ServeHTTP(w, r)
 		case ResourceServiceListResourcesProcedure:
 			resourceServiceListResourcesHandler.ServeHTTP(w, r)
+		case ResourceServiceGetResourceProcedure:
+			resourceServiceGetResourceHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -135,4 +160,8 @@ func (UnimplementedResourceServiceHandler) ListResourceKinds(context.Context, *c
 
 func (UnimplementedResourceServiceHandler) ListResources(context.Context, *connect.Request[v1.ListResourcesRequest]) (*connect.Response[v1.ListResourcesResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.ResourceService.ListResources is not implemented"))
+}
+
+func (UnimplementedResourceServiceHandler) GetResource(context.Context, *connect.Request[v1.GetResourceRequest]) (*connect.Response[v1.GetResourceResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.ResourceService.GetResource is not implemented"))
 }

--- a/gen/kubeswift/v1/kubeswiftv1connect/telemetry.connect.go
+++ b/gen/kubeswift/v1/kubeswiftv1connect/telemetry.connect.go
@@ -36,11 +36,15 @@ const (
 	// TelemetryServiceGetGuestMetricsProcedure is the fully-qualified name of the TelemetryService's
 	// GetGuestMetrics RPC.
 	TelemetryServiceGetGuestMetricsProcedure = "/kubeswift.v1.TelemetryService/GetGuestMetrics"
+	// TelemetryServiceGetNodeMetricsProcedure is the fully-qualified name of the TelemetryService's
+	// GetNodeMetrics RPC.
+	TelemetryServiceGetNodeMetricsProcedure = "/kubeswift.v1.TelemetryService/GetNodeMetrics"
 )
 
 // TelemetryServiceClient is a client for the kubeswift.v1.TelemetryService service.
 type TelemetryServiceClient interface {
 	GetGuestMetrics(context.Context, *connect.Request[v1.GetGuestMetricsRequest]) (*connect.Response[v1.GetGuestMetricsResponse], error)
+	GetNodeMetrics(context.Context, *connect.Request[v1.GetNodeMetricsRequest]) (*connect.Response[v1.GetNodeMetricsResponse], error)
 }
 
 // NewTelemetryServiceClient constructs a client for the kubeswift.v1.TelemetryService service. By
@@ -60,12 +64,19 @@ func NewTelemetryServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(telemetryServiceMethods.ByName("GetGuestMetrics")),
 			connect.WithClientOptions(opts...),
 		),
+		getNodeMetrics: connect.NewClient[v1.GetNodeMetricsRequest, v1.GetNodeMetricsResponse](
+			httpClient,
+			baseURL+TelemetryServiceGetNodeMetricsProcedure,
+			connect.WithSchema(telemetryServiceMethods.ByName("GetNodeMetrics")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // telemetryServiceClient implements TelemetryServiceClient.
 type telemetryServiceClient struct {
 	getGuestMetrics *connect.Client[v1.GetGuestMetricsRequest, v1.GetGuestMetricsResponse]
+	getNodeMetrics  *connect.Client[v1.GetNodeMetricsRequest, v1.GetNodeMetricsResponse]
 }
 
 // GetGuestMetrics calls kubeswift.v1.TelemetryService.GetGuestMetrics.
@@ -73,9 +84,15 @@ func (c *telemetryServiceClient) GetGuestMetrics(ctx context.Context, req *conne
 	return c.getGuestMetrics.CallUnary(ctx, req)
 }
 
+// GetNodeMetrics calls kubeswift.v1.TelemetryService.GetNodeMetrics.
+func (c *telemetryServiceClient) GetNodeMetrics(ctx context.Context, req *connect.Request[v1.GetNodeMetricsRequest]) (*connect.Response[v1.GetNodeMetricsResponse], error) {
+	return c.getNodeMetrics.CallUnary(ctx, req)
+}
+
 // TelemetryServiceHandler is an implementation of the kubeswift.v1.TelemetryService service.
 type TelemetryServiceHandler interface {
 	GetGuestMetrics(context.Context, *connect.Request[v1.GetGuestMetricsRequest]) (*connect.Response[v1.GetGuestMetricsResponse], error)
+	GetNodeMetrics(context.Context, *connect.Request[v1.GetNodeMetricsRequest]) (*connect.Response[v1.GetNodeMetricsResponse], error)
 }
 
 // NewTelemetryServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -91,10 +108,18 @@ func NewTelemetryServiceHandler(svc TelemetryServiceHandler, opts ...connect.Han
 		connect.WithSchema(telemetryServiceMethods.ByName("GetGuestMetrics")),
 		connect.WithHandlerOptions(opts...),
 	)
+	telemetryServiceGetNodeMetricsHandler := connect.NewUnaryHandler(
+		TelemetryServiceGetNodeMetricsProcedure,
+		svc.GetNodeMetrics,
+		connect.WithSchema(telemetryServiceMethods.ByName("GetNodeMetrics")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/kubeswift.v1.TelemetryService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case TelemetryServiceGetGuestMetricsProcedure:
 			telemetryServiceGetGuestMetricsHandler.ServeHTTP(w, r)
+		case TelemetryServiceGetNodeMetricsProcedure:
+			telemetryServiceGetNodeMetricsHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -106,4 +131,8 @@ type UnimplementedTelemetryServiceHandler struct{}
 
 func (UnimplementedTelemetryServiceHandler) GetGuestMetrics(context.Context, *connect.Request[v1.GetGuestMetricsRequest]) (*connect.Response[v1.GetGuestMetricsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.TelemetryService.GetGuestMetrics is not implemented"))
+}
+
+func (UnimplementedTelemetryServiceHandler) GetNodeMetrics(context.Context, *connect.Request[v1.GetNodeMetricsRequest]) (*connect.Response[v1.GetNodeMetricsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.TelemetryService.GetNodeMetrics is not implemented"))
 }

--- a/gen/kubeswift/v1/resource.pb.go
+++ b/gen/kubeswift/v1/resource.pb.go
@@ -403,6 +403,132 @@ func (x *ListResourcesResponse) GetError() *ClusterError {
 	return nil
 }
 
+// GetResourceRequest fetches one object's full content (for the detail drawer +
+// the YAML editor).
+type GetResourceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Cluster       string                 `protobuf:"bytes,1,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	Kind          string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"` // a ResourceKind.key
+	Namespace     string                 `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Name          string                 `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetResourceRequest) Reset() {
+	*x = GetResourceRequest{}
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetResourceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetResourceRequest) ProtoMessage() {}
+
+func (x *GetResourceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetResourceRequest.ProtoReflect.Descriptor instead.
+func (*GetResourceRequest) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_resource_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *GetResourceRequest) GetCluster() string {
+	if x != nil {
+		return x.Cluster
+	}
+	return ""
+}
+
+func (x *GetResourceRequest) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *GetResourceRequest) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *GetResourceRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type GetResourceResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// yaml is the object rendered as YAML (managedFields stripped) — what the
+	// editor shows and what ApplyResource accepts back.
+	Yaml string `protobuf:"bytes,1,opt,name=yaml,proto3" json:"yaml,omitempty"`
+	// json is the same object as a compact JSON string, so the UI can read fields
+	// (conditions, capacity, …) without a YAML parser.
+	Json          string `protobuf:"bytes,2,opt,name=json,proto3" json:"json,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetResourceResponse) Reset() {
+	*x = GetResourceResponse{}
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetResourceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetResourceResponse) ProtoMessage() {}
+
+func (x *GetResourceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetResourceResponse.ProtoReflect.Descriptor instead.
+func (*GetResourceResponse) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_resource_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *GetResourceResponse) GetYaml() string {
+	if x != nil {
+		return x.Yaml
+	}
+	return ""
+}
+
+func (x *GetResourceResponse) GetJson() string {
+	if x != nil {
+		return x.Json
+	}
+	return ""
+}
+
 var File_kubeswift_v1_resource_proto protoreflect.FileDescriptor
 
 const file_kubeswift_v1_resource_proto_rawDesc = "" +
@@ -437,10 +563,19 @@ const file_kubeswift_v1_resource_proto_rawDesc = "" +
 	"\tnamespace\x18\x03 \x01(\tR\tnamespace\"\x7f\n" +
 	"\x15ListResourcesResponse\x124\n" +
 	"\tresources\x18\x01 \x03(\v2\x16.kubeswift.v1.ResourceR\tresources\x120\n" +
-	"\x05error\x18\x02 \x01(\v2\x1a.kubeswift.v1.ClusterErrorR\x05error2\xd1\x01\n" +
+	"\x05error\x18\x02 \x01(\v2\x1a.kubeswift.v1.ClusterErrorR\x05error\"t\n" +
+	"\x12GetResourceRequest\x12\x18\n" +
+	"\acluster\x18\x01 \x01(\tR\acluster\x12\x12\n" +
+	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x1c\n" +
+	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x12\x12\n" +
+	"\x04name\x18\x04 \x01(\tR\x04name\"=\n" +
+	"\x13GetResourceResponse\x12\x12\n" +
+	"\x04yaml\x18\x01 \x01(\tR\x04yaml\x12\x12\n" +
+	"\x04json\x18\x02 \x01(\tR\x04json2\xa5\x02\n" +
 	"\x0fResourceService\x12d\n" +
 	"\x11ListResourceKinds\x12&.kubeswift.v1.ListResourceKindsRequest\x1a'.kubeswift.v1.ListResourceKindsResponse\x12X\n" +
-	"\rListResources\x12\".kubeswift.v1.ListResourcesRequest\x1a#.kubeswift.v1.ListResourcesResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
+	"\rListResources\x12\".kubeswift.v1.ListResourcesRequest\x1a#.kubeswift.v1.ListResourcesResponse\x12R\n" +
+	"\vGetResource\x12 .kubeswift.v1.GetResourceRequest\x1a!.kubeswift.v1.GetResourceResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
 
 var (
 	file_kubeswift_v1_resource_proto_rawDescOnce sync.Once
@@ -454,7 +589,7 @@ func file_kubeswift_v1_resource_proto_rawDescGZIP() []byte {
 	return file_kubeswift_v1_resource_proto_rawDescData
 }
 
-var file_kubeswift_v1_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_kubeswift_v1_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_kubeswift_v1_resource_proto_goTypes = []any{
 	(*ResourceKind)(nil),              // 0: kubeswift.v1.ResourceKind
 	(*ListResourceKindsRequest)(nil),  // 1: kubeswift.v1.ListResourceKindsRequest
@@ -462,27 +597,31 @@ var file_kubeswift_v1_resource_proto_goTypes = []any{
 	(*Resource)(nil),                  // 3: kubeswift.v1.Resource
 	(*ListResourcesRequest)(nil),      // 4: kubeswift.v1.ListResourcesRequest
 	(*ListResourcesResponse)(nil),     // 5: kubeswift.v1.ListResourcesResponse
-	nil,                               // 6: kubeswift.v1.Resource.ColumnsEntry
-	(*ObjectRef)(nil),                 // 7: kubeswift.v1.ObjectRef
-	(*timestamppb.Timestamp)(nil),     // 8: google.protobuf.Timestamp
-	(*ClusterError)(nil),              // 9: kubeswift.v1.ClusterError
+	(*GetResourceRequest)(nil),        // 6: kubeswift.v1.GetResourceRequest
+	(*GetResourceResponse)(nil),       // 7: kubeswift.v1.GetResourceResponse
+	nil,                               // 8: kubeswift.v1.Resource.ColumnsEntry
+	(*ObjectRef)(nil),                 // 9: kubeswift.v1.ObjectRef
+	(*timestamppb.Timestamp)(nil),     // 10: google.protobuf.Timestamp
+	(*ClusterError)(nil),              // 11: kubeswift.v1.ClusterError
 }
 var file_kubeswift_v1_resource_proto_depIdxs = []int32{
-	0, // 0: kubeswift.v1.ListResourceKindsResponse.kinds:type_name -> kubeswift.v1.ResourceKind
-	7, // 1: kubeswift.v1.Resource.ref:type_name -> kubeswift.v1.ObjectRef
-	8, // 2: kubeswift.v1.Resource.created_at:type_name -> google.protobuf.Timestamp
-	6, // 3: kubeswift.v1.Resource.columns:type_name -> kubeswift.v1.Resource.ColumnsEntry
-	3, // 4: kubeswift.v1.ListResourcesResponse.resources:type_name -> kubeswift.v1.Resource
-	9, // 5: kubeswift.v1.ListResourcesResponse.error:type_name -> kubeswift.v1.ClusterError
-	1, // 6: kubeswift.v1.ResourceService.ListResourceKinds:input_type -> kubeswift.v1.ListResourceKindsRequest
-	4, // 7: kubeswift.v1.ResourceService.ListResources:input_type -> kubeswift.v1.ListResourcesRequest
-	2, // 8: kubeswift.v1.ResourceService.ListResourceKinds:output_type -> kubeswift.v1.ListResourceKindsResponse
-	5, // 9: kubeswift.v1.ResourceService.ListResources:output_type -> kubeswift.v1.ListResourcesResponse
-	8, // [8:10] is the sub-list for method output_type
-	6, // [6:8] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	0,  // 0: kubeswift.v1.ListResourceKindsResponse.kinds:type_name -> kubeswift.v1.ResourceKind
+	9,  // 1: kubeswift.v1.Resource.ref:type_name -> kubeswift.v1.ObjectRef
+	10, // 2: kubeswift.v1.Resource.created_at:type_name -> google.protobuf.Timestamp
+	8,  // 3: kubeswift.v1.Resource.columns:type_name -> kubeswift.v1.Resource.ColumnsEntry
+	3,  // 4: kubeswift.v1.ListResourcesResponse.resources:type_name -> kubeswift.v1.Resource
+	11, // 5: kubeswift.v1.ListResourcesResponse.error:type_name -> kubeswift.v1.ClusterError
+	1,  // 6: kubeswift.v1.ResourceService.ListResourceKinds:input_type -> kubeswift.v1.ListResourceKindsRequest
+	4,  // 7: kubeswift.v1.ResourceService.ListResources:input_type -> kubeswift.v1.ListResourcesRequest
+	6,  // 8: kubeswift.v1.ResourceService.GetResource:input_type -> kubeswift.v1.GetResourceRequest
+	2,  // 9: kubeswift.v1.ResourceService.ListResourceKinds:output_type -> kubeswift.v1.ListResourceKindsResponse
+	5,  // 10: kubeswift.v1.ResourceService.ListResources:output_type -> kubeswift.v1.ListResourcesResponse
+	7,  // 11: kubeswift.v1.ResourceService.GetResource:output_type -> kubeswift.v1.GetResourceResponse
+	9,  // [9:12] is the sub-list for method output_type
+	6,  // [6:9] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_kubeswift_v1_resource_proto_init() }
@@ -497,7 +636,7 @@ func file_kubeswift_v1_resource_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kubeswift_v1_resource_proto_rawDesc), len(file_kubeswift_v1_resource_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/kubeswift/v1/telemetry.pb.go
+++ b/gen/kubeswift/v1/telemetry.pb.go
@@ -262,6 +262,132 @@ func (x *GetGuestMetricsResponse) GetError() *ClusterError {
 	return nil
 }
 
+// GetNodeMetricsRequest asks for one node's recent utilization. The gateway
+// resolves the node's InternalIP and range-queries the member's Prometheus:
+// node-exporter for CPU/mem/net, DCGM for GPU (absent → empty GPU series).
+type GetNodeMetricsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Cluster       string                 `protobuf:"bytes,1,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	Node          string                 `protobuf:"bytes,2,opt,name=node,proto3" json:"node,omitempty"`
+	WindowSeconds int32                  `protobuf:"varint,3,opt,name=window_seconds,json=windowSeconds,proto3" json:"window_seconds,omitempty"` // default 900
+	StepSeconds   int32                  `protobuf:"varint,4,opt,name=step_seconds,json=stepSeconds,proto3" json:"step_seconds,omitempty"`       // default 30
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetNodeMetricsRequest) Reset() {
+	*x = GetNodeMetricsRequest{}
+	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetNodeMetricsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetNodeMetricsRequest) ProtoMessage() {}
+
+func (x *GetNodeMetricsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetNodeMetricsRequest.ProtoReflect.Descriptor instead.
+func (*GetNodeMetricsRequest) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_telemetry_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *GetNodeMetricsRequest) GetCluster() string {
+	if x != nil {
+		return x.Cluster
+	}
+	return ""
+}
+
+func (x *GetNodeMetricsRequest) GetNode() string {
+	if x != nil {
+		return x.Node
+	}
+	return ""
+}
+
+func (x *GetNodeMetricsRequest) GetWindowSeconds() int32 {
+	if x != nil {
+		return x.WindowSeconds
+	}
+	return 0
+}
+
+func (x *GetNodeMetricsRequest) GetStepSeconds() int32 {
+	if x != nil {
+		return x.StepSeconds
+	}
+	return 0
+}
+
+// GetNodeMetricsResponse carries the series (cpu_util/mem_util/net_rx_bps/
+// net_tx_bps/gpu_util — the utilization series are 0–1 ratios), or an error
+// when the member's Prometheus is unconfigured/unreachable.
+type GetNodeMetricsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Series        []*MetricSeries        `protobuf:"bytes,1,rep,name=series,proto3" json:"series,omitempty"`
+	Error         *ClusterError          `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetNodeMetricsResponse) Reset() {
+	*x = GetNodeMetricsResponse{}
+	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetNodeMetricsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetNodeMetricsResponse) ProtoMessage() {}
+
+func (x *GetNodeMetricsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_telemetry_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetNodeMetricsResponse.ProtoReflect.Descriptor instead.
+func (*GetNodeMetricsResponse) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_telemetry_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *GetNodeMetricsResponse) GetSeries() []*MetricSeries {
+	if x != nil {
+		return x.Series
+	}
+	return nil
+}
+
+func (x *GetNodeMetricsResponse) GetError() *ClusterError {
+	if x != nil {
+		return x.Error
+	}
+	return nil
+}
+
 var File_kubeswift_v1_telemetry_proto protoreflect.FileDescriptor
 
 const file_kubeswift_v1_telemetry_proto_rawDesc = "" +
@@ -280,9 +406,18 @@ const file_kubeswift_v1_telemetry_proto_rawDesc = "" +
 	"\x06points\x18\x03 \x03(\v2\x19.kubeswift.v1.MetricPointR\x06points\"\x7f\n" +
 	"\x17GetGuestMetricsResponse\x122\n" +
 	"\x06series\x18\x01 \x03(\v2\x1a.kubeswift.v1.MetricSeriesR\x06series\x120\n" +
-	"\x05error\x18\x02 \x01(\v2\x1a.kubeswift.v1.ClusterErrorR\x05error2r\n" +
+	"\x05error\x18\x02 \x01(\v2\x1a.kubeswift.v1.ClusterErrorR\x05error\"\x8f\x01\n" +
+	"\x15GetNodeMetricsRequest\x12\x18\n" +
+	"\acluster\x18\x01 \x01(\tR\acluster\x12\x12\n" +
+	"\x04node\x18\x02 \x01(\tR\x04node\x12%\n" +
+	"\x0ewindow_seconds\x18\x03 \x01(\x05R\rwindowSeconds\x12!\n" +
+	"\fstep_seconds\x18\x04 \x01(\x05R\vstepSeconds\"~\n" +
+	"\x16GetNodeMetricsResponse\x122\n" +
+	"\x06series\x18\x01 \x03(\v2\x1a.kubeswift.v1.MetricSeriesR\x06series\x120\n" +
+	"\x05error\x18\x02 \x01(\v2\x1a.kubeswift.v1.ClusterErrorR\x05error2\xcf\x01\n" +
 	"\x10TelemetryService\x12^\n" +
-	"\x0fGetGuestMetrics\x12$.kubeswift.v1.GetGuestMetricsRequest\x1a%.kubeswift.v1.GetGuestMetricsResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
+	"\x0fGetGuestMetrics\x12$.kubeswift.v1.GetGuestMetricsRequest\x1a%.kubeswift.v1.GetGuestMetricsResponse\x12[\n" +
+	"\x0eGetNodeMetrics\x12#.kubeswift.v1.GetNodeMetricsRequest\x1a$.kubeswift.v1.GetNodeMetricsResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
 
 var (
 	file_kubeswift_v1_telemetry_proto_rawDescOnce sync.Once
@@ -296,29 +431,35 @@ func file_kubeswift_v1_telemetry_proto_rawDescGZIP() []byte {
 	return file_kubeswift_v1_telemetry_proto_rawDescData
 }
 
-var file_kubeswift_v1_telemetry_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_kubeswift_v1_telemetry_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_kubeswift_v1_telemetry_proto_goTypes = []any{
 	(*GetGuestMetricsRequest)(nil),  // 0: kubeswift.v1.GetGuestMetricsRequest
 	(*MetricPoint)(nil),             // 1: kubeswift.v1.MetricPoint
 	(*MetricSeries)(nil),            // 2: kubeswift.v1.MetricSeries
 	(*GetGuestMetricsResponse)(nil), // 3: kubeswift.v1.GetGuestMetricsResponse
-	(*ObjectRef)(nil),               // 4: kubeswift.v1.ObjectRef
-	(*timestamppb.Timestamp)(nil),   // 5: google.protobuf.Timestamp
-	(*ClusterError)(nil),            // 6: kubeswift.v1.ClusterError
+	(*GetNodeMetricsRequest)(nil),   // 4: kubeswift.v1.GetNodeMetricsRequest
+	(*GetNodeMetricsResponse)(nil),  // 5: kubeswift.v1.GetNodeMetricsResponse
+	(*ObjectRef)(nil),               // 6: kubeswift.v1.ObjectRef
+	(*timestamppb.Timestamp)(nil),   // 7: google.protobuf.Timestamp
+	(*ClusterError)(nil),            // 8: kubeswift.v1.ClusterError
 }
 var file_kubeswift_v1_telemetry_proto_depIdxs = []int32{
-	4, // 0: kubeswift.v1.GetGuestMetricsRequest.ref:type_name -> kubeswift.v1.ObjectRef
-	5, // 1: kubeswift.v1.MetricPoint.ts:type_name -> google.protobuf.Timestamp
+	6, // 0: kubeswift.v1.GetGuestMetricsRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	7, // 1: kubeswift.v1.MetricPoint.ts:type_name -> google.protobuf.Timestamp
 	1, // 2: kubeswift.v1.MetricSeries.points:type_name -> kubeswift.v1.MetricPoint
 	2, // 3: kubeswift.v1.GetGuestMetricsResponse.series:type_name -> kubeswift.v1.MetricSeries
-	6, // 4: kubeswift.v1.GetGuestMetricsResponse.error:type_name -> kubeswift.v1.ClusterError
-	0, // 5: kubeswift.v1.TelemetryService.GetGuestMetrics:input_type -> kubeswift.v1.GetGuestMetricsRequest
-	3, // 6: kubeswift.v1.TelemetryService.GetGuestMetrics:output_type -> kubeswift.v1.GetGuestMetricsResponse
-	6, // [6:7] is the sub-list for method output_type
-	5, // [5:6] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	8, // 4: kubeswift.v1.GetGuestMetricsResponse.error:type_name -> kubeswift.v1.ClusterError
+	2, // 5: kubeswift.v1.GetNodeMetricsResponse.series:type_name -> kubeswift.v1.MetricSeries
+	8, // 6: kubeswift.v1.GetNodeMetricsResponse.error:type_name -> kubeswift.v1.ClusterError
+	0, // 7: kubeswift.v1.TelemetryService.GetGuestMetrics:input_type -> kubeswift.v1.GetGuestMetricsRequest
+	4, // 8: kubeswift.v1.TelemetryService.GetNodeMetrics:input_type -> kubeswift.v1.GetNodeMetricsRequest
+	3, // 9: kubeswift.v1.TelemetryService.GetGuestMetrics:output_type -> kubeswift.v1.GetGuestMetricsResponse
+	5, // 10: kubeswift.v1.TelemetryService.GetNodeMetrics:output_type -> kubeswift.v1.GetNodeMetricsResponse
+	9, // [9:11] is the sub-list for method output_type
+	7, // [7:9] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_kubeswift_v1_telemetry_proto_init() }
@@ -333,7 +474,7 @@ func file_kubeswift_v1_telemetry_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kubeswift_v1_telemetry_proto_rawDesc), len(file_kubeswift_v1_telemetry_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/gateway/resource_service.go
+++ b/internal/gateway/resource_service.go
@@ -2,13 +2,16 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 
 	connect "connectrpc.com/connect"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/yaml"
 
 	kubeswiftv1 "github.com/projectbeskar/kubeswift/gen/kubeswift/v1"
 	"github.com/projectbeskar/kubeswift/gen/kubeswift/v1/kubeswiftv1connect"
@@ -101,6 +104,46 @@ func (s *ResourceService) ListResources(ctx context.Context, req *connect.Reques
 	}
 	sortResources(out.Resources)
 	return connect.NewResponse(out), nil
+}
+
+// GetResource returns one object's full content (YAML for the editor + JSON for
+// the UI to read fields from), as the impersonated user. managedFields are
+// stripped. Feeds the detail drawer and the YAML editor.
+func (s *ResourceService) GetResource(ctx context.Context, req *connect.Request[kubeswiftv1.GetResourceRequest]) (*connect.Response[kubeswiftv1.GetResourceResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	cluster, name := req.Msg.GetCluster(), req.Msg.GetName()
+	if cluster == "" || name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cluster and name are required"))
+	}
+	kind := lookupKind(req.Msg.GetKind())
+	if kind == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unknown kind %q", req.Msg.GetKind()))
+	}
+	dyn, err := s.pool.DynamicFor(cluster, id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	var ri dynamic.ResourceInterface = dyn.Resource(kind.gvr)
+	if kind.namespaced {
+		ri = dyn.Resource(kind.gvr).Namespace(req.Msg.GetNamespace())
+	}
+	obj, err := ri.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, mapAccessErr(err)
+	}
+	unstructured.RemoveNestedField(obj.Object, "metadata", "managedFields")
+	jsonBytes, err := json.Marshal(obj.Object)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	yamlBytes, err := yaml.Marshal(obj.Object)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&kubeswiftv1.GetResourceResponse{Yaml: string(yamlBytes), Json: string(jsonBytes)}), nil
 }
 
 func resourcesErr(cluster, msg string) *connect.Response[kubeswiftv1.ListResourcesResponse] {

--- a/internal/gateway/telemetry_service.go
+++ b/internal/gateway/telemetry_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 	connect "connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 
 	kubeswiftv1 "github.com/projectbeskar/kubeswift/gen/kubeswift/v1"
@@ -188,6 +190,86 @@ func orDefaultInt32(v, def int32) int32 {
 
 func clusterMetricsErr(cluster, msg string) *connect.Response[kubeswiftv1.GetGuestMetricsResponse] {
 	return connect.NewResponse(&kubeswiftv1.GetGuestMetricsResponse{
+		Error: &kubeswiftv1.ClusterError{Cluster: cluster, Message: msg},
+	})
+}
+
+// GetNodeMetrics range-queries a node's utilization. It resolves the node's
+// InternalIP (node-exporter's `instance` is <ip>:9100), then queries
+// node-exporter for CPU/mem/net and DCGM for GPU. GPU yields no points where
+// DCGM isn't installed — a graceful empty series, not an error. The CPU/mem/GPU
+// series are 0–1 utilization ratios; net is bytes/sec.
+func (s *TelemetryService) GetNodeMetrics(ctx context.Context, req *connect.Request[kubeswiftv1.GetNodeMetricsRequest]) (*connect.Response[kubeswiftv1.GetNodeMetricsResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	cluster, node := req.Msg.GetCluster(), req.Msg.GetNode()
+	if cluster == "" || node == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cluster and node are required"))
+	}
+	endpoint := strings.TrimRight(s.pool.PrometheusEndpoint(cluster), "/")
+	if endpoint == "" {
+		return nodeMetricsErr(cluster, "no prometheusEndpoint registered for this cluster"), nil
+	}
+	// Resolve the node's InternalIP as the impersonated user (authz: the caller
+	// can only chart a node it may get).
+	dyn, err := s.pool.DynamicFor(cluster, id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	nodeObj, err := dyn.Resource(nodeGVR).Get(ctx, node, metav1.GetOptions{})
+	if err != nil {
+		return nil, mapAccessErr(err)
+	}
+	ip := nodeInternalIP(nodeObj)
+	if ip == "" {
+		return nodeMetricsErr(cluster, "node has no InternalIP"), nil
+	}
+	inst := regexp.QuoteMeta(ip) + ":.*"
+	nodeRe := regexp.QuoteMeta(node)
+
+	const rateWin = "2m"
+	window := time.Duration(orDefaultInt32(req.Msg.GetWindowSeconds(), 900)) * time.Second
+	step := time.Duration(orDefaultInt32(req.Msg.GetStepSeconds(), 30)) * time.Second
+	end := time.Now()
+	start := end.Add(-window)
+
+	defs := []promSeries{
+		{"cpu_util", "ratio", fmt.Sprintf(`1 - avg(rate(node_cpu_seconds_total{mode="idle",instance=~"%s"}[%s]))`, inst, rateWin)},
+		{"mem_util", "ratio", fmt.Sprintf(`1 - sum(node_memory_MemAvailable_bytes{instance=~"%s"}) / sum(node_memory_MemTotal_bytes{instance=~"%s"})`, inst, inst)},
+		{"net_rx_bps", "bytes/sec", fmt.Sprintf(`sum(rate(node_network_receive_bytes_total{instance=~"%s",device!="lo"}[%s]))`, inst, rateWin)},
+		{"net_tx_bps", "bytes/sec", fmt.Sprintf(`sum(rate(node_network_transmit_bytes_total{instance=~"%s",device!="lo"}[%s]))`, inst, rateWin)},
+		// DCGM util is 0–100 per GPU; average across the node's GPUs ÷ 100.
+		// dcgm-exporter labels by Hostname (the node) and/or kubernetes_node —
+		// match either so it works with the standalone exporter or the GPU Operator.
+		{"gpu_util", "ratio", fmt.Sprintf(`avg(DCGM_FI_DEV_GPU_UTIL{Hostname=~"%s.*"} or DCGM_FI_DEV_GPU_UTIL{kubernetes_node="%s"}) / 100`, nodeRe, node)},
+	}
+
+	out := &kubeswiftv1.GetNodeMetricsResponse{}
+	for _, d := range defs {
+		pts, err := s.queryRange(ctx, endpoint, d.query, start, end, step)
+		if err != nil {
+			return nodeMetricsErr(cluster, fmt.Sprintf("prometheus query failed: %v", err)), nil
+		}
+		out.Series = append(out.Series, &kubeswiftv1.MetricSeries{Kind: d.kind, Unit: d.unit, Points: pts})
+	}
+	return connect.NewResponse(out), nil
+}
+
+func nodeInternalIP(n *unstructured.Unstructured) string {
+	addrs, _, _ := unstructured.NestedSlice(n.Object, "status", "addresses")
+	for _, a := range addrs {
+		if m, ok := a.(map[string]interface{}); ok && m["type"] == "InternalIP" {
+			ip, _ := m["address"].(string)
+			return ip
+		}
+	}
+	return ""
+}
+
+func nodeMetricsErr(cluster, msg string) *connect.Response[kubeswiftv1.GetNodeMetricsResponse] {
+	return connect.NewResponse(&kubeswiftv1.GetNodeMetricsResponse{
 		Error: &kubeswiftv1.ClusterError{Cluster: cluster, Message: msg},
 	})
 }

--- a/proto/kubeswift/v1/resource.proto
+++ b/proto/kubeswift/v1/resource.proto
@@ -63,11 +63,29 @@ message ListResourcesResponse {
   ClusterError error = 2;
 }
 
-// ResourceService is the read-only cluster explorer. ListResourceKinds returns
-// the browsable catalog; ListResources lists one kind on one member as the
-// impersonated user. Read-only by design — VM lifecycle stays the typed
-// Start/Stop/Migrate path.
+// GetResourceRequest fetches one object's full content (for the detail drawer +
+// the YAML editor).
+message GetResourceRequest {
+  string cluster = 1;
+  string kind = 2; // a ResourceKind.key
+  string namespace = 3;
+  string name = 4;
+}
+
+message GetResourceResponse {
+  // yaml is the object rendered as YAML (managedFields stripped) — what the
+  // editor shows and what ApplyResource accepts back.
+  string yaml = 1;
+  // json is the same object as a compact JSON string, so the UI can read fields
+  // (conditions, capacity, …) without a YAML parser.
+  string json = 2;
+}
+
+// ResourceService is the cluster explorer + object editor. ListResourceKinds /
+// ListResources / GetResource read; the read plane is the default and the
+// write RPCs (P3.3) are gated entirely by the impersonated user's RBAC.
 service ResourceService {
   rpc ListResourceKinds(ListResourceKindsRequest) returns (ListResourceKindsResponse);
   rpc ListResources(ListResourcesRequest) returns (ListResourcesResponse);
+  rpc GetResource(GetResourceRequest) returns (GetResourceResponse);
 }

--- a/proto/kubeswift/v1/telemetry.proto
+++ b/proto/kubeswift/v1/telemetry.proto
@@ -45,8 +45,28 @@ message GetGuestMetricsResponse {
   ClusterError error = 2;
 }
 
-// TelemetryService serves per-VM telemetry sourced from each member's
-// Prometheus (cAdvisor today, O5 swiftletd vm.counters in v2 — decision D4).
+// GetNodeMetricsRequest asks for one node's recent utilization. The gateway
+// resolves the node's InternalIP and range-queries the member's Prometheus:
+// node-exporter for CPU/mem/net, DCGM for GPU (absent → empty GPU series).
+message GetNodeMetricsRequest {
+  string cluster = 1;
+  string node = 2;
+  int32 window_seconds = 3; // default 900
+  int32 step_seconds = 4;   // default 30
+}
+
+// GetNodeMetricsResponse carries the series (cpu_util/mem_util/net_rx_bps/
+// net_tx_bps/gpu_util — the utilization series are 0–1 ratios), or an error
+// when the member's Prometheus is unconfigured/unreachable.
+message GetNodeMetricsResponse {
+  repeated MetricSeries series = 1;
+  ClusterError error = 2;
+}
+
+// TelemetryService serves per-VM + per-node telemetry sourced from each member's
+// Prometheus (cAdvisor + node-exporter + DCGM; O5 swiftletd vm.counters in v2 —
+// decision D4).
 service TelemetryService {
   rpc GetGuestMetrics(GetGuestMetricsRequest) returns (GetGuestMetricsResponse);
+  rpc GetNodeMetrics(GetNodeMetricsRequest) returns (GetNodeMetricsResponse);
 }


### PR DESCRIPTION
Backend for **UI Phase 3 / P3.2 (node insights)** + the shared `GetResource` the detail drawer and the future YAML editor both use.

- **`TelemetryService.GetNodeMetrics(cluster, node)`** — resolves the node's InternalIP (node-exporter's `instance` is `<ip>:9100`, confirmed by recon) and range-queries the member Prometheus: node-exporter for `cpu_util`/`mem_util` (0–1 ratios) + `net_rx_bps`/`net_tx_bps`, and **DCGM** (`DCGM_FI_DEV_GPU_UTIL`, matched by `Hostname` or `kubernetes_node`) for `gpu_util`. **GPU is a graceful empty series where DCGM isn't installed** — not an error.
- **`ResourceService.GetResource(cluster, kind, namespace, name)`** — one object's full content as **YAML** (managedFields stripped, for the editor) + **JSON** (so the UI reads node conditions/capacity without a YAML parser).

Both read-only, gated by the impersonated user's RBAC. `go build/vet/test` + `make proto-lint` green.

**Next increment:** the UI (node health dot + right drawer with conditions/capacity + CPU/MEM/Net/GPU sparklines), deploying the DCGM exporter on the dev GPU node (boba's GTX 1080 is `driver=nvidia`, so it's feasible), and cluster validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)