### PR TITLE
feat(chart): ui.enabled — deploy the kubeswift-ui web console (+ ui.oidc)

### DIFF
--- a/charts/kubeswift/templates/ui/deployment.yaml
+++ b/charts/kubeswift/templates/ui/deployment.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.ui.enabled }}
+# kubeswift-ui: the KubeSwift web console (an Angular SPA served by nginx),
+# released from the separate projectbeskar/kubeswift-ui repo. It talks to the
+# gateway above; in the default ui.gateway.mode=proxy the UI's nginx
+# reverse-proxies the in-cluster kubeswift-gateway Service so the browser uses a
+# single origin. See docs/ui/gateway.md and the kubeswift-ui README.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubeswift-ui
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: ui
+spec:
+  replicas: {{ .Values.ui.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubeswift
+      app.kubernetes.io/component: ui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubeswift
+        app.kubernetes.io/component: ui
+    spec:
+      {{- with .Values.ui.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ui
+          # Independently released from the kubeswift-ui repo, so (unlike the
+          # operator images) the tag is NOT derived from the chart appVersion.
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          env:
+            # How the BROWSER reaches the gateway (see values.yaml ui.gateway):
+            {{- if eq .Values.ui.gateway.mode "proxy" }}
+            # proxy: nginx reverse-proxies the gateway Service; the SPA points
+            # at its own origin.
+            - name: KUBESWIFT_GATEWAY_URL
+              value: "@origin"
+            - name: KUBESWIFT_GATEWAY_UPSTREAM
+              value: "{{ .Values.ui.gateway.service }}.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.ui.gateway.port }}"
+            {{- else }}
+            # url: the SPA calls the gateway directly at this absolute URL.
+            # Empty falls back to the app's built-in default (dev port-forward).
+            - name: KUBESWIFT_GATEWAY_URL
+              value: {{ .Values.ui.gateway.url | quote }}
+            {{- end }}
+            {{- if and .Values.ui.oidc.issuer .Values.ui.oidc.clientId }}
+            # Browser OIDC login (must match gateway.oidc — same issuer+audience).
+            - name: KUBESWIFT_OIDC_ISSUER
+              value: {{ .Values.ui.oidc.issuer | quote }}
+            - name: KUBESWIFT_OIDC_CLIENT_ID
+              value: {{ .Values.ui.oidc.clientId | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            # nginx regenerates /usr/share/nginx/html/config.js and writes temp
+            # files at startup, so the root filesystem stays writable (the image
+            # runs unprivileged, non-root, with all capabilities dropped).
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.ui.resources | nindent 12 }}
+{{- end }}

--- a/charts/kubeswift/templates/ui/ingress.yaml
+++ b/charts/kubeswift/templates/ui/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.ui.enabled .Values.ui.ingress.enabled }}
+# Optional Ingress for the web console. Plain HTTP/1.1 static assets (plus, in
+# ui.gateway.mode=proxy, the gateway's Connect RPCs and the /console WebSocket
+# forwarded by the UI's nginx) — so no gRPC backend-protocol annotation is
+# needed here (that lives on the gateway's own Ingress). For the /console
+# WebSocket through this Ingress, the controller must allow connection upgrades
+# (most do by default; nginx-ingress honours Upgrade/Connection headers).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kubeswift-ui
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: ui
+  {{- with .Values.ui.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ui.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ui.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kubeswift-ui
+                port:
+                  name: http
+  {{- with .Values.ui.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kubeswift/templates/ui/service.yaml
+++ b/charts/kubeswift/templates/ui/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.ui.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubeswift-ui
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: ui
+spec:
+  type: {{ .Values.ui.service.type }}
+  selector:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: ui
+  ports:
+    - name: http
+      port: {{ .Values.ui.service.port }}
+      targetPort: http
+{{- end }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -143,6 +143,70 @@ gateway:
       cpu: 500m
       memory: 256Mi
 
+# KubeSwift web console (the kubeswift-ui Angular app, served by nginx). Opt-in.
+# It talks to the gateway above, so enable gateway.enabled too (or point
+# ui.gateway.url at an externally reachable gateway). The kubeswift-ui image is
+# released from the SEPARATE projectbeskar/kubeswift-ui repo, so — unlike the
+# operator images — its tag is NOT derived from the chart appVersion: pin a
+# published kubeswift-ui tag in ui.image.tag. See docs/ui/gateway.md.
+ui:
+  enabled: false
+  image:
+    # Full image repository (kubeswift-ui is a top-level package, not under the
+    # ghcr.io/projectbeskar/kubeswift/ prefix the operator images use).
+    repository: ghcr.io/projectbeskar/kubeswift-ui
+    # Pin a published tag (sha-<short> or vX.Y.Z). "latest" tracks the
+    # kubeswift-ui main branch; fine for dev, pin a version for production.
+    tag: latest
+    pullPolicy: IfNotPresent
+  # New ghcr packages default PRIVATE; until the kubeswift-ui package is made
+  # public (one-time, web UI), reference a docker-registry pull Secret here,
+  # e.g. [{name: ghcr-kubeswift-ui}].
+  imagePullSecrets: []
+  replicas: 1
+  # How the BROWSER reaches the gateway:
+  #   proxy (default): the UI's nginx reverse-proxies the gateway's Connect RPCs
+  #     and the /console WebSocket to the in-cluster gateway Service, so the
+  #     browser uses ONE origin (the UI's) — no CORS, no separate gateway
+  #     exposure. Requires gateway.enabled in THIS cluster (or a Service named
+  #     ui.gateway.service in this namespace).
+  #   url: the browser calls the gateway directly at an absolute, externally
+  #     reachable URL (the gateway's own Ingress/LB). gateway.corsAllowOrigin
+  #     must allow the UI's origin. Leave url empty to let the app fall back to
+  #     its built-in default (a dev port-forward of the gateway on :18080).
+  gateway:
+    mode: proxy
+    # proxy mode: in-cluster gateway Service name + port to reverse-proxy to.
+    service: kubeswift-gateway
+    port: 8080
+    # url mode: absolute browser-reachable gateway URL, e.g.
+    # https://kubeswift-gateway.example.com
+    url: ""
+  # Browser OIDC login (Authorization Code + PKCE). Set BOTH to turn login on;
+  # the browser authenticates against issuer and sends the ID token to the
+  # gateway. MUST match gateway.oidc.issuerURL / gateway.oidc.clientID (the
+  # browser and the gateway verify the same issuer + audience). Leave empty and
+  # the UI runs auth-OFF (pair with gateway.authMode=insecure).
+  oidc:
+    issuer: "" # e.g. https://keycloak.example.com/realms/kubeswift
+    clientId: "" # the public OIDC client the browser logs in with
+  service:
+    type: ClusterIP
+    port: 80
+  ingress:
+    enabled: false
+    className: ""
+    host: kubeswift-ui.example.com
+    annotations: {}
+    tls: []
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
 # Admission webhooks (optional). Requires cert-manager. When enabled, controller-manager runs with --webhook-enabled=true.
 webhook:
   enabled: false


### PR DESCRIPTION
Third UI-exposure PR — the chart's UI half, so one `helm upgrade` stands up the console. **Supersedes #277** (rebased clean onto main; the stale Explorer commit dropped).

- `templates/ui/{deployment,service,ingress}.yaml` — non-root nginx; the **`ui.gateway.mode=proxy`** default makes nginx reverse-proxy the in-cluster gateway Service + the `/console` WebSocket, so the browser is **single-origin** (no CORS, no separate gateway exposure); `imagePullSecrets` for the private ghcr package.
- `values.yaml` `ui` block. The kubeswift-ui image ships from the **separate** projectbeskar/kubeswift-ui repo, so its tag is pinned (not chart appVersion).
- **`ui.oidc.{issuer,clientId}`** → the container's OIDC env (kubeswift-ui #17), turning on the browser PKCE login. Must match `gateway.oidc.*` (same issuer + audience).

`helm template` renders the proxy upstream, the OIDC env, and the ingress host. Completes the Helm packaging for "expose the UI via ingress with a real OIDC login + RBAC."

Together with kubeswift [#289](https://github.com/projectbeskar/kubeswift/pull/289) (gateway OIDC) and kubeswift-ui [#17](https://github.com/projectbeskar/kubeswift-ui/pull/17) (container OIDC env), `helm upgrade --set ui.enabled=true --set gateway.enabled=true --set gateway.authMode=oidc --set gateway.oidc.* --set ui.oidc.*` is the whole thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)