### PR TITLE
fix(snapshot): stop the source guest before terminating its launcher (cold-migration capture)

### DIFF
--- a/docs/design/oras-cold-migration.md
+++ b/docs/design/oras-cold-migration.md
@@ -204,7 +204,11 @@ The runtime (CH `--restore`, launcher, resume) is **untouched**.
      the guard is reactive, so the flip must precede the Delete or the launcher
      resurrects (LM-Phase-1 "Stopped-before-Delete"). The source stays down (the
      operator deletes it once the clone is up); the clone still resolves the source
-     spec because a Stopped guest still exists.
+     spec because a Stopped guest still exists. **Cluster-confirmed 2026-07-02**
+     (controller `sha-29014b6`): a fresh full-state capture held
+     `src.runPolicy=Stopped` + `launcher=NONE` through the entire Uploading→Ready
+     window (no resurrection), vs the pre-fix run where the source came back 2/2
+     Running mid-capture; both artifacts still pushed.
   2. **RAM-only tmpfs token missing on the resumed clone — narrow fidelity
      curiosity, LOW.** The `/dev/shm/cm-ram-token` written before the snapshot is
      absent on the clone, while `boot_id` (kernel RAM) and all other resume

--- a/docs/design/oras-cold-migration.md
+++ b/docs/design/oras-cold-migration.md
@@ -191,19 +191,20 @@ The runtime (CH `--restore`, launcher, resume) is **untouched**.
     node).
   - **Two findings (below), neither blocking the import path.**
 - **Findings from validation:**
-  1. **Source resurrection (capture-half, PR 1b) — real, migration-semantics
-     bug.** `handleFullStateDiskCapture` deletes the source launcher to release the
-     frozen root PVC but does NOT set the source `runPolicy: Stopped`, so the
-     SwiftGuest controller **recreates** it (the reactive-stop-guard lesson from
-     Live Migration Phase 1). Consequences: (a) a coherency race between the
-     disk-chunk Job (reads `image.raw` ro) and the resurrected guest's CH (writes
-     `image.raw` rw) on the same node; (b) split-brain — after the clone resumes
-     elsewhere the source is ALSO Running, contradicting §5 "P4 terminates the
-     source (it's a migration)". **Fix (follow-up):** patch the source
-     `runPolicy: Stopped` combined with the launcher Delete in the includeDisk
-     capture path (LM-Phase-1 "single combined MergeFrom + Delete, not just
-     Stopped"). Workaround today: the operator stops/deletes the source after the
-     snapshot is Ready.
+  1. **Source resurrection (capture-half, PR 1b) — RESOLVED (fix/coldmig-source-stop).**
+     `handleFullStateDiskCapture` deleted the source launcher to release the frozen
+     root PVC but did NOT set the source `runPolicy: Stopped`, so the SwiftGuest
+     controller **recreated** it (the reactive-stop-guard lesson from Live Migration
+     Phase 1). Consequences: (a) a coherency race between the disk-chunk Job (reads
+     `image.raw` ro) and the resurrected guest's CH (writes `image.raw` rw) on the
+     same node; (b) split-brain — after the clone resumes elsewhere the source was
+     ALSO Running, contradicting §5 "P4 terminates the source (it's a migration)".
+     **Fix:** a new step 0 `stopSourceGuest` patches the source `runPolicy: Stopped`
+     (idempotent; NotFound/already-Stopped = no-op) BEFORE the launcher Delete —
+     the guard is reactive, so the flip must precede the Delete or the launcher
+     resurrects (LM-Phase-1 "Stopped-before-Delete"). The source stays down (the
+     operator deletes it once the clone is up); the clone still resolves the source
+     spec because a Stopped guest still exists.
   2. **RAM-only tmpfs token missing on the resumed clone — narrow fidelity
      curiosity, LOW.** The `/dev/shm/cm-ram-token` written before the snapshot is
      absent on the clone, while `boot_id` (kernel RAM) and all other resume

--- a/internal/controller/swiftsnapshot/coldmig.go
+++ b/internal/controller/swiftsnapshot/coldmig.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/snapshot/clonecommon"
 )
 
@@ -66,13 +67,27 @@ func (r *SwiftSnapshotReconciler) rootDiskIsBlock(ctx context.Context, snap *sna
 
 // handleFullStateDiskCapture is the capture-then-terminate disk half. It runs in
 // the Uploading phase BEFORE the memory push, so status.OCI.Disk is set first and
-// handleUploadingOCI preserves it. Sequence: terminate the (paused) launcher to
-// release the root PVC → chunk the released disk to oci → stamp status.OCI.Disk.
-// Returns (done, errMsg, err); done=false means requeue.
+// handleUploadingOCI preserves it. Sequence: STOP the source guest → terminate the
+// (paused) launcher to release the root PVC → chunk the released disk to oci →
+// stamp status.OCI.Disk. Returns (done, errMsg, err); done=false means requeue.
 func (r *SwiftSnapshotReconciler) handleFullStateDiskCapture(ctx context.Context, snap *snapshotv1alpha1.SwiftSnapshot, status *snapshotv1alpha1.SwiftSnapshotStatus) (bool, string, error) {
 	if r.SnapshotORASImage == "" {
 		return false, "snapshot-oras image not configured (set " + SnapshotORASImageEnv + ")", nil
 	}
+	// 0. Stop the source guest FIRST — flip runPolicy=Stopped so the SwiftGuest
+	//    controller does NOT recreate the launcher after we delete it in step 1.
+	//    The stop-guard is reactive: recreation happens while runPolicy=Running, so
+	//    a bare Delete without the Stopped flip lets the launcher resurrect — a
+	//    split-brain with the resumed clone AND a coherency race between the
+	//    disk-chunk Job (reads image.raw ro) and the resurrected guest's CH
+	//    (writes it rw). This is the "terminate the source" of capture-then-
+	//    terminate (design §2.1/§5): a full-state capture is a migration, so the
+	//    source stays down (the operator deletes it once the clone is up). Mirrors
+	//    the Live Migration Phase 1 combined runPolicy=Stopped-before-Delete rule.
+	if err := r.stopSourceGuest(ctx, snap.Namespace, snap.Spec.GuestRef.Name); err != nil {
+		return false, "", err
+	}
+
 	// 1. Terminate the launcher so the RWO root PVC releases (frozen at the
 	//    snapshot instant — the VM was captured with ResumeAfterSnapshot=false and
 	//    never resumed). Idempotent: re-Delete while it drains, requeue until gone.
@@ -127,6 +142,31 @@ func (r *SwiftSnapshotReconciler) handleFullStateDiskCapture(ctx context.Context
 		}
 	}
 	return false, "", nil // still chunking
+}
+
+// stopSourceGuest patches the source SwiftGuest to runPolicy=Stopped (idempotent)
+// so the SwiftGuest controller's stop-guard does not recreate the launcher after
+// handleFullStateDiskCapture deletes it. runPolicy must flip to Stopped BEFORE the
+// Delete (the guard is reactive — it prevents recreation, it does not stop a
+// running pod), so this is step 0. A source-gone (NotFound) or already-Stopped
+// guest is a no-op — the capture is re-entrant across requeues. The clone still
+// resolves the source spec later (prepareCloneFromSnapshot needs the guest to
+// exist, not to be running); the operator deletes the stopped source once the
+// clone is up.
+func (r *SwiftSnapshotReconciler) stopSourceGuest(ctx context.Context, namespace, guestName string) error {
+	var guest swiftv1alpha1.SwiftGuest
+	if err := r.Get(ctx, client.ObjectKey{Name: guestName, Namespace: namespace}, &guest); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil // source already gone → nothing to stop
+		}
+		return err
+	}
+	if guest.Spec.RunPolicy == swiftv1alpha1.RunPolicyStopped {
+		return nil // already stopped (idempotent re-entry)
+	}
+	patch := client.MergeFrom(guest.DeepCopy())
+	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyStopped
+	return r.Patch(ctx, &guest, patch)
 }
 
 // buildDiskChunkJob constructs the node-pinned Job that chunks the released root

--- a/internal/controller/swiftsnapshot/coldmig_test.go
+++ b/internal/controller/swiftsnapshot/coldmig_test.go
@@ -1,12 +1,15 @@
 package swiftsnapshot
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 )
 
 func TestOCIDiskTagAndReference(t *testing.T) {
@@ -107,6 +110,42 @@ func TestBuildDiskChunkJob_InsecureAndCreds(t *testing.T) {
 	}
 	if !authVol {
 		t.Errorf("oras-auth credential volume missing")
+	}
+}
+
+// stopSourceGuest is capture-then-terminate step 0: flip the source runPolicy to
+// Stopped BEFORE the launcher Delete so the SwiftGuest controller doesn't
+// resurrect it (split-brain / disk-coherency-race fix). Must be idempotent and
+// tolerant of a source that is already stopped or already gone.
+func TestStopSourceGuest_PatchesRunningToStopped(t *testing.T) {
+	g := makeGuest("team-a", "g1")
+	g.Spec.RunPolicy = swiftv1alpha1.RunPolicyRunning
+	r, c := newReconciler(t, g)
+	if err := r.stopSourceGuest(context.Background(), "team-a", "g1"); err != nil {
+		t.Fatalf("stopSourceGuest: %v", err)
+	}
+	var got swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "g1", Namespace: "team-a"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec.RunPolicy != swiftv1alpha1.RunPolicyStopped {
+		t.Errorf("source runPolicy = %q, want Stopped (else the launcher resurrects)", got.Spec.RunPolicy)
+	}
+}
+
+func TestStopSourceGuest_AlreadyStopped_NoOp(t *testing.T) {
+	g := makeGuest("team-a", "g1")
+	g.Spec.RunPolicy = swiftv1alpha1.RunPolicyStopped
+	r, _ := newReconciler(t, g)
+	if err := r.stopSourceGuest(context.Background(), "team-a", "g1"); err != nil {
+		t.Fatalf("idempotent re-entry on an already-Stopped source must not error: %v", err)
+	}
+}
+
+func TestStopSourceGuest_SourceGone_NoOp(t *testing.T) {
+	r, _ := newReconciler(t) // no source guest
+	if err := r.stopSourceGuest(context.Background(), "team-a", "nonexistent"); err != nil {
+		t.Fatalf("a missing source must be a no-op, not an error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

Finding #1 from [#307](https://github.com/kubeswift-io/kubeswift/pull/307)'s cluster validation: a full-state `includeDisk` capture **resurrected the source guest**.

`handleFullStateDiskCapture` deleted the source launcher to release the frozen RWO root PVC but never set the source `runPolicy: Stopped`, so the SwiftGuest controller **recreated** the launcher — the stop-guard is *reactive* (it prevents recreation while `runPolicy=Stopped`; it does not stop a running pod). Two consequences observed on-cluster:

- **(a) disk-coherency race** — the disk-chunk Job reads `image.raw` read-only while the resurrected guest's CH writes it read-write, on the same node.
- **(b) split-brain** — after the clone resumes on another node, the source is *also* Running, contradicting the design's "P4 terminates the source (it's a migration)" (§2.1/§5).

## Fix

A new step-0 `stopSourceGuest` patches the source `runPolicy: Stopped` **before** the launcher Delete — the Live-Migration-Phase-1 *Stopped-before-Delete* rule. Idempotent: a `NotFound` or already-`Stopped` source is a no-op, so it is safe across the capture's requeues. The source stays down (the operator deletes it once the clone is up); the clone still resolves the source spec because a Stopped guest still exists (validated in #307's run).

## Scope

- **No RBAC change** — the controller-manager ClusterRole already has full verbs on `swiftguests`.
- **No CRD change.**
- Unit tests: `Running→Stopped`, the already-`Stopped` no-op, and the source-gone no-op.

`go build`/`go vet`/`gofmt`/`go test ./internal/controller/swiftsnapshot/...` clean.

Design: `docs/design/oras-cold-migration.md` §4 (finding #1 marked RESOLVED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)