### PR TITLE
fix(gateway): node-metrics PromQL 400 — drop regexp.QuoteMeta in =~ matchers

### DIFF
--- a/internal/gateway/telemetry_service.go
+++ b/internal/gateway/telemetry_service.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -226,8 +225,13 @@ func (s *TelemetryService) GetNodeMetrics(ctx context.Context, req *connect.Requ
 	if ip == "" {
 		return nodeMetricsErr(cluster, "node has no InternalIP"), nil
 	}
-	inst := regexp.QuoteMeta(ip) + ":.*"
-	nodeRe := regexp.QuoteMeta(node)
+	// Raw values, used directly in PromQL =~ regex matchers. Do NOT
+	// regexp.QuoteMeta them: its backslash escapes (e.g. `\.`) are invalid
+	// escape sequences inside a PromQL double-quoted string literal and 400 the
+	// whole query. An unescaped dot is regex-any here, which still matches the
+	// literal dot in an IP/node name (no real collision risk).
+	inst := ip + ":.*"
+	nodeRe := node
 
 	const rateWin = "2m"
 	window := time.Duration(orDefaultInt32(req.Msg.GetWindowSeconds(), 900)) * time.Second

--- a/internal/gateway/telemetry_service_test.go
+++ b/internal/gateway/telemetry_service_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
 	connect "connectrpc.com/connect"
@@ -74,6 +76,60 @@ func TestTelemetryService_NoEndpoint(t *testing.T) {
 	// No silent empty chart: an unconfigured endpoint surfaces as a cluster error.
 	if resp.Msg.Error == nil || resp.Msg.Error.Cluster != "boba" {
 		t.Errorf("want a cluster error for the missing endpoint, got %+v", resp.Msg.Error)
+	}
+}
+
+// TestTelemetryService_GetNodeMetrics_ValidPromQL records the queries the
+// service sends and guards the regression that 400'd node metrics on cluster:
+// regexp.QuoteMeta'd dots produce `\.`, an INVALID escape inside a PromQL
+// double-quoted string literal. No built query may contain it.
+func TestTelemetryService_GetNodeMetrics_ValidPromQL(t *testing.T) {
+	var mu sync.Mutex
+	var queries []string
+	prom := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		queries = append(queries, r.URL.Query().Get("query"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[{"metric":{},"values":[[1700000000,"0.5"],[1700000030,"0.7"]]}]}}`))
+	}))
+	defer prom.Close()
+
+	boba := fakeExplorerDyn(mkNode("boba", true)) // mkNode sets InternalIP 10.0.0.1
+	prov := &fakeProvider{
+		clients: map[string]dynamic.Interface{"boba": boba},
+		prom:    map[string]string{"boba": prom.URL},
+	}
+	svc := NewTelemetryService(prov, NewInsecureAuthenticator())
+
+	resp, err := svc.GetNodeMetrics(context.Background(), connect.NewRequest(&kubeswiftv1.GetNodeMetricsRequest{
+		Cluster: "boba", Node: "boba",
+	}))
+	if err != nil {
+		t.Fatalf("GetNodeMetrics: %v", err)
+	}
+	if resp.Msg.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Msg.Error)
+	}
+	if len(resp.Msg.Series) != 5 {
+		t.Fatalf("want 5 series (cpu/mem/rx/tx/gpu), got %d", len(resp.Msg.Series))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(queries) != 5 {
+		t.Fatalf("want 5 queries sent, got %d", len(queries))
+	}
+	sawIP := false
+	for _, q := range queries {
+		if strings.Contains(q, `\.`) {
+			t.Errorf("query contains invalid PromQL escape %q: %s", `\.`, q)
+		}
+		if strings.Contains(q, "10.0.0.1:.*") {
+			sawIP = true
+		}
+	}
+	if !sawIP {
+		t.Errorf("no query keyed on the node InternalIP matcher; got %v", queries)
 	}
 }
 


### PR DESCRIPTION
Hotfix for UI Phase 3 node insights (#281). `GetNodeMetrics` returned a per-cluster error `prometheus returned 400 Bad Request` for every node — the node CPU/MEM/Net/GPU sparklines were dead.

## Cause

The queries used `regexp.QuoteMeta(ip)` / `regexp.QuoteMeta(node)` inside `=~` label matchers. `QuoteMeta("5.9.122.244")` → `5\.9\.122\.244`, and **`\.` is an invalid escape sequence inside a PromQL double-quoted string literal** → Prometheus 400s the whole query. The W5 pattern again: the fake-Prometheus unit test returns canned JSON and never parses the PromQL, so it stayed green.

## Fix

Use the raw IP/node in the regex matchers. An unescaped dot is regex-any, which still matches the literal dot in an IP / node name (no real collision risk for `instance=~"<ip>:.*"` / `Hostname=~"<node>.*"`).

## Verify

- Cluster-verified: the fixed `cpu_util`/`mem_util` queries return 200 with real data for boba (7.6% CPU, 7.8% mem); the GPU query reads the DCGM series.
- New regression test records the queries the service sends and asserts none contains the invalid `\.` escape (fails against the reverted fix). `go test ./internal/gateway/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)