### PR TITLE
feat(image): golden-image chunked transfer — upload/download-image (P3, PR 2a)

### DIFF
--- a/cmd/snapshot-oras/image.go
+++ b/cmd/snapshot-oras/image.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	godigest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+)
+
+// Golden-image (P3) artifact types. A golden VM disk is stored CHUNKED so
+// identical chunks dedup by content address: zero windows are never stored, and
+// unchanged blocks across versions (v1 -> v1.1) are shared. See
+// docs/design/oras-golden-image.md.
+const (
+	vmImageArtifactType = "application/vnd.kubeswift.vmimage.v1"
+	vmImageConfigType   = "application/vnd.kubeswift.vmimage.config.v1+json"
+	vmDiskChunkType     = "application/vnd.kubeswift.vmdisk.chunk.v1"
+	// chunkOffsetAnnotation records a chunk layer's byte offset in the disk;
+	// the offset is authoritative (not layer order), so an identical chunk at the
+	// same offset across versions yields a byte-identical descriptor -> dedup.
+	chunkOffsetAnnotation = "kubeswift.io/chunk-offset"
+)
+
+// vmImageConfig is the artifact's config blob: enough to reassemble the sparse
+// disk (totalSize is the truncate target; chunkSize is informational).
+type vmImageConfig struct {
+	TotalSize int64  `json:"totalSize"`
+	ChunkSize int64  `json:"chunkSize"`
+	Format    string `json:"format"`
+	OSType    string `json:"osType,omitempty"`
+}
+
+// chunkAndPush streams filePath in chunkSize windows, SKIPS all-zero windows
+// (never stored — a raw disk is sparse), and pushes each non-zero chunk as one
+// digest-addressed layer. A chunk already present in dst (a re-push of an
+// unchanged v1.1 block, or a repeated non-zero pattern) is counted as skipped
+// (deduped), not re-uploaded — so transferredBytes/totalBytes is the dedup
+// figure. Streams window-by-window; the whole disk is never held in memory.
+func chunkAndPush(ctx context.Context, filePath string, dst oras.Target, tag string, chunkSize int64, format, osType string) (ocispec.Descriptor, transferStats, error) {
+	var zero ocispec.Descriptor
+	f, err := os.Open(filePath)
+	if err != nil {
+		return zero, transferStats{}, err
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		return zero, transferStats{}, err
+	}
+	totalSize := fi.Size()
+
+	buf := make([]byte, chunkSize)
+	zeros := make([]byte, chunkSize)
+	var layers []ocispec.Descriptor
+	var transferred, skipped int64
+	offset := int64(0)
+	for {
+		n, rerr := io.ReadFull(f, buf)
+		if n > 0 {
+			chunk := buf[:n]
+			if !bytes.Equal(chunk, zeros[:n]) {
+				desc := ocispec.Descriptor{
+					MediaType:   vmDiskChunkType,
+					Digest:      godigest.FromBytes(chunk),
+					Size:        int64(n),
+					Annotations: map[string]string{chunkOffsetAnnotation: strconv.FormatInt(offset, 10)},
+				}
+				exists, eerr := dst.Exists(ctx, desc)
+				if eerr != nil {
+					return zero, transferStats{}, fmt.Errorf("exists check at offset %d: %w", offset, eerr)
+				}
+				if exists {
+					skipped += int64(n)
+				} else {
+					// Push reads the reader fully before returning, so buf is safe to reuse.
+					if perr := dst.Push(ctx, desc, bytes.NewReader(chunk)); perr != nil {
+						return zero, transferStats{}, fmt.Errorf("push chunk at offset %d: %w", offset, perr)
+					}
+					transferred += int64(n)
+				}
+				layers = append(layers, desc)
+			}
+			offset += int64(n)
+		}
+		if rerr == io.EOF || rerr == io.ErrUnexpectedEOF {
+			break
+		}
+		if rerr != nil {
+			return zero, transferStats{}, fmt.Errorf("read %s: %w", filePath, rerr)
+		}
+	}
+
+	// Config blob (must be pushed before the manifest that references it).
+	cfgBytes, err := json.Marshal(vmImageConfig{TotalSize: totalSize, ChunkSize: chunkSize, Format: format, OSType: osType})
+	if err != nil {
+		return zero, transferStats{}, err
+	}
+	cfgDesc := ocispec.Descriptor{MediaType: vmImageConfigType, Digest: godigest.FromBytes(cfgBytes), Size: int64(len(cfgBytes))}
+	if exists, _ := dst.Exists(ctx, cfgDesc); !exists {
+		if err := dst.Push(ctx, cfgDesc, bytes.NewReader(cfgBytes)); err != nil {
+			return zero, transferStats{}, fmt.Errorf("push config: %w", err)
+		}
+	}
+
+	manifestDesc, err := oras.PackManifest(ctx, dst, oras.PackManifestVersion1_1, vmImageArtifactType,
+		oras.PackManifestOptions{Layers: layers, ConfigDescriptor: &cfgDesc})
+	if err != nil {
+		return zero, transferStats{}, fmt.Errorf("pack manifest: %w", err)
+	}
+	if err := dst.Tag(ctx, manifestDesc, tag); err != nil {
+		return zero, transferStats{}, fmt.Errorf("tag: %w", err)
+	}
+	return manifestDesc, transferStats{
+		TransferredBytes: transferred,
+		SkippedBytes:     skipped,
+		TotalBytes:       totalSize,
+		ManifestDigest:   manifestDesc.Digest.String(),
+	}, nil
+}
+
+// pullAndReassemble resolves ref (tag or digest), reads the config, truncates
+// filePath to totalSize (a sparse file — omitted zero windows cost nothing), then
+// fetches each chunk layer (content.FetchAll verifies the digest, so a corrupt
+// chunk fails loudly) and writes it at its recorded offset.
+func pullAndReassemble(ctx context.Context, src oras.ReadOnlyTarget, ref, filePath string) (ocispec.Descriptor, error) {
+	var zero ocispec.Descriptor
+	manifestDesc, err := src.Resolve(ctx, ref)
+	if err != nil {
+		return zero, fmt.Errorf("resolve %s: %w", ref, err)
+	}
+	manifestBytes, err := content.FetchAll(ctx, src, manifestDesc)
+	if err != nil {
+		return zero, fmt.Errorf("fetch manifest: %w", err)
+	}
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return zero, fmt.Errorf("parse manifest: %w", err)
+	}
+	if manifest.ArtifactType != vmImageArtifactType && manifest.Config.MediaType != vmImageConfigType {
+		return zero, fmt.Errorf("not a kubeswift golden image (artifactType %q)", manifest.ArtifactType)
+	}
+	cfgBytes, err := content.FetchAll(ctx, src, manifest.Config)
+	if err != nil {
+		return zero, fmt.Errorf("fetch config: %w", err)
+	}
+	var cfg vmImageConfig
+	if err := json.Unmarshal(cfgBytes, &cfg); err != nil {
+		return zero, fmt.Errorf("parse config: %w", err)
+	}
+
+	f, err := os.Create(filePath)
+	if err != nil {
+		return zero, err
+	}
+	defer f.Close()
+	if err := f.Truncate(cfg.TotalSize); err != nil {
+		return zero, fmt.Errorf("truncate to %d: %w", cfg.TotalSize, err)
+	}
+	for _, layer := range manifest.Layers {
+		// Skip non-chunk layers — oras.PackManifest injects an OCI "empty"
+		// placeholder layer when there are no real layers (an all-zero disk).
+		if layer.MediaType != vmDiskChunkType {
+			continue
+		}
+		off, err := strconv.ParseInt(layer.Annotations[chunkOffsetAnnotation], 10, 64)
+		if err != nil {
+			return zero, fmt.Errorf("chunk %s missing/bad %s: %w", layer.Digest, chunkOffsetAnnotation, err)
+		}
+		data, err := content.FetchAll(ctx, src, layer) // verifies digest + size
+		if err != nil {
+			return zero, fmt.Errorf("fetch chunk at offset %d: %w", off, err)
+		}
+		if _, err := f.WriteAt(data, off); err != nil {
+			return zero, fmt.Errorf("write chunk at offset %d: %w", off, err)
+		}
+	}
+	return manifestDesc, nil
+}

--- a/cmd/snapshot-oras/image_test.go
+++ b/cmd/snapshot-oras/image_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oras.land/oras-go/v2/content/memory"
+)
+
+func writeDisk(t *testing.T, path string, windows [][]byte) {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, w := range windows {
+		buf.Write(w)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const testChunk = 4096
+
+func mkWindows() (a, b, short, zero []byte) {
+	return bytes.Repeat([]byte{0xAB}, testChunk),
+		bytes.Repeat([]byte{0xCD}, testChunk),
+		bytes.Repeat([]byte{0xEF}, 100),
+		make([]byte, testChunk)
+}
+
+// A disk of 6 windows: data, zero, data, zero, zero, short-data. 3 non-zero
+// chunks stored; 3 zero windows skipped; total = 5*chunk + 100.
+func TestChunkRoundTrip_ByteIdentical_ZeroSkip(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "image.raw")
+	a, b, short, zero := mkWindows()
+	writeDisk(t, src, [][]byte{a, zero, b, zero, zero, short})
+	orig, _ := os.ReadFile(src)
+
+	store := memory.New()
+	_, stats, err := chunkAndPush(context.Background(), src, store, "v1", testChunk, "raw", "linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantTransferred := int64(2*testChunk + 100) // a + b + short; zeros skipped
+	wantTotal := int64(5*testChunk + 100)
+	if stats.TransferredBytes != wantTransferred {
+		t.Errorf("transferred = %d, want %d (zero windows must not be pushed)", stats.TransferredBytes, wantTransferred)
+	}
+	if stats.SkippedBytes != 0 {
+		t.Errorf("skipped = %d, want 0 on a fresh store", stats.SkippedBytes)
+	}
+	if stats.TotalBytes != wantTotal {
+		t.Errorf("total = %d, want %d", stats.TotalBytes, wantTotal)
+	}
+
+	dst := filepath.Join(dir, "out.raw")
+	if _, err := pullAndReassemble(context.Background(), store, "v1", dst); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(dst)
+	if !bytes.Equal(got, orig) {
+		t.Errorf("reassembled disk differs from original (len got=%d orig=%d)", len(got), len(orig))
+	}
+}
+
+// Re-pushing a v1.1 that changed ONE chunk transfers only that chunk; the
+// unchanged chunks (same digest) are deduped as skipped. This is the ~97%
+// cross-version dedup in miniature.
+func TestChunkDedup_ChangedChunkOnly(t *testing.T) {
+	dir := t.TempDir()
+	a, b, short, zero := mkWindows()
+	store := memory.New()
+
+	v1 := filepath.Join(dir, "v1.raw")
+	writeDisk(t, v1, [][]byte{a, zero, b, zero, zero, short})
+	if _, _, err := chunkAndPush(context.Background(), v1, store, "v1", testChunk, "raw", "linux"); err != nil {
+		t.Fatal(err)
+	}
+
+	// v1.1: same layout, but the middle data chunk changed in place.
+	bChanged := bytes.Repeat([]byte{0x12}, testChunk)
+	v2 := filepath.Join(dir, "v2.raw")
+	writeDisk(t, v2, [][]byte{a, zero, bChanged, zero, zero, short})
+	_, stats2, err := chunkAndPush(context.Background(), v2, store, "v11", testChunk, "raw", "linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats2.TransferredBytes != int64(testChunk) {
+		t.Errorf("v1.1 transferred = %d, want %d (only the one changed chunk)", stats2.TransferredBytes, testChunk)
+	}
+	if stats2.SkippedBytes != int64(testChunk+100) {
+		t.Errorf("v1.1 skipped = %d, want %d (a + short deduped)", stats2.SkippedBytes, testChunk+100)
+	}
+
+	// v1.1 still reassembles correctly.
+	out := filepath.Join(dir, "v2out.raw")
+	if _, err := pullAndReassemble(context.Background(), store, "v11", out); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(out)
+	orig, _ := os.ReadFile(v2)
+	if !bytes.Equal(got, orig) {
+		t.Error("v1.1 reassembled disk differs from original")
+	}
+}
+
+// An all-zero disk stores nothing but still round-trips to the right size.
+func TestChunkAllZero_NoLayers(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "sparse.raw")
+	if err := os.WriteFile(src, make([]byte, 3*testChunk), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := memory.New()
+	_, stats, err := chunkAndPush(context.Background(), src, store, "z", testChunk, "raw", "linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.TransferredBytes != 0 {
+		t.Errorf("all-zero disk transferred = %d, want 0", stats.TransferredBytes)
+	}
+	if stats.TotalBytes != int64(3*testChunk) {
+		t.Errorf("total = %d, want %d", stats.TotalBytes, 3*testChunk)
+	}
+	out := filepath.Join(dir, "zout.raw")
+	if _, err := pullAndReassemble(context.Background(), store, "z", out); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(out)
+	if !bytes.Equal(got, make([]byte, 3*testChunk)) {
+		t.Error("all-zero reassembly is not all-zero / wrong size")
+	}
+}

--- a/cmd/snapshot-oras/main.go
+++ b/cmd/snapshot-oras/main.go
@@ -12,6 +12,13 @@
 //	snapshot-oras --mode=download --dir=/snap --repository=REPO --tag=TAG [--digest=sha256:...] [--insecure]
 //	snapshot-oras --mode=delete   --repository=REPO --tag=TAG [--insecure]
 //
+// It also chunks/reassembles a golden raw VM disk (P3 — sparse, zero-skipping,
+// content-addressed chunks that dedup zero regions + unchanged cross-version
+// blocks; see docs/design/oras-golden-image.md):
+//
+//	snapshot-oras --mode=upload-image   --file=/data/image.raw --repository=REPO --tag=TAG [--chunk-size-mib=64] [--os-type=linux] [--insecure]
+//	snapshot-oras --mode=download-image --file=/data/image.raw --repository=REPO --tag=TAG [--digest=sha256:...] [--insecure]
+//
 // Registry credentials come from a Docker config (DOCKER_CONFIG points at the
 // dockerconfigjson pull-secret the controller mounts) — never from flags or logs.
 package main
@@ -44,20 +51,25 @@ func reportTransfer(s transferStats) {
 }
 
 func main() {
-	mode := flag.String("mode", "", "upload | download | delete")
+	mode := flag.String("mode", "", "upload | download | upload-image | download-image | delete")
 	dir := flag.String("dir", "", "local snapshot directory (source for upload, destination for download)")
 	repository := flag.String("repository", "", "OCI repository without a tag (e.g. ghcr.io/org/vm-snapshots)")
 	tag := flag.String("tag", "", "artifact tag")
-	digest := flag.String("digest", "", "pull by this manifest digest instead of the tag — pins the artifact (download only)")
+	digest := flag.String("digest", "", "pull by this manifest digest instead of the tag — pins the artifact (download / download-image)")
 	insecure := flag.Bool("insecure", false, "allow a plaintext (http) registry — UNSAFE; in-cluster / test registry only")
 	snapName := flag.String("snapshot", "", "ns/name of the SwiftSnapshot, recorded in the manifest annotations (upload only)")
 	includeMemory := flag.Bool("include-memory", false, "record includeMemory=true in the manifest (upload only)")
 	signKey := flag.String("sign-key", "", "path to a cosign private key; when set, cosign-sign the pushed artifact as an OCI referrer (upload only; COSIGN_PASSWORD from env)")
+	file := flag.String("file", "", "raw disk image path — golden-image chunking (upload-image: source; download-image: destination)")
+	chunkSizeMiB := flag.Int("chunk-size-mib", 64, "chunk size in MiB for golden-image chunking (upload-image only)")
+	osType := flag.String("os-type", "linux", "os family recorded in the golden-image config: linux | windows (upload-image only)")
+	format := flag.String("format", "raw", "disk format recorded in the golden-image config (upload-image only)")
 	flag.Parse()
 
 	if err := run(runArgs{
 		mode: *mode, dir: *dir, repository: *repository, tag: *tag, digest: *digest,
 		insecure: *insecure, snapName: *snapName, includeMemory: *includeMemory, signKey: *signKey,
+		file: *file, chunkSizeMiB: *chunkSizeMiB, osType: *osType, format: *format,
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, "snapshot-oras:", err)
 		os.Exit(1)
@@ -66,25 +78,46 @@ func main() {
 
 type runArgs struct {
 	mode, dir, repository, tag, digest, snapName, signKey string
+	file, osType, format                                  string
+	chunkSizeMiB                                          int
 	insecure, includeMemory                               bool
 }
 
 func (a runArgs) validate() error {
+	if a.repository == "" {
+		return fmt.Errorf("--repository is required")
+	}
 	switch a.mode {
 	case "upload", "download":
 		if a.dir == "" {
 			return fmt.Errorf("--dir is required for %s", a.mode)
 		}
+		if a.tag == "" {
+			return fmt.Errorf("--tag is required")
+		}
+	case "upload-image":
+		if a.file == "" {
+			return fmt.Errorf("--file is required for upload-image")
+		}
+		if a.tag == "" {
+			return fmt.Errorf("--tag is required")
+		}
+		if a.chunkSizeMiB <= 0 {
+			return fmt.Errorf("--chunk-size-mib must be positive")
+		}
+	case "download-image":
+		if a.file == "" {
+			return fmt.Errorf("--file is required for download-image")
+		}
+		if a.tag == "" && a.digest == "" {
+			return fmt.Errorf("--tag or --digest is required for download-image")
+		}
 	case "delete":
-		// delete operates purely on the registry (no local dir).
+		if a.tag == "" {
+			return fmt.Errorf("--tag is required")
+		}
 	default:
-		return fmt.Errorf("--mode must be \"upload\", \"download\", or \"delete\"")
-	}
-	if a.repository == "" {
-		return fmt.Errorf("--repository is required")
-	}
-	if a.tag == "" {
-		return fmt.Errorf("--tag is required")
+		return fmt.Errorf("--mode must be \"upload\", \"download\", \"upload-image\", \"download-image\", or \"delete\"")
 	}
 	return nil
 }
@@ -128,6 +161,27 @@ func run(a runArgs) error {
 		}
 		// Download reports the footprint on the status side; wire-vs-skip byte
 		// accounting is an upload-side concern.
+		reportTransfer(transferStats{Reference: ref, ManifestDigest: desc.Digest.String()})
+	case "upload-image":
+		format := a.format
+		if format == "" {
+			format = "raw"
+		}
+		_, stats, err := chunkAndPush(ctx, a.file, repo, a.tag, int64(a.chunkSizeMiB)*1024*1024, format, a.osType)
+		if err != nil {
+			return err
+		}
+		stats.Reference = ref
+		reportTransfer(stats)
+	case "download-image":
+		pullRef := a.tag
+		if a.digest != "" {
+			pullRef = a.digest // pinned pull by digest
+		}
+		desc, err := pullAndReassemble(ctx, repo, pullRef, a.file)
+		if err != nil {
+			return err
+		}
 		reportTransfer(transferStats{Reference: ref, ManifestDigest: desc.Digest.String()})
 	case "delete":
 		return deleteArtifact(ctx, repo, a.tag)

--- a/docs/design/oras-golden-image.md
+++ b/docs/design/oras-golden-image.md
@@ -1,173 +1,174 @@
 # ORAS Golden Image (P3) — `SwiftImage.spec.source.oci` Design
 
-Status: **Proposed** — Staff-Architect, 2026-07-01. Sub-phase P3 of the ORAS arc
+Status: **Accepted (Path B — chunked dedup)** — Staff-Architect, 2026-07-01.
+Sub-phase P3 of the ORAS arc
 ([`oras-vm-disk-artifacts.md`](oras-vm-disk-artifacts.md) §6, §11). Follows P1
-(snapshot/restore/clone triad, #295–#299) and P2 (provenance signing, #300).
+(snapshot/restore/clone triad, #295–#299) and P2 (provenance signing, #300). The
+API surface shipped in **PR 1 (#301)**; this doc now specifies the **chunked**
+artifact + transfer (PR 2), the path chosen for the cross-version dedup win.
 
-Adds a fourth **image source** — pull a golden VM disk from an OCI registry —
-so a base image is published once and consumed everywhere: portable across
-clusters, content-addressed (one digest → stored once), and layer-cache-reused.
-This is the consumption side of the ADR's golden-image story; the ~97%
-cross-version dedup the spike measured is a **follow-on** (needs disk chunking —
-§5), not P3 v1.
+Adds a fourth **image source** — pull a golden VM disk from an OCI registry — so a
+base image is published once and consumed everywhere, and (the reason for Path B)
+a mostly-unchanged **v1.1 re-uses v1's bytes**: the registry stores only the
+chunks that actually changed.
 
 ---
 
 ## 1. Goal
 
-`SwiftImage.spec.source.oci` pulls a golden **raw** disk artifact from any OCI
+`SwiftImage.spec.source.oci` materializes a golden **raw** disk from an OCI
 registry into the import PVC, then reuses the existing import tail
 (resize + `sgdisk -e` + GRUB/serial patch) to produce the same `Ready` raw
-`preparedArtifact` an `http` source produces. A `source: oci` image then composes
-with `cloneStrategy: copy|snapshot` **unchanged** — the import PVC is identical,
-so per-guest cloning, snapshots, pools, and boot all work as-is.
+`preparedArtifact` an `http` source produces. Composes with
+`cloneStrategy: copy|snapshot` unchanged.
+
+The disk is stored **chunked** so identical chunks dedup by content address:
+- **zero regions** (a raw disk is mostly zeros) collapse — they are never stored,
+- **unchanged blocks across versions** (a package upgrade rewrites scattered
+  blocks, not the whole disk) are shared,
+
+yielding the spike's ~97% cross-version dedup for a mostly-unchanged image.
 
 Grounding (the pipeline this slots into):
 [`import.go:StartImport()`](../../internal/controller/swiftimage/import.go)
-dispatches on `spec.source` → `importHTTP` builds an `ubuntu:22.04` Job whose
-`importScript()` does curl-download → `qemu-img convert` (qcow2 only) → size →
-GRUB patch (Linux, privileged loop-mount); `Prepare()` stamps
-`status.preparedArtifact` (raw PVC). P3 adds an `importOCI` sibling that swaps the
-**download step only**.
+dispatches on `spec.source`; `importHTTP` builds an `ubuntu:22.04` Job whose
+`importScript()` does curl-download → `qemu-img convert` (qcow2) → size → GRUB
+patch (Linux, privileged loop-mount); `Prepare()` stamps
+`status.preparedArtifact`. P3 adds an `importOCI` sibling that swaps the
+**download step** for a chunk-reassembling puller.
 
 ---
 
 ## 2. Decisions
 
-### 2.1 The artifact — a single raw disk layer, `artifactType` distinct from snapshots
+### 2.1 Chunking scheme — sparse, offset-based, **fixed-size** (default 64 MiB)
 
-A golden image is **one raw disk blob**, far simpler than a snapshot's
-multi-file layout (config.json/state.json/memory-ranges). The OCI artifact:
+The golden raw disk is split into fixed-size windows. Each window is classified:
 
-- `artifactType: application/vnd.kubeswift.vmimage.v1` — **distinct** from the
-  snapshot type (`…vmsnapshot.v1`); a golden image is semantically not a
-  snapshot, and the distinct type lets a registry/tooling tell them apart.
-- **one layer**, mediaType `application/vnd.kubeswift.vmdisk.raw.v1`, title
-  annotation `image.raw` — so the existing `snapshot-oras --mode=download`
-  materializes it to `<dir>/image.raw` by title, no new puller code.
-- manifest annotations record the source OS / format for humans.
+- **all-zero → recorded as nothing.** A raw disk is sparse (a 40 GiB disk with a
+  3 GiB OS is ~90% zero); the manifest simply omits zero windows, so no zero
+  bytes are ever pushed, pulled, or stored. The importer zero-fills by writing
+  chunks into a sparse file at their offsets.
+- **non-zero → one OCI layer**, `digest = sha256(chunk)`, recorded in the
+  manifest as `{offset, size, digest}`. The registry dedups identical digests
+  automatically: the same OS block at the same offset in v1 and v1.1 is one blob;
+  a changed block gets a new digest and is the only thing re-pushed.
 
-**Raw at rest** (Design Principle #3): the published artifact SHOULD be raw so
-the import skips `qemu-img convert` and the bytes are dedup-friendly. The import
-still honors `spec.format` (converts a qcow2 layer) for flexibility, but raw is
-recommended and is what the publish recipe (§2.4) produces.
+**Fixed-size, not content-defined (CDC).** VM disks are block-addressed and
+updated **in place** — a package upgrade rewrites blocks at their existing
+offsets; it does not *insert* bytes and shift the tail. So fixed-size windows stay
+aligned across versions and dedup without a rolling hash. CDC (buzhash /
+casync-style, shift-resistant) is a follow-on **only if** cluster-measured
+v1→v1.1 dedup on real images proves low (§4 measures it). Chunk size is
+configurable on publish; **64 MiB** default balances dedup granularity against
+layer count (a 3 GiB OS → ~48 data chunks). **Uncompressed** in v1 — dedup
+already handles the sparse/zero case (nothing to compress); per-chunk compression
+is a size/CPU follow-on (deterministic gzip preserves digests, so it stays
+dedup-compatible).
 
-### 2.2 The import path — reuse the snapshot-oras puller as an init container
+### 2.2 Artifact layout
 
-`importOCI` builds a Job with **two containers**, reusing both existing pieces:
+An OCI artifact, `artifactType: application/vnd.kubeswift.vmimage.v1` (distinct
+from the snapshot type):
 
-1. **initContainer** `snapshot-oras --mode=download --repository=<repo>
-   --tag=<tag>|--digest=<digest> [--insecure] --dir=/data` — pulls + digest-
-   verifies the artifact (oras `Copy` already verifies every blob against the
-   manifest) and materializes `image.raw` into the shared `/data` (the import
-   PVC). Auth reuses the dockerconfigjson mount pattern from
-   [`clonecommon.BuildOCIDownloadJob`](../../internal/snapshot/clonecommon/download.go)
-   (`DOCKER_CONFIG=/oras-auth`, or anonymous).
-2. **main container** `ubuntu:22.04` — runs an `importScript` variant that
-   **skips the curl download** (`/data/image.raw` already exists) and keeps the
-   tail: convert-if-qcow2 → size → GRUB/serial patch (Linux) — the exact
-   privileged-loop-mount steps `importHTTP` uses, gated by `osType` identically
-   (Windows → skip patch, unprivileged main container).
+- **config** blob (`application/vnd.kubeswift.vmimage.config.v1+json`): records
+  `{ totalSize, chunkSize, format: raw, osType }`.
+- **N layers**, `application/vnd.kubeswift.vmdisk.chunk.v1`, one per non-zero
+  chunk, each annotated `kubeswift.io/chunk-offset: <bytes>`. Order is by offset;
+  the offset is authoritative (not layer position), so identical chunks at the
+  same offset across versions produce byte-identical descriptors → dedup.
 
-This writes to the **import PVC** (not a node-local hostPath), so — unlike the
-snapshot download Job — it is **not node-pinned** (the PVC attaches wherever the
-Job schedules). No new pull mechanism; `importOCI` reuses `importHTTP`'s PVC
-creation/sizing verbatim.
+### 2.3 Publish — a chunking tool (`snapshot-oras --mode=upload-image`)
 
-### 2.3 Auth + API surface
-
-```go
-// ImageSource gains:
-OCI *OCIImageSource `json:"oci,omitempty"`
-
-type OCIImageSource struct {
-    Repository string  // e.g. ghcr.io/org/golden-ubuntu-noble (no tag)
-    Tag        string  // mutually exclusive with Digest
-    Digest     string  // sha256:… — pins the artifact (recommended for reproducibility)
-    Insecure   bool    // plaintext registry — UNSAFE, in-cluster/test only
-    CredentialsSecretRef *SecretObjectReference // kubernetes.io/dockerconfigjson; empty = anonymous
-}
-```
-
-`credentialsSecretRef` = dockerconfigjson (mirrors `OCIBackend` on snapshots +
-SwiftKernel's `OCIRef.PullSecret`) — the pull-credential shape the project
-already uses; NOT an S3-style access key.
-
-### 2.4 Publishing — documented `oras push` recipe (v1); first-party tool is a follow-on
-
-P3 v1 is **pull-only** — the operator publishes the golden artifact out-of-band
-with a documented layout:
+Chunking can't be a plain `oras push`, so the `snapshot-oras` binary gains:
 
 ```
-oras push <repo>:<tag> \
-  --artifact-type application/vnd.kubeswift.vmimage.v1 \
-  image.raw:application/vnd.kubeswift.vmdisk.raw.v1
+snapshot-oras --mode=upload-image --file=/data/image.raw --chunk-size=64Mi \
+  --repository=<repo> --tag=<tag> [--insecure] [--os-type=linux|windows]
 ```
 
-(`oras push` sets the layer title to the filename `image.raw` — exactly what the
-puller materializes by.) A first-party `swiftctl image publish <swiftimage>`
-(push a Ready SwiftImage's raw PVC to a registry, optionally cosign-sign via P2)
-is a clean **follow-on** — the consumption side (the portability win) is what P3
-v1 ships.
+It streams the raw file in `chunk-size` windows, **skips all-zero windows**,
+pushes each non-zero chunk (oras/registry dedups by digest — a re-push of v1.1
+only transfers changed chunks), packs the config + chunk layers into the manifest,
+and reports `{totalBytes, transferredBytes, skippedBytes, reference,
+manifestDigest}` (the existing `clonecommon.TransferReport` shape — so the dedup
+% is observable). A first-party `swiftctl image publish <swiftimage>` (chunk a
+Ready SwiftImage's PVC via a Job, optionally P2-sign) is a **follow-on**; v1 ships
+the tool + a documented recipe.
 
-### 2.5 Webhook
+### 2.4 Import — reassemble into a sparse file (`--mode=download-image`)
 
-Add `OCI` to the exactly-one-of rule in
-[`validateSwiftImage`](../../internal/webhook/swiftimage/validator.go) (HTTP /
-Upload / PVCClone / **OCI**), require `oci.repository`, and reject `tag` + `digest`
-both set. Spec-immutability-when-Ready is inherited (a golden image's source is
-fixed once imported).
+`importOCI` runs a puller init-container:
+
+```
+snapshot-oras --mode=download-image --repository=<repo> --tag=<tag>|--digest=<d> \
+  [--insecure] --file=/data/image.raw
+```
+
+It pulls the manifest + config, `truncate`s `/data/image.raw` to `totalSize` (a
+sparse file — the zero regions cost nothing), then pulls each chunk layer
+(oras verifies every blob against its digest; the registry/node layer cache dedups
+the pull) and writes it at its `chunk-offset`. The main `ubuntu:22.04` container
+then runs the existing convert-if-qcow2 → size → GRUB/serial patch tail (Linux;
+Windows skips the patch, unprivileged), gated by `osType` exactly as `importHTTP`.
+Writes to the **import PVC** (not hostPath) → **not node-pinned**.
+
+### 2.5 API + webhook (shipped — PR 1 / #301)
+
+`spec.source.oci` = `OCIImageSource{repository, tag|digest, insecure,
+credentialsSecretRef}` (dockerconfigjson; anonymous when empty) + the exactly-one-of
+source rule (`http|upload|pvcClone|oci`). Chunking is **transparent to the API** —
+a `source: oci` is a `source: oci`; the artifact happens to be chunked. No API
+change for Path B.
 
 ---
 
 ## 3. Phasing
 
-- **P3 design** (this note).
-- **P3 PR 1** — API: `OCIImageSource` + `ImageSource.OCI` + webhook one-of +
-  `make generate` + chart CRD sync + deepcopy. Unit-test the webhook.
-- **P3 PR 2** — import path: `importOCI` (puller init-container + `importScript`
-  download-skip variant), source dispatch branch, `snapshot-oras` image resolver
-  reused (`SnapshotORASImage()`), status stamping. Unit-test the Job shape;
-  cluster-validate.
+- **PR 1 (#301, merged)** — API surface + webhook + design.
+- **PR 2a** — `snapshot-oras` transfer modes: `--mode=upload-image` (sparse
+  chunk + push) and `--mode=download-image` (pull + reassemble into a sparse
+  file). Hermetic tests: chunk/reassemble round-trip byte-identical; zero windows
+  skipped; a modified-one-chunk re-push transfers only the changed chunk
+  (dedup assertion via a `memory.Store`).
+- **PR 2b** — controller `importOCI` (puller init-container + `importScript`
+  download-skip variant), source dispatch, `SnapshotORASImage()` reuse, status
+  stamping. Cluster-validate + **measure real v1→v1.1 dedup**.
 
-## 4. Cluster validation (P3 PR 2)
+## 4. Cluster validation (PR 2b) — the measurement doubles as the Path-B spike
 
-Publish a golden **raw** Ubuntu image to the in-cluster Zot (`oras push`); create
-a `SwiftImage` with `source.oci` (by digest) → **Ready** with a raw
-`preparedArtifact`; boot a SwiftGuest from it (Running + IP). Then create a
-**second** SwiftImage from the **same digest** → its pull is layer-cache-served
-(same-digest dedup, the v1 win). Confirm `cloneStrategy: copy` and `snapshot`
-both work off an oci-sourced image.
+1. `upload-image` a golden **raw** Ubuntu Noble disk to the in-cluster Zot →
+   record `transferredBytes` (unique data; ≪ disk size, proving zero-skip).
+2. Build a **v1.1** (in-place `apt upgrade` of the same disk) → `upload-image` to
+   the same repo, new tag → **`skippedBytes / totalBytes` is the dedup %** (target
+   ~high; this de-risks the block-aligned assumption — if low, CDC per §2.1).
+3. `SwiftImage` `source.oci` (by digest) → **Ready** with a raw
+   `preparedArtifact`; boot a SwiftGuest (Running + IP).
+4. A second SwiftImage from the same digest → chunk pulls are cache-served.
+5. `cloneStrategy: copy` and `snapshot` both work off an oci-sourced image.
 
-## 5. Non-goals (P3 v1)
+## 5. Non-goals (P3 Path B v1)
 
-- **Cross-version chunked dedup** (the spike's ~97%) — a single-blob raw layer
-  dedups only when byte-identical (same digest). Sharing unchanged regions across
-  golden v1/v1.1 needs the disk **chunked into fixed-size layers** (or CH v52
-  sparse artifacts) — a follow-on; P3 v1's honest win is portability +
-  content-addressed single-source + layer-cache reuse.
+- **Content-defined chunking** (rolling-hash shift-resistance) — fixed-size fits
+  block-addressed disks; CDC only if §4 measures low.
+- **Per-chunk compression** — dedup handles the sparse/zero case; compression is a
+  transfer-size follow-on (deterministic gzip keeps digests dedup-stable).
 - **Thin overlay** (registry base + local CoW delta, never materializing the full
-  image) — a much larger storage-layer change; P3 v1 full-materializes into the
-  import PVC like `http`.
-- **First-party publish** (`swiftctl image publish`) — documented `oras push`
-  recipe in v1.
-- **qcow2-at-rest** — allowed (import converts) but discouraged; raw is the
-  dedup-friendly, recommended form.
+  disk) — a much larger storage-layer change; v1 full-materializes into the import
+  PVC.
+- **First-party publish** (`swiftctl image publish`) — the `upload-image` tool +
+  a documented recipe in v1.
 
 ## 6. Open questions
 
-1. **Verify a signed golden image on pull?** P2 signs snapshot artifacts; a golden
-   image can be signed the same way. Should `importOCI` optionally `cosign verify`
-   before importing (a `verifyKeySecretRef` on `OCIImageSource`)? Deferred —
-   pull-and-verify is a clean P3.x once operators ask; the TLS-for-verify caveat
-   (P2 §2.5) applies.
-2. **Layer title robustness** — v1 relies on the layer being titled `image.raw`.
-   If operators push with a different title, the puller misses it. A
-   `--mode=download-image` that materializes the single disk layer regardless of
-   title (or reads it from `artifactType`) is a small hardening follow-on.
-3. **Digest-pinned vs tag** — recommend digest for reproducibility; a tag is
-   mutable (a re-push under the same tag changes content). The webhook allows both
-   but docs steer to digest for production.
+1. **Chunk-size default tuning** — 64 MiB is a starting point; §4's measurement
+   informs whether 32/128 MiB dedups better for the target images.
+2. **Signed golden images** — a golden image can be P2-cosign-signed; an optional
+   `verifyKeySecretRef` on `OCIImageSource` (cosign verify before import) is a
+   clean P3.x (the TLS-for-verify caveat, P2 §2.5, applies).
+3. **Manifest size at large disks** — a 40 GiB disk at 64 MiB is ≤640 chunk
+   entries (fewer after zero-skip); acceptable, but a very large sparse disk with
+   scattered data is the case to watch. Chunk-size is the lever.
 
 ---
 


### PR DESCRIPTION
## Golden-image chunked transfer (P3 Path B, PR 2a)

The dedup half of P3. `snapshot-oras` gains two modes so a golden raw VM disk is stored **chunked** — identical chunks dedup by content address, so a mostly-unchanged **v1.1 re-uses v1's bytes**.

Design (rewritten for Path B): [`docs/design/oras-golden-image.md`](docs/design/oras-golden-image.md).

### Mechanism — sparse, offset-based, fixed-size chunking
- **`--mode=upload-image`**: streams the raw disk in `--chunk-size-mib` windows (default 64), **skips all-zero windows** (a raw disk is ~90% zero — never stored), and pushes each non-zero chunk as one digest-addressed layer annotated with its byte offset. A chunk already in the registry (an unchanged v1.1 block) is counted **skipped, not re-uploaded** → `transferredBytes/totalBytes` is the dedup figure. Streams window-by-window; the whole disk is never in memory.
- **`--mode=download-image`**: reads the config, `truncate`s a sparse file to `totalSize` (omitted zero windows cost nothing), fetches each chunk (digest-verified), writes it at its offset.

**Fixed-size, not content-defined:** VM disks are block-addressed and updated **in place**, so windows stay aligned across versions — no rolling hash needed. Uncompressed v1 (dedup already collapses zeros). CDC + compression are follow-ons (design §5) if cluster-measured dedup is low.

### Artifact
`artifactType application/vnd.kubeswift.vmimage.v1`; a config blob (`{totalSize, chunkSize, format, osType}`) + N `application/vnd.kubeswift.vmdisk.chunk.v1` layers, each annotated `kubeswift.io/chunk-offset`.

### Test (hermetic, `memory.Store`)
- round-trip byte-identical (mixed data/zero/short windows);
- zero-skip accounting (zeros never pushed);
- all-zero disk stores **nothing**, round-trips to the right size;
- **v1.1 with one changed chunk transfers only that chunk** (the ~97% dedup in miniature).

`go build ./...`, `go vet`, `go test ./cmd/snapshot-oras/...` — green.

### Next (PR 2b)
Controller `importOCI` (puller init-container `--mode=download-image` → `image.raw` in the import PVC → the existing resize/sgdisk/GRUB tail) + source dispatch + cluster-validate + **measure real v1→v1.1 dedup** on a Noble image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
