### PR TITLE
feat(snapshot): oci backend restore path — SwiftRestore (Phase 1, PR 2c)

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -210,9 +210,10 @@ func main() {
 	}
 
 	if err = (&swiftrestore.SwiftRestoreReconciler{
-		Client:          mgr.GetClient(),
-		Scheme:          mgr.GetScheme(),
-		SnapshotS3Image: swiftsnapshot.SnapshotS3Image(),
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		SnapshotS3Image:   swiftsnapshot.SnapshotS3Image(),
+		SnapshotORASImage: swiftsnapshot.SnapshotORASImage(),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftRestore controller")
 		os.Exit(1)

--- a/internal/controller/swiftrestore/controller.go
+++ b/internal/controller/swiftrestore/controller.go
@@ -46,6 +46,9 @@ type SwiftRestoreReconciler struct {
 	// SnapshotS3Image is the snapshot-s3 image used by the s3 (Tier C)
 	// backend's download Job. Wired from KUBESWIFT_SNAPSHOT_S3_IMAGE.
 	SnapshotS3Image string
+	// SnapshotORASImage is the snapshot-oras image used by the oci backend's
+	// download Job. Wired from KUBESWIFT_SNAPSHOT_ORAS_IMAGE.
+	SnapshotORASImage string
 }
 
 // Reconcile drives the SwiftRestore state machine.
@@ -87,10 +90,14 @@ func (r *SwiftRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 
 	case snapshotv1alpha1.SwiftRestorePhaseDownloading:
-		// s3 backend only: watch the download Job pull artifacts into the
+		// s3 / oci backends: watch the download Job pull artifacts into the
 		// node-local cache, then hand off to the shared Tier B restore tail
 		// (materializeRestoreTarget) and advance to Restoring.
-		advanced, requeue, errMsg, err := r.handleDownloading(ctx, &restore, status)
+		handleDl := r.handleDownloading
+		if r.downloadBackendIsOCI(ctx, &restore) {
+			handleDl = r.handleDownloadingOCI
+		}
+		advanced, requeue, errMsg, err := handleDl(ctx, &restore, status)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -219,6 +226,8 @@ func (r *SwiftRestoreReconciler) handlePending(
 		return r.handlePendingLocal(ctx, restore, &snap, status)
 	case snapshotv1alpha1.SnapshotBackendS3:
 		return r.handlePendingS3(ctx, restore, &snap, status)
+	case snapshotv1alpha1.SnapshotBackendOCI:
+		return r.handlePendingOCI(ctx, restore, &snap, status)
 	default:
 		setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
 		setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed,

--- a/internal/controller/swiftrestore/local.go
+++ b/internal/controller/swiftrestore/local.go
@@ -175,13 +175,16 @@ func parseVersion(s string) (int, int, int, bool) {
 
 // IsTierBRestore returns true when the snapshot's backend drives the
 // node-local-cache restore path (CH --restore from a hostPath) rather than
-// CSI. That covers both local (Tier B) and s3 (Tier C): once the s3 download
-// Job has populated the node-local cache, the Restoring/Resuming phases are
-// identical to local. The Pending phase still forks (local vs s3-download)
-// before reaching that shared path.
+// CSI. That covers local (Tier B), s3 (Tier C), and oci: once the download Job
+// has populated the node-local cache, the Restoring/Resuming phases are
+// identical to local. The Pending phase still forks (local vs s3/oci-download)
+// before reaching that shared path. It must include EVERY memory-snapshot
+// backend — a missing one routes the restore to the CSI disk path, which fails
+// "no root disk" on the (empty) status.disks of a memory snapshot.
 func IsTierBRestore(snap *snapshotv1alpha1.SwiftSnapshot) bool {
 	return snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendLocal ||
-		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3
+		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendS3 ||
+		snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendOCI
 }
 
 // IsInPlaceRestore returns true when this is the fast-path: target name

--- a/internal/controller/swiftrestore/oci.go
+++ b/internal/controller/swiftrestore/oci.go
@@ -1,0 +1,198 @@
+// oci (OCI registry / ORAS) restore support for SwiftRestore.
+//
+// The oci backend pulls the snapshot's OCI artifact from the registry into a
+// node-local cache via the snapshot-oras image, then the EXISTING Tier B restore
+// tail (materializeRestoreTarget) takes over — identical to the s3 path, just a
+// registry pull instead of an object-store download. The restore pulls by the
+// captured manifest digest (status.oci.manifestDigest), so it materializes the
+// exact artifact regardless of any later retag.
+package swiftrestore
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/metrics"
+	"github.com/kubeswift-io/kubeswift/internal/snapshot/clonecommon"
+)
+
+// ociDownloadJobName is the deterministic name of the download Job.
+func ociDownloadJobName(restore *snapshotv1alpha1.SwiftRestore) string {
+	return restore.Name + "-oci-download"
+}
+
+// ociRestoreTag resolves the artifact tag the same way the capture side does:
+// the operator-supplied tag, or the "<namespace>-<name>" default.
+func ociRestoreTag(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	if snap.Spec.Backend.OCI != nil && snap.Spec.Backend.OCI.Tag != "" {
+		return snap.Spec.Backend.OCI.Tag
+	}
+	return snap.Namespace + "-" + snap.Name
+}
+
+// downloadBackendIsOCI reports whether the restore's referenced snapshot uses
+// the oci backend, so the Downloading phase picks the right download handler.
+// Any lookup error returns false; the s3 handler then surfaces the real error.
+func (r *SwiftRestoreReconciler) downloadBackendIsOCI(ctx context.Context, restore *snapshotv1alpha1.SwiftRestore) bool {
+	var snap snapshotv1alpha1.SwiftSnapshot
+	if err := r.Get(ctx, client.ObjectKey{Name: restore.Spec.SnapshotRef.Name, Namespace: restore.Namespace}, &snap); err != nil {
+		return false
+	}
+	return snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendOCI
+}
+
+// handlePendingOCI validates the pushed snapshot, resolves the target node, and
+// starts the download Job. Advances to Downloading.
+func (r *SwiftRestoreReconciler) handlePendingOCI(
+	ctx context.Context,
+	restore *snapshotv1alpha1.SwiftRestore,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+	status *snapshotv1alpha1.SwiftRestoreStatus,
+) (bool, time.Duration, error) {
+	if r.hypervisorVersionBlocked(restore, snap, status) {
+		return true, 0, nil
+	}
+	if snap.Spec.Backend.OCI == nil {
+		setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
+		setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed,
+			"SwiftSnapshot "+snap.Name+" has no backend.oci — oci restore requires the registry config")
+		return true, 0, nil
+	}
+	if snap.Status.OCI == nil || snap.Status.OCI.ManifestDigest == "" {
+		setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
+		setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed,
+			"SwiftSnapshot "+snap.Name+" has no status.oci — oci restore requires a completed push")
+		return true, 0, nil
+	}
+	node, failMsg, err := r.resolveS3RestoreNode(ctx, restore, snap)
+	if err != nil {
+		return false, 0, err
+	}
+	if failMsg != "" {
+		setPhase(status, snapshotv1alpha1.SwiftRestorePhaseFailed)
+		setReadyCondition(status, metav1.ConditionFalse, ReasonRestoreFailed, failMsg)
+		return true, 0, nil
+	}
+	if err := r.ensureOCIDownloadJob(ctx, restore, snap, node); err != nil {
+		return false, 0, err
+	}
+	setPhase(status, snapshotv1alpha1.SwiftRestorePhaseDownloading)
+	setReadyCondition(status, metav1.ConditionFalse, ReasonDownloading,
+		"pulling snapshot from "+snap.Status.OCI.Reference+" to node "+node)
+	return true, 0, nil
+}
+
+// handleDownloadingOCI watches the download Job. On Complete it hands off to the
+// shared Tier B restore tail (materializeRestoreTarget) with the node-local
+// cache dir; on Failed it returns an errMsg. Mirrors handleDownloading.
+func (r *SwiftRestoreReconciler) handleDownloadingOCI(
+	ctx context.Context,
+	restore *snapshotv1alpha1.SwiftRestore,
+	status *snapshotv1alpha1.SwiftRestoreStatus,
+) (bool, time.Duration, string, error) {
+	var snap snapshotv1alpha1.SwiftSnapshot
+	if err := r.Get(ctx, client.ObjectKey{Name: restore.Spec.SnapshotRef.Name, Namespace: restore.Namespace}, &snap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, 0, "source SwiftSnapshot " + restore.Spec.SnapshotRef.Name + " disappeared during download", nil
+		}
+		return false, 0, "", err
+	}
+
+	var job batchv1.Job
+	err := r.Get(ctx, client.ObjectKey{Name: ociDownloadJobName(restore), Namespace: restore.Namespace}, &job)
+	if apierrors.IsNotFound(err) {
+		node, failMsg, rerr := r.resolveS3RestoreNode(ctx, restore, &snap)
+		if rerr != nil {
+			return false, 0, "", rerr
+		}
+		if failMsg != "" {
+			return false, 0, failMsg, nil
+		}
+		if cerr := r.ensureOCIDownloadJob(ctx, restore, &snap, node); cerr != nil {
+			return false, 0, "", cerr
+		}
+		return false, 5 * time.Second, "", nil
+	}
+	if err != nil {
+		return false, 0, "", err
+	}
+
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			if status.DownloadedBytes == 0 {
+				if rep, ok, rerr := clonecommon.JobTransferReport(ctx, r.Client, restore.Namespace, ociDownloadJobName(restore)); rerr == nil && ok {
+					status.DownloadedBytes = rep.TotalBytes
+					metrics.RestoreDownloadBytesTotal.Add(float64(rep.TransferredBytes))
+				}
+			}
+			node, failMsg, rerr := r.resolveS3RestoreNode(ctx, restore, &snap)
+			if rerr != nil {
+				return false, 0, "", rerr
+			}
+			if failMsg != "" {
+				return false, 0, failMsg, nil
+			}
+			advanced, requeue, merr := r.materializeRestoreTarget(ctx, restore, &snap, status, s3RestoreLocalDir(&snap), node)
+			return advanced, requeue, "", merr
+		}
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return false, 0, "OCI download Job failed: " + c.Message, nil
+		}
+	}
+	return false, 5 * time.Second, "", nil // still downloading
+}
+
+// ensureOCIDownloadJob creates the node-pinned download Job (idempotent) owned
+// by the SwiftRestore. Fails if the snapshot-oras image is not configured.
+func (r *SwiftRestoreReconciler) ensureOCIDownloadJob(
+	ctx context.Context,
+	restore *snapshotv1alpha1.SwiftRestore,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+	node string,
+) error {
+	if r.SnapshotORASImage == "" {
+		return fmt.Errorf("snapshot-oras image not configured (set KUBESWIFT_SNAPSHOT_ORAS_IMAGE)")
+	}
+	job := buildOCIDownloadJob(restore, snap, r.SnapshotORASImage, node)
+	if err := ctrl.SetControllerReference(restore, job, r.Scheme); err != nil {
+		return err
+	}
+	if err := r.Create(ctx, job); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create oci download Job: %w", err)
+	}
+	return nil
+}
+
+// buildOCIDownloadJob constructs the node-pinned download Job (pinned to the
+// resolved restore node). Pulls by digest for the exact captured artifact;
+// credentials, when configured, come from the snapshot's dockerconfigjson Secret.
+func buildOCIDownloadJob(restore *snapshotv1alpha1.SwiftRestore, snap *snapshotv1alpha1.SwiftSnapshot, image, node string) *batchv1.Job {
+	oci := snap.Spec.Backend.OCI
+	credName := ""
+	if oci.CredentialsSecretRef != nil {
+		credName = oci.CredentialsSecretRef.Name
+	}
+	return clonecommon.BuildOCIDownloadJob(clonecommon.OCIDownloadJobParams{
+		Snapshot:              snap,
+		Repository:            oci.Repository,
+		Tag:                   ociRestoreTag(snap),
+		Digest:                snap.Status.OCI.ManifestDigest,
+		Insecure:              oci.Insecure,
+		CredentialsSecretName: credName,
+		Image:                 image,
+		Name:                  ociDownloadJobName(restore),
+		Namespace:             restore.Namespace,
+		Node:                  node,
+		Component:             "snapshot-oci-download",
+		ExtraLabels:           map[string]string{"kubeswift.io/swiftrestore": restore.Name},
+	})
+}

--- a/internal/controller/swiftrestore/oci_test.go
+++ b/internal/controller/swiftrestore/oci_test.go
@@ -1,0 +1,124 @@
+package swiftrestore
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+)
+
+func ociSnapForRestore(withCreds bool) *snapshotv1alpha1.SwiftSnapshot {
+	oci := &snapshotv1alpha1.OCIBackend{Repository: "zot.svc:5000/vm-snapshots", Insecure: true}
+	if withCreds {
+		oci.CredentialsSecretRef = &snapshotv1alpha1.SecretObjectReference{Name: "reg-creds"}
+	}
+	return &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "snap1", Namespace: "team-a"},
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			Backend: snapshotv1alpha1.SwiftSnapshotBackend{Type: snapshotv1alpha1.SnapshotBackendOCI, OCI: oci},
+		},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{
+			OCI: &snapshotv1alpha1.OCISnapshotStatus{
+				Reference:      "zot.svc:5000/vm-snapshots:team-a-snap1",
+				ManifestDigest: "sha256:abc123",
+			},
+		},
+	}
+}
+
+func ociRestore() *snapshotv1alpha1.SwiftRestore {
+	return &snapshotv1alpha1.SwiftRestore{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "team-a"},
+		Spec: snapshotv1alpha1.SwiftRestoreSpec{
+			SnapshotRef: snapshotv1alpha1.SwiftRestoreSnapshotRef{Name: "snap1"},
+			TargetGuest: snapshotv1alpha1.SwiftRestoreTarget{Name: "g1"},
+			TargetNode:  "miles",
+		},
+	}
+}
+
+func TestOCIRestoreTag(t *testing.T) {
+	if got := ociRestoreTag(ociSnapForRestore(false)); got != "team-a-snap1" {
+		t.Errorf("default tag = %q, want team-a-snap1", got)
+	}
+	s := ociSnapForRestore(false)
+	s.Spec.Backend.OCI.Tag = "prod-9"
+	if got := ociRestoreTag(s); got != "prod-9" {
+		t.Errorf("explicit tag = %q", got)
+	}
+}
+
+func TestBuildOCIDownloadJob(t *testing.T) {
+	job := buildOCIDownloadJob(ociRestore(), ociSnapForRestore(true), "img:tag", "miles")
+	if job.Name != "r1-oci-download" || job.Namespace != "team-a" {
+		t.Errorf("job meta = %s/%s", job.Namespace, job.Name)
+	}
+	pod := job.Spec.Template.Spec
+	if pod.NodeName != "miles" {
+		t.Errorf("not pinned to restore node: %q", pod.NodeName)
+	}
+	c := pod.Containers[0]
+	args := strings.Join(c.Args, " ")
+	for _, want := range []string{
+		"--mode=download", "--dir=/snap",
+		"--repository=zot.svc:5000/vm-snapshots", "--tag=team-a-snap1",
+		"--digest=sha256:abc123", "--insecure",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("args missing %q; got %q", want, args)
+		}
+	}
+	// Runs as root to write the kubelet-created root-owned cache hostPath.
+	if c.SecurityContext == nil || c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 0 {
+		t.Errorf("download container must RunAsUser 0")
+	}
+	// dockerconfigjson creds → DOCKER_CONFIG + oras-auth volume.
+	var hasDockerCfg, authVol bool
+	for _, e := range c.Env {
+		if e.Name == "DOCKER_CONFIG" {
+			hasDockerCfg = true
+		}
+	}
+	for _, v := range pod.Volumes {
+		if v.Name == "oras-auth" && v.Secret != nil && v.Secret.SecretName == "reg-creds" {
+			authVol = true
+		}
+	}
+	if !hasDockerCfg || !authVol {
+		t.Errorf("credentialed download must set DOCKER_CONFIG (%v) + mount oras-auth (%v)", hasDockerCfg, authVol)
+	}
+}
+
+func TestBuildOCIDownloadJob_Anonymous(t *testing.T) {
+	job := buildOCIDownloadJob(ociRestore(), ociSnapForRestore(false), "img:tag", "miles")
+	pod := job.Spec.Template.Spec
+	for _, e := range pod.Containers[0].Env {
+		if e.Name == "DOCKER_CONFIG" {
+			t.Errorf("anonymous download must not set DOCKER_CONFIG")
+		}
+	}
+	for _, v := range pod.Volumes {
+		if v.Name == "oras-auth" {
+			t.Errorf("anonymous download must not mount a credential volume")
+		}
+	}
+}
+
+// TestHandlePendingOCI_MissingStatus: an oci restore of a snapshot with no
+// status.oci fails loudly (no silent boot from an incomplete push).
+func TestHandlePendingOCI_MissingStatus(t *testing.T) {
+	r := &SwiftRestoreReconciler{}
+	snap := ociSnapForRestore(false)
+	snap.Status.OCI = nil // push not completed
+	status := &snapshotv1alpha1.SwiftRestoreStatus{}
+	advanced, _, err := r.handlePendingOCI(context.Background(), ociRestore(), snap, status)
+	if err != nil || !advanced {
+		t.Fatalf("advanced=%v err=%v", advanced, err)
+	}
+	if status.Phase != snapshotv1alpha1.SwiftRestorePhaseFailed {
+		t.Errorf("phase = %q, want Failed", status.Phase)
+	}
+}

--- a/internal/controller/swiftrestore/oci_test.go
+++ b/internal/controller/swiftrestore/oci_test.go
@@ -122,3 +122,30 @@ func TestHandlePendingOCI_MissingStatus(t *testing.T) {
 		t.Errorf("phase = %q, want Failed", status.Phase)
 	}
 }
+
+// TestIsTierBRestore_IncludesOCI guards the phase-dispatch classifier: oci is a
+// memory-snapshot backend and MUST route to the Tier B (CH --restore) restore
+// path, not the CSI disk path. A missing oci here sends the restore to
+// handleRestoring -> findRootDisk -> "no root disk" on a memory snapshot's empty
+// status.disks (the PR 2c cluster-validation bug this asserts against).
+func TestIsTierBRestore_IncludesOCI(t *testing.T) {
+	cases := []struct {
+		backend snapshotv1alpha1.SnapshotBackendType
+		want    bool
+	}{
+		{snapshotv1alpha1.SnapshotBackendLocal, true},
+		{snapshotv1alpha1.SnapshotBackendS3, true},
+		{snapshotv1alpha1.SnapshotBackendOCI, true},
+		{snapshotv1alpha1.SnapshotBackendCSIVolumeSnapshot, false},
+	}
+	for _, c := range cases {
+		snap := &snapshotv1alpha1.SwiftSnapshot{
+			Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+				Backend: snapshotv1alpha1.SwiftSnapshotBackend{Type: c.backend},
+			},
+		}
+		if got := IsTierBRestore(snap); got != c.want {
+			t.Errorf("IsTierBRestore(%s) = %v, want %v", c.backend, got, c.want)
+		}
+	}
+}

--- a/internal/snapshot/clonecommon/download.go
+++ b/internal/snapshot/clonecommon/download.go
@@ -143,3 +143,110 @@ func BuildDownloadJob(p DownloadJobParams) *batchv1.Job {
 		},
 	}
 }
+
+// ociDownloadAuthMount is where the dockerconfigjson credential is mounted for
+// the oci download Job; DOCKER_CONFIG points here so oras-go reads config.json.
+const ociDownloadAuthMount = "/oras-auth"
+
+// OCIDownloadJobParams parameterizes the node-pinned oci (ORAS) download Job for
+// both the SwiftRestore and cloneFromSnapshot paths. The restore pulls by
+// Digest (status.oci.manifestDigest) so it materializes the exact captured
+// artifact; Tag is passed for the reference. The caller sets the ownerRef.
+type OCIDownloadJobParams struct {
+	// Snapshot supplies the node-local cache dir (S3LocalDir, backend-neutral).
+	Snapshot *snapshotv1alpha1.SwiftSnapshot
+	// Repository / Tag / Digest identify the artifact; Digest pins it.
+	Repository string
+	Tag        string
+	Digest     string
+	Insecure   bool
+	// CredentialsSecretName is a dockerconfigjson Secret; "" = anonymous.
+	CredentialsSecretName string
+	// Image is the snapshot-oras uploader/downloader image.
+	Image string
+	// Name / Namespace / Node of the Job; Component is the component label.
+	Name, Namespace, Node, Component string
+	ExtraLabels                      map[string]string
+}
+
+// BuildOCIDownloadJob constructs the node-pinned oci download Job: it pulls the
+// snapshot's OCI artifact from the registry into the node-local cache hostPath
+// (S3LocalDir) — ORAS verifies every blob's digest against the manifest. Runs
+// as root because it writes the kubelet-created root-owned cache hostPath; still
+// drop ALL / no-priv-esc / ro-rootfs. Registry credentials, when configured,
+// come from a dockerconfigjson Secret at DOCKER_CONFIG; else anonymous.
+func BuildOCIDownloadJob(p OCIDownloadJobParams) *batchv1.Job {
+	args := []string{
+		"--mode=download",
+		"--dir=" + DownloadMount,
+		"--repository=" + p.Repository,
+		"--tag=" + p.Tag,
+	}
+	if p.Digest != "" {
+		args = append(args, "--digest="+p.Digest)
+	}
+	if p.Insecure {
+		args = append(args, "--insecure")
+	}
+
+	volumes := []corev1.Volume{{
+		Name: "cache",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: S3LocalDir(p.Snapshot),
+				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+			},
+		},
+	}}
+	mounts := []corev1.VolumeMount{{Name: "cache", MountPath: DownloadMount}}
+	var env []corev1.EnvVar
+	if p.CredentialsSecretName != "" {
+		env = append(env, corev1.EnvVar{Name: "DOCKER_CONFIG", Value: ociDownloadAuthMount})
+		mounts = append(mounts, corev1.VolumeMount{Name: "oras-auth", MountPath: ociDownloadAuthMount, ReadOnly: true})
+		volumes = append(volumes, corev1.Volume{
+			Name: "oras-auth",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: p.CredentialsSecretName,
+					Items:      []corev1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
+				},
+			},
+		})
+	}
+
+	labels := map[string]string{
+		"app.kubernetes.io/name":      "kubeswift",
+		"app.kubernetes.io/component": p.Component,
+	}
+	for k, v := range p.ExtraLabels {
+		labels[k] = v
+	}
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: p.Name, Namespace: p.Namespace, Labels: labels},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: ptr.To(DownloadBackoffLimit),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					NodeName:      p.Node,
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+					Containers: []corev1.Container{{
+						Name:         "download",
+						Image:        p.Image,
+						Args:         args,
+						Env:          env,
+						VolumeMounts: mounts,
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+							RunAsUser:                ptr.To(int64(0)),
+							RunAsNonRoot:             ptr.To(false),
+							ReadOnlyRootFilesystem:   ptr.To(true),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						},
+					}},
+					Volumes: volumes,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## ORAS at-rest VM-disk artifacts — Phase 1, PR 2c (SwiftRestore restore path)

Fourth PR of the ORAS arc (after #295 API, #296 image, #297 capture). Adds the **SwiftRestore** restore path for the `oci` backend: pull the OCI artifact from the registry into a node-local cache via a `snapshot-oras` download Job, then the **shared Tier-B restore tail** (`materializeRestoreTarget`) boots the restore-receive guest — identical to the s3 restore, just a registry pull. The restore pulls **by `status.oci.manifestDigest`** (pinned to the exact captured artifact).

### What's in
- **`clonecommon.BuildOCIDownloadJob`** — node-pinned, `/snap` RW cache hostPath, RunAsRoot, dockerconfigjson creds at `DOCKER_CONFIG` (or anonymous), pull `--digest`.
- **`swiftrestore/oci.go`** — `handlePendingOCI` (validate `status.oci` + resolve node + ensure download Job → Downloading) + `handleDownloadingOCI` (watch Job → shared Tier-B tail); reuses `resolveS3RestoreNode` + `s3RestoreLocalDir` (backend-neutral).
- **`controller.go`** — Pending `oci` case + Downloading branch (`downloadBackendIsOCI`).
- **`main.go`** — `SnapshotORASImage` on the SwiftRestore reconciler.

### Test
Unit: `buildOCIDownloadJob` (args, `--digest`, node-pin, RunAsRoot, dockerconfigjson + anonymous), `ociRestoreTag`, and `handlePendingOCI` fail-loud on a snapshot with no `status.oci`. All swiftrestore + clonecommon tests green; build/vet/fmt clean.

### Not in this PR
- **cloneFromSnapshot-from-oci** (boot a clone directly from an oci snapshot) — PR 2d.
- **Cluster restore round-trip** — restoring the `oci-snap1` artifact (already in Zot from #297's validation) → new guest boots byte-identical. Running now on the 2c branch controller image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)