### PR TITLE
feat(snapshot): oci backend controller capture path (Phase 1, PR 2b)

### DIFF
--- a/charts/kubeswift/templates/controller-manager/deployment.yaml
+++ b/charts/kubeswift/templates/controller-manager/deployment.yaml
@@ -27,6 +27,8 @@ spec:
               value: {{ .Values.swiftletd.image.registry }}/swiftletd:{{ include "kubeswift.imageTag" (dict "tag" .Values.swiftletd.image.tag "appVersion" .Chart.AppVersion) }}
             - name: KUBESWIFT_SNAPSHOT_S3_IMAGE
               value: {{ .Values.snapshotS3.image.registry }}/snapshot-s3:{{ include "kubeswift.imageTag" (dict "tag" .Values.snapshotS3.image.tag "appVersion" .Chart.AppVersion) }}
+            - name: KUBESWIFT_SNAPSHOT_ORAS_IMAGE
+              value: {{ .Values.snapshotORAS.image.registry }}/snapshot-oras:{{ include "kubeswift.imageTag" (dict "tag" .Values.snapshotORAS.image.tag "appVersion" .Chart.AppVersion) }}
             - name: KUBESWIFT_MIGRATION_STUNNEL_IMAGE
               value: {{ .Values.migrationStunnel.image.registry }}/migration-stunnel:{{ include "kubeswift.imageTag" (dict "tag" .Values.migrationStunnel.image.tag "appVersion" .Chart.AppVersion) }}
             - name: POD_NAMESPACE

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -49,6 +49,16 @@ snapshotS3:
     # Same as controllerManager; use tag: latest for local build+load.
     tag: latest
 
+# snapshot-oras: the uploader/downloader image for the oci (OCI registry / ORAS)
+# snapshot backend. The controller passes this to the per-snapshot push Job (and
+# the per-restore download Job) via the KUBESWIFT_SNAPSHOT_ORAS_IMAGE env var. No
+# separate workload is deployed for it; this only sets the image reference.
+snapshotORAS:
+  image:
+    registry: ghcr.io/kubeswift-io/kubeswift
+    # Same as controllerManager; use tag: latest for local build+load.
+    tag: latest
+
 # migration-stunnel: the mTLS sidecar image for cross-node live migration
 # (Phase 3c). The controller injects it into launcher pods when
 # migration.mtls.enabled=true, reading KUBESWIFT_MIGRATION_STUNNEL_IMAGE.

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -202,6 +202,7 @@ func main() {
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
 		SnapshotS3Image:       swiftsnapshot.SnapshotS3Image(),
+		SnapshotORASImage:     swiftsnapshot.SnapshotORASImage(),
 		VolumeSnapshotEnabled: volumeSnapshotEnabled,
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftSnapshot controller")

--- a/internal/controller/swiftsnapshot/controller.go
+++ b/internal/controller/swiftsnapshot/controller.go
@@ -38,6 +38,9 @@ type SwiftSnapshotReconciler struct {
 	// SnapshotS3Image is the snapshot-s3 uploader image used by the s3
 	// (Tier C) backend's upload Job. Wired from KUBESWIFT_SNAPSHOT_S3_IMAGE.
 	SnapshotS3Image string
+	// SnapshotORASImage is the snapshot-oras uploader image used by the oci
+	// backend's push Job. Wired from KUBESWIFT_SNAPSHOT_ORAS_IMAGE.
+	SnapshotORASImage string
 	// VolumeSnapshotEnabled gates the Owns(VolumeSnapshot) watch. When the CSI
 	// external-snapshotter CRDs (snapshot.storage.k8s.io/v1) are absent, that watch
 	// cannot sync its cache and the manager fatally exits. Set from a one-time
@@ -125,9 +128,13 @@ func (r *SwiftSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 	case snapshotv1alpha1.SwiftSnapshotPhaseUploading:
-		// s3 backend only: the capture is on the node-local hostPath; watch the
-		// upload Job push it to S3, then stamp status.S3 and go Ready.
-		ready, errMsg, err := r.handleUploading(ctx, &snap, status)
+		// s3 / oci backends: the capture is on the node-local hostPath; watch the
+		// upload/push Job move it to the store, then stamp status and go Ready.
+		handleUpload := r.handleUploading
+		if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendOCI {
+			handleUpload = r.handleUploadingOCI
+		}
+		ready, errMsg, err := handleUpload(ctx, &snap, status)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -170,7 +177,7 @@ func (r *SwiftSnapshotReconciler) handlePending(
 	switch snap.Spec.Backend.Type {
 	case snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot:
 		// Falls through to the existing csi-volume-snapshot path.
-	case snapshotv1alpha1.SnapshotBackendLocal, snapshotv1alpha1.SnapshotBackendS3:
+	case snapshotv1alpha1.SnapshotBackendLocal, snapshotv1alpha1.SnapshotBackendS3, snapshotv1alpha1.SnapshotBackendOCI:
 		return r.handlePendingLocal(ctx, snap, status)
 	default:
 		setPhase(status, snapshotv1alpha1.SwiftSnapshotPhaseFailed)
@@ -257,7 +264,8 @@ func (r *SwiftSnapshotReconciler) handleCapturing(
 	// Backend dispatch — local and s3 both capture via the launcher pod's
 	// status annotations (s3 just uploads afterward); CSI drives VolumeSnapshot.
 	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendLocal ||
-		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3 {
+		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3 ||
+		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendOCI {
 		return r.handleCapturingLocal(ctx, snap, status)
 	}
 	pvc, err := r.guestRootPVC(ctx, snap.Namespace, snap.Spec.GuestRef.Name)

--- a/internal/controller/swiftsnapshot/local.go
+++ b/internal/controller/swiftsnapshot/local.go
@@ -264,10 +264,10 @@ func (r *SwiftSnapshotReconciler) handleCapturingLocal(
 		Handle: captureDestDir(snap),
 	}
 
-	// s3 backend: capture is done locally; now upload to S3. Create the
-	// node-pinned upload Job and advance to Uploading (handleUploading watches
-	// it to completion, then stamps status.S3 + Ready). The local backend is
-	// done — go straight to Ready.
+	// s3 / oci backends: capture is done locally; now move it to the store.
+	// Create the node-pinned upload/push Job and advance to Uploading (the
+	// matching handler watches it to completion, then stamps status + Ready).
+	// The local backend is done — go straight to Ready.
 	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3 {
 		if err := r.ensureUploadJob(ctx, snap, status); err != nil {
 			return false, "", err
@@ -275,6 +275,15 @@ func (r *SwiftSnapshotReconciler) handleCapturingLocal(
 		setPhase(status, snapshotv1alpha1.SwiftSnapshotPhaseUploading)
 		setReadyCondition(status, metav1.ConditionFalse, ReasonCapturing,
 			"capture complete on node "+status.NodeName+"; uploading to S3")
+		return true, "", nil
+	}
+	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendOCI {
+		if err := r.ensureOCIPushJob(ctx, snap, status); err != nil {
+			return false, "", err
+		}
+		setPhase(status, snapshotv1alpha1.SwiftSnapshotPhaseUploading)
+		setReadyCondition(status, metav1.ConditionFalse, ReasonCapturing,
+			"capture complete on node "+status.NodeName+"; pushing to "+ociReference(snap))
 		return true, "", nil
 	}
 

--- a/internal/controller/swiftsnapshot/oci.go
+++ b/internal/controller/swiftsnapshot/oci.go
@@ -1,0 +1,241 @@
+// oci (OCI registry / ORAS) backend support for SwiftSnapshot.
+//
+// The oci backend reuses Tier B's node-local capture, then runs a node-pinned
+// push Job that packages the captured artifacts as an OCI artifact and pushes
+// them to a registry via the snapshot-oras image. This file builds that Job and
+// drives the Capturing -> Uploading -> Ready transition (ensureOCIPushJob +
+// handleUploadingOCI); the controller's phase switch routes an oci-backend
+// Uploading phase here. It mirrors s3.go, with two differences: registry
+// credentials come from a mounted dockerconfigjson (not AWS env vars), and the
+// artifact is content-addressed so status.oci pins it by manifest digest.
+package swiftsnapshot
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/metrics"
+	"github.com/kubeswift-io/kubeswift/internal/snapshot/clonecommon"
+)
+
+// SnapshotORASImageEnv overrides the snapshot-oras uploader/downloader image
+// used by the oci backend's push + download Jobs.
+const SnapshotORASImageEnv = "KUBESWIFT_SNAPSHOT_ORAS_IMAGE"
+
+// SnapshotORASImageDefault is the fallback when SnapshotORASImageEnv is unset
+// (the Helm chart overrides it with a version-pinned tag). Mirrors
+// SnapshotS3ImageDefault so a chart-less deploy still resolves a usable image.
+const SnapshotORASImageDefault = "ghcr.io/kubeswift-io/kubeswift/snapshot-oras:latest"
+
+// SnapshotORASImage returns the snapshot-oras image, from SnapshotORASImageEnv
+// or SnapshotORASImageDefault.
+func SnapshotORASImage() string {
+	if img := os.Getenv(SnapshotORASImageEnv); img != "" {
+		return img
+	}
+	return SnapshotORASImageDefault
+}
+
+const (
+	// ociUploadMount is where the node-local snapshot dir is mounted (read-only)
+	// inside the push Job.
+	ociUploadMount = "/snap"
+	// ociAuthMount is where the dockerconfigjson credential is mounted; DOCKER_CONFIG
+	// points here so oras-go's credential store reads <dir>/config.json.
+	ociAuthMount = "/oras-auth"
+	// ociPushBackoffLimit bounds Job retries; snapshot-oras is idempotent (the
+	// registry dedups already-present layers by digest), so a retry resumes.
+	ociPushBackoffLimit int32 = 4
+)
+
+// ociLocalDir is the node-local hostPath directory the oci backend captures into
+// (and the push Job reads from). Shares the backend-neutral snapshot cache path.
+func ociLocalDir(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	return clonecommon.S3LocalDir(snap)
+}
+
+// ociTag resolves the artifact tag: the operator-supplied tag, or a stable
+// per-snapshot default of "<namespace>-<name>".
+func ociTag(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	if snap.Spec.Backend.OCI != nil && snap.Spec.Backend.OCI.Tag != "" {
+		return snap.Spec.Backend.OCI.Tag
+	}
+	return snap.Namespace + "-" + snap.Name
+}
+
+// ociReference is the "repository:tag" recorded in status.
+func ociReference(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	return snap.Spec.Backend.OCI.Repository + ":" + ociTag(snap)
+}
+
+// ociPushJobName is the deterministic name of the push Job.
+func ociPushJobName(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	return snap.Name + "-oci-push"
+}
+
+// ensureOCIPushJob creates the node-pinned push Job (idempotent) owned by the
+// SwiftSnapshot. Fails if the snapshot-oras image is not configured.
+func (r *SwiftSnapshotReconciler) ensureOCIPushJob(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot, status *snapshotv1alpha1.SwiftSnapshotStatus) error {
+	if r.SnapshotORASImage == "" {
+		return fmt.Errorf("snapshot-oras image not configured (set %s)", SnapshotORASImageEnv)
+	}
+	job := buildOCIPushJob(snap, r.SnapshotORASImage, status.NodeName)
+	if err := ctrl.SetControllerReference(snap, job, r.Scheme); err != nil {
+		return err
+	}
+	if err := r.Create(ctx, job); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create oci push Job: %w", err)
+	}
+	return nil
+}
+
+// handleUploadingOCI watches the push Job. On Complete it stamps status.OCI and
+// transitions to Ready; on Failed it returns an errMsg (caller -> Failed).
+// Returns (ready, errMsg, err) following handleUploading's contract.
+func (r *SwiftSnapshotReconciler) handleUploadingOCI(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot, status *snapshotv1alpha1.SwiftSnapshotStatus) (bool, string, error) {
+	var job batchv1.Job
+	err := r.Get(ctx, client.ObjectKey{Name: ociPushJobName(snap), Namespace: snap.Namespace}, &job)
+	if apierrors.IsNotFound(err) {
+		// Job missing (controller restarted before observing creation, or it was
+		// deleted). Recreate — idempotent, and the binary resumes.
+		if cerr := r.ensureOCIPushJob(ctx, snap, status); cerr != nil {
+			return false, "", cerr
+		}
+		return false, "", nil
+	}
+	if err != nil {
+		return false, "", err
+	}
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			now := metav1.Now()
+			status.OCI = &snapshotv1alpha1.OCISnapshotStatus{
+				Reference: ociReference(snap),
+				PushedAt:  &now,
+			}
+			// Read the push Job's byte report (best-effort; a missing report leaves
+			// bytes/digest empty and is not a failure). status carries the registry
+			// footprint + the pinned digest; the metric counts actual wire traffic.
+			if rep, ok, rerr := clonecommon.JobTransferReport(ctx, r.Client, snap.Namespace, ociPushJobName(snap)); rerr == nil && ok {
+				status.OCI.PushedBytes = rep.TotalBytes
+				status.OCI.ManifestDigest = rep.ManifestDigest
+				metrics.SnapshotUploadBytesTotal.Add(float64(rep.TransferredBytes))
+			}
+			setPhase(status, snapshotv1alpha1.SwiftSnapshotPhaseReady)
+			setReadyCondition(status, metav1.ConditionTrue, ReasonSnapshotReady,
+				"snapshot pushed to "+ociReference(snap))
+			return true, "", nil
+		}
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return false, "OCI push Job failed: " + c.Message, nil
+		}
+	}
+	return false, "", nil // still pushing
+}
+
+// buildOCIPushJob constructs the node-pinned push Job. It mounts the captured
+// snapshot dir read-only and runs snapshot-oras --mode=upload. Pinned to the
+// capture node (status.NodeName) because the artifacts live in that node's
+// hostPath. Registry credentials, when configured, come from a dockerconfigjson
+// Secret mounted at ociAuthMount with DOCKER_CONFIG pointed at it; an empty
+// credentialsSecretRef means anonymous access. The caller sets the ownerRef.
+func buildOCIPushJob(snap *snapshotv1alpha1.SwiftSnapshot, image, captureNode string) *batchv1.Job {
+	oci := snap.Spec.Backend.OCI
+	args := []string{
+		"--mode=upload",
+		"--dir=" + ociUploadMount,
+		"--repository=" + oci.Repository,
+		"--tag=" + ociTag(snap),
+		"--snapshot=" + snap.Namespace + "/" + snap.Name,
+	}
+	if oci.Insecure {
+		args = append(args, "--insecure")
+	}
+	if snap.Spec.IncludeMemory {
+		args = append(args, "--include-memory")
+	}
+
+	volumes := []corev1.Volume{{
+		Name: "snapshot",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: ociLocalDir(snap),
+				Type: ptr.To(corev1.HostPathDirectory),
+			},
+		},
+	}}
+	mounts := []corev1.VolumeMount{{
+		Name:      "snapshot",
+		MountPath: ociUploadMount,
+		ReadOnly:  true,
+	}}
+	var env []corev1.EnvVar
+	if oci.CredentialsSecretRef != nil && oci.CredentialsSecretRef.Name != "" {
+		env = append(env, corev1.EnvVar{Name: "DOCKER_CONFIG", Value: ociAuthMount})
+		mounts = append(mounts, corev1.VolumeMount{Name: "oras-auth", MountPath: ociAuthMount, ReadOnly: true})
+		volumes = append(volumes, corev1.Volume{
+			Name: "oras-auth",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: oci.CredentialsSecretRef.Name,
+					// A kubernetes.io/dockerconfigjson Secret stores the auth under
+					// .dockerconfigjson; oras-go expects a Docker config.json.
+					Items: []corev1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
+				},
+			},
+		})
+	}
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ociPushJobName(snap),
+			Namespace: snap.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "kubeswift",
+				"app.kubernetes.io/component": "snapshot-oci-push",
+				"kubeswift.io/swiftsnapshot":  snap.Name,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: ptr.To(ociPushBackoffLimit),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					NodeName:      captureNode,
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+					Containers: []corev1.Container{{
+						Name:         "push",
+						Image:        image,
+						Args:         args,
+						Env:          env,
+						VolumeMounts: mounts,
+						// Runs as root: the capture writes the artifacts (config.json,
+						// state.json, memory-ranges) as root mode 0600 (serialized
+						// guest RAM), so a non-root container cannot read them even via
+						// a read-only mount. Mirrors buildUploadJob. Otherwise maximally
+						// constrained: drop ALL, no privilege escalation, read-only
+						// rootfs; the mounts expose only the snapshot dir + the
+						// credential file.
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+							RunAsUser:                ptr.To(int64(0)),
+							RunAsNonRoot:             ptr.To(false),
+							ReadOnlyRootFilesystem:   ptr.To(true),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						},
+					}},
+					Volumes: volumes,
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/swiftsnapshot/oci_test.go
+++ b/internal/controller/swiftsnapshot/oci_test.go
@@ -1,0 +1,123 @@
+package swiftsnapshot
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+)
+
+func ociSnap(mut func(*snapshotv1alpha1.OCIBackend)) *snapshotv1alpha1.SwiftSnapshot {
+	oci := &snapshotv1alpha1.OCIBackend{Repository: "zot.svc:5000/vm-snapshots"}
+	if mut != nil {
+		mut(oci)
+	}
+	return &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "snap1", Namespace: "team-a"},
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			GuestRef:      snapshotv1alpha1.SwiftSnapshotGuestRef{Name: "g1"},
+			IncludeMemory: true,
+			Backend:       snapshotv1alpha1.SwiftSnapshotBackend{Type: snapshotv1alpha1.SnapshotBackendOCI, OCI: oci},
+		},
+	}
+}
+
+func TestOCITag_DefaultAndExplicit(t *testing.T) {
+	if got := ociTag(ociSnap(nil)); got != "team-a-snap1" {
+		t.Errorf("default tag = %q, want team-a-snap1", got)
+	}
+	explicit := ociSnap(func(o *snapshotv1alpha1.OCIBackend) { o.Tag = "prod-42" })
+	if got := ociTag(explicit); got != "prod-42" {
+		t.Errorf("explicit tag = %q, want prod-42", got)
+	}
+	if got := ociReference(ociSnap(nil)); got != "zot.svc:5000/vm-snapshots:team-a-snap1" {
+		t.Errorf("reference = %q", got)
+	}
+}
+
+func TestBuildOCIPushJob_WithCredentials(t *testing.T) {
+	snap := ociSnap(func(o *snapshotv1alpha1.OCIBackend) {
+		o.Insecure = true
+		o.CredentialsSecretRef = &snapshotv1alpha1.SecretObjectReference{Name: "reg-creds"}
+	})
+	job := buildOCIPushJob(snap, "img:tag", "boba")
+
+	if job.Name != "snap1-oci-push" || job.Namespace != "team-a" {
+		t.Errorf("job meta = %s/%s", job.Namespace, job.Name)
+	}
+	pod := job.Spec.Template.Spec
+	if pod.NodeName != "boba" {
+		t.Errorf("not pinned to capture node: %q", pod.NodeName)
+	}
+	c := pod.Containers[0]
+	args := strings.Join(c.Args, " ")
+	for _, want := range []string{
+		"--mode=upload", "--dir=/snap",
+		"--repository=zot.svc:5000/vm-snapshots", "--tag=team-a-snap1",
+		"--snapshot=team-a/snap1", "--insecure", "--include-memory",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("args missing %q; got %q", want, args)
+		}
+	}
+	// Runs as root to read the 0600 capture artifacts.
+	if c.SecurityContext == nil || c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 0 {
+		t.Errorf("push container must RunAsUser 0")
+	}
+	// DOCKER_CONFIG env + the dockerconfigjson-mounted volume are present.
+	var hasDockerCfg bool
+	for _, e := range c.Env {
+		if e.Name == "DOCKER_CONFIG" && e.Value == ociAuthMount {
+			hasDockerCfg = true
+		}
+	}
+	if !hasDockerCfg {
+		t.Errorf("DOCKER_CONFIG env missing")
+	}
+	var authVol bool
+	for _, v := range pod.Volumes {
+		if v.Name == "oras-auth" {
+			if v.Secret == nil || v.Secret.SecretName != "reg-creds" {
+				t.Errorf("oras-auth volume not from the creds Secret: %+v", v.Secret)
+			}
+			if len(v.Secret.Items) != 1 || v.Secret.Items[0].Key != ".dockerconfigjson" || v.Secret.Items[0].Path != "config.json" {
+				t.Errorf("dockerconfigjson not remapped to config.json: %+v", v.Secret.Items)
+			}
+			authVol = true
+		}
+	}
+	if !authVol {
+		t.Errorf("oras-auth volume missing")
+	}
+}
+
+func TestBuildOCIPushJob_Anonymous(t *testing.T) {
+	job := buildOCIPushJob(ociSnap(nil), "img:tag", "miles")
+	pod := job.Spec.Template.Spec
+	for _, e := range pod.Containers[0].Env {
+		if e.Name == "DOCKER_CONFIG" {
+			t.Errorf("anonymous push must not set DOCKER_CONFIG")
+		}
+	}
+	for _, v := range pod.Volumes {
+		if v.Name == "oras-auth" {
+			t.Errorf("anonymous push must not mount a credential volume")
+		}
+	}
+	// The snapshot hostPath volume is always present.
+	var snapVol bool
+	for _, v := range pod.Volumes {
+		if v.Name == "snapshot" {
+			snapVol = true
+		}
+	}
+	if !snapVol {
+		t.Errorf("snapshot hostPath volume missing")
+	}
+	// Not-insecure snapshot omits the --insecure flag.
+	if strings.Contains(strings.Join(pod.Containers[0].Args, " "), "--insecure") {
+		t.Errorf("--insecure should be absent when Insecure=false")
+	}
+}

--- a/internal/controller/swiftsnapshot/s3.go
+++ b/internal/controller/swiftsnapshot/s3.go
@@ -121,6 +121,9 @@ func captureDestDir(snap *snapshotv1alpha1.SwiftSnapshot) string {
 	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3 {
 		return s3LocalDir(snap)
 	}
+	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendOCI {
+		return ociLocalDir(snap)
+	}
 	if snap.Spec.Backend.Local != nil {
 		return snap.Spec.Backend.Local.HostPath
 	}

--- a/internal/snapshot/clonecommon/jobreport.go
+++ b/internal/snapshot/clonecommon/jobreport.go
@@ -8,11 +8,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// TransferReport mirrors the JSON the snapshot-s3 binary writes to its
-// container termination message on a successful transfer
-// (cmd/snapshot-s3 transferStats). Keep the json tags in sync with that struct:
-// the two are coupled only by this wire shape (the binary stays minimal and does
-// not import this package). transferredBytes + skippedBytes == totalBytes.
+// TransferReport mirrors the JSON the snapshot-s3 and snapshot-oras binaries
+// write to their container termination message on a successful transfer
+// (cmd/snapshot-s3 transferStats / cmd/snapshot-oras transferStats). Keep the
+// json tags in sync with those structs: the two sides are coupled only by this
+// wire shape (the binaries stay minimal and do not import this package).
+// transferredBytes + skippedBytes == totalBytes.
 type TransferReport struct {
 	// TransferredBytes is the artifact bytes actually moved over the wire
 	// (excludes resume-skipped objects) — the bandwidth/cost figure.
@@ -21,6 +22,11 @@ type TransferReport struct {
 	SkippedBytes int64 `json:"skippedBytes"`
 	// TotalBytes is the snapshot's full artifact footprint.
 	TotalBytes int64 `json:"totalBytes"`
+	// Reference is the pushed artifact reference (oci backend only; empty for s3).
+	Reference string `json:"reference,omitempty"`
+	// ManifestDigest is the sha256 of the pushed OCI manifest (oci backend only;
+	// empty for s3). Restore pins the artifact by this digest.
+	ManifestDigest string `json:"manifestDigest,omitempty"`
 }
 
 // JobTransferReport reads the byte report a completed snapshot-s3 Job left in


### PR DESCRIPTION
## ORAS at-rest VM-disk artifacts — Phase 1, PR 2b (controller capture path)

Third PR of the ORAS arc (after #295 API + #296 the `snapshot-oras` image). Wires the `oci` snapshot backend's **capture path** into the controller: a `backend.type: oci` SwiftSnapshot now captures (reusing the Tier B node-local CH snapshot) then pushes the artifact to a registry via a node-pinned `snapshot-oras` Job, mirroring the s3 backend.

### What's in
- **`oci.go`** — `SnapshotORASImage` resolver (`KUBESWIFT_SNAPSHOT_ORAS_IMAGE`, default `snapshot-oras:latest`); `ensureOCIPushJob` + `handleUploadingOCI`; `buildOCIPushJob` (node-pinned to the capture node, `/snap` RO hostPath, **RunAsRoot** to read the 0600 capture artifacts, drop ALL; **dockerconfigjson** creds mounted at `DOCKER_CONFIG`, or anonymous); `ociTag` defaults to `<ns>-<name>`.
- **Dispatch** (`controller.go` / `local.go`) — `oci` routes through `handlePendingLocal`/`handleCapturingLocal` (reusing the CH capture); on capture completion → `ensureOCIPushJob` → **Uploading** → `handleUploadingOCI` stamps `status.oci{reference, manifestDigest, pushedBytes}` + **Ready**.
- **`clonecommon.TransferReport`** gains `reference`/`manifestDigest` (omitempty; s3 unaffected) so the controller reads the pushed digest from the Job's termination-message report.
- **Deploy** — `main.go` wires `SnapshotORASImage`; chart sets `KUBESWIFT_SNAPSHOT_ORAS_IMAGE` + `values.snapshotORAS`.

### Test
Unit: `buildOCIPushJob` (args, node-pin, RunAsRoot, dockerconfigjson→`config.json` remap, anonymous path) + `ociTag` defaulting; all controller-package tests green; `go build ./...`, `go vet`, `gofmt` clean; `helm template` renders the env.

### Not in this PR
- **Restore-side** (SwiftRestore / cloneFromSnapshot download from an oci snapshot) — PR 2c.
- **Cluster round-trip against Zot** — the W5-pattern gap (only a real Job + kubelet mount exercises it). Pending a controller image from this branch (or the post-merge `release-dev` image); capture → Zot → verify `status.oci` runs then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)