### PR TITLE
feat(snapshot): cloneFromSnapshot from an oci snapshot (Phase 1, PR 2d)

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -170,6 +170,7 @@ func main() {
 		MigrationMTLSEnabled: *migrationMTLSEnabled,
 		SystemNamespace:      leaderElectionNS,
 		SnapshotS3Image:      swiftsnapshot.SnapshotS3Image(),
+		SnapshotORASImage:    swiftsnapshot.SnapshotORASImage(),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftGuest controller")
 		os.Exit(1)

--- a/internal/controller/swiftguest/clone.go
+++ b/internal/controller/swiftguest/clone.go
@@ -86,8 +86,28 @@ func (r *SwiftGuestReconciler) prepareCloneFromSnapshot(
 			return nil, "", true, nil
 		}
 		snapshotPath = clonecommon.S3LocalDir(&snap)
+	case snapshotv1alpha1.SnapshotBackendOCI:
+		node = src.TargetNode
+		if node == "" {
+			return nil, "cloneFromSnapshot from an oci snapshot requires spec.cloneFromSnapshot.targetNode", false, nil
+		}
+		if snap.Status.OCI == nil || snap.Status.OCI.ManifestDigest == "" {
+			return nil, "SwiftSnapshot " + snap.Name + " has no status.oci — its push is not complete", false, nil
+		}
+		done, failReason, derr := r.ensureCloneDownloadJob(ctx, guest, &snap, node)
+		if derr != nil {
+			return nil, "", false, derr
+		}
+		if failReason != "" {
+			return nil, failReason, false, nil
+		}
+		if !done {
+			// Still pulling the snapshot artifacts onto the target node.
+			return nil, "", true, nil
+		}
+		snapshotPath = clonecommon.S3LocalDir(&snap)
 	default:
-		return nil, "cloneFromSnapshot requires a memory snapshot (backend.type: local or s3); got " + string(snap.Spec.Backend.Type), false, nil
+		return nil, "cloneFromSnapshot requires a memory snapshot (backend.type: local, s3, or oci); got " + string(snap.Spec.Backend.Type), false, nil
 	}
 
 	// The clone needs the source guest's full spec (image/seed/class) to build
@@ -254,23 +274,15 @@ func (r *SwiftGuestReconciler) ensureCloneDownloadJob(
 	snap *snapshotv1alpha1.SwiftSnapshot,
 	node string,
 ) (bool, string, error) {
-	if r.SnapshotS3Image == "" {
-		return false, "snapshot-s3 image not configured (set KUBESWIFT_SNAPSHOT_S3_IMAGE)", nil
-	}
 	// The Job lives in the snapshot's namespace (== the guest's namespace).
 	name := cloneDownloadJobName(snap, node)
 	var job batchv1.Job
 	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: snap.Namespace}, &job)
 	if apierrors.IsNotFound(err) {
-		j := clonecommon.BuildDownloadJob(clonecommon.DownloadJobParams{
-			Snapshot:    snap,
-			Image:       r.SnapshotS3Image,
-			Name:        name,
-			Namespace:   snap.Namespace,
-			Node:        node,
-			Component:   "snapshot-s3-clone-download",
-			ExtraLabels: map[string]string{"kubeswift.io/snapshot": snap.Name},
-		})
+		j, failReason := r.buildCloneDownloadJob(snap, node, name)
+		if failReason != "" {
+			return false, failReason, nil
+		}
 		if cerr := ctrl.SetControllerReference(guest, j, r.Scheme); cerr != nil {
 			return false, "", cerr
 		}
@@ -299,4 +311,56 @@ func (r *SwiftGuestReconciler) ensureCloneDownloadJob(
 		}
 	}
 	return false, "", nil
+}
+
+// buildCloneDownloadJob builds the s3 or oci clone download Job for the
+// snapshot's backend. Returns (job, failReason): a non-empty failReason is
+// terminal (the required transfer image is not configured).
+func (r *SwiftGuestReconciler) buildCloneDownloadJob(snap *snapshotv1alpha1.SwiftSnapshot, node, name string) (*batchv1.Job, string) {
+	labels := map[string]string{"kubeswift.io/snapshot": snap.Name}
+	if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendOCI {
+		if r.SnapshotORASImage == "" {
+			return nil, "snapshot-oras image not configured (set KUBESWIFT_SNAPSHOT_ORAS_IMAGE)"
+		}
+		oci := snap.Spec.Backend.OCI
+		credName := ""
+		if oci.CredentialsSecretRef != nil {
+			credName = oci.CredentialsSecretRef.Name
+		}
+		return clonecommon.BuildOCIDownloadJob(clonecommon.OCIDownloadJobParams{
+			Snapshot:              snap,
+			Repository:            oci.Repository,
+			Tag:                   cloneOCITag(snap),
+			Digest:                snap.Status.OCI.ManifestDigest,
+			Insecure:              oci.Insecure,
+			CredentialsSecretName: credName,
+			Image:                 r.SnapshotORASImage,
+			Name:                  name,
+			Namespace:             snap.Namespace,
+			Node:                  node,
+			Component:             "snapshot-oci-clone-download",
+			ExtraLabels:           labels,
+		}), ""
+	}
+	if r.SnapshotS3Image == "" {
+		return nil, "snapshot-s3 image not configured (set KUBESWIFT_SNAPSHOT_S3_IMAGE)"
+	}
+	return clonecommon.BuildDownloadJob(clonecommon.DownloadJobParams{
+		Snapshot:    snap,
+		Image:       r.SnapshotS3Image,
+		Name:        name,
+		Namespace:   snap.Namespace,
+		Node:        node,
+		Component:   "snapshot-s3-clone-download",
+		ExtraLabels: labels,
+	}), ""
+}
+
+// cloneOCITag resolves the artifact tag: the operator-supplied tag, or the
+// "<namespace>-<name>" default (matching the capture + restore sides).
+func cloneOCITag(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	if snap.Spec.Backend.OCI != nil && snap.Spec.Backend.OCI.Tag != "" {
+		return snap.Spec.Backend.OCI.Tag
+	}
+	return snap.Namespace + "-" + snap.Name
 }

--- a/internal/controller/swiftguest/clone_test.go
+++ b/internal/controller/swiftguest/clone_test.go
@@ -183,6 +183,74 @@ func TestPrepareCloneFromSnapshot_TierC_DownloadsThenProceeds(t *testing.T) {
 	}
 }
 
+func ociCloneSnap() *snapshotv1alpha1.SwiftSnapshot {
+	return &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "snap", Namespace: "ns"},
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			GuestRef: snapshotv1alpha1.SwiftSnapshotGuestRef{Name: "src"},
+			Backend: snapshotv1alpha1.SwiftSnapshotBackend{
+				Type: snapshotv1alpha1.SnapshotBackendOCI,
+				OCI:  &snapshotv1alpha1.OCIBackend{Repository: "zot.svc:5000/vmsnap", Insecure: true},
+			},
+		},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{
+			Phase: snapshotv1alpha1.SwiftSnapshotPhaseReady,
+			OCI:   &snapshotv1alpha1.OCISnapshotStatus{Reference: "zot.svc:5000/vmsnap:ns-snap", ManifestDigest: "sha256:abc"},
+		},
+	}
+}
+
+func TestCloneOCITag(t *testing.T) {
+	if got := cloneOCITag(ociCloneSnap()); got != "ns-snap" {
+		t.Errorf("default oci clone tag = %q, want ns-snap", got)
+	}
+}
+
+func TestPrepareCloneFromSnapshot_OCI_RequiresTargetNode(t *testing.T) {
+	g := cloneGuest() // no targetNode
+	r, _ := newCloneReconciler(t, g, sourceGuest(), ociCloneSnap())
+	r.SnapshotORASImage = "img"
+	_, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || !strings.Contains(fail, "requires spec.cloneFromSnapshot.targetNode") {
+		t.Fatalf("oci clone without targetNode should fail; fail=%q err=%v", fail, err)
+	}
+}
+
+func TestPrepareCloneFromSnapshot_OCI_DownloadsThenProceeds(t *testing.T) {
+	g := cloneGuest()
+	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	r, c := newCloneReconciler(t, g, sourceGuest(), ociCloneSnap())
+	r.SnapshotORASImage = "img"
+
+	// First pass: creates the oci download Job + requeues (not yet complete).
+	_, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || fail != "" || !requeue {
+		t.Fatalf("first pass should create the oci download Job + requeue; fail=%q requeue=%v err=%v", fail, requeue, err)
+	}
+	var job batchv1.Job
+	wantJob := cloneDownloadJobName(ociCloneSnap(), "boba")
+	if err := c.Get(context.Background(), client.ObjectKey{Name: wantJob, Namespace: "ns"}, &job); err != nil {
+		t.Fatalf("oci download Job not created: %v", err)
+	}
+	args := strings.Join(job.Spec.Template.Spec.Containers[0].Args, " ")
+	if !strings.Contains(args, "--mode=download") || !strings.Contains(args, "--repository=zot.svc:5000/vmsnap") || !strings.Contains(args, "--digest=sha256:abc") {
+		t.Errorf("download Job is not an oci pull-by-digest: %q", args)
+	}
+	if job.Spec.Template.Spec.NodeName != "boba" {
+		t.Errorf("oci download Job must pin to targetNode boba; got %q", job.Spec.Template.Spec.NodeName)
+	}
+
+	// Mark the Job complete; second pass should proceed (effective + stamped).
+	job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+	if err := c.Status().Update(context.Background(), &job); err != nil {
+		t.Fatal(err)
+	}
+	eff, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || fail != "" || requeue || eff == nil {
+		t.Fatalf("after oci download completes, should proceed; fail=%q requeue=%v err=%v", fail, requeue, err)
+	}
+}
+
 func TestCloneDownloadJobName_PerNodeSnapshot(t *testing.T) {
 	snap := s3CloneSnap()
 	// Deterministic + DNS-1123 valid + guest-independent.

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -82,6 +82,10 @@ type SwiftGuestReconciler struct {
 	// before the restore-receive launcher boots. Wired from
 	// KUBESWIFT_SNAPSHOT_S3_IMAGE.
 	SnapshotS3Image string
+	// SnapshotORASImage is the snapshot-oras downloader image used by a
+	// cloneFromSnapshot guest cloning from an oci snapshot. Wired from
+	// KUBESWIFT_SNAPSHOT_ORAS_IMAGE.
+	SnapshotORASImage string
 }
 
 // Reconcile implements the reconcile loop.


### PR DESCRIPTION
## ORAS at-rest VM-disk artifacts — Phase 1, PR 2d (cloneFromSnapshot-from-oci)

Final PR of the ORAS Phase-1 arc (after #295 API, #296 image, #297 capture, #298 restore). Boots a `SwiftGuest.spec.cloneFromSnapshot` clone **directly from a `backend.type: oci` snapshot**: a node-pinned `snapshot-oras` download Job (shared per `(node, snapshot)` across replicas) pulls the artifact **by digest** into the target node's cache, then the clone boots via CH `--restore` — mirroring the s3 clone path. **Completes the oci snapshot/restore/clone triad.**

### What's in
- **`clone.go`** — `oci` case in `prepareCloneFromSnapshot` (requires `spec.cloneFromSnapshot.targetNode` + `status.oci`); `ensureCloneDownloadJob` branches s3-vs-oci via a `buildCloneDownloadJob` helper (`clonecommon.BuildOCIDownloadJob`, pull by `status.oci.manifestDigest`, dockerconfigjson or anonymous); `cloneOCITag` defaults to `<ns>-<name>`.
- **`controller.go` + `main.go`** — `SnapshotORASImage` on the SwiftGuest reconciler.

### Test
Unit: `TestPrepareCloneFromSnapshot_OCI_DownloadsThenProceeds` (download Job is an oci pull-by-digest, node-pinned, then proceeds on completion), `_RequiresTargetNode`, `TestCloneOCITag`; all swiftguest tests green; build/vet/fmt clean.

### Works for pools
A `SwiftGuestPool` templating `cloneFromSnapshot` on an oci snapshot dedups the download per `(node, snapshot)` exactly like s3 (the `cloneDownloadJobName` + cache dir are snapshot-keyed).

### Cluster validation
Running now on the 2d branch controller — a `cloneFromSnapshot` guest from the `oci-snap1` artifact (in Zot from #297) → boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)