### PR TITLE
feat(gateway): GetGuestEvents — boot diagnostics

### DIFF
--- a/gen/kubeswift/v1/guest.pb.go
+++ b/gen/kubeswift/v1/guest.pb.go
@@ -1211,6 +1211,180 @@ func (*DeleteGuestResponse) Descriptor() ([]byte, []int) {
 	return file_kubeswift_v1_guest_proto_rawDescGZIP(), []int{16}
 }
 
+// GuestEventEntry is one Kubernetes Event involving the guest or its launcher
+// pod — the "why won't my VM boot" diagnostics surface.
+type GuestEventEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Type          string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"` // Normal | Warning
+	Reason        string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	Message       string                 `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	Count         int32                  `protobuf:"varint,4,opt,name=count,proto3" json:"count,omitempty"`
+	Object        string                 `protobuf:"bytes,5,opt,name=object,proto3" json:"object,omitempty"` // involvedObject kind/name
+	LastSeen      *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=last_seen,json=lastSeen,proto3" json:"last_seen,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GuestEventEntry) Reset() {
+	*x = GuestEventEntry{}
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GuestEventEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GuestEventEntry) ProtoMessage() {}
+
+func (x *GuestEventEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GuestEventEntry.ProtoReflect.Descriptor instead.
+func (*GuestEventEntry) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_guest_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *GuestEventEntry) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *GuestEventEntry) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+func (x *GuestEventEntry) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *GuestEventEntry) GetCount() int32 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
+func (x *GuestEventEntry) GetObject() string {
+	if x != nil {
+		return x.Object
+	}
+	return ""
+}
+
+func (x *GuestEventEntry) GetLastSeen() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastSeen
+	}
+	return nil
+}
+
+type GetGuestEventsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ref           *ObjectRef             `protobuf:"bytes,1,opt,name=ref,proto3" json:"ref,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetGuestEventsRequest) Reset() {
+	*x = GetGuestEventsRequest{}
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetGuestEventsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetGuestEventsRequest) ProtoMessage() {}
+
+func (x *GetGuestEventsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetGuestEventsRequest.ProtoReflect.Descriptor instead.
+func (*GetGuestEventsRequest) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_guest_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *GetGuestEventsRequest) GetRef() *ObjectRef {
+	if x != nil {
+		return x.Ref
+	}
+	return nil
+}
+
+type GetGuestEventsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Events        []*GuestEventEntry     `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"` // newest first
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetGuestEventsResponse) Reset() {
+	*x = GetGuestEventsResponse{}
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetGuestEventsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetGuestEventsResponse) ProtoMessage() {}
+
+func (x *GetGuestEventsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_guest_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetGuestEventsResponse.ProtoReflect.Descriptor instead.
+func (*GetGuestEventsResponse) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_guest_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *GetGuestEventsResponse) GetEvents() []*GuestEventEntry {
+	if x != nil {
+		return x.Events
+	}
+	return nil
+}
+
 var File_kubeswift_v1_guest_proto protoreflect.FileDescriptor
 
 const file_kubeswift_v1_guest_proto_rawDesc = "" +
@@ -1319,7 +1493,18 @@ const file_kubeswift_v1_guest_proto_rawDesc = "" +
 	"\x03ref\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\x03ref\"?\n" +
 	"\x12DeleteGuestRequest\x12)\n" +
 	"\x03ref\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\x03ref\"\x15\n" +
-	"\x13DeleteGuestResponse2\xad\x05\n" +
+	"\x13DeleteGuestResponse\"\xbe\x01\n" +
+	"\x0fGuestEventEntry\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x18\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\x12\x14\n" +
+	"\x05count\x18\x04 \x01(\x05R\x05count\x12\x16\n" +
+	"\x06object\x18\x05 \x01(\tR\x06object\x127\n" +
+	"\tlast_seen\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\blastSeen\"B\n" +
+	"\x15GetGuestEventsRequest\x12)\n" +
+	"\x03ref\x18\x01 \x01(\v2\x17.kubeswift.v1.ObjectRefR\x03ref\"O\n" +
+	"\x16GetGuestEventsResponse\x125\n" +
+	"\x06events\x18\x01 \x03(\v2\x1d.kubeswift.v1.GuestEventEntryR\x06events2\x8a\x06\n" +
 	"\fGuestService\x12O\n" +
 	"\n" +
 	"ListGuests\x12\x1f.kubeswift.v1.ListGuestsRequest\x1a .kubeswift.v1.ListGuestsResponse\x12K\n" +
@@ -1330,7 +1515,8 @@ const file_kubeswift_v1_guest_proto_rawDesc = "" +
 	"\tStopGuest\x12 .kubeswift.v1.GuestActionRequest\x1a!.kubeswift.v1.GuestActionResponse\x12U\n" +
 	"\fMigrateGuest\x12!.kubeswift.v1.MigrateGuestRequest\x1a\".kubeswift.v1.MigrateGuestResponse\x12R\n" +
 	"\vCreateGuest\x12 .kubeswift.v1.CreateGuestRequest\x1a!.kubeswift.v1.CreateGuestResponse\x12R\n" +
-	"\vDeleteGuest\x12 .kubeswift.v1.DeleteGuestRequest\x1a!.kubeswift.v1.DeleteGuestResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
+	"\vDeleteGuest\x12 .kubeswift.v1.DeleteGuestRequest\x1a!.kubeswift.v1.DeleteGuestResponse\x12[\n" +
+	"\x0eGetGuestEvents\x12#.kubeswift.v1.GetGuestEventsRequest\x1a$.kubeswift.v1.GetGuestEventsResponseBAZ?github.com/projectbeskar/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
 
 var (
 	file_kubeswift_v1_guest_proto_rawDescOnce sync.Once
@@ -1344,7 +1530,7 @@ func file_kubeswift_v1_guest_proto_rawDescGZIP() []byte {
 	return file_kubeswift_v1_guest_proto_rawDescData
 }
 
-var file_kubeswift_v1_guest_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_kubeswift_v1_guest_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_kubeswift_v1_guest_proto_goTypes = []any{
 	(*Guest)(nil),                  // 0: kubeswift.v1.Guest
 	(*ListGuestsRequest)(nil),      // 1: kubeswift.v1.ListGuestsRequest
@@ -1363,61 +1549,69 @@ var file_kubeswift_v1_guest_proto_goTypes = []any{
 	(*CreateGuestResponse)(nil),    // 14: kubeswift.v1.CreateGuestResponse
 	(*DeleteGuestRequest)(nil),     // 15: kubeswift.v1.DeleteGuestRequest
 	(*DeleteGuestResponse)(nil),    // 16: kubeswift.v1.DeleteGuestResponse
-	nil,                            // 17: kubeswift.v1.Guest.LabelsEntry
-	(*ObjectRef)(nil),              // 18: kubeswift.v1.ObjectRef
-	(*timestamppb.Timestamp)(nil),  // 19: google.protobuf.Timestamp
-	(*Condition)(nil),              // 20: kubeswift.v1.Condition
-	(*ClusterSelector)(nil),        // 21: kubeswift.v1.ClusterSelector
-	(*PageRequest)(nil),            // 22: kubeswift.v1.PageRequest
-	(*PageResponse)(nil),           // 23: kubeswift.v1.PageResponse
-	(*ClusterError)(nil),           // 24: kubeswift.v1.ClusterError
-	(EventType)(0),                 // 25: kubeswift.v1.EventType
+	(*GuestEventEntry)(nil),        // 17: kubeswift.v1.GuestEventEntry
+	(*GetGuestEventsRequest)(nil),  // 18: kubeswift.v1.GetGuestEventsRequest
+	(*GetGuestEventsResponse)(nil), // 19: kubeswift.v1.GetGuestEventsResponse
+	nil,                            // 20: kubeswift.v1.Guest.LabelsEntry
+	(*ObjectRef)(nil),              // 21: kubeswift.v1.ObjectRef
+	(*timestamppb.Timestamp)(nil),  // 22: google.protobuf.Timestamp
+	(*Condition)(nil),              // 23: kubeswift.v1.Condition
+	(*ClusterSelector)(nil),        // 24: kubeswift.v1.ClusterSelector
+	(*PageRequest)(nil),            // 25: kubeswift.v1.PageRequest
+	(*PageResponse)(nil),           // 26: kubeswift.v1.PageResponse
+	(*ClusterError)(nil),           // 27: kubeswift.v1.ClusterError
+	(EventType)(0),                 // 28: kubeswift.v1.EventType
 }
 var file_kubeswift_v1_guest_proto_depIdxs = []int32{
-	18, // 0: kubeswift.v1.Guest.ref:type_name -> kubeswift.v1.ObjectRef
-	19, // 1: kubeswift.v1.Guest.created_at:type_name -> google.protobuf.Timestamp
-	20, // 2: kubeswift.v1.Guest.conditions:type_name -> kubeswift.v1.Condition
-	17, // 3: kubeswift.v1.Guest.labels:type_name -> kubeswift.v1.Guest.LabelsEntry
-	21, // 4: kubeswift.v1.ListGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
-	22, // 5: kubeswift.v1.ListGuestsRequest.page:type_name -> kubeswift.v1.PageRequest
+	21, // 0: kubeswift.v1.Guest.ref:type_name -> kubeswift.v1.ObjectRef
+	22, // 1: kubeswift.v1.Guest.created_at:type_name -> google.protobuf.Timestamp
+	23, // 2: kubeswift.v1.Guest.conditions:type_name -> kubeswift.v1.Condition
+	20, // 3: kubeswift.v1.Guest.labels:type_name -> kubeswift.v1.Guest.LabelsEntry
+	24, // 4: kubeswift.v1.ListGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
+	25, // 5: kubeswift.v1.ListGuestsRequest.page:type_name -> kubeswift.v1.PageRequest
 	0,  // 6: kubeswift.v1.ListGuestsResponse.guests:type_name -> kubeswift.v1.Guest
-	23, // 7: kubeswift.v1.ListGuestsResponse.page:type_name -> kubeswift.v1.PageResponse
-	24, // 8: kubeswift.v1.ListGuestsResponse.errors:type_name -> kubeswift.v1.ClusterError
-	21, // 9: kubeswift.v1.WatchGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
-	25, // 10: kubeswift.v1.GuestEvent.type:type_name -> kubeswift.v1.EventType
+	26, // 7: kubeswift.v1.ListGuestsResponse.page:type_name -> kubeswift.v1.PageResponse
+	27, // 8: kubeswift.v1.ListGuestsResponse.errors:type_name -> kubeswift.v1.ClusterError
+	24, // 9: kubeswift.v1.WatchGuestsRequest.clusters:type_name -> kubeswift.v1.ClusterSelector
+	28, // 10: kubeswift.v1.GuestEvent.type:type_name -> kubeswift.v1.EventType
 	0,  // 11: kubeswift.v1.GuestEvent.guest:type_name -> kubeswift.v1.Guest
-	24, // 12: kubeswift.v1.GuestEvent.error:type_name -> kubeswift.v1.ClusterError
-	18, // 13: kubeswift.v1.GetGuestDetailRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	27, // 12: kubeswift.v1.GuestEvent.error:type_name -> kubeswift.v1.ClusterError
+	21, // 13: kubeswift.v1.GetGuestDetailRequest.ref:type_name -> kubeswift.v1.ObjectRef
 	0,  // 14: kubeswift.v1.GetGuestDetailResponse.guest:type_name -> kubeswift.v1.Guest
 	6,  // 15: kubeswift.v1.GetGuestDetailResponse.spec:type_name -> kubeswift.v1.GuestSpec
-	18, // 16: kubeswift.v1.GuestActionRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	21, // 16: kubeswift.v1.GuestActionRequest.ref:type_name -> kubeswift.v1.ObjectRef
 	0,  // 17: kubeswift.v1.GuestActionResponse.guest:type_name -> kubeswift.v1.Guest
-	18, // 18: kubeswift.v1.MigrateGuestRequest.ref:type_name -> kubeswift.v1.ObjectRef
-	18, // 19: kubeswift.v1.MigrateGuestResponse.migration:type_name -> kubeswift.v1.ObjectRef
+	21, // 18: kubeswift.v1.MigrateGuestRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	21, // 19: kubeswift.v1.MigrateGuestResponse.migration:type_name -> kubeswift.v1.ObjectRef
 	12, // 20: kubeswift.v1.CreateGuestRequest.ports:type_name -> kubeswift.v1.GuestPortSpec
-	18, // 21: kubeswift.v1.CreateGuestResponse.ref:type_name -> kubeswift.v1.ObjectRef
-	18, // 22: kubeswift.v1.DeleteGuestRequest.ref:type_name -> kubeswift.v1.ObjectRef
-	1,  // 23: kubeswift.v1.GuestService.ListGuests:input_type -> kubeswift.v1.ListGuestsRequest
-	3,  // 24: kubeswift.v1.GuestService.WatchGuests:input_type -> kubeswift.v1.WatchGuestsRequest
-	5,  // 25: kubeswift.v1.GuestService.GetGuestDetail:input_type -> kubeswift.v1.GetGuestDetailRequest
-	8,  // 26: kubeswift.v1.GuestService.StartGuest:input_type -> kubeswift.v1.GuestActionRequest
-	8,  // 27: kubeswift.v1.GuestService.StopGuest:input_type -> kubeswift.v1.GuestActionRequest
-	10, // 28: kubeswift.v1.GuestService.MigrateGuest:input_type -> kubeswift.v1.MigrateGuestRequest
-	13, // 29: kubeswift.v1.GuestService.CreateGuest:input_type -> kubeswift.v1.CreateGuestRequest
-	15, // 30: kubeswift.v1.GuestService.DeleteGuest:input_type -> kubeswift.v1.DeleteGuestRequest
-	2,  // 31: kubeswift.v1.GuestService.ListGuests:output_type -> kubeswift.v1.ListGuestsResponse
-	4,  // 32: kubeswift.v1.GuestService.WatchGuests:output_type -> kubeswift.v1.GuestEvent
-	7,  // 33: kubeswift.v1.GuestService.GetGuestDetail:output_type -> kubeswift.v1.GetGuestDetailResponse
-	9,  // 34: kubeswift.v1.GuestService.StartGuest:output_type -> kubeswift.v1.GuestActionResponse
-	9,  // 35: kubeswift.v1.GuestService.StopGuest:output_type -> kubeswift.v1.GuestActionResponse
-	11, // 36: kubeswift.v1.GuestService.MigrateGuest:output_type -> kubeswift.v1.MigrateGuestResponse
-	14, // 37: kubeswift.v1.GuestService.CreateGuest:output_type -> kubeswift.v1.CreateGuestResponse
-	16, // 38: kubeswift.v1.GuestService.DeleteGuest:output_type -> kubeswift.v1.DeleteGuestResponse
-	31, // [31:39] is the sub-list for method output_type
-	23, // [23:31] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	21, // 21: kubeswift.v1.CreateGuestResponse.ref:type_name -> kubeswift.v1.ObjectRef
+	21, // 22: kubeswift.v1.DeleteGuestRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	22, // 23: kubeswift.v1.GuestEventEntry.last_seen:type_name -> google.protobuf.Timestamp
+	21, // 24: kubeswift.v1.GetGuestEventsRequest.ref:type_name -> kubeswift.v1.ObjectRef
+	17, // 25: kubeswift.v1.GetGuestEventsResponse.events:type_name -> kubeswift.v1.GuestEventEntry
+	1,  // 26: kubeswift.v1.GuestService.ListGuests:input_type -> kubeswift.v1.ListGuestsRequest
+	3,  // 27: kubeswift.v1.GuestService.WatchGuests:input_type -> kubeswift.v1.WatchGuestsRequest
+	5,  // 28: kubeswift.v1.GuestService.GetGuestDetail:input_type -> kubeswift.v1.GetGuestDetailRequest
+	8,  // 29: kubeswift.v1.GuestService.StartGuest:input_type -> kubeswift.v1.GuestActionRequest
+	8,  // 30: kubeswift.v1.GuestService.StopGuest:input_type -> kubeswift.v1.GuestActionRequest
+	10, // 31: kubeswift.v1.GuestService.MigrateGuest:input_type -> kubeswift.v1.MigrateGuestRequest
+	13, // 32: kubeswift.v1.GuestService.CreateGuest:input_type -> kubeswift.v1.CreateGuestRequest
+	15, // 33: kubeswift.v1.GuestService.DeleteGuest:input_type -> kubeswift.v1.DeleteGuestRequest
+	18, // 34: kubeswift.v1.GuestService.GetGuestEvents:input_type -> kubeswift.v1.GetGuestEventsRequest
+	2,  // 35: kubeswift.v1.GuestService.ListGuests:output_type -> kubeswift.v1.ListGuestsResponse
+	4,  // 36: kubeswift.v1.GuestService.WatchGuests:output_type -> kubeswift.v1.GuestEvent
+	7,  // 37: kubeswift.v1.GuestService.GetGuestDetail:output_type -> kubeswift.v1.GetGuestDetailResponse
+	9,  // 38: kubeswift.v1.GuestService.StartGuest:output_type -> kubeswift.v1.GuestActionResponse
+	9,  // 39: kubeswift.v1.GuestService.StopGuest:output_type -> kubeswift.v1.GuestActionResponse
+	11, // 40: kubeswift.v1.GuestService.MigrateGuest:output_type -> kubeswift.v1.MigrateGuestResponse
+	14, // 41: kubeswift.v1.GuestService.CreateGuest:output_type -> kubeswift.v1.CreateGuestResponse
+	16, // 42: kubeswift.v1.GuestService.DeleteGuest:output_type -> kubeswift.v1.DeleteGuestResponse
+	19, // 43: kubeswift.v1.GuestService.GetGuestEvents:output_type -> kubeswift.v1.GetGuestEventsResponse
+	35, // [35:44] is the sub-list for method output_type
+	26, // [26:35] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_kubeswift_v1_guest_proto_init() }
@@ -1432,7 +1626,7 @@ func file_kubeswift_v1_guest_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kubeswift_v1_guest_proto_rawDesc), len(file_kubeswift_v1_guest_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   18,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/kubeswift/v1/kubeswiftv1connect/guest.connect.go
+++ b/gen/kubeswift/v1/kubeswiftv1connect/guest.connect.go
@@ -54,6 +54,9 @@ const (
 	// GuestServiceDeleteGuestProcedure is the fully-qualified name of the GuestService's DeleteGuest
 	// RPC.
 	GuestServiceDeleteGuestProcedure = "/kubeswift.v1.GuestService/DeleteGuest"
+	// GuestServiceGetGuestEventsProcedure is the fully-qualified name of the GuestService's
+	// GetGuestEvents RPC.
+	GuestServiceGetGuestEventsProcedure = "/kubeswift.v1.GuestService/GetGuestEvents"
 )
 
 // GuestServiceClient is a client for the kubeswift.v1.GuestService service.
@@ -75,6 +78,8 @@ type GuestServiceClient interface {
 	CreateGuest(context.Context, *connect.Request[v1.CreateGuestRequest]) (*connect.Response[v1.CreateGuestResponse], error)
 	// Delete (write plane, P3): delete a SwiftGuest as the impersonated user.
 	DeleteGuest(context.Context, *connect.Request[v1.DeleteGuestRequest]) (*connect.Response[v1.DeleteGuestResponse], error)
+	// Diagnostics (read, P3): Kubernetes Events for the guest + its launcher pod.
+	GetGuestEvents(context.Context, *connect.Request[v1.GetGuestEventsRequest]) (*connect.Response[v1.GetGuestEventsResponse], error)
 }
 
 // NewGuestServiceClient constructs a client for the kubeswift.v1.GuestService service. By default,
@@ -136,6 +141,12 @@ func NewGuestServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 			connect.WithSchema(guestServiceMethods.ByName("DeleteGuest")),
 			connect.WithClientOptions(opts...),
 		),
+		getGuestEvents: connect.NewClient[v1.GetGuestEventsRequest, v1.GetGuestEventsResponse](
+			httpClient,
+			baseURL+GuestServiceGetGuestEventsProcedure,
+			connect.WithSchema(guestServiceMethods.ByName("GetGuestEvents")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -149,6 +160,7 @@ type guestServiceClient struct {
 	migrateGuest   *connect.Client[v1.MigrateGuestRequest, v1.MigrateGuestResponse]
 	createGuest    *connect.Client[v1.CreateGuestRequest, v1.CreateGuestResponse]
 	deleteGuest    *connect.Client[v1.DeleteGuestRequest, v1.DeleteGuestResponse]
+	getGuestEvents *connect.Client[v1.GetGuestEventsRequest, v1.GetGuestEventsResponse]
 }
 
 // ListGuests calls kubeswift.v1.GuestService.ListGuests.
@@ -191,6 +203,11 @@ func (c *guestServiceClient) DeleteGuest(ctx context.Context, req *connect.Reque
 	return c.deleteGuest.CallUnary(ctx, req)
 }
 
+// GetGuestEvents calls kubeswift.v1.GuestService.GetGuestEvents.
+func (c *guestServiceClient) GetGuestEvents(ctx context.Context, req *connect.Request[v1.GetGuestEventsRequest]) (*connect.Response[v1.GetGuestEventsResponse], error) {
+	return c.getGuestEvents.CallUnary(ctx, req)
+}
+
 // GuestServiceHandler is an implementation of the kubeswift.v1.GuestService service.
 type GuestServiceHandler interface {
 	ListGuests(context.Context, *connect.Request[v1.ListGuestsRequest]) (*connect.Response[v1.ListGuestsResponse], error)
@@ -210,6 +227,8 @@ type GuestServiceHandler interface {
 	CreateGuest(context.Context, *connect.Request[v1.CreateGuestRequest]) (*connect.Response[v1.CreateGuestResponse], error)
 	// Delete (write plane, P3): delete a SwiftGuest as the impersonated user.
 	DeleteGuest(context.Context, *connect.Request[v1.DeleteGuestRequest]) (*connect.Response[v1.DeleteGuestResponse], error)
+	// Diagnostics (read, P3): Kubernetes Events for the guest + its launcher pod.
+	GetGuestEvents(context.Context, *connect.Request[v1.GetGuestEventsRequest]) (*connect.Response[v1.GetGuestEventsResponse], error)
 }
 
 // NewGuestServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -267,6 +286,12 @@ func NewGuestServiceHandler(svc GuestServiceHandler, opts ...connect.HandlerOpti
 		connect.WithSchema(guestServiceMethods.ByName("DeleteGuest")),
 		connect.WithHandlerOptions(opts...),
 	)
+	guestServiceGetGuestEventsHandler := connect.NewUnaryHandler(
+		GuestServiceGetGuestEventsProcedure,
+		svc.GetGuestEvents,
+		connect.WithSchema(guestServiceMethods.ByName("GetGuestEvents")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/kubeswift.v1.GuestService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case GuestServiceListGuestsProcedure:
@@ -285,6 +310,8 @@ func NewGuestServiceHandler(svc GuestServiceHandler, opts ...connect.HandlerOpti
 			guestServiceCreateGuestHandler.ServeHTTP(w, r)
 		case GuestServiceDeleteGuestProcedure:
 			guestServiceDeleteGuestHandler.ServeHTTP(w, r)
+		case GuestServiceGetGuestEventsProcedure:
+			guestServiceGetGuestEventsHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -324,4 +351,8 @@ func (UnimplementedGuestServiceHandler) CreateGuest(context.Context, *connect.Re
 
 func (UnimplementedGuestServiceHandler) DeleteGuest(context.Context, *connect.Request[v1.DeleteGuestRequest]) (*connect.Response[v1.DeleteGuestResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.GuestService.DeleteGuest is not implemented"))
+}
+
+func (UnimplementedGuestServiceHandler) GetGuestEvents(context.Context, *connect.Request[v1.GetGuestEventsRequest]) (*connect.Response[v1.GetGuestEventsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.GuestService.GetGuestEvents is not implemented"))
 }

--- a/internal/gateway/access_capabilities.go
+++ b/internal/gateway/access_capabilities.go
@@ -33,10 +33,11 @@ func rule(groups, resources, verbs []string) rbacv1.PolicyRule {
 var capabilities = []capability{
 	{
 		key: "view-vms", displayName: "View VMs",
-		description: "Read SwiftGuests, pools, classes, and migrations.",
+		description: "Read SwiftGuests, pools, classes, migrations, and their Events (boot diagnostics).",
 		rules: []rbacv1.PolicyRule{
 			rule([]string{"swift.kubeswift.io"}, []string{"swiftguests", "swiftguestpools", "swiftguestclasses"}, []string{"get", "list", "watch"}),
 			rule([]string{"migration.kubeswift.io"}, []string{"swiftmigrations"}, []string{"get", "list", "watch"}),
+			rule([]string{""}, []string{"events"}, []string{"get", "list", "watch"}),
 		},
 	},
 	{

--- a/internal/gateway/guest_service.go
+++ b/internal/gateway/guest_service.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"sort"
 	"sync"
+	"time"
 
 	connect "connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 
@@ -461,6 +464,93 @@ func buildSwiftGuest(m *kubeswiftv1.CreateGuestRequest) *unstructured.Unstructur
 		"metadata":   map[string]interface{}{"name": m.GetName(), "namespace": m.GetNamespace()},
 		"spec":       spec,
 	}}
+}
+
+var eventsGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}
+
+// GetGuestEvents returns the Kubernetes Events involving the guest and its
+// launcher pod (the "why won't my VM boot" surface), newest first, as the
+// impersonated user. The launcher pod is named after the guest (so one query by
+// name catches both the SwiftGuest and Pod events); a migrated guest's pod is
+// renamed, so its podRef is queried too.
+func (s *GuestService) GetGuestEvents(ctx context.Context, req *connect.Request[kubeswiftv1.GetGuestEventsRequest]) (*connect.Response[kubeswiftv1.GetGuestEventsResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	ref := req.Msg.GetRef()
+	if ref == nil || ref.GetCluster() == "" || ref.GetName() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("ref.cluster and ref.name are required"))
+	}
+	dyn, err := s.pool.DynamicFor(ref.GetCluster(), id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	ns := ref.GetNamespace()
+
+	// Resolve the launcher pod name (renamed after a live migration).
+	queryNames := []string{ref.GetName()}
+	if gu, err := dyn.Resource(swiftGuestGVR).Namespace(ns).Get(ctx, ref.GetName(), metav1.GetOptions{}); err == nil {
+		if p, ok, _ := unstructured.NestedString(gu.Object, "status", "podRef", "name"); ok && p != "" && p != ref.GetName() {
+			queryNames = append(queryNames, p)
+		}
+	}
+
+	seen := map[string]bool{}
+	out := &kubeswiftv1.GetGuestEventsResponse{}
+	for i, qn := range queryNames {
+		list, err := dyn.Resource(eventsGVR).Namespace(ns).List(ctx, metav1.ListOptions{
+			FieldSelector: "involvedObject.name=" + qn,
+		})
+		if err != nil {
+			if i == 0 {
+				return nil, mapAccessErr(err) // surface RBAC/connectivity, never a silent empty
+			}
+			continue // best-effort on the secondary (pod) query
+		}
+		for j := range list.Items {
+			e := &list.Items[j]
+			if uid, _, _ := unstructured.NestedString(e.Object, "metadata", "uid"); uid != "" {
+				if seen[uid] {
+					continue
+				}
+				seen[uid] = true
+			}
+			out.Events = append(out.Events, mapEvent(e))
+		}
+	}
+	sort.Slice(out.Events, func(i, j int) bool {
+		return out.Events[i].GetLastSeen().AsTime().After(out.Events[j].GetLastSeen().AsTime())
+	})
+	return connect.NewResponse(out), nil
+}
+
+func mapEvent(e *unstructured.Unstructured) *kubeswiftv1.GuestEventEntry {
+	str := func(f ...string) string { v, _, _ := unstructured.NestedString(e.Object, f...); return v }
+	count, _, _ := unstructured.NestedInt64(e.Object, "count")
+	entry := &kubeswiftv1.GuestEventEntry{
+		Type:    str("type"),
+		Reason:  str("reason"),
+		Message: str("message"),
+		Count:   int32(count),
+		Object:  str("involvedObject", "kind") + "/" + str("involvedObject", "name"),
+	}
+	for _, f := range []string{"lastTimestamp", "eventTime"} {
+		if ts := str(f); ts != "" {
+			if t, perr := time.Parse(time.RFC3339, ts); perr == nil {
+				entry.LastSeen = timestamppb.New(t)
+				break
+			}
+		}
+	}
+	if entry.LastSeen == nil {
+		if ts := str("metadata", "creationTimestamp"); ts != "" {
+			if t, perr := time.Parse(time.RFC3339, ts); perr == nil {
+				entry.LastSeen = timestamppb.New(t)
+			}
+		}
+	}
+	return entry
 }
 
 // targetClusters resolves the selector against the registered members. An empty

--- a/internal/gateway/guest_service_test.go
+++ b/internal/gateway/guest_service_test.go
@@ -289,6 +289,48 @@ func TestGuestService_DeleteGuest(t *testing.T) {
 	}
 }
 
+func uEvent(ns, name, objName, typ, reason, msg, lastTs string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1", "kind": "Event",
+		"metadata":       map[string]interface{}{"namespace": ns, "name": name, "uid": name},
+		"type":           typ,
+		"reason":         reason,
+		"message":        msg,
+		"count":          int64(1),
+		"lastTimestamp":  lastTs,
+		"involvedObject": map[string]interface{}{"kind": "SwiftGuest", "name": objName},
+	}}
+}
+
+func TestGuestService_GetGuestEvents(t *testing.T) {
+	guest := uGuest("default", "vm-a", "Pending")
+	ev1 := uEvent("default", "ev1", "vm-a", "Warning", "FailedScheduling", "0/3 nodes available", "2026-01-01T00:00:00Z")
+	ev2 := uEvent("default", "ev2", "vm-a", "Normal", "Scheduled", "assigned to boba", "2026-01-01T00:01:00Z")
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			swiftGuestGVR: "SwiftGuestList",
+			eventsGVR:     "EventList",
+		}, guest, ev1, ev2)
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": dyn}}, NewInsecureAuthenticator())
+
+	resp, err := svc.GetGuestEvents(context.Background(), connect.NewRequest(&kubeswiftv1.GetGuestEventsRequest{
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Msg.Events) != 2 {
+		t.Fatalf("want 2 events, got %d", len(resp.Msg.Events))
+	}
+	// Newest first.
+	if resp.Msg.Events[0].Reason != "Scheduled" {
+		t.Errorf("want newest event (Scheduled) first, got %q", resp.Msg.Events[0].Reason)
+	}
+	if resp.Msg.Events[0].Object != "SwiftGuest/vm-a" {
+		t.Errorf("object = %q, want SwiftGuest/vm-a", resp.Msg.Events[0].Object)
+	}
+}
+
 // GetGuestDetail surfaces the structured spec (for Clone).
 func TestGuestService_GetGuestDetail_Spec(t *testing.T) {
 	g := &unstructured.Unstructured{Object: map[string]interface{}{

--- a/proto/kubeswift/v1/guest.proto
+++ b/proto/kubeswift/v1/guest.proto
@@ -175,6 +175,25 @@ message DeleteGuestRequest {
 
 message DeleteGuestResponse {}
 
+// GuestEventEntry is one Kubernetes Event involving the guest or its launcher
+// pod — the "why won't my VM boot" diagnostics surface.
+message GuestEventEntry {
+  string type = 1; // Normal | Warning
+  string reason = 2;
+  string message = 3;
+  int32 count = 4;
+  string object = 5; // involvedObject kind/name
+  google.protobuf.Timestamp last_seen = 6;
+}
+
+message GetGuestEventsRequest {
+  ObjectRef ref = 1;
+}
+
+message GetGuestEventsResponse {
+  repeated GuestEventEntry events = 1; // newest first
+}
+
 // GuestService is the read plane for VM inventory plus the P1/P2 write actions.
 // List/Watch fan out across the selected member clusters and merge, stamping
 // the cluster dimension on every row; a per-cluster error surface preserves
@@ -201,4 +220,7 @@ service GuestService {
 
   // Delete (write plane, P3): delete a SwiftGuest as the impersonated user.
   rpc DeleteGuest(DeleteGuestRequest) returns (DeleteGuestResponse);
+
+  // Diagnostics (read, P3): Kubernetes Events for the guest + its launcher pod.
+  rpc GetGuestEvents(GetGuestEventsRequest) returns (GetGuestEventsResponse);
 }


### PR DESCRIPTION
UI Phase 3 — boot diagnostics backend (the "why won't my VM boot" tool).

`GetGuestEvents(ref)` returns the Kubernetes Events involving the guest and its launcher pod, newest first, as the **impersonated user**. The launcher pod is named after the guest, so one `involvedObject.name` query catches both the `SwiftGuest` and `Pod` events; a migrated guest's renamed pod (`status.podRef`) is queried too, results deduped by uid. A list failure (RBAC / connectivity) surfaces via `mapAccessErr` — never a silent empty.

Extends the **`view-vms`** capability with `events get/list/watch` so the role model covers diagnostics. Test: two events for a guest returned newest-first with the involvedObject label. `make proto-lint` clean; gateway suite green.

Next: a Diagnostics section in the guest drawer (events list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)