### PR TITLE
feat(gateway): GuestService.CreateGuest — Create-VM wizard backend

### DIFF
--- a/gen/kubeswift/v1/guest.pb.go
+++ b/gen/kubeswift/v1/guest.pb.go
@@ -723,6 +723,293 @@ func (x *MigrateGuestResponse) GetMigration() *ObjectRef {
 	return nil
 }
 
+// GuestPortSpec is one declarative service port for a created guest (the
+// service-exposure surface). expose mints a per-guest Service; omitted = DNAT
+// only.
+type GuestPortSpec struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"` // required when more than one port
+	Port          int32                  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	TargetPort    int32                  `protobuf:"varint,3,opt,name=target_port,json=targetPort,proto3" json:"target_port,omitempty"` // defaults to port
+	Protocol      string                 `protobuf:"bytes,4,opt,name=protocol,proto3" json:"protocol,omitempty"`                        // TCP (default) | UDP | SCTP
+	Expose        string                 `protobuf:"bytes,5,opt,name=expose,proto3" json:"expose,omitempty"`                            // "" | ClusterIP | NodePort | LoadBalancer
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GuestPortSpec) Reset() {
+	*x = GuestPortSpec{}
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GuestPortSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GuestPortSpec) ProtoMessage() {}
+
+func (x *GuestPortSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GuestPortSpec.ProtoReflect.Descriptor instead.
+func (*GuestPortSpec) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_guest_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *GuestPortSpec) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *GuestPortSpec) GetPort() int32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+func (x *GuestPortSpec) GetTargetPort() int32 {
+	if x != nil {
+		return x.TargetPort
+	}
+	return 0
+}
+
+func (x *GuestPortSpec) GetProtocol() string {
+	if x != nil {
+		return x.Protocol
+	}
+	return ""
+}
+
+func (x *GuestPortSpec) GetExpose() string {
+	if x != nil {
+		return x.Expose
+	}
+	return ""
+}
+
+// CreateGuestRequest is the structured input the Create-VM wizard submits. The
+// gateway builds a SwiftGuest from it and server-side-applies it AS THE
+// IMPERSONATED USER, so the member's RBAC + the SwiftGuest admission webhook are
+// the authority (a denial surfaces, never a silent create). Exactly one boot
+// source (image / kernel / clone) is required.
+type CreateGuestRequest struct {
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Cluster   string                 `protobuf:"bytes,1,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	Namespace string                 `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Name      string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	// Boot source — exactly one of:
+	ImageRef         string           `protobuf:"bytes,4,opt,name=image_ref,json=imageRef,proto3" json:"image_ref,omitempty"`                           // SwiftImage name (disk boot)
+	KernelRef        string           `protobuf:"bytes,5,opt,name=kernel_ref,json=kernelRef,proto3" json:"kernel_ref,omitempty"`                        // SwiftKernel name (kernel boot)
+	KernelCmdline    string           `protobuf:"bytes,6,opt,name=kernel_cmdline,json=kernelCmdline,proto3" json:"kernel_cmdline,omitempty"`            // optional, with kernel_ref
+	CloneSnapshotRef string           `protobuf:"bytes,7,opt,name=clone_snapshot_ref,json=cloneSnapshotRef,proto3" json:"clone_snapshot_ref,omitempty"` // SwiftSnapshot name (cloneFromSnapshot)
+	CloneTargetNode  string           `protobuf:"bytes,8,opt,name=clone_target_node,json=cloneTargetNode,proto3" json:"clone_target_node,omitempty"`    // optional pin (required for an s3 snapshot)
+	GuestClassRef    string           `protobuf:"bytes,9,opt,name=guest_class_ref,json=guestClassRef,proto3" json:"guest_class_ref,omitempty"`          // REQUIRED (CPU/mem)
+	SeedProfileRef   string           `protobuf:"bytes,10,opt,name=seed_profile_ref,json=seedProfileRef,proto3" json:"seed_profile_ref,omitempty"`      // optional (cloud-init; disk boot)
+	GpuProfileRef    string           `protobuf:"bytes,11,opt,name=gpu_profile_ref,json=gpuProfileRef,proto3" json:"gpu_profile_ref,omitempty"`         // optional (combines with image, not kernel)
+	RunPolicy        string           `protobuf:"bytes,12,opt,name=run_policy,json=runPolicy,proto3" json:"run_policy,omitempty"`                       // default Running
+	OsType           string           `protobuf:"bytes,13,opt,name=os_type,json=osType,proto3" json:"os_type,omitempty"`                                // "" | linux | windows
+	NodeName         string           `protobuf:"bytes,14,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`                          // optional pin
+	Ports            []*GuestPortSpec `protobuf:"bytes,15,rep,name=ports,proto3" json:"ports,omitempty"`                                                // optional service ports
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *CreateGuestRequest) Reset() {
+	*x = CreateGuestRequest{}
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateGuestRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateGuestRequest) ProtoMessage() {}
+
+func (x *CreateGuestRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateGuestRequest.ProtoReflect.Descriptor instead.
+func (*CreateGuestRequest) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_guest_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *CreateGuestRequest) GetCluster() string {
+	if x != nil {
+		return x.Cluster
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetImageRef() string {
+	if x != nil {
+		return x.ImageRef
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetKernelRef() string {
+	if x != nil {
+		return x.KernelRef
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetKernelCmdline() string {
+	if x != nil {
+		return x.KernelCmdline
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetCloneSnapshotRef() string {
+	if x != nil {
+		return x.CloneSnapshotRef
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetCloneTargetNode() string {
+	if x != nil {
+		return x.CloneTargetNode
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetGuestClassRef() string {
+	if x != nil {
+		return x.GuestClassRef
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetSeedProfileRef() string {
+	if x != nil {
+		return x.SeedProfileRef
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetGpuProfileRef() string {
+	if x != nil {
+		return x.GpuProfileRef
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetRunPolicy() string {
+	if x != nil {
+		return x.RunPolicy
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetOsType() string {
+	if x != nil {
+		return x.OsType
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetNodeName() string {
+	if x != nil {
+		return x.NodeName
+	}
+	return ""
+}
+
+func (x *CreateGuestRequest) GetPorts() []*GuestPortSpec {
+	if x != nil {
+		return x.Ports
+	}
+	return nil
+}
+
+// CreateGuestResponse returns the new guest's ref; the live WatchGuests stream
+// carries its phase from there.
+type CreateGuestResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ref           *ObjectRef             `protobuf:"bytes,1,opt,name=ref,proto3" json:"ref,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateGuestResponse) Reset() {
+	*x = CreateGuestResponse{}
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateGuestResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateGuestResponse) ProtoMessage() {}
+
+func (x *CreateGuestResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateGuestResponse.ProtoReflect.Descriptor instead.
+func (*CreateGuestResponse) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_guest_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *CreateGuestResponse) GetRef() *ObjectRef {
+	if x != nil {
+		return x.Ref
+	}
+	return nil
+}
+
 var File_kubeswift_v1_guest_proto protoreflect.FileDescriptor
 
 const file_kubeswift_v1_guest_proto_rawDesc = "" +
@@ -787,7 +1074,35 @@ const file_kubeswift_v1_guest_proto_rawDesc = "" +
 	"\x04mode\x18\x03 \x01(\tR\x04mode\x12&\n" +
 	"\x0fallow_ip_change\x18\x04 \x01(\bR\rallowIpChange\"M\n" +
 	"\x14MigrateGuestResponse\x125\n" +
-	"\tmigration\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\tmigration2\x85\x04\n" +
+	"\tmigration\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\tmigration\"\x8c\x01\n" +
+	"\rGuestPortSpec\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port\x12\x1f\n" +
+	"\vtarget_port\x18\x03 \x01(\x05R\n" +
+	"targetPort\x12\x1a\n" +
+	"\bprotocol\x18\x04 \x01(\tR\bprotocol\x12\x16\n" +
+	"\x06expose\x18\x05 \x01(\tR\x06expose\"\x9f\x04\n" +
+	"\x12CreateGuestRequest\x12\x18\n" +
+	"\acluster\x18\x01 \x01(\tR\acluster\x12\x1c\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12\x1b\n" +
+	"\timage_ref\x18\x04 \x01(\tR\bimageRef\x12\x1d\n" +
+	"\n" +
+	"kernel_ref\x18\x05 \x01(\tR\tkernelRef\x12%\n" +
+	"\x0ekernel_cmdline\x18\x06 \x01(\tR\rkernelCmdline\x12,\n" +
+	"\x12clone_snapshot_ref\x18\a \x01(\tR\x10cloneSnapshotRef\x12*\n" +
+	"\x11clone_target_node\x18\b \x01(\tR\x0fcloneTargetNode\x12&\n" +
+	"\x0fguest_class_ref\x18\t \x01(\tR\rguestClassRef\x12(\n" +
+	"\x10seed_profile_ref\x18\n" +
+	" \x01(\tR\x0eseedProfileRef\x12&\n" +
+	"\x0fgpu_profile_ref\x18\v \x01(\tR\rgpuProfileRef\x12\x1d\n" +
+	"\n" +
+	"run_policy\x18\f \x01(\tR\trunPolicy\x12\x17\n" +
+	"\aos_type\x18\r \x01(\tR\x06osType\x12\x1b\n" +
+	"\tnode_name\x18\x0e \x01(\tR\bnodeName\x121\n" +
+	"\x05ports\x18\x0f \x03(\v2\x1b.kubeswift.v1.GuestPortSpecR\x05ports\"@\n" +
+	"\x13CreateGuestResponse\x12)\n" +
+	"\x03ref\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\x03ref2\xd9\x04\n" +
 	"\fGuestService\x12O\n" +
 	"\n" +
 	"ListGuests\x12\x1f.kubeswift.v1.ListGuestsRequest\x1a .kubeswift.v1.ListGuestsResponse\x12K\n" +
@@ -796,7 +1111,8 @@ const file_kubeswift_v1_guest_proto_rawDesc = "" +
 	"\n" +
 	"StartGuest\x12 .kubeswift.v1.GuestActionRequest\x1a!.kubeswift.v1.GuestActionResponse\x12P\n" +
 	"\tStopGuest\x12 .kubeswift.v1.GuestActionRequest\x1a!.kubeswift.v1.GuestActionResponse\x12U\n" +
-	"\fMigrateGuest\x12!.kubeswift.v1.MigrateGuestRequest\x1a\".kubeswift.v1.MigrateGuestResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
+	"\fMigrateGuest\x12!.kubeswift.v1.MigrateGuestRequest\x1a\".kubeswift.v1.MigrateGuestResponse\x12R\n" +
+	"\vCreateGuest\x12 .kubeswift.v1.CreateGuestRequest\x1a!.kubeswift.v1.CreateGuestResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
 
 var (
 	file_kubeswift_v1_guest_proto_rawDescOnce sync.Once
@@ -810,7 +1126,7 @@ func file_kubeswift_v1_guest_proto_rawDescGZIP() []byte {
 	return file_kubeswift_v1_guest_proto_rawDescData
 }
 
-var file_kubeswift_v1_guest_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_kubeswift_v1_guest_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_kubeswift_v1_guest_proto_goTypes = []any{
 	(*Guest)(nil),                  // 0: kubeswift.v1.Guest
 	(*ListGuestsRequest)(nil),      // 1: kubeswift.v1.ListGuestsRequest
@@ -823,53 +1139,60 @@ var file_kubeswift_v1_guest_proto_goTypes = []any{
 	(*GuestActionResponse)(nil),    // 8: kubeswift.v1.GuestActionResponse
 	(*MigrateGuestRequest)(nil),    // 9: kubeswift.v1.MigrateGuestRequest
 	(*MigrateGuestResponse)(nil),   // 10: kubeswift.v1.MigrateGuestResponse
-	nil,                            // 11: kubeswift.v1.Guest.LabelsEntry
-	(*ObjectRef)(nil),              // 12: kubeswift.v1.ObjectRef
-	(*timestamppb.Timestamp)(nil),  // 13: google.protobuf.Timestamp
-	(*Condition)(nil),              // 14: kubeswift.v1.Condition
-	(*ClusterSelector)(nil),        // 15: kubeswift.v1.ClusterSelector
-	(*PageRequest)(nil),            // 16: kubeswift.v1.PageRequest
-	(*PageResponse)(nil),           // 17: kubeswift.v1.PageResponse
-	(*ClusterError)(nil),           // 18: kubeswift.v1.ClusterError
-	(EventType)(0),                 // 19: kubeswift.v1.EventType
+	(*GuestPortSpec)(nil),          // 11: kubeswift.v1.GuestPortSpec
+	(*CreateGuestRequest)(nil),     // 12: kubeswift.v1.CreateGuestRequest
+	(*CreateGuestResponse)(nil),    // 13: kubeswift.v1.CreateGuestResponse
+	nil,                            // 14: kubeswift.v1.Guest.LabelsEntry
+	(*ObjectRef)(nil),              // 15: kubeswift.v1.ObjectRef
+	(*timestamppb.Timestamp)(nil),  // 16: google.protobuf.Timestamp
+	(*Condition)(nil),              // 17: kubeswift.v1.Condition
+	(*ClusterSelector)(nil),        // 18: kubeswift.v1.ClusterSelector
+	(*PageRequest)(nil),            // 19: kubeswift.v1.PageRequest
+	(*PageResponse)(nil),           // 20: kubeswift.v1.PageResponse
+	(*ClusterError)(nil),           // 21: kubeswift.v1.ClusterError
+	(EventType)(0),                 // 22: kubeswift.v1.EventType
 }
 var file_kubeswift_v1_guest_proto_depIdxs = []int32{
-	12, // 0: kubeswift.v1.Guest.ref:type_name -> kubeswift.v1.ObjectRef
-	13, // 1: kubeswift.v1.Guest.created_at:type_name -> google.protobuf.Timestamp
-	14, // 2: kubeswift.v1.Guest.conditions:type_name -> kubeswift.v1.Condition
-	11, // 3: kubeswift.v1.Guest.labels:type_name -> kubeswift.v1.Guest.LabelsEntry
-	15, // 4: kubeswift.v1.ListGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
-	16, // 5: kubeswift.v1.ListGuestsRequest.page:type_name -> kubeswift.v1.PageRequest
+	15, // 0: kubeswift.v1.Guest.ref:type_name -> kubeswift.v1.ObjectRef
+	16, // 1: kubeswift.v1.Guest.created_at:type_name -> google.protobuf.Timestamp
+	17, // 2: kubeswift.v1.Guest.conditions:type_name -> kubeswift.v1.Condition
+	14, // 3: kubeswift.v1.Guest.labels:type_name -> kubeswift.v1.Guest.LabelsEntry
+	18, // 4: kubeswift.v1.ListGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
+	19, // 5: kubeswift.v1.ListGuestsRequest.page:type_name -> kubeswift.v1.PageRequest
 	0,  // 6: kubeswift.v1.ListGuestsResponse.guests:type_name -> kubeswift.v1.Guest
-	17, // 7: kubeswift.v1.ListGuestsResponse.page:type_name -> kubeswift.v1.PageResponse
-	18, // 8: kubeswift.v1.ListGuestsResponse.errors:type_name -> kubeswift.v1.ClusterError
-	15, // 9: kubeswift.v1.WatchGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
-	19, // 10: kubeswift.v1.GuestEvent.type:type_name -> kubeswift.v1.EventType
+	20, // 7: kubeswift.v1.ListGuestsResponse.page:type_name -> kubeswift.v1.PageResponse
+	21, // 8: kubeswift.v1.ListGuestsResponse.errors:type_name -> kubeswift.v1.ClusterError
+	18, // 9: kubeswift.v1.WatchGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
+	22, // 10: kubeswift.v1.GuestEvent.type:type_name -> kubeswift.v1.EventType
 	0,  // 11: kubeswift.v1.GuestEvent.guest:type_name -> kubeswift.v1.Guest
-	18, // 12: kubeswift.v1.GuestEvent.error:type_name -> kubeswift.v1.ClusterError
-	12, // 13: kubeswift.v1.GetGuestDetailRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	21, // 12: kubeswift.v1.GuestEvent.error:type_name -> kubeswift.v1.ClusterError
+	15, // 13: kubeswift.v1.GetGuestDetailRequest.ref:type_name -> kubeswift.v1.ObjectRef
 	0,  // 14: kubeswift.v1.GetGuestDetailResponse.guest:type_name -> kubeswift.v1.Guest
-	12, // 15: kubeswift.v1.GuestActionRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	15, // 15: kubeswift.v1.GuestActionRequest.ref:type_name -> kubeswift.v1.ObjectRef
 	0,  // 16: kubeswift.v1.GuestActionResponse.guest:type_name -> kubeswift.v1.Guest
-	12, // 17: kubeswift.v1.MigrateGuestRequest.ref:type_name -> kubeswift.v1.ObjectRef
-	12, // 18: kubeswift.v1.MigrateGuestResponse.migration:type_name -> kubeswift.v1.ObjectRef
-	1,  // 19: kubeswift.v1.GuestService.ListGuests:input_type -> kubeswift.v1.ListGuestsRequest
-	3,  // 20: kubeswift.v1.GuestService.WatchGuests:input_type -> kubeswift.v1.WatchGuestsRequest
-	5,  // 21: kubeswift.v1.GuestService.GetGuestDetail:input_type -> kubeswift.v1.GetGuestDetailRequest
-	7,  // 22: kubeswift.v1.GuestService.StartGuest:input_type -> kubeswift.v1.GuestActionRequest
-	7,  // 23: kubeswift.v1.GuestService.StopGuest:input_type -> kubeswift.v1.GuestActionRequest
-	9,  // 24: kubeswift.v1.GuestService.MigrateGuest:input_type -> kubeswift.v1.MigrateGuestRequest
-	2,  // 25: kubeswift.v1.GuestService.ListGuests:output_type -> kubeswift.v1.ListGuestsResponse
-	4,  // 26: kubeswift.v1.GuestService.WatchGuests:output_type -> kubeswift.v1.GuestEvent
-	6,  // 27: kubeswift.v1.GuestService.GetGuestDetail:output_type -> kubeswift.v1.GetGuestDetailResponse
-	8,  // 28: kubeswift.v1.GuestService.StartGuest:output_type -> kubeswift.v1.GuestActionResponse
-	8,  // 29: kubeswift.v1.GuestService.StopGuest:output_type -> kubeswift.v1.GuestActionResponse
-	10, // 30: kubeswift.v1.GuestService.MigrateGuest:output_type -> kubeswift.v1.MigrateGuestResponse
-	25, // [25:31] is the sub-list for method output_type
-	19, // [19:25] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	15, // 17: kubeswift.v1.MigrateGuestRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	15, // 18: kubeswift.v1.MigrateGuestResponse.migration:type_name -> kubeswift.v1.ObjectRef
+	11, // 19: kubeswift.v1.CreateGuestRequest.ports:type_name -> kubeswift.v1.GuestPortSpec
+	15, // 20: kubeswift.v1.CreateGuestResponse.ref:type_name -> kubeswift.v1.ObjectRef
+	1,  // 21: kubeswift.v1.GuestService.ListGuests:input_type -> kubeswift.v1.ListGuestsRequest
+	3,  // 22: kubeswift.v1.GuestService.WatchGuests:input_type -> kubeswift.v1.WatchGuestsRequest
+	5,  // 23: kubeswift.v1.GuestService.GetGuestDetail:input_type -> kubeswift.v1.GetGuestDetailRequest
+	7,  // 24: kubeswift.v1.GuestService.StartGuest:input_type -> kubeswift.v1.GuestActionRequest
+	7,  // 25: kubeswift.v1.GuestService.StopGuest:input_type -> kubeswift.v1.GuestActionRequest
+	9,  // 26: kubeswift.v1.GuestService.MigrateGuest:input_type -> kubeswift.v1.MigrateGuestRequest
+	12, // 27: kubeswift.v1.GuestService.CreateGuest:input_type -> kubeswift.v1.CreateGuestRequest
+	2,  // 28: kubeswift.v1.GuestService.ListGuests:output_type -> kubeswift.v1.ListGuestsResponse
+	4,  // 29: kubeswift.v1.GuestService.WatchGuests:output_type -> kubeswift.v1.GuestEvent
+	6,  // 30: kubeswift.v1.GuestService.GetGuestDetail:output_type -> kubeswift.v1.GetGuestDetailResponse
+	8,  // 31: kubeswift.v1.GuestService.StartGuest:output_type -> kubeswift.v1.GuestActionResponse
+	8,  // 32: kubeswift.v1.GuestService.StopGuest:output_type -> kubeswift.v1.GuestActionResponse
+	10, // 33: kubeswift.v1.GuestService.MigrateGuest:output_type -> kubeswift.v1.MigrateGuestResponse
+	13, // 34: kubeswift.v1.GuestService.CreateGuest:output_type -> kubeswift.v1.CreateGuestResponse
+	28, // [28:35] is the sub-list for method output_type
+	21, // [21:28] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_kubeswift_v1_guest_proto_init() }
@@ -884,7 +1207,7 @@ func file_kubeswift_v1_guest_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kubeswift_v1_guest_proto_rawDesc), len(file_kubeswift_v1_guest_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/kubeswift/v1/kubeswiftv1connect/guest.connect.go
+++ b/gen/kubeswift/v1/kubeswiftv1connect/guest.connect.go
@@ -48,6 +48,9 @@ const (
 	// GuestServiceMigrateGuestProcedure is the fully-qualified name of the GuestService's MigrateGuest
 	// RPC.
 	GuestServiceMigrateGuestProcedure = "/kubeswift.v1.GuestService/MigrateGuest"
+	// GuestServiceCreateGuestProcedure is the fully-qualified name of the GuestService's CreateGuest
+	// RPC.
+	GuestServiceCreateGuestProcedure = "/kubeswift.v1.GuestService/CreateGuest"
 )
 
 // GuestServiceClient is a client for the kubeswift.v1.GuestService service.
@@ -63,6 +66,10 @@ type GuestServiceClient interface {
 	// Migrate (write plane, P2): create a SwiftMigration to move the guest. The
 	// impersonated user must be allowed to create swiftmigrations on the member.
 	MigrateGuest(context.Context, *connect.Request[v1.MigrateGuestRequest]) (*connect.Response[v1.MigrateGuestResponse], error)
+	// Create (write plane, P3): build + server-side-apply a SwiftGuest from the
+	// wizard's structured input. The impersonated user must be allowed to create
+	// swiftguests on the member; the admission webhook validates the spec.
+	CreateGuest(context.Context, *connect.Request[v1.CreateGuestRequest]) (*connect.Response[v1.CreateGuestResponse], error)
 }
 
 // NewGuestServiceClient constructs a client for the kubeswift.v1.GuestService service. By default,
@@ -112,6 +119,12 @@ func NewGuestServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 			connect.WithSchema(guestServiceMethods.ByName("MigrateGuest")),
 			connect.WithClientOptions(opts...),
 		),
+		createGuest: connect.NewClient[v1.CreateGuestRequest, v1.CreateGuestResponse](
+			httpClient,
+			baseURL+GuestServiceCreateGuestProcedure,
+			connect.WithSchema(guestServiceMethods.ByName("CreateGuest")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -123,6 +136,7 @@ type guestServiceClient struct {
 	startGuest     *connect.Client[v1.GuestActionRequest, v1.GuestActionResponse]
 	stopGuest      *connect.Client[v1.GuestActionRequest, v1.GuestActionResponse]
 	migrateGuest   *connect.Client[v1.MigrateGuestRequest, v1.MigrateGuestResponse]
+	createGuest    *connect.Client[v1.CreateGuestRequest, v1.CreateGuestResponse]
 }
 
 // ListGuests calls kubeswift.v1.GuestService.ListGuests.
@@ -155,6 +169,11 @@ func (c *guestServiceClient) MigrateGuest(ctx context.Context, req *connect.Requ
 	return c.migrateGuest.CallUnary(ctx, req)
 }
 
+// CreateGuest calls kubeswift.v1.GuestService.CreateGuest.
+func (c *guestServiceClient) CreateGuest(ctx context.Context, req *connect.Request[v1.CreateGuestRequest]) (*connect.Response[v1.CreateGuestResponse], error) {
+	return c.createGuest.CallUnary(ctx, req)
+}
+
 // GuestServiceHandler is an implementation of the kubeswift.v1.GuestService service.
 type GuestServiceHandler interface {
 	ListGuests(context.Context, *connect.Request[v1.ListGuestsRequest]) (*connect.Response[v1.ListGuestsResponse], error)
@@ -168,6 +187,10 @@ type GuestServiceHandler interface {
 	// Migrate (write plane, P2): create a SwiftMigration to move the guest. The
 	// impersonated user must be allowed to create swiftmigrations on the member.
 	MigrateGuest(context.Context, *connect.Request[v1.MigrateGuestRequest]) (*connect.Response[v1.MigrateGuestResponse], error)
+	// Create (write plane, P3): build + server-side-apply a SwiftGuest from the
+	// wizard's structured input. The impersonated user must be allowed to create
+	// swiftguests on the member; the admission webhook validates the spec.
+	CreateGuest(context.Context, *connect.Request[v1.CreateGuestRequest]) (*connect.Response[v1.CreateGuestResponse], error)
 }
 
 // NewGuestServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -213,6 +236,12 @@ func NewGuestServiceHandler(svc GuestServiceHandler, opts ...connect.HandlerOpti
 		connect.WithSchema(guestServiceMethods.ByName("MigrateGuest")),
 		connect.WithHandlerOptions(opts...),
 	)
+	guestServiceCreateGuestHandler := connect.NewUnaryHandler(
+		GuestServiceCreateGuestProcedure,
+		svc.CreateGuest,
+		connect.WithSchema(guestServiceMethods.ByName("CreateGuest")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/kubeswift.v1.GuestService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case GuestServiceListGuestsProcedure:
@@ -227,6 +256,8 @@ func NewGuestServiceHandler(svc GuestServiceHandler, opts ...connect.HandlerOpti
 			guestServiceStopGuestHandler.ServeHTTP(w, r)
 		case GuestServiceMigrateGuestProcedure:
 			guestServiceMigrateGuestHandler.ServeHTTP(w, r)
+		case GuestServiceCreateGuestProcedure:
+			guestServiceCreateGuestHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -258,4 +289,8 @@ func (UnimplementedGuestServiceHandler) StopGuest(context.Context, *connect.Requ
 
 func (UnimplementedGuestServiceHandler) MigrateGuest(context.Context, *connect.Request[v1.MigrateGuestRequest]) (*connect.Response[v1.MigrateGuestResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.GuestService.MigrateGuest is not implemented"))
+}
+
+func (UnimplementedGuestServiceHandler) CreateGuest(context.Context, *connect.Request[v1.CreateGuestRequest]) (*connect.Response[v1.CreateGuestResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.GuestService.CreateGuest is not implemented"))
 }

--- a/internal/gateway/guest_service.go
+++ b/internal/gateway/guest_service.go
@@ -287,6 +287,124 @@ func (s *GuestService) MigrateGuest(ctx context.Context, req *connect.Request[ku
 	}), nil
 }
 
+// CreateGuest builds a SwiftGuest from the wizard's structured input and
+// server-side-applies it as the impersonated user. The admission webhook is the
+// authority on spec validity (boot-source exclusivity, gpu+kernel, osType, …); a
+// denial surfaces as FailedPrecondition, never a silent create.
+func (s *GuestService) CreateGuest(ctx context.Context, req *connect.Request[kubeswiftv1.CreateGuestRequest]) (*connect.Response[kubeswiftv1.CreateGuestResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	m := req.Msg
+	if m.GetCluster() == "" || m.GetNamespace() == "" || m.GetName() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cluster, namespace, and name are required"))
+	}
+	if m.GetGuestClassRef() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("guest_class_ref is required"))
+	}
+	// Exactly one boot source — a clear gateway error ahead of the webhook.
+	boot := 0
+	for _, v := range []string{m.GetImageRef(), m.GetKernelRef(), m.GetCloneSnapshotRef()} {
+		if v != "" {
+			boot++
+		}
+	}
+	if boot != 1 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("exactly one boot source is required: image_ref, kernel_ref, or clone_snapshot_ref"))
+	}
+
+	dyn, err := s.pool.DynamicFor(m.GetCluster(), id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	obj := buildSwiftGuest(m)
+	// Create (not apply) — a "create a new VM" must fail loudly on a name clash
+	// rather than silently overwrite an existing guest's spec.
+	if _, err := guestResource(dyn, m.GetNamespace()).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+		// A name clash, a webhook denial (boot-source / gpu / osType rules), or an
+		// RBAC refusal surfaces here with its reason — never a silent create.
+		code := connect.CodeInternal
+		switch {
+		case apierrors.IsAlreadyExists(err):
+			code = connect.CodeAlreadyExists
+		case apierrors.IsForbidden(err) || apierrors.IsInvalid(err) || apierrors.IsBadRequest(err):
+			code = connect.CodeFailedPrecondition
+		}
+		return nil, connect.NewError(code, err)
+	}
+	return connect.NewResponse(&kubeswiftv1.CreateGuestResponse{
+		Ref: &kubeswiftv1.ObjectRef{Cluster: m.GetCluster(), Namespace: m.GetNamespace(), Name: m.GetName()},
+	}), nil
+}
+
+// buildSwiftGuest constructs the SwiftGuest unstructured object from the wizard
+// request — only the set fields are written; CRD defaults + the webhook handle
+// the rest.
+func buildSwiftGuest(m *kubeswiftv1.CreateGuestRequest) *unstructured.Unstructured {
+	ref := func(name string) map[string]interface{} { return map[string]interface{}{"name": name} }
+	spec := map[string]interface{}{"guestClassRef": ref(m.GetGuestClassRef())}
+
+	switch {
+	case m.GetImageRef() != "":
+		spec["imageRef"] = ref(m.GetImageRef())
+	case m.GetKernelRef() != "":
+		spec["kernelRef"] = ref(m.GetKernelRef())
+		if c := m.GetKernelCmdline(); c != "" {
+			spec["kernelCmdline"] = c
+		}
+	case m.GetCloneSnapshotRef() != "":
+		clone := map[string]interface{}{"snapshotRef": ref(m.GetCloneSnapshotRef())}
+		if t := m.GetCloneTargetNode(); t != "" {
+			clone["targetNode"] = t
+		}
+		spec["cloneFromSnapshot"] = clone
+	}
+
+	if v := m.GetSeedProfileRef(); v != "" {
+		spec["seedProfileRef"] = ref(v)
+	}
+	if v := m.GetGpuProfileRef(); v != "" {
+		spec["gpuProfileRef"] = ref(v)
+	}
+	if v := m.GetRunPolicy(); v != "" {
+		spec["runPolicy"] = v
+	}
+	if v := m.GetOsType(); v != "" {
+		spec["osType"] = v
+	}
+	if v := m.GetNodeName(); v != "" {
+		spec["nodeName"] = v
+	}
+	if ports := m.GetPorts(); len(ports) > 0 {
+		out := make([]interface{}, 0, len(ports))
+		for _, p := range ports {
+			port := map[string]interface{}{"port": int64(p.GetPort())}
+			if p.GetName() != "" {
+				port["name"] = p.GetName()
+			}
+			if p.GetTargetPort() != 0 {
+				port["targetPort"] = int64(p.GetTargetPort())
+			}
+			if p.GetProtocol() != "" {
+				port["protocol"] = p.GetProtocol()
+			}
+			if p.GetExpose() != "" {
+				port["expose"] = p.GetExpose()
+			}
+			out = append(out, port)
+		}
+		spec["network"] = map[string]interface{}{"ports": out}
+	}
+
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "swift.kubeswift.io/v1alpha1",
+		"kind":       "SwiftGuest",
+		"metadata":   map[string]interface{}{"name": m.GetName(), "namespace": m.GetNamespace()},
+		"spec":       spec,
+	}}
+}
+
 // targetClusters resolves the selector against the registered members. An empty
 // or all-clusters selector targets the whole fleet.
 func (s *GuestService) targetClusters(sel *kubeswiftv1.ClusterSelector) []string {

--- a/internal/gateway/guest_service_test.go
+++ b/internal/gateway/guest_service_test.go
@@ -234,3 +234,57 @@ func TestGuestService_MigrateGuest(t *testing.T) {
 		t.Errorf("missing target_node should be InvalidArgument, got %v", err)
 	}
 }
+
+func TestGuestService_CreateGuest(t *testing.T) {
+	boba := fakeDyn()
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+
+	resp, err := svc.CreateGuest(context.Background(), connect.NewRequest(&kubeswiftv1.CreateGuestRequest{
+		Cluster: "boba", Namespace: "default", Name: "web-1",
+		ImageRef: "ubuntu-noble", GuestClassRef: "small", SeedProfileRef: "default-seed", RunPolicy: "Running",
+		Ports: []*kubeswiftv1.GuestPortSpec{{Name: "ssh", Port: 22, Expose: "ClusterIP"}},
+	}))
+	if err != nil {
+		t.Fatalf("CreateGuest: %v", err)
+	}
+	if resp.Msg.Ref.GetName() != "web-1" || resp.Msg.Ref.GetCluster() != "boba" {
+		t.Errorf("unexpected ref: %+v", resp.Msg.Ref)
+	}
+	// The SwiftGuest exists with the wizard's spec.
+	got, err := boba.Resource(swiftGuestGVR).Namespace("default").Get(context.Background(), "web-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("created guest not found: %v", err)
+	}
+	image, _, _ := unstructured.NestedString(got.Object, "spec", "imageRef", "name")
+	class, _, _ := unstructured.NestedString(got.Object, "spec", "guestClassRef", "name")
+	ports, _, _ := unstructured.NestedSlice(got.Object, "spec", "network", "ports")
+	if image != "ubuntu-noble" || class != "small" || len(ports) != 1 {
+		t.Errorf("spec wrong: image=%q class=%q ports=%d", image, class, len(ports))
+	}
+
+	// A name clash fails loudly (no silent overwrite of an existing VM).
+	_, err = svc.CreateGuest(context.Background(), connect.NewRequest(&kubeswiftv1.CreateGuestRequest{
+		Cluster: "boba", Namespace: "default", Name: "web-1", ImageRef: "x", GuestClassRef: "small",
+	}))
+	if connect.CodeOf(err) != connect.CodeAlreadyExists {
+		t.Errorf("duplicate name should be AlreadyExists, got %v", err)
+	}
+}
+
+func TestGuestService_CreateGuest_Validation(t *testing.T) {
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeDyn()}}, NewInsecureAuthenticator())
+	cases := []struct {
+		name string
+		req  *kubeswiftv1.CreateGuestRequest
+	}{
+		{"missing name", &kubeswiftv1.CreateGuestRequest{Cluster: "boba", Namespace: "default", ImageRef: "x", GuestClassRef: "small"}},
+		{"missing class", &kubeswiftv1.CreateGuestRequest{Cluster: "boba", Namespace: "default", Name: "g", ImageRef: "x"}},
+		{"no boot source", &kubeswiftv1.CreateGuestRequest{Cluster: "boba", Namespace: "default", Name: "g", GuestClassRef: "small"}},
+		{"two boot sources", &kubeswiftv1.CreateGuestRequest{Cluster: "boba", Namespace: "default", Name: "g", ImageRef: "x", KernelRef: "y", GuestClassRef: "small"}},
+	}
+	for _, tc := range cases {
+		if _, err := svc.CreateGuest(context.Background(), connect.NewRequest(tc.req)); connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("%s: want InvalidArgument, got %v", tc.name, err)
+		}
+	}
+}

--- a/proto/kubeswift/v1/guest.proto
+++ b/proto/kubeswift/v1/guest.proto
@@ -107,6 +107,50 @@ message MigrateGuestResponse {
   ObjectRef migration = 1;
 }
 
+// GuestPortSpec is one declarative service port for a created guest (the
+// service-exposure surface). expose mints a per-guest Service; omitted = DNAT
+// only.
+message GuestPortSpec {
+  string name = 1; // required when more than one port
+  int32 port = 2;
+  int32 target_port = 3; // defaults to port
+  string protocol = 4; // TCP (default) | UDP | SCTP
+  string expose = 5; // "" | ClusterIP | NodePort | LoadBalancer
+}
+
+// CreateGuestRequest is the structured input the Create-VM wizard submits. The
+// gateway builds a SwiftGuest from it and server-side-applies it AS THE
+// IMPERSONATED USER, so the member's RBAC + the SwiftGuest admission webhook are
+// the authority (a denial surfaces, never a silent create). Exactly one boot
+// source (image / kernel / clone) is required.
+message CreateGuestRequest {
+  string cluster = 1;
+  string namespace = 2;
+  string name = 3;
+
+  // Boot source — exactly one of:
+  string image_ref = 4; // SwiftImage name (disk boot)
+  string kernel_ref = 5; // SwiftKernel name (kernel boot)
+  string kernel_cmdline = 6; // optional, with kernel_ref
+  string clone_snapshot_ref = 7; // SwiftSnapshot name (cloneFromSnapshot)
+  string clone_target_node = 8; // optional pin (required for an s3 snapshot)
+
+  string guest_class_ref = 9; // REQUIRED (CPU/mem)
+  string seed_profile_ref = 10; // optional (cloud-init; disk boot)
+  string gpu_profile_ref = 11; // optional (combines with image, not kernel)
+  string run_policy = 12; // default Running
+  string os_type = 13; // "" | linux | windows
+  string node_name = 14; // optional pin
+
+  repeated GuestPortSpec ports = 15; // optional service ports
+}
+
+// CreateGuestResponse returns the new guest's ref; the live WatchGuests stream
+// carries its phase from there.
+message CreateGuestResponse {
+  ObjectRef ref = 1;
+}
+
 // GuestService is the read plane for VM inventory plus the P1/P2 write actions.
 // List/Watch fan out across the selected member clusters and merge, stamping
 // the cluster dimension on every row; a per-cluster error surface preserves
@@ -125,4 +169,9 @@ service GuestService {
   // Migrate (write plane, P2): create a SwiftMigration to move the guest. The
   // impersonated user must be allowed to create swiftmigrations on the member.
   rpc MigrateGuest(MigrateGuestRequest) returns (MigrateGuestResponse);
+
+  // Create (write plane, P3): build + server-side-apply a SwiftGuest from the
+  // wizard's structured input. The impersonated user must be allowed to create
+  // swiftguests on the member; the admission webhook validates the spec.
+  rpc CreateGuest(CreateGuestRequest) returns (CreateGuestResponse);
 }


### PR DESCRIPTION
UI Phase 3 — the backend for the Create-VM wizard (the biggest UX gap: today the only way to make a VM in the UI is hand-writing YAML in the Explorer).

## What

`GuestService.CreateGuest` takes a structured request and builds + creates a `SwiftGuest` as the **impersonated user**:
- name / namespace
- **exactly one boot source**: `image_ref` (disk) | `kernel_ref` (+ cmdline) | `clone_snapshot_ref` (+ optional target node)
- required `guest_class_ref`; optional `seed_profile_ref`, `gpu_profile_ref`, `run_policy`, `os_type`, `node_name`
- optional service `ports[]` (the service-exposure surface — `expose` mints a Service)

It uses **`Create`, not server-side-apply** — a "new VM" should fail loudly on a name clash, never silently overwrite an existing guest's spec.

## No silent failure

The member's RBAC + the SwiftGuest admission webhook are the authority:
- name clash → `AlreadyExists`
- webhook denial (boot-source exclusivity, gpu+kernel, osType) or RBAC refusal → `FailedPrecondition`
- light gateway validation (required fields + exactly-one boot source) → `InvalidArgument` ahead of the webhook

The wizard's dropdowns reuse the existing `ResourceService` catalog reads (images / kernels / classes / seeds / GPU profiles / snapshots are all already browsable), so **no new read RPC**.

## Tests

Created-object spec assertion (`imageRef` / `guestClassRef` / `network.ports`), name-clash → `AlreadyExists`, input validation (name / class / zero-or-two boot sources). `make proto-lint` clean; gateway suite green.

Next: the wizard UI (a stepper form feeding this RPC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)