### PR TITLE
feat(snapshot): cold-migration capture flow — includeDisk (P4, PR 1b)

### DIFF
--- a/internal/controller/swiftsnapshot/coldmig.go
+++ b/internal/controller/swiftsnapshot/coldmig.go
@@ -1,0 +1,220 @@
+// Cold / suspended-state migration (P4) — the disk half of an includeDisk oci
+// snapshot. A full-state snapshot pairs the memory artifact (the normal oci
+// capture) with a chunked artifact of the guest's disk, so the pair can resume
+// in another cluster. Coherence is capture-then-terminate: the guest is paused
+// and memory-snapshotted with ResumeAfterSnapshot=false (set in
+// handlePendingLocal), so it stays paused; this file then TERMINATES the launcher
+// to release the RWO root PVC (frozen at the snapshot instant) and chunks the
+// released disk to the registry via snapshot-oras --mode=upload-image (P3).
+// See docs/design/oras-cold-migration.md.
+package swiftsnapshot
+
+import (
+	"context"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/snapshot/clonecommon"
+)
+
+const (
+	// Root-disk PVC name + in-launcher disk paths, mirrored from
+	// internal/controller/swiftguest (a local copy avoids a controller import
+	// cycle; these are stable on-disk contract paths).
+	rootDiskPVCPrefix  = "swiftguest-root-"
+	rootDiskDevicePath = "/dev/kubeswift-root" // Block root disk (raw device)
+	// diskChunkMount is where the chunk Job mounts a Filesystem root PVC (the disk
+	// is image.raw under it).
+	diskChunkMount = "/rootdisk"
+)
+
+func rootDiskPVCName(guestName string) string { return rootDiskPVCPrefix + guestName }
+
+// ociDiskTag is the disk artifact's tag — the memory tag + "-disk" so both
+// artifacts share the repository but are distinct manifests.
+func ociDiskTag(snap *snapshotv1alpha1.SwiftSnapshot) string { return ociTag(snap) + "-disk" }
+
+func ociDiskReference(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	return snap.Spec.Backend.OCI.Repository + ":" + ociDiskTag(snap)
+}
+
+func diskChunkJobName(snap *snapshotv1alpha1.SwiftSnapshot) string {
+	return snap.Name + "-oci-disk"
+}
+
+// rootDiskIsBlock reports whether the guest's root PVC is Block-mode (raw device)
+// vs Filesystem (image.raw file). Defaults to Filesystem when the PVC or its
+// volumeMode is absent.
+func (r *SwiftSnapshotReconciler) rootDiskIsBlock(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot) (bool, error) {
+	var pvc corev1.PersistentVolumeClaim
+	err := r.Get(ctx, client.ObjectKey{Name: rootDiskPVCName(snap.Spec.GuestRef.Name), Namespace: snap.Namespace}, &pvc)
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == corev1.PersistentVolumeBlock, nil
+}
+
+// handleFullStateDiskCapture is the capture-then-terminate disk half. It runs in
+// the Uploading phase BEFORE the memory push, so status.OCI.Disk is set first and
+// handleUploadingOCI preserves it. Sequence: terminate the (paused) launcher to
+// release the root PVC → chunk the released disk to oci → stamp status.OCI.Disk.
+// Returns (done, errMsg, err); done=false means requeue.
+func (r *SwiftSnapshotReconciler) handleFullStateDiskCapture(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot, status *snapshotv1alpha1.SwiftSnapshotStatus) (bool, string, error) {
+	if r.SnapshotORASImage == "" {
+		return false, "snapshot-oras image not configured (set " + SnapshotORASImageEnv + ")", nil
+	}
+	// 1. Terminate the launcher so the RWO root PVC releases (frozen at the
+	//    snapshot instant — the VM was captured with ResumeAfterSnapshot=false and
+	//    never resumed). Idempotent: re-Delete while it drains, requeue until gone.
+	pod, err := r.findLauncherPod(ctx, snap.Namespace, snap.Spec.GuestRef.Name)
+	if err != nil {
+		return false, "", err
+	}
+	if pod != nil {
+		grace := int64(0)
+		if delErr := r.Delete(ctx, pod, &client.DeleteOptions{GracePeriodSeconds: &grace}); delErr != nil && !apierrors.IsNotFound(delErr) {
+			return false, "", delErr
+		}
+		return false, "", nil // requeue: wait for the launcher to be gone (PVC released)
+	}
+
+	// 2. Launcher gone → ensure the node-pinned disk-chunk Job.
+	var job batchv1.Job
+	jerr := r.Get(ctx, client.ObjectKey{Name: diskChunkJobName(snap), Namespace: snap.Namespace}, &job)
+	if apierrors.IsNotFound(jerr) {
+		block, berr := r.rootDiskIsBlock(ctx, snap)
+		if berr != nil {
+			return false, "", berr
+		}
+		j := buildDiskChunkJob(snap, r.SnapshotORASImage, status.NodeName, block)
+		if serr := ctrl.SetControllerReference(snap, j, r.Scheme); serr != nil {
+			return false, "", serr
+		}
+		if cerr := r.Create(ctx, j); cerr != nil && !apierrors.IsAlreadyExists(cerr) {
+			return false, "", cerr
+		}
+		return false, "", nil
+	}
+	if jerr != nil {
+		return false, "", jerr
+	}
+
+	// 3. Job status.
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			if status.OCI == nil {
+				status.OCI = &snapshotv1alpha1.OCISnapshotStatus{}
+			}
+			status.OCI.Disk = &snapshotv1alpha1.OCIDiskArtifact{Reference: ociDiskReference(snap)}
+			if rep, ok, rerr := clonecommon.JobTransferReport(ctx, r.Client, snap.Namespace, diskChunkJobName(snap)); rerr == nil && ok {
+				status.OCI.Disk.ManifestDigest = rep.ManifestDigest
+				status.OCI.Disk.PushedBytes = rep.TotalBytes
+			}
+			return true, "", nil
+		}
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return false, "OCI disk chunk Job failed: " + c.Message, nil
+		}
+	}
+	return false, "", nil // still chunking
+}
+
+// buildDiskChunkJob constructs the node-pinned Job that chunks the released root
+// PVC to the registry. Block root disks attach via volumeDevices at
+// rootDiskDevicePath; Filesystem root disks mount at diskChunkMount and the disk
+// is image.raw. Pinned to the capture node (the disk's node) so the RWO PVC
+// re-attaches locally. Runs as root to read the raw disk. The caller sets the
+// ownerRef.
+func buildDiskChunkJob(snap *snapshotv1alpha1.SwiftSnapshot, image, captureNode string, block bool) *batchv1.Job {
+	oci := snap.Spec.Backend.OCI
+	// Filesystem root: the PVC mounts at diskChunkMount, the disk is image.raw.
+	// Block root: the raw device attaches at rootDiskDevicePath.
+	diskPath := diskChunkMount + "/image.raw"
+	if block {
+		diskPath = rootDiskDevicePath
+	}
+	args := []string{
+		"--mode=upload-image",
+		"--file=" + diskPath,
+		"--repository=" + oci.Repository,
+		"--tag=" + ociDiskTag(snap),
+	}
+	if oci.Insecure {
+		args = append(args, "--insecure")
+	}
+
+	container := corev1.Container{
+		Name:  "chunk",
+		Image: image,
+		Args:  args,
+		// Root to read the raw disk (device or 0644 image); otherwise maximally
+		// constrained — upload-image streams chunks to the registry, no disk temp.
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			RunAsUser:                ptr.To(int64(0)),
+			RunAsNonRoot:             ptr.To(false),
+			ReadOnlyRootFilesystem:   ptr.To(true),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		},
+	}
+	rootVol := corev1.Volume{
+		Name: "rootdisk",
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: rootDiskPVCName(snap.Spec.GuestRef.Name)},
+		},
+	}
+	if block {
+		container.VolumeDevices = []corev1.VolumeDevice{{Name: "rootdisk", DevicePath: rootDiskDevicePath}}
+	} else {
+		container.VolumeMounts = []corev1.VolumeMount{{Name: "rootdisk", MountPath: diskChunkMount, ReadOnly: true}}
+	}
+	volumes := []corev1.Volume{rootVol}
+
+	// Registry credentials (dockerconfigjson), mirroring buildOCIPushJob.
+	if oci.CredentialsSecretRef != nil && oci.CredentialsSecretRef.Name != "" {
+		container.Env = append(container.Env, corev1.EnvVar{Name: "DOCKER_CONFIG", Value: ociAuthMount})
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{Name: "oras-auth", MountPath: ociAuthMount, ReadOnly: true})
+		volumes = append(volumes, corev1.Volume{
+			Name: "oras-auth",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: oci.CredentialsSecretRef.Name,
+					Items:      []corev1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
+				},
+			},
+		})
+	}
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      diskChunkJobName(snap),
+			Namespace: snap.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "kubeswift",
+				"app.kubernetes.io/component": "snapshot-oci-disk",
+				"kubeswift.io/swiftsnapshot":  snap.Name,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: ptr.To(ociPushBackoffLimit),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					NodeName:      captureNode,
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+					Containers:    []corev1.Container{container},
+					Volumes:       volumes,
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/swiftsnapshot/coldmig_test.go
+++ b/internal/controller/swiftsnapshot/coldmig_test.go
@@ -1,0 +1,119 @@
+package swiftsnapshot
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+)
+
+func TestOCIDiskTagAndReference(t *testing.T) {
+	s := ociSnap(nil) // team-a/snap1, repo zot.svc:5000/vm-snapshots
+	if got := ociDiskTag(s); got != "team-a-snap1-disk" {
+		t.Errorf("disk tag = %q, want team-a-snap1-disk", got)
+	}
+	if got := ociDiskReference(s); got != "zot.svc:5000/vm-snapshots:team-a-snap1-disk" {
+		t.Errorf("disk reference = %q", got)
+	}
+}
+
+func TestBuildDiskChunkJob_Filesystem(t *testing.T) {
+	job := buildDiskChunkJob(ociSnap(nil), "oras:img", "miles", false)
+	pod := job.Spec.Template.Spec
+	if pod.NodeName != "miles" {
+		t.Errorf("disk chunk Job must be pinned to the capture node; got %q", pod.NodeName)
+	}
+	c := pod.Containers[0]
+	args := strings.Join(c.Args, " ")
+	for _, want := range []string{
+		"--mode=upload-image",
+		"--file=/rootdisk/image.raw",
+		"--repository=zot.svc:5000/vm-snapshots",
+		"--tag=team-a-snap1-disk",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("args missing %q; got %q", want, args)
+		}
+	}
+	// Filesystem root: mounted, not a raw device.
+	if len(c.VolumeDevices) != 0 {
+		t.Errorf("Filesystem root must not use volumeDevices; got %+v", c.VolumeDevices)
+	}
+	var mounted bool
+	for _, m := range c.VolumeMounts {
+		if m.Name == "rootdisk" && m.MountPath == "/rootdisk" {
+			mounted = true
+		}
+	}
+	if !mounted {
+		t.Errorf("Filesystem root must mount the PVC at /rootdisk; got %+v", c.VolumeMounts)
+	}
+	// Volume from the guest's root PVC.
+	if len(pod.Volumes) == 0 || pod.Volumes[0].PersistentVolumeClaim == nil ||
+		pod.Volumes[0].PersistentVolumeClaim.ClaimName != "swiftguest-root-g1" {
+		t.Errorf("rootdisk volume not backed by swiftguest-root-g1: %+v", pod.Volumes)
+	}
+	if c.SecurityContext == nil || c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 0 {
+		t.Errorf("disk chunk container must RunAsUser 0 to read the raw disk")
+	}
+}
+
+func TestBuildDiskChunkJob_Block(t *testing.T) {
+	job := buildDiskChunkJob(ociSnap(nil), "oras:img", "boba", true)
+	c := job.Spec.Template.Spec.Containers[0]
+	if !strings.Contains(strings.Join(c.Args, " "), "--file=/dev/kubeswift-root") {
+		t.Errorf("Block root must chunk the raw device; got %q", strings.Join(c.Args, " "))
+	}
+	if len(c.VolumeMounts) != 0 {
+		t.Errorf("Block root must not filesystem-mount the PVC; got %+v", c.VolumeMounts)
+	}
+	var dev bool
+	for _, d := range c.VolumeDevices {
+		if d.Name == "rootdisk" && d.DevicePath == "/dev/kubeswift-root" {
+			dev = true
+		}
+	}
+	if !dev {
+		t.Errorf("Block root must attach the PVC as a device at /dev/kubeswift-root; got %+v", c.VolumeDevices)
+	}
+}
+
+func TestBuildDiskChunkJob_InsecureAndCreds(t *testing.T) {
+	snap := ociSnap(func(o *snapshotv1alpha1.OCIBackend) {
+		o.Insecure = true
+		o.CredentialsSecretRef = &snapshotv1alpha1.SecretObjectReference{Name: "reg-creds"}
+	})
+	job := buildDiskChunkJob(snap, "oras:img", "miles", false)
+	c := job.Spec.Template.Spec.Containers[0]
+	if !strings.Contains(strings.Join(c.Args, " "), "--insecure") {
+		t.Errorf("--insecure must be present; got %q", strings.Join(c.Args, " "))
+	}
+	var dockerCfg bool
+	for _, e := range c.Env {
+		if e.Name == "DOCKER_CONFIG" && e.Value == ociAuthMount {
+			dockerCfg = true
+		}
+	}
+	if !dockerCfg {
+		t.Errorf("DOCKER_CONFIG env missing on the disk chunk Job")
+	}
+	var authVol bool
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if v.Name == "oras-auth" && v.Secret != nil && v.Secret.SecretName == "reg-creds" {
+			authVol = true
+		}
+	}
+	if !authVol {
+		t.Errorf("oras-auth credential volume missing")
+	}
+}
+
+// The pod-level VolumeMode default (nil) is treated as Filesystem by the Job
+// builder path; assert the enum sentinel we compare against.
+func TestRootDiskBlockSentinel(t *testing.T) {
+	if corev1.PersistentVolumeBlock != "Block" {
+		t.Fatalf("unexpected Block volumeMode sentinel %q", corev1.PersistentVolumeBlock)
+	}
+}

--- a/internal/controller/swiftsnapshot/controller.go
+++ b/internal/controller/swiftsnapshot/controller.go
@@ -128,6 +128,29 @@ func (r *SwiftSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 	case snapshotv1alpha1.SwiftSnapshotPhaseUploading:
+		// Full-state (P4 includeDisk): capture-then-terminate the DISK to oci
+		// first — terminate the still-paused launcher to release the root PVC,
+		// then chunk it — before the memory push below. handleUploadingOCI
+		// preserves the status.oci.disk this stamps.
+		if snap.Spec.Backend.Type == snapshotv1alpha1.SnapshotBackendOCI &&
+			snap.Spec.IncludeDisk && (status.OCI == nil || status.OCI.Disk == nil) {
+			done, errMsg, err := r.handleFullStateDiskCapture(ctx, &snap, status)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if errMsg != "" {
+				setPhase(status, snapshotv1alpha1.SwiftSnapshotPhaseFailed)
+				setReadyCondition(status, metav1.ConditionFalse, ReasonSnapshotFailed, errMsg)
+				return ctrl.Result{}, r.persist(ctx, &snap, status)
+			}
+			if !done {
+				if updateErr := r.persist(ctx, &snap, status); updateErr != nil {
+					return ctrl.Result{}, updateErr
+				}
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+			}
+			// disk artifact done — fall through to the memory push.
+		}
 		// s3 / oci backends: the capture is on the node-local hostPath; watch the
 		// upload/push Job move it to the store, then stamp status and go Ready.
 		handleUpload := r.handleUploading

--- a/internal/controller/swiftsnapshot/local.go
+++ b/internal/controller/swiftsnapshot/local.go
@@ -163,9 +163,16 @@ func (r *SwiftSnapshotReconciler) handlePendingLocal(
 	// only processes the capture once.
 	actionID := capturingActionID(snap)
 
+	// Full-state (includeDisk) capture is capture-then-terminate: the guest must
+	// stay paused after the memory snapshot so the disk is frozen at that instant
+	// for the disk-chunk step — never resume it, regardless of the spec field.
+	resumeAfter := snap.Spec.ResumeAfterSnapshot
+	if snap.Spec.IncludeDisk {
+		resumeAfter = false
+	}
 	args := captureArgs{
 		DestinationURL:      srcURL,
-		ResumeAfterSnapshot: snap.Spec.ResumeAfterSnapshot,
+		ResumeAfterSnapshot: resumeAfter,
 	}
 	argsJSON, err := json.Marshal(args)
 	if err != nil {

--- a/internal/controller/swiftsnapshot/oci.go
+++ b/internal/controller/swiftsnapshot/oci.go
@@ -132,6 +132,13 @@ func (r *SwiftSnapshotReconciler) handleUploadingOCI(ctx context.Context, snap *
 	for _, c := range job.Status.Conditions {
 		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
 			now := metav1.Now()
+			// Preserve the full-state disk ref (P4 includeDisk): the disk is
+			// captured before this memory push, so status.OCI.Disk is already set
+			// and must survive this (re)assignment of status.OCI.
+			var disk *snapshotv1alpha1.OCIDiskArtifact
+			if status.OCI != nil {
+				disk = status.OCI.Disk
+			}
 			status.OCI = &snapshotv1alpha1.OCISnapshotStatus{
 				Reference: ociReference(snap),
 				PushedAt:  &now,
@@ -139,6 +146,7 @@ func (r *SwiftSnapshotReconciler) handleUploadingOCI(ctx context.Context, snap *
 				// a signing failure fails the Job). Robust against a missing byte
 				// report (which would leave rep.Signed false).
 				Signed: ociSigningRequested(snap),
+				Disk:   disk,
 			}
 			// Read the push Job's byte report (best-effort; a missing report leaves
 			// bytes/digest empty and is not a failure). status carries the registry


### PR DESCRIPTION
## Cold-migration capture flow (P4, PR 1b)

The capture half of suspended-state migration (design: [`docs/design/oras-cold-migration.md`](docs/design/oras-cold-migration.md); API in #305). When `spec.includeDisk`, an `oci` snapshot captures **memory + disk** coherently via **capture-then-terminate**.

### Flow
1. **Freeze** (`handlePendingLocal`): `includeDisk` forces `ResumeAfterSnapshot=false` — the guest stays paused after the memory snapshot, so the disk is frozen at that instant.
2. **Disk capture** (`coldmig.go`, in the Uploading phase before the memory push): terminate the paused launcher (grace 0) to release the RWO root PVC → a node-pinned Job chunks the released disk to a `<tag>-disk` artifact via `snapshot-oras --mode=upload-image` (P3). **Block** roots attach via `volumeDevices` at `/dev/kubeswift-root`; **Filesystem** roots mount + chunk `image.raw` (from the PVC's `volumeMode`). Stamps `status.oci.disk` from the transfer report.
3. **Memory push** (`handleUploadingOCI`): unchanged, but now preserves `status.oci.disk`. `Ready` gates on both artifacts.

### Reuse / cost
Composes P1 (memory oci) + P3 (`upload-image`) + the existing `resumeAfterSnapshot=false` freeze — **no swiftletd change, no new RBAC** (the controller-manager already has `pods … delete`). The runtime is untouched.

### Test
`go build ./...`, `go vet`, `go test ./internal/controller/swiftsnapshot/...` — green. Unit tests: disk-chunk Job Block/Filesystem/creds shapes + the disk tag/reference.

### Next
**PR 2** — full-state `cloneFromSnapshot` import (materialize disk from oci + `--restore` memory + resume) + the end-to-end cluster validation (the `boot_id`/sentinel resume proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)