### PR TITLE
feat(image): golden-image source.oci import path — importOCI (P3, PR 2b)

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -154,6 +154,7 @@ func main() {
 		Converter:             swiftimage.StubConverter{},
 		Clientset:             clientset,
 		VolumeSnapshotEnabled: volumeSnapshotEnabled,
+		SnapshotORASImage:     swiftsnapshot.SnapshotORASImage(),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftImage controller")
 		os.Exit(1)

--- a/cmd/snapshot-oras/image.go
+++ b/cmd/snapshot-oras/image.go
@@ -174,13 +174,29 @@ func pullAndReassemble(ctx context.Context, src oras.ReadOnlyTarget, ref, filePa
 		if err != nil {
 			return zero, fmt.Errorf("chunk %s missing/bad %s: %w", layer.Digest, chunkOffsetAnnotation, err)
 		}
-		data, err := content.FetchAll(ctx, src, layer) // verifies digest + size
-		if err != nil {
-			return zero, fmt.Errorf("fetch chunk at offset %d: %w", off, err)
-		}
-		if _, err := f.WriteAt(data, off); err != nil {
-			return zero, fmt.Errorf("write chunk at offset %d: %w", off, err)
+		if err := fetchChunkAt(ctx, src, layer, f, off); err != nil {
+			return zero, fmt.Errorf("chunk at offset %d: %w", off, err)
 		}
 	}
 	return manifestDesc, nil
+}
+
+// fetchChunkAt streams one chunk layer into f at off, verifying digest + size.
+// It streams (VerifyReader), NOT content.FetchAll, because FetchAll refuses any
+// blob larger than oras's 32 MiB in-memory cap (maxDescriptorSize) — chunks are
+// commonly 64 MiB — and streaming also avoids buffering the whole chunk.
+func fetchChunkAt(ctx context.Context, src oras.ReadOnlyTarget, layer ocispec.Descriptor, f *os.File, off int64) error {
+	rc, err := src.Fetch(ctx, layer)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	vr := content.NewVerifyReader(rc, layer)
+	if _, err := f.Seek(off, io.SeekStart); err != nil {
+		return err
+	}
+	if _, err := io.Copy(f, vr); err != nil {
+		return err
+	}
+	return vr.Verify() // digest + size mismatch fails loudly
 }

--- a/cmd/snapshot-oras/image_test.go
+++ b/cmd/snapshot-oras/image_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"oras.land/oras-go/v2/content/memory"
+	"oras.land/oras-go/v2/content/oci"
 )
 
 func writeDisk(t *testing.T, path string, windows [][]byte) {
@@ -104,6 +105,43 @@ func TestChunkDedup_ChangedChunkOnly(t *testing.T) {
 	orig, _ := os.ReadFile(v2)
 	if !bytes.Equal(got, orig) {
 		t.Error("v1.1 reassembled disk differs from original")
+	}
+}
+
+// A chunk larger than oras's 32 MiB content.FetchAll cap must still round-trip
+// (regression for the streaming fix — FetchAll refuses >32 MiB blobs, so the
+// download path streams instead). Uses a 33 MiB chunk = one layer.
+func TestChunkLargerThan32MiB_RoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	const big = 33 * 1024 * 1024 // > maxDescriptorSize (32 MiB)
+	data := make([]byte, big)
+	for i := range data {
+		data[i] = byte(i % 251) // non-zero, non-uniform
+	}
+	src := filepath.Join(dir, "big.raw")
+	if err := os.WriteFile(src, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Disk-backed store: memory.Store caps blobs at 32 MiB (like content.FetchAll),
+	// but a real registry does not — oci.Store models that.
+	store, err := oci.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, stats, err := chunkAndPush(context.Background(), src, store, "big", big, "raw", "linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.TransferredBytes != int64(big) {
+		t.Errorf("transferred = %d, want %d", stats.TransferredBytes, big)
+	}
+	out := filepath.Join(dir, "big-out.raw")
+	if _, err := pullAndReassemble(context.Background(), store, "big", out); err != nil {
+		t.Fatalf("reassemble of a >32MiB chunk failed (FetchAll cap regression?): %v", err)
+	}
+	got, _ := os.ReadFile(out)
+	if !bytes.Equal(got, data) {
+		t.Error(">32MiB chunk did not round-trip byte-identical")
 	}
 }
 

--- a/internal/controller/swiftimage/controller.go
+++ b/internal/controller/swiftimage/controller.go
@@ -32,6 +32,10 @@ type SwiftImageReconciler struct {
 	// discovery check in main. When false, cloneStrategy=snapshot is unavailable;
 	// the import pipeline and cloneStrategy=copy are unaffected.
 	VolumeSnapshotEnabled bool
+	// SnapshotORASImage is the snapshot-oras image the source.oci import Job's
+	// puller init container runs (--mode=download-image). Set in main from
+	// swiftsnapshot.SnapshotORASImage(); empty fails an oci import loudly.
+	SnapshotORASImage string
 }
 
 // Reconcile implements the reconcile loop.

--- a/internal/controller/swiftimage/import.go
+++ b/internal/controller/swiftimage/import.go
@@ -39,7 +39,22 @@ func importScript(sourceURL, sourceFormat, osType string) string {
 	base := importVolumeMountPath
 	source := base + "/" + importSourceFile
 	output := base + "/" + importOutputFile
-	grubPatch := `
+	grubPatch := grubPatchBlock(osType)
+	if sourceFormat == "qcow2" {
+		return fmt.Sprintf("set -e\nOUTPUT=%q\napt-get update -qq && apt-get install -y -qq curl qemu-utils util-linux >/dev/null\ncurl -fsSL -o %q %q\nqemu-img convert -f qcow2 -O raw %q \"$OUTPUT\"%s\nstat -c %%s \"$OUTPUT\" > \"$OUTPUT.size\"\necho \"Image size: $(cat $OUTPUT.size) bytes\"", output, source, sourceURL, source, grubPatch)
+	}
+	return fmt.Sprintf("set -e\nOUTPUT=%q\napt-get update -qq && apt-get install -y -qq curl util-linux >/dev/null\ncurl -fsSL -o \"$OUTPUT\" %q%s\nstat -c %%s \"$OUTPUT\" > \"$OUTPUT.size\"\necho \"Image size: $(cat $OUTPUT.size) bytes\"", output, sourceURL, grubPatch)
+}
+
+// grubPatchBlock is the shell that loop-mounts a Linux disk image and injects
+// console=ttyS0 into GRUB for the Cloud Hypervisor serial console (it reads the
+// disk from $OUTPUT). Shared by the http and oci import scripts. Empty for
+// Windows (no GRUB — it boots bootmgfw and manages serial via EMS/SAC).
+func grubPatchBlock(osType string) string {
+	if osType == string(imagev1alpha1.OSTypeWindows) {
+		return ""
+	}
+	return `
 patch_grub() {
   local mnt="$1"
   for grub in $(find "$mnt" \( -name "grub.cfg" -o -name "grub.conf" \) 2>/dev/null); do
@@ -89,15 +104,21 @@ for offset in $GPT_OFFSETS $FALLBACK_OFFSETS; do
 done
 rmdir /mnt/disk 2>/dev/null || true
 `
-	// Windows: no GRUB to patch, and the loop-mount the patch needs is
-	// pointless on an NTFS/Windows layout. Skip the whole block.
-	if osType == string(imagev1alpha1.OSTypeWindows) {
-		grubPatch = ""
-	}
+}
+
+// importScriptOCI is the main-container script for a source.oci import. The
+// puller init container has already materialized the disk at $OUTPUT
+// (/data/image.raw); this skips the download and runs the same tail as the http
+// path: convert-if-qcow2 (in place), size measurement, and the Linux GRUB/serial
+// patch. Golden images are expected raw (raw-at-rest; §2.1) so the qcow2 branch
+// is the rare escape hatch.
+func importScriptOCI(sourceFormat, osType string) string {
+	output := importVolumeMountPath + "/" + importOutputFile
+	grubPatch := grubPatchBlock(osType)
 	if sourceFormat == "qcow2" {
-		return fmt.Sprintf("set -e\nOUTPUT=%q\napt-get update -qq && apt-get install -y -qq curl qemu-utils util-linux >/dev/null\ncurl -fsSL -o %q %q\nqemu-img convert -f qcow2 -O raw %q \"$OUTPUT\"%s\nstat -c %%s \"$OUTPUT\" > \"$OUTPUT.size\"\necho \"Image size: $(cat $OUTPUT.size) bytes\"", output, source, sourceURL, source, grubPatch)
+		return fmt.Sprintf("set -e\nOUTPUT=%q\napt-get update -qq && apt-get install -y -qq qemu-utils util-linux >/dev/null\nqemu-img convert -f qcow2 -O raw \"$OUTPUT\" \"$OUTPUT.tmp\"\nmv \"$OUTPUT.tmp\" \"$OUTPUT\"%s\nstat -c %%s \"$OUTPUT\" > \"$OUTPUT.size\"\necho \"Image size: $(cat $OUTPUT.size) bytes\"", output, grubPatch)
 	}
-	return fmt.Sprintf("set -e\nOUTPUT=%q\napt-get update -qq && apt-get install -y -qq curl util-linux >/dev/null\ncurl -fsSL -o \"$OUTPUT\" %q%s\nstat -c %%s \"$OUTPUT\" > \"$OUTPUT.size\"\necho \"Image size: $(cat $OUTPUT.size) bytes\"", output, sourceURL, grubPatch)
+	return fmt.Sprintf("set -e\nOUTPUT=%q\napt-get update -qq && apt-get install -y -qq util-linux >/dev/null%s\nstat -c %%s \"$OUTPUT\" > \"$OUTPUT.size\"\necho \"Image size: $(cat $OUTPUT.size) bytes\"", output, grubPatch)
 }
 
 // ImportResult holds the outcome of an import attempt.
@@ -116,6 +137,8 @@ func (r *SwiftImageReconciler) StartImport(ctx context.Context, img *imagev1alph
 		return r.importHTTP(ctx, img)
 	case src.PVCClone != nil:
 		return r.importPVCClone(ctx, img)
+	case src.OCI != nil:
+		return r.importOCI(ctx, img)
 	case src.Upload != nil:
 		return &ImportResult{Phase: imagev1alpha1.SwiftImagePhasePending, Error: ReasonUploadNotImpl}, nil
 	default:
@@ -203,6 +226,132 @@ func (r *SwiftImageReconciler) importHTTP(ctx context.Context, img *imagev1alpha
 		return nil, err
 	}
 
+	return &ImportResult{
+		Phase:  imagev1alpha1.SwiftImagePhaseImporting,
+		PVCRef: &imagev1alpha1.PVCObjectReference{Name: pvcName, Namespace: img.Namespace},
+	}, nil
+}
+
+// importOCI creates the import PVC and a Job whose puller init container
+// (snapshot-oras --mode=download-image) reassembles the golden raw disk into the
+// PVC, then the main container runs the shared resize/patch tail. Same PVC + Job
+// name as importHTTP, so CheckImportStatus/Validate/Prepare are unchanged.
+func (r *SwiftImageReconciler) importOCI(ctx context.Context, img *imagev1alpha1.SwiftImage) (*ImportResult, error) {
+	if r.SnapshotORASImage == "" {
+		return &ImportResult{Phase: imagev1alpha1.SwiftImagePhaseFailed, Error: "snapshot-oras image not configured for oci source"}, nil
+	}
+	pvcName := importPVCNamePrefix + img.Name
+	jobName := importJobNamePrefix + img.Name
+
+	storageReq := resource.MustParse("10Gi")
+	if img.Spec.RootDisk != nil && img.Spec.RootDisk.Size != nil && !img.Spec.RootDisk.Size.IsZero() {
+		storageReq = *img.Spec.RootDisk.Size
+	}
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: img.Namespace},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: storageReq},
+			},
+		},
+	}
+	if err := controllerutil.SetControllerReference(img, pvc, r.Scheme); err != nil {
+		return nil, err
+	}
+	if err := r.Create(ctx, pvc); err != nil && !errors.IsAlreadyExists(err) {
+		return nil, err
+	}
+
+	oci := img.Spec.Source.OCI
+	output := importVolumeMountPath + "/" + importOutputFile
+	pullArgs := []string{
+		"--mode=download-image",
+		"--repository=" + oci.Repository,
+		"--file=" + output,
+	}
+	if oci.Digest != "" {
+		pullArgs = append(pullArgs, "--digest="+oci.Digest)
+	} else {
+		pullArgs = append(pullArgs, "--tag="+oci.Tag)
+	}
+	if oci.Insecure {
+		pullArgs = append(pullArgs, "--insecure")
+	}
+
+	dataMount := corev1.VolumeMount{Name: "data", MountPath: importVolumeMountPath}
+	volumes := []corev1.Volume{{
+		Name: "data",
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+		},
+	}}
+	pullMounts := []corev1.VolumeMount{dataMount}
+	var pullEnv []corev1.EnvVar
+	if oci.CredentialsSecretRef != nil && oci.CredentialsSecretRef.Name != "" {
+		pullEnv = append(pullEnv, corev1.EnvVar{Name: "DOCKER_CONFIG", Value: "/oras-auth"})
+		pullMounts = append(pullMounts, corev1.VolumeMount{Name: "oras-auth", MountPath: "/oras-auth", ReadOnly: true})
+		volumes = append(volumes, corev1.Volume{
+			Name: "oras-auth",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: oci.CredentialsSecretRef.Name,
+					// A kubernetes.io/dockerconfigjson Secret stores the auth under
+					// .dockerconfigjson; oras-go expects a Docker config.json.
+					Items: []corev1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
+				},
+			},
+		})
+	}
+
+	script := importScriptOCI(string(img.Spec.Format), string(img.Spec.OSType))
+	// Privileged only for the Linux GRUB-patch loop-mount (Windows skips it).
+	privileged := img.Spec.OSType != imagev1alpha1.OSTypeWindows
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: img.Namespace},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+					SecurityContext: &corev1.PodSecurityContext{
+						// Root: the init container writes into the (root-owned) PVC
+						// mount; the main container runs apt-get (+ Linux loop-mount).
+						RunAsUser: ptr.To(int64(0)),
+					},
+					InitContainers: []corev1.Container{{
+						Name:         "pull",
+						Image:        r.SnapshotORASImage,
+						Args:         pullArgs,
+						Env:          pullEnv,
+						VolumeMounts: pullMounts,
+						// Minimal: writes only to the mounted PVC; no disk temp
+						// (oras streams chunks into the sparse file).
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+							ReadOnlyRootFilesystem:   ptr.To(true),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name:    "import",
+						Image:   "ubuntu:22.04",
+						Command: []string{"sh", "-c", script},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged: ptr.To(privileged),
+						},
+						VolumeMounts: []corev1.VolumeMount{dataMount},
+					}},
+					Volumes: volumes,
+				},
+			},
+		},
+	}
+	if err := controllerutil.SetControllerReference(img, job, r.Scheme); err != nil {
+		return nil, err
+	}
+	if err := r.Create(ctx, job); err != nil && !errors.IsAlreadyExists(err) {
+		return nil, err
+	}
 	return &ImportResult{
 		Phase:  imagev1alpha1.SwiftImagePhaseImporting,
 		PVCRef: &imagev1alpha1.PVCObjectReference{Name: pvcName, Namespace: img.Namespace},

--- a/internal/controller/swiftimage/oci_import_test.go
+++ b/internal/controller/swiftimage/oci_import_test.go
@@ -1,0 +1,134 @@
+package swiftimage
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	imagev1alpha1 "github.com/kubeswift-io/kubeswift/api/image/v1alpha1"
+)
+
+func ociImageResource(oci imagev1alpha1.OCIImageSource) *imagev1alpha1.SwiftImage {
+	return &imagev1alpha1.SwiftImage{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "default"},
+		Spec: imagev1alpha1.SwiftImageSpec{
+			Format: imagev1alpha1.DiskFormatRaw,
+			Source: imagev1alpha1.ImageSource{OCI: &oci},
+		},
+	}
+}
+
+func TestStartImport_OCISourceCreatesJobWithPuller(t *testing.T) {
+	scheme := testScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &SwiftImageReconciler{Client: client, Scheme: scheme, SnapshotORASImage: "ghcr.io/k/snapshot-oras:test"}
+	img := ociImageResource(imagev1alpha1.OCIImageSource{
+		Repository: "zot.svc:5000/golden-ubuntu", Digest: "sha256:deadbeef",
+	})
+
+	result, err := r.StartImport(context.Background(), img)
+	if err != nil {
+		t.Fatalf("StartImport: %v", err)
+	}
+	if result.Phase != imagev1alpha1.SwiftImagePhaseImporting {
+		t.Errorf("phase = %s, want Importing", result.Phase)
+	}
+	var pvc corev1.PersistentVolumeClaim
+	if err := client.Get(context.Background(), types.NamespacedName{Name: importPVCNamePrefix + "gold", Namespace: "default"}, &pvc); err != nil {
+		t.Fatalf("PVC not created: %v", err)
+	}
+	var job batchv1.Job
+	if err := client.Get(context.Background(), types.NamespacedName{Name: importJobNamePrefix + "gold", Namespace: "default"}, &job); err != nil {
+		t.Fatalf("Job not created: %v", err)
+	}
+	spec := job.Spec.Template.Spec
+	if len(spec.InitContainers) != 1 {
+		t.Fatalf("want 1 init container (the puller); got %d", len(spec.InitContainers))
+	}
+	pull := spec.InitContainers[0]
+	if pull.Image != "ghcr.io/k/snapshot-oras:test" {
+		t.Errorf("puller image = %q, want the configured snapshot-oras image", pull.Image)
+	}
+	args := strings.Join(pull.Args, " ")
+	for _, want := range []string{
+		"--mode=download-image",
+		"--repository=zot.svc:5000/golden-ubuntu",
+		"--digest=sha256:deadbeef",
+		"--file=/data/image.raw",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("puller args missing %q; got %q", want, args)
+		}
+	}
+	// The main container reuses the ubuntu importer for the resize/patch tail.
+	if len(spec.Containers) != 1 || spec.Containers[0].Image != "ubuntu:22.04" {
+		t.Errorf("want a single ubuntu:22.04 main container; got %+v", spec.Containers)
+	}
+	// Both containers share the import PVC at /data.
+	if len(spec.Volumes) < 1 || spec.Volumes[0].PersistentVolumeClaim == nil ||
+		spec.Volumes[0].PersistentVolumeClaim.ClaimName != importPVCNamePrefix+"gold" {
+		t.Errorf("data volume not backed by the import PVC: %+v", spec.Volumes)
+	}
+}
+
+func TestStartImport_OCISourceInsecureTagAndCreds(t *testing.T) {
+	scheme := testScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &SwiftImageReconciler{Client: client, Scheme: scheme, SnapshotORASImage: "img:test"}
+	img := ociImageResource(imagev1alpha1.OCIImageSource{
+		Repository:           "zot.svc:5000/golden",
+		Tag:                  "noble",
+		Insecure:             true,
+		CredentialsSecretRef: &imagev1alpha1.SecretObjectReference{Name: "reg-creds"},
+	})
+	if _, err := r.StartImport(context.Background(), img); err != nil {
+		t.Fatalf("StartImport: %v", err)
+	}
+	var job batchv1.Job
+	if err := client.Get(context.Background(), types.NamespacedName{Name: importJobNamePrefix + "gold", Namespace: "default"}, &job); err != nil {
+		t.Fatalf("Job not created: %v", err)
+	}
+	pull := job.Spec.Template.Spec.InitContainers[0]
+	args := strings.Join(pull.Args, " ")
+	if !strings.Contains(args, "--tag=noble") || !strings.Contains(args, "--insecure") {
+		t.Errorf("expected --tag=noble + --insecure; got %q", args)
+	}
+	var dockerCfg bool
+	for _, e := range pull.Env {
+		if e.Name == "DOCKER_CONFIG" && e.Value == "/oras-auth" {
+			dockerCfg = true
+		}
+	}
+	if !dockerCfg {
+		t.Error("DOCKER_CONFIG env missing on the puller")
+	}
+	var authVol bool
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if v.Name == "oras-auth" && v.Secret != nil && v.Secret.SecretName == "reg-creds" {
+			authVol = true
+		}
+	}
+	if !authVol {
+		t.Error("oras-auth credential volume missing")
+	}
+}
+
+func TestStartImport_OCINoImageConfigured_Failed(t *testing.T) {
+	scheme := testScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &SwiftImageReconciler{Client: client, Scheme: scheme} // SnapshotORASImage empty
+	img := ociImageResource(imagev1alpha1.OCIImageSource{Repository: "r", Tag: "t"})
+	result, err := r.StartImport(context.Background(), img)
+	if err != nil {
+		t.Fatalf("StartImport: %v", err)
+	}
+	if result.Phase != imagev1alpha1.SwiftImagePhaseFailed {
+		t.Errorf("phase = %s, want Failed when snapshot-oras image is unconfigured", result.Phase)
+	}
+}


### PR DESCRIPTION
## Golden-image source.oci import path (P3 Path B, PR 2b) — cluster-validated

The controller half + the fix a real registry surfaced. A `source.oci` SwiftImage imports via a two-container Job: a **puller init container** (`snapshot-oras --mode=download-image`) reassembles the chunked golden disk into the import PVC at `/data/image.raw`, then the **ubuntu main container** runs the shared resize/sgdisk/GRUB tail. Same PVC + Job name as `importHTTP`; composes with `cloneStrategy: copy|snapshot`; auth via dockerconfigjson `credentialsSecretRef`.

### Fix surfaced by cluster validation (the W5 pattern)
`content.FetchAll` refuses any blob **> 32 MiB** (`maxDescriptorSize`), so `download-image` failed `invalid descriptor size` on the 64 MiB chunks — the memory.Store hermetic test used 4 KiB chunks and missed it. Fixed: `pullAndReassemble` **streams** each chunk to the sparse file via a `VerifyReader` (digest+size verified) instead of buffering through `FetchAll`. Regression test uses a 33 MiB chunk on a disk-backed `oci.Store`.

### Cluster validation (field-testing, controller sha-be57b9b + snapshot-oras sha-0fd41ac, in-cluster Zot)
- **Publish v1** (chunk the 3.5 GiB ubuntu-noble disk): `transferredBytes=2.44 GiB` of `totalBytes=3.5 GiB` → **zero-skip dropped ~1.06 GiB** of sparse regions.
- **`SwiftImage source.oci` → Ready** (raw, 3584Mi); the import loop-mounted the reassembled disk and **patched GRUB** (`Patched /mnt/disk/EFI/ubuntu/grub.cfg`) — proving the chunked reassembly is a valid, bootable Ubuntu disk.
- **`SwiftGuest imageRef: golden-oci` → Running** on miles — boots from the golden oci image.
- **Dedup:** a v1.1 with a ~192 MiB in-place delta (3 misaligned 64 MiB writes → 6 touched chunks) re-uploaded **384 MiB, skipped 2.19 GiB** → a re-upload moved 384 MiB instead of ~2.44 GiB (**~84% reduction**; ~89% vs the raw disk). A smaller real apt-upgrade delta trends toward the ~97% headline.

### Test
Unit: puller args, dockerconfigjson mount, unconfigured-image → Failed; `>32 MiB` chunk round-trip regression. `go build ./...`, `go vet`, `go test ./cmd/snapshot-oras/... ./internal/controller/swiftimage/...` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
