### PR TITLE
fix(gateway): map member RBAC 403 to PermissionDenied (not Internal)

### DIFF
--- a/internal/gateway/access_service.go
+++ b/internal/gateway/access_service.go
@@ -312,10 +312,19 @@ func (s *AccessService) ensureRole(ctx context.Context, rc rbacv1client.RbacV1In
 	return nil
 }
 
+// mapAccessErr maps a Kubernetes apimachinery error from an impersonated
+// member-cluster call to the matching Connect code, so the UI can tell a
+// permission denial (RBAC 403) apart from a generic server error. Used gateway-
+// wide for impersonated reads/actions that carry NO validating webhook (reads,
+// Explorer, Start/Stop). The webhook-heavy write paths (Create/Migrate/Delete)
+// keep their own FailedPrecondition mapping on purpose: a k8s 403 there can be a
+// webhook policy denial, not an RBAC denial, and the message carries the reason.
 func mapAccessErr(err error) *connect.Error {
 	switch {
 	case apierrors.IsForbidden(err):
 		return connect.NewError(connect.CodePermissionDenied, err)
+	case apierrors.IsUnauthorized(err):
+		return connect.NewError(connect.CodeUnauthenticated, err)
 	case apierrors.IsAlreadyExists(err):
 		return connect.NewError(connect.CodeAlreadyExists, err)
 	case apierrors.IsNotFound(err):

--- a/internal/gateway/access_service_test.go
+++ b/internal/gateway/access_service_test.go
@@ -7,8 +7,10 @@ import (
 
 	connect "connectrpc.com/connect"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 
@@ -202,5 +204,27 @@ func TestAccess_ListAssignments_Roundtrip(t *testing.T) {
 	a := resp.Msg.Assignments[0]
 	if a.Role != "kubeswift-admin" || a.Subject.Name != "root@example.com" || a.Scope != "Cluster" {
 		t.Errorf("assignment = %+v", a)
+	}
+}
+
+func TestMapAccessErr(t *testing.T) {
+	gr := schema.GroupResource{Group: "swift.kubeswift.io", Resource: "swiftguests"}
+	cases := []struct {
+		name string
+		err  error
+		want connect.Code
+	}{
+		{"forbidden->permission_denied", apierrors.NewForbidden(gr, "vm", errors.New("rbac")), connect.CodePermissionDenied},
+		{"unauthorized->unauthenticated", apierrors.NewUnauthorized("token expired"), connect.CodeUnauthenticated},
+		{"notfound->not_found", apierrors.NewNotFound(gr, "vm"), connect.CodeNotFound},
+		{"alreadyexists->already_exists", apierrors.NewAlreadyExists(gr, "vm"), connect.CodeAlreadyExists},
+		{"other->internal", errors.New("boom"), connect.CodeInternal},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := connect.CodeOf(mapAccessErr(c.err)); got != c.want {
+				t.Errorf("mapAccessErr(%s) = %v, want %v", c.name, got, c.want)
+			}
+		})
 	}
 }

--- a/internal/gateway/guest_service.go
+++ b/internal/gateway/guest_service.go
@@ -193,7 +193,7 @@ func (s *GuestService) GetGuestDetail(ctx context.Context, req *connect.Request[
 	}
 	u, err := dyn.Resource(swiftGuestGVR).Namespace(ref.GetNamespace()).Get(ctx, ref.GetName(), metav1.GetOptions{})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, mapAccessErr(err) // RBAC 403 -> PermissionDenied, not Internal
 	}
 	g, err := toSwiftGuest(u)
 	if err != nil {
@@ -339,7 +339,9 @@ func (s *GuestService) guestAction(ctx context.Context, req *connect.Request[kub
 	}
 	u, err := action(ctx, dyn, ref.GetNamespace(), ref.GetName())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		// Start/Stop patch runPolicy (no policy webhook denies it), so a 403 here
+		// is an RBAC denial -> PermissionDenied, and NotFound -> NotFound.
+		return nil, mapAccessErr(err)
 	}
 	g, err := toSwiftGuest(u)
 	if err != nil {

--- a/internal/gateway/telemetry_service.go
+++ b/internal/gateway/telemetry_service.go
@@ -79,7 +79,7 @@ func (s *TelemetryService) GetGuestMetrics(ctx context.Context, req *connect.Req
 	pods, err := dyn.Resource(podGVR).Namespace(ref.GetNamespace()).
 		List(ctx, metav1.ListOptions{LabelSelector: guestPodLabel + "=" + ref.GetName()})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, mapAccessErr(err) // RBAC 403 -> PermissionDenied, not Internal
 	}
 	if len(pods.Items) == 0 {
 		// Stopped guest — no pod, no series. Not an error.


### PR DESCRIPTION
The W5 finding from the OIDC RBAC test: a viewer's denied write came back as connect `code: "internal"` instead of `permission_denied`, so the UI can't show a clean "you don't have permission" toast.

A member-cluster **403 Forbidden** on the **no-policy-webhook** paths (`GetGuestDetail`, `Start`/`Stop`, telemetry pod-list) was flattened to `CodeInternal`. Fix: reuse the existing `mapAccessErr` helper (already used by the Explorer + RBAC editor) at those three sites, and add its missing `IsUnauthorized → Unauthenticated` case.

The webhook-heavy write paths (`Create`/`Migrate`/`Delete`) **keep** their `FailedPrecondition` mapping deliberately — a 403 there can be a validating-webhook **policy** denial (e.g. `allowIPChange required`), not RBAC, and the message carries the reason. Documented that split on `mapAccessErr`.

`go test ./internal/gateway/...` green (added a mapping table test). The message was always shown (no silent failure); this gets the **code** right so the UI can branch on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)