### PR TITLE
release: v0.6.1 — rehome to the kubeswift-io org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.6.1] — 2026-06-30
+
+Project rehomed to the **kubeswift-io** GitHub organization. **No functional
+changes** — this release re-points the Go module path, container images, and the
+Helm OCI chart to the new org. Old `projectbeskar` URLs and images keep working
+(GitHub redirects + the old packages remain), so existing installs are unaffected
+until they upgrade.
+
+### Changed
+- **Go module**: `github.com/projectbeskar/kubeswift` → `github.com/kubeswift-io/kubeswift`.
+- **Images**: `ghcr.io/kubeswift-io/kubeswift/*` (controller-manager, swiftletd,
+  kubeswift-gateway, gpu-discovery, snapshot-s3, migration-stunnel,
+  kubeswift-dra-driver); the web console at `ghcr.io/kubeswift-io/kubeswift-ui`.
+- **Helm chart**: `oci://ghcr.io/kubeswift-io/charts/kubeswift`.
+- **Repos**: `github.com/kubeswift-io/{kubeswift,kubeswift-ui}`.
+
+---
+
 ## [v0.6.0] — 2026-06-25
 
 Adds the **KubeSwift web console** — a multi-cluster operator UI for the fleet,

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.6.1
+appVersion: "0.6.1"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/config/dra-driver/dra-driver.yaml
+++ b/config/dra-driver/dra-driver.yaml
@@ -83,7 +83,7 @@ spec:
         - name: dra-driver
           # Pinned to the release (no :latest tag is published). Bump on release;
           # or use the Helm chart (dra.enabled=true), which manages this version.
-          image: ghcr.io/kubeswift-io/kubeswift/kubeswift-dra-driver:v0.6.0
+          image: ghcr.io/kubeswift-io/kubeswift/kubeswift-dra-driver:v0.6.1
           args:
             - --v=2
           env:

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -100,7 +100,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.6.0 -n kubeswift-system --create-namespace \
+  --version 0.6.1 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.6.0 \
+  --version 0.6.1 \
   -n kubeswift-system \
   --create-namespace
 ```


### PR DESCRIPTION
First release published from **kubeswift-io**. **No functional changes** — bumps the chart to v0.6.1 so there's a clean versioned image + OCI chart set under the new org.

- Chart `0.6.0 → 0.6.1` (version + appVersion); install pins (quickstart, dra-allocation, dra-driver).
- CHANGELOG `[v0.6.1]` — the org rehome.

On merge I'll tag `v0.6.1` → release-stable publishes v0.6.1 images + `oci://ghcr.io/kubeswift-io/charts/kubeswift`. Signed-off (DCO); squash-merge yields a GitHub-signed commit (satisfies the required-signatures ruleset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)