### PR TITLE
feat(gateway): OIDC chart wiring + private-CA trust (--oidc-ca-file)

### DIFF
--- a/charts/kubeswift/templates/gateway/deployment.yaml
+++ b/charts/kubeswift/templates/gateway/deployment.yaml
@@ -36,11 +36,32 @@ spec:
             - --clusters-namespace={{ .Values.namespace }}
             - --auth-mode={{ .Values.gateway.authMode }}
             - --cors-allow-origin={{ .Values.gateway.corsAllowOrigin }}
+            {{- if eq .Values.gateway.authMode "oidc" }}
+            - --oidc-issuer-url={{ required "gateway.oidc.issuerURL is required when gateway.authMode=oidc" .Values.gateway.oidc.issuerURL }}
+            - --oidc-client-id={{ required "gateway.oidc.clientID is required when gateway.authMode=oidc" .Values.gateway.oidc.clientID }}
+            - --oidc-username-claim={{ .Values.gateway.oidc.usernameClaim }}
+            - --oidc-groups-claim={{ .Values.gateway.oidc.groupsClaim }}
+            {{- with .Values.gateway.oidc.usernamePrefix }}
+            - --oidc-username-prefix={{ . }}
+            {{- end }}
+            {{- with .Values.gateway.oidc.groupsPrefix }}
+            - --oidc-groups-prefix={{ . }}
+            {{- end }}
+            {{- if .Values.gateway.oidc.caSecret }}
+            - --oidc-ca-file=/etc/kubeswift/oidc-ca/{{ .Values.gateway.oidc.caKey }}
+            {{- end }}
+            {{- end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- if and (eq .Values.gateway.authMode "oidc") .Values.gateway.oidc.caSecret }}
+          volumeMounts:
+            - name: oidc-ca
+              mountPath: /etc/kubeswift/oidc-ca
+              readOnly: true
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.gateway.port }}
@@ -66,4 +87,10 @@ spec:
                 - ALL
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
+      {{- if and (eq .Values.gateway.authMode "oidc") .Values.gateway.oidc.caSecret }}
+      volumes:
+        - name: oidc-ca
+          secret:
+            secretName: {{ .Values.gateway.oidc.caSecret }}
+      {{- end }}
 {{- end }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -115,16 +115,37 @@ gateway:
   replicas: 1
   port: 8080
   # End-user auth (decision D1):
-  #   token    - impersonate the bearer-token user via the hub's TokenReview
-  #              (production). The fleet should share an OIDC identity provider
-  #              so the impersonated subject authorizes uniformly on each member.
+  #   oidc     - verify the browser's IdP-issued OIDC ID token (gateway.oidc
+  #              below) and impersonate the claim-derived user+groups on each
+  #              member. The production path with a shared IdP (e.g. Keycloak).
+  #   token    - impersonate the bearer-token user via the hub's TokenReview.
+  #              The fleet should share an OIDC identity provider so the
+  #              impersonated subject authorizes uniformly on each member.
   #   insecure - member queries run as the gateway's own credential, with NO
   #              per-user impersonation. DEV/LAB ONLY: every UI user inherits
   #              whatever the member credentials grant. Do not use in production.
   authMode: insecure
+  # OIDC settings (used only when authMode=oidc). The gateway verifies the
+  # browser-supplied ID token against issuerURL's JWKS and impersonates the
+  # claim-derived user+groups onto each member. issuerURL must resolve to ONE URL
+  # reachable from BOTH the browser and the gateway (see docs/ui/auth.md). Mirror
+  # these into the UI via ui.oidc so the browser logs in against the same issuer.
+  oidc:
+    issuerURL: "" # e.g. https://keycloak.example.com/realms/kubeswift
+    clientID: "" # the OIDC client ID / audience the ID token must carry
+    usernameClaim: email # claim used as the impersonated username
+    groupsClaim: groups # claim used as the impersonated groups
+    usernamePrefix: "" # mirrors apiserver --oidc-username-prefix
+    groupsPrefix: "" # mirrors apiserver --oidc-groups-prefix
+    # caSecret: trust a private/self-signed IdP CA for the JWKS fetch. Name a
+    # Secret in .Values.namespace holding the PEM at key caKey; the gateway mounts
+    # it and passes --oidc-ca-file. Empty = system roots only.
+    caSecret: ""
+    caKey: ca.crt
   # Browser origin allowed to call the Connect/gRPC-Web surface (the kubeswift-ui
   # app's origin). "*" is acceptable for a token-auth API (no cookies); pin it
-  # for a hardened install.
+  # for a hardened install. With ui.gateway.mode=proxy the browser is same-origin,
+  # so CORS does not apply.
   corsAllowOrigin: "*"
   service:
     type: ClusterIP

--- a/cmd/kubeswift-gateway/main.go
+++ b/cmd/kubeswift-gateway/main.go
@@ -41,6 +41,7 @@ func main() {
 	oidcGroupsClaim := flag.String("oidc-groups-claim", "groups", "OIDC claim to use as the impersonated groups")
 	oidcUsernamePrefix := flag.String("oidc-username-prefix", "", "prefix prepended to the OIDC username (mirrors apiserver --oidc-username-prefix)")
 	oidcGroupsPrefix := flag.String("oidc-groups-prefix", "", "prefix prepended to each OIDC group")
+	oidcCAFile := flag.String("oidc-ca-file", "", "PEM CA bundle to trust when fetching the OIDC issuer's discovery/JWKS (for a private-CA IdP, e.g. a self-signed Keycloak); empty = system roots")
 	klog.InitFlags(nil)
 	flag.Parse()
 
@@ -76,6 +77,7 @@ func main() {
 		groupsClaim:    *oidcGroupsClaim,
 		usernamePrefix: *oidcUsernamePrefix,
 		groupsPrefix:   *oidcGroupsPrefix,
+		caFile:         *oidcCAFile,
 	})
 	if err != nil {
 		log.Error(err, "unable to build authenticator")
@@ -169,6 +171,7 @@ type oidcOptions struct {
 	issuer, clientID             string
 	usernameClaim, groupsClaim   string
 	usernamePrefix, groupsPrefix string
+	caFile                       string
 }
 
 // buildAuthenticator selects the end-user auth strategy (decision D1).
@@ -182,8 +185,8 @@ func buildAuthenticator(mode string, cfg *rest.Config, log logr.Logger, oidc oid
 		if oidc.issuer == "" || oidc.clientID == "" {
 			return nil, fmt.Errorf("auth-mode=oidc requires --oidc-issuer-url and --oidc-client-id")
 		}
-		log.Info("auth-mode=oidc: impersonate the OIDC-token user", "issuer", oidc.issuer, "clientID", oidc.clientID, "usernameClaim", oidc.usernameClaim)
-		return gateway.NewOIDCAuthenticator(oidc.issuer, oidc.clientID, gateway.OIDCClaimConfig{
+		log.Info("auth-mode=oidc: impersonate the OIDC-token user", "issuer", oidc.issuer, "clientID", oidc.clientID, "usernameClaim", oidc.usernameClaim, "caFile", oidc.caFile)
+		return gateway.NewOIDCAuthenticator(oidc.issuer, oidc.clientID, oidc.caFile, gateway.OIDCClaimConfig{
 			UsernameClaim:  oidc.usernameClaim,
 			GroupsClaim:    oidc.groupsClaim,
 			UsernamePrefix: oidc.usernamePrefix,

--- a/internal/gateway/auth_oidc.go
+++ b/internal/gateway/auth_oidc.go
@@ -2,8 +2,11 @@ package gateway
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 
 	connect "connectrpc.com/connect"
@@ -34,6 +37,7 @@ type OIDCClaimConfig struct {
 type oidcAuthenticator struct {
 	issuerURL string
 	clientID  string
+	caFile    string
 	claims    OIDCClaimConfig
 
 	mu       sync.Mutex
@@ -42,15 +46,18 @@ type oidcAuthenticator struct {
 
 // NewOIDCAuthenticator builds a gateway-side OIDC authenticator. issuerURL is
 // the IdP's OIDC issuer (its discovery doc + JWKS are fetched lazily on first
-// use); clientID is the audience the ID token must carry.
-func NewOIDCAuthenticator(issuerURL, clientID string, claims OIDCClaimConfig) Authenticator {
+// use); clientID is the audience the ID token must carry. caFile, when set, is a
+// PEM CA bundle added to the system roots for the discovery/JWKS fetch — needed
+// when the IdP serves a private/self-signed cert (e.g. a self-signed Keycloak);
+// empty means system roots only.
+func NewOIDCAuthenticator(issuerURL, clientID, caFile string, claims OIDCClaimConfig) Authenticator {
 	if claims.UsernameClaim == "" {
 		claims.UsernameClaim = "email"
 	}
 	if claims.GroupsClaim == "" {
 		claims.GroupsClaim = "groups"
 	}
-	return &oidcAuthenticator{issuerURL: issuerURL, clientID: clientID, claims: claims}
+	return &oidcAuthenticator{issuerURL: issuerURL, clientID: clientID, caFile: caFile, claims: claims}
 }
 
 func (a *oidcAuthenticator) getVerifier(ctx context.Context) (*oidc.IDTokenVerifier, error) {
@@ -59,12 +66,40 @@ func (a *oidcAuthenticator) getVerifier(ctx context.Context) (*oidc.IDTokenVerif
 	if a.verifier != nil {
 		return a.verifier, nil
 	}
+	// Trust a private IdP CA for the discovery/JWKS fetch when configured.
+	if a.caFile != "" {
+		client, err := httpClientWithCA(a.caFile)
+		if err != nil {
+			return nil, err
+		}
+		ctx = oidc.ClientContext(ctx, client)
+	}
 	provider, err := oidc.NewProvider(ctx, a.issuerURL)
 	if err != nil {
 		return nil, err
 	}
 	a.verifier = provider.Verifier(&oidc.Config{ClientID: a.clientID})
 	return a.verifier, nil
+}
+
+// httpClientWithCA returns an http.Client whose TLS root pool is the system
+// roots plus the PEM bundle at caFile. The provider/verifier are cached, so the
+// file is read at most once per gateway lifetime (on the first OIDC request).
+func httpClientWithCA(caFile string) (*http.Client, error) {
+	pem, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("read oidc CA file %q: %w", caFile, err)
+	}
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("oidc CA file %q: no PEM certificates parsed", caFile)
+	}
+	return &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+	}}, nil
 }
 
 func (a *oidcAuthenticator) Authenticate(ctx context.Context, h http.Header) (Identity, error) {

--- a/internal/gateway/auth_oidc_test.go
+++ b/internal/gateway/auth_oidc_test.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"context"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	connect "connectrpc.com/connect"
@@ -79,7 +81,7 @@ func TestStringSliceClaim_Variants(t *testing.T) {
 }
 
 func TestNewOIDCAuthenticator_AppliesDefaults(t *testing.T) {
-	a := NewOIDCAuthenticator("https://issuer.example", "kubeswift", OIDCClaimConfig{})
+	a := NewOIDCAuthenticator("https://issuer.example", "kubeswift", "", OIDCClaimConfig{})
 	oa, ok := a.(*oidcAuthenticator)
 	if !ok {
 		t.Fatal("NewOIDCAuthenticator did not return an *oidcAuthenticator")
@@ -92,9 +94,22 @@ func TestNewOIDCAuthenticator_AppliesDefaults(t *testing.T) {
 // A missing bearer token is rejected before any IdP round-trip, so this needs no
 // live issuer.
 func TestOIDCAuthenticator_MissingToken(t *testing.T) {
-	a := NewOIDCAuthenticator("https://issuer.example", "kubeswift", OIDCClaimConfig{})
+	a := NewOIDCAuthenticator("https://issuer.example", "kubeswift", "", OIDCClaimConfig{})
 	_, err := a.Authenticate(context.Background(), http.Header{})
 	if connect.CodeOf(err) != connect.CodeUnauthenticated {
 		t.Errorf("want Unauthenticated for a missing token, got %v", err)
+	}
+}
+
+func TestHTTPClientWithCA(t *testing.T) {
+	if _, err := httpClientWithCA("/no/such/oidc-ca.pem"); err == nil {
+		t.Error("expected error for a missing CA file")
+	}
+	f := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(f, []byte("not a pem"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := httpClientWithCA(f); err == nil {
+		t.Error("expected error for a file with no PEM certificates")
 	}
 }


### PR DESCRIPTION
First of three small PRs to make the UI exposable via ingress with a real login (OIDC/Keycloak) + RBAC, packaged in Helm.

The gateway already supports `auth-mode=oidc` in code, but the **chart couldn't configure it** (the deployment only passed `--auth-mode`/`--cors`), and it couldn't verify tokens from a **private/self-signed IdP**. This closes both:

- **`--oidc-ca-file`** — when set, the OIDC discovery/JWKS fetch trusts a PEM CA on top of the system roots (`httpClientWithCA` + `oidc.ClientContext`), read once lazily on the first OIDC request. Needed for a self-signed Keycloak.
- **`gateway.oidc.*` values** (`issuerURL`, `clientID`, `usernameClaim`, `groupsClaim`, prefixes, `caSecret`/`caKey`); the deployment passes `--oidc-*` when `authMode=oidc` and mounts `caSecret` at `/etc/kubeswift/oidc-ca`. `required` helpers fail fast if issuer/clientID are unset.

Tests cover the CA-helper error paths (missing file / non-PEM); existing OIDC tests updated for the new signature; `helm template` renders the args + CA mount + secret volume. `go build/test/vet` green.

Next: the UI container emits the OIDC env (kubeswift-ui) + finishing #277 (UI chart) with `ui.oidc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)