### PR TITLE
feat(swiftctl): guest export/import for cold / suspended-state migration (P4)

### DIFF
--- a/cmd/swiftctl/guest_coldmig.go
+++ b/cmd/swiftctl/guest_coldmig.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+)
+
+// Cold / suspended-state migration CLI (P4). "guest export" captures a running
+// VM's full state (memory + disk) to an OCI registry via a full-state
+// SwiftSnapshot (capture-then-terminate: the source is stopped at the snapshot
+// instant); "guest import" resumes it elsewhere as a cloneFromSnapshot guest.
+// Thin wrappers over the SwiftSnapshot(oci,includeDisk) + cloneFromSnapshot
+// mechanism — see docs/snapshots/cold-migration.md and
+// docs/design/oras-cold-migration.md.
+
+var (
+	exportRepo        string
+	exportTag         string
+	exportInsecure    bool
+	exportCredsSecret string
+	exportSignKey     string
+	exportSnapName    string
+	exportWait        bool
+	exportTimeout     time.Duration
+
+	importFromSnap   string
+	importTargetNode string
+	importGuestClass string
+	importWait       bool
+	importTimeout    time.Duration
+)
+
+var guestCmd = &cobra.Command{
+	Use:   "guest",
+	Short: "Cold / suspended-state migration of a SwiftGuest via an OCI registry",
+	Long: `Move a VM's full state (memory + disk) between nodes or clusters through an
+OCI registry. "guest export" suspends a running guest and pushes a full-state
+artifact pair; "guest import" resumes it elsewhere. The registry is the async
+seam — the source cluster and target cluster never talk directly.`,
+	RunE: func(cmd *cobra.Command, args []string) error { return cmd.Help() },
+}
+
+var guestExportCmd = &cobra.Command{
+	Use:          "export [guest]",
+	Short:        "Capture a running SwiftGuest's full state (memory + disk) to an OCI registry",
+	SilenceUsage: true,
+	Long: `Capture a running SwiftGuest's full state (memory + disk) to an OCI registry
+as a full-state SwiftSnapshot (backend=oci, includeMemory + includeDisk).
+
+This is capture-then-terminate: the guest is paused, its memory is snapshotted,
+the source is STOPPED (runPolicy=Stopped) at the snapshot instant, and a
+memory + disk artifact pair is pushed to the registry. The source stays down —
+this is a migration, not a backup. Resume it elsewhere (another node or cluster)
+with "swiftctl guest import".`,
+	Example: `  swiftctl guest export db --to ghcr.io/acme/vm-snapshots --wait
+  swiftctl guest export db --to zot.registry.svc:5000/snapshots --insecure --wait
+  swiftctl guest export db --to ghcr.io/acme/vm-snapshots \
+    --credentials-secret regcreds --sign-key cosign-key`,
+	Args: cobra.ExactArgs(1),
+	RunE: runGuestExport,
+}
+
+var guestImportCmd = &cobra.Command{
+	Use:          "import [new-guest]",
+	Short:        "Resume a full-state snapshot as a new SwiftGuest (clone-from-snapshot)",
+	SilenceUsage: true,
+	Long: `Resume a full-state SwiftSnapshot as a new SwiftGuest via cloneFromSnapshot.
+The new guest CH-restores the captured memory against a root disk materialized
+from the snapshot's OCI disk artifact — it resumes where the source left off
+(not a fresh boot).
+
+The referenced SwiftSnapshot must be Ready in this namespace. --guest-class is
+required (a clone needs a guestClassRef even though CPU/memory come from the
+snapshot); --target-node pins where the clone runs (and where its disk is
+downloaded).`,
+	Example: `  swiftctl guest import db2 --from-snapshot db-export --target-node boba --guest-class ft-small --wait`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    runGuestImport,
+}
+
+func init() {
+	guestExportCmd.Flags().StringVar(&exportRepo, "to", "", "Target OCI repository WITHOUT a tag, e.g. ghcr.io/acme/vm-snapshots (required)")
+	guestExportCmd.Flags().StringVar(&exportTag, "tag", "", "Artifact tag (default: <namespace>-<snapshot>)")
+	guestExportCmd.Flags().BoolVar(&exportInsecure, "insecure", false, "Allow a plaintext (http) registry — UNSAFE; in-cluster / test registry only")
+	guestExportCmd.Flags().StringVar(&exportCredsSecret, "credentials-secret", "", "Name of a kubernetes.io/dockerconfigjson Secret (same namespace) with registry credentials")
+	guestExportCmd.Flags().StringVar(&exportSignKey, "sign-key", "", "Name of a Secret (same namespace) with a cosign keypair (cosign.key + cosign.password) to sign the artifact")
+	guestExportCmd.Flags().StringVar(&exportSnapName, "name", "", "SwiftSnapshot name (default: <guest>-export)")
+	guestExportCmd.Flags().BoolVar(&exportWait, "wait", false, "Wait for the export to reach Ready and print the artifact references")
+	guestExportCmd.Flags().DurationVar(&exportTimeout, "timeout", 15*time.Minute, "Timeout for --wait")
+	_ = guestExportCmd.MarkFlagRequired("to")
+
+	guestImportCmd.Flags().StringVar(&importFromSnap, "from-snapshot", "", "Name of a Ready full-state SwiftSnapshot in this namespace (required)")
+	guestImportCmd.Flags().StringVar(&importTargetNode, "target-node", "", "Node to run the resumed clone on (required for an oci snapshot)")
+	guestImportCmd.Flags().StringVar(&importGuestClass, "guest-class", "", "SwiftGuestClass for the clone (required; resources come from the snapshot but a guestClassRef is mandatory)")
+	guestImportCmd.Flags().BoolVar(&importWait, "wait", false, "Wait for the imported guest to reach Running")
+	guestImportCmd.Flags().DurationVar(&importTimeout, "timeout", 15*time.Minute, "Timeout for --wait")
+	_ = guestImportCmd.MarkFlagRequired("from-snapshot")
+	_ = guestImportCmd.MarkFlagRequired("target-node")
+	_ = guestImportCmd.MarkFlagRequired("guest-class")
+
+	guestCmd.AddCommand(guestExportCmd)
+	guestCmd.AddCommand(guestImportCmd)
+}
+
+func runGuestExport(cmd *cobra.Command, args []string) error {
+	guestName := args[0]
+	ns := getNamespace()
+	snapName := exportSnapName
+	if snapName == "" {
+		snapName = guestName + "-export"
+	}
+	c, err := newSnapshotClient()
+	if err != nil {
+		return err
+	}
+	snap := buildExportSnapshot(snapName, ns, guestName, exportRepo, exportTag, exportInsecure, exportCredsSecret, exportSignKey)
+	if err := c.Create(context.Background(), snap); err != nil {
+		return fmt.Errorf("create SwiftSnapshot: %w", err)
+	}
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Exporting %s/%s -> SwiftSnapshot %s (full-state: memory + disk, backend=oci, repo=%s)\n",
+		ns, guestName, snapName, exportRepo)
+	fmt.Fprintf(out, "The source is stopped at the snapshot instant and stays down (cold migration).\n")
+	if !exportWait {
+		fmt.Fprintf(out, "\nWatch:  kubectl get swiftsnapshot -n %s %s -w\n", ns, snapName)
+		fmt.Fprintf(out, "Import: swiftctl guest import <new-guest> --from-snapshot %s --target-node <node> --guest-class <class>\n", snapName)
+		return nil
+	}
+	return waitExportReady(cmd, c, ns, snapName)
+}
+
+func waitExportReady(cmd *cobra.Command, c client.Client, ns, snapName string) error {
+	out := cmd.OutOrStdout()
+	ctx, cancel := context.WithTimeout(context.Background(), exportTimeout)
+	defer cancel()
+	for {
+		var got snapshotv1alpha1.SwiftSnapshot
+		if err := c.Get(ctx, client.ObjectKey{Name: snapName, Namespace: ns}, &got); err != nil {
+			return err
+		}
+		switch got.Status.Phase {
+		case snapshotv1alpha1.SwiftSnapshotPhaseReady:
+			fmt.Fprintf(out, "\nReady. Artifacts:\n")
+			if got.Status.OCI != nil {
+				fmt.Fprintf(out, "  memory: %s (%s)\n", got.Status.OCI.Reference, got.Status.OCI.ManifestDigest)
+				if got.Status.OCI.Disk != nil {
+					fmt.Fprintf(out, "  disk:   %s (%s)\n", got.Status.OCI.Disk.Reference, got.Status.OCI.Disk.ManifestDigest)
+				}
+				if got.Status.OCI.Signed {
+					fmt.Fprintf(out, "  signed: true\n")
+				}
+			}
+			fmt.Fprintf(out, "\nImport: swiftctl guest import <new-guest> --from-snapshot %s --target-node <node> --guest-class <class>\n", snapName)
+			return nil
+		case snapshotv1alpha1.SwiftSnapshotPhaseFailed:
+			return fmt.Errorf("export failed: %s", terminalConditionMessage(got.Status.Conditions))
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out after %s waiting for %s to be Ready (phase=%s)", exportTimeout, snapName, got.Status.Phase)
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func runGuestImport(cmd *cobra.Command, args []string) error {
+	newName := args[0]
+	ns := getNamespace()
+	c, err := newSnapshotClient()
+	if err != nil {
+		return err
+	}
+	guest := buildImportGuest(newName, ns, importFromSnap, importTargetNode, importGuestClass)
+	if err := c.Create(context.Background(), guest); err != nil {
+		return fmt.Errorf("create SwiftGuest: %w", err)
+	}
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Importing SwiftSnapshot %s -> SwiftGuest %s/%s (resume on node %s)\n",
+		importFromSnap, ns, newName, importTargetNode)
+	if !importWait {
+		fmt.Fprintf(out, "\nWatch: kubectl get swiftguest -n %s %s -w\n", ns, newName)
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), importTimeout)
+	defer cancel()
+	for {
+		var got swiftv1alpha1.SwiftGuest
+		if err := c.Get(ctx, client.ObjectKey{Name: newName, Namespace: ns}, &got); err != nil {
+			return err
+		}
+		switch got.Status.Phase {
+		case swiftv1alpha1.SwiftGuestPhaseRunning:
+			fmt.Fprintf(out, "\nRunning on %s", got.Status.NodeName)
+			if got.Status.Network != nil && got.Status.Network.PrimaryIP != "" {
+				fmt.Fprintf(out, " (IP %s)", got.Status.Network.PrimaryIP)
+			}
+			fmt.Fprintln(out)
+			return nil
+		case swiftv1alpha1.SwiftGuestPhaseFailed:
+			return fmt.Errorf("import failed (guest phase=Failed); see: swiftctl describe %s -n %s", newName, ns)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out after %s waiting for %s to be Running (phase=%s)", importTimeout, newName, got.Status.Phase)
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// buildExportSnapshot constructs the full-state (memory + disk) oci SwiftSnapshot
+// that "guest export" creates. Extracted for unit testing the spec shape.
+func buildExportSnapshot(name, ns, guestName, repo, tag string, insecure bool, credsSecret, signKey string) *snapshotv1alpha1.SwiftSnapshot {
+	oci := &snapshotv1alpha1.OCIBackend{
+		Repository: repo,
+		Tag:        tag,
+		Insecure:   insecure,
+	}
+	if credsSecret != "" {
+		oci.CredentialsSecretRef = &snapshotv1alpha1.SecretObjectReference{Name: credsSecret}
+	}
+	if signKey != "" {
+		oci.SigningKeySecretRef = &snapshotv1alpha1.SecretObjectReference{Name: signKey}
+	}
+	return &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			GuestRef:      snapshotv1alpha1.SwiftSnapshotGuestRef{Name: guestName},
+			IncludeMemory: true,
+			IncludeDisk:   true,
+			Backend: snapshotv1alpha1.SwiftSnapshotBackend{
+				Type: snapshotv1alpha1.SnapshotBackendOCI,
+				OCI:  oci,
+			},
+		},
+	}
+}
+
+// buildImportGuest constructs the cloneFromSnapshot SwiftGuest that "guest import"
+// creates. Extracted for unit testing the spec shape.
+func buildImportGuest(name, ns, fromSnap, targetNode, guestClass string) *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			CloneFromSnapshot: &swiftv1alpha1.CloneFromSnapshotSource{
+				SnapshotRef: corev1.LocalObjectReference{Name: fromSnap},
+				TargetNode:  targetNode,
+			},
+			GuestClassRef: corev1.LocalObjectReference{Name: guestClass},
+			RunPolicy:     swiftv1alpha1.RunPolicyRunning,
+		},
+	}
+}
+
+// terminalConditionMessage returns the message of the first False condition, or
+// a generic note. Used to surface why an export Failed.
+func terminalConditionMessage(conds []metav1.Condition) string {
+	for _, c := range conds {
+		if c.Status == metav1.ConditionFalse && c.Message != "" {
+			return c.Message
+		}
+	}
+	return "see: swiftctl snapshot describe"
+}

--- a/cmd/swiftctl/guest_coldmig_test.go
+++ b/cmd/swiftctl/guest_coldmig_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+)
+
+func TestBuildExportSnapshot_FullStateOCI(t *testing.T) {
+	s := buildExportSnapshot("db-export", "team-a", "db", "ghcr.io/acme/vm-snapshots", "", false, "", "")
+	if s.Spec.Backend.Type != snapshotv1alpha1.SnapshotBackendOCI {
+		t.Errorf("backend = %q, want oci", s.Spec.Backend.Type)
+	}
+	if !s.Spec.IncludeMemory || !s.Spec.IncludeDisk {
+		t.Errorf("export must be full-state (includeMemory && includeDisk); got mem=%v disk=%v",
+			s.Spec.IncludeMemory, s.Spec.IncludeDisk)
+	}
+	if s.Spec.GuestRef.Name != "db" {
+		t.Errorf("guestRef = %q, want db", s.Spec.GuestRef.Name)
+	}
+	if s.Spec.Backend.OCI == nil || s.Spec.Backend.OCI.Repository != "ghcr.io/acme/vm-snapshots" {
+		t.Errorf("oci.repository not set: %+v", s.Spec.Backend.OCI)
+	}
+	if s.Spec.Backend.OCI.CredentialsSecretRef != nil || s.Spec.Backend.OCI.SigningKeySecretRef != nil {
+		t.Errorf("no creds/sign secrets should be set when flags empty: %+v", s.Spec.Backend.OCI)
+	}
+	if s.Spec.Backend.OCI.Insecure {
+		t.Errorf("insecure must default false")
+	}
+}
+
+func TestBuildExportSnapshot_InsecureCredsSignTag(t *testing.T) {
+	s := buildExportSnapshot("snap", "ns", "vm", "zot.svc:5000/snaps", "custom-tag", true, "regcreds", "cosign-key")
+	oci := s.Spec.Backend.OCI
+	if !oci.Insecure {
+		t.Errorf("--insecure not propagated")
+	}
+	if oci.Tag != "custom-tag" {
+		t.Errorf("tag = %q, want custom-tag", oci.Tag)
+	}
+	if oci.CredentialsSecretRef == nil || oci.CredentialsSecretRef.Name != "regcreds" {
+		t.Errorf("credentials secret not set: %+v", oci.CredentialsSecretRef)
+	}
+	if oci.SigningKeySecretRef == nil || oci.SigningKeySecretRef.Name != "cosign-key" {
+		t.Errorf("signing key secret not set: %+v", oci.SigningKeySecretRef)
+	}
+}
+
+func TestBuildImportGuest_CloneFromSnapshot(t *testing.T) {
+	g := buildImportGuest("db2", "team-a", "db-export", "boba", "ft-small")
+	if g.Spec.CloneFromSnapshot == nil {
+		t.Fatal("import guest must set cloneFromSnapshot")
+	}
+	if g.Spec.CloneFromSnapshot.SnapshotRef.Name != "db-export" {
+		t.Errorf("snapshotRef = %q, want db-export", g.Spec.CloneFromSnapshot.SnapshotRef.Name)
+	}
+	if g.Spec.CloneFromSnapshot.TargetNode != "boba" {
+		t.Errorf("targetNode = %q, want boba", g.Spec.CloneFromSnapshot.TargetNode)
+	}
+	// guestClassRef is required by the CRD/webhook even for a clone.
+	if g.Spec.GuestClassRef.Name != "ft-small" {
+		t.Errorf("guestClassRef = %q, want ft-small", g.Spec.GuestClassRef.Name)
+	}
+	// A clone must NOT set imageRef (mutually exclusive with cloneFromSnapshot).
+	if g.Spec.ImageRef != nil {
+		t.Errorf("import guest must not set imageRef; got %+v", g.Spec.ImageRef)
+	}
+	if g.Spec.RunPolicy != swiftv1alpha1.RunPolicyRunning {
+		t.Errorf("runPolicy = %q, want Running", g.Spec.RunPolicy)
+	}
+}
+
+func TestTerminalConditionMessage(t *testing.T) {
+	msg := terminalConditionMessage([]metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionFalse, Message: "OCI disk chunk Job failed: boom"},
+	})
+	if msg != "OCI disk chunk Job failed: boom" {
+		t.Errorf("got %q", msg)
+	}
+	if got := terminalConditionMessage(nil); got == "" {
+		t.Errorf("empty conditions should still yield a non-empty hint")
+	}
+}

--- a/cmd/swiftctl/root.go
+++ b/cmd/swiftctl/root.go
@@ -47,6 +47,7 @@ func init() {
 	rootCmd.AddCommand(scheduleCmd)
 	rootCmd.AddCommand(migrateCmd)
 	rootCmd.AddCommand(migrationCmd)
+	rootCmd.AddCommand(guestCmd)
 }
 
 // newDynamicClient builds a dynamic client from the resolved kubeconfig. The

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,6 +75,7 @@ The `docs/` directory also contains these focused reference documents:
 
 - [snapshots/fast-vms.md](snapshots/fast-vms.md) — Snapshots, restore, and instant clones overview
 - [snapshots/clone-from-snapshot.md](snapshots/clone-from-snapshot.md) — `cloneFromSnapshot`: fan out N VMs from one snapshot
+- [snapshots/cold-migration.md](snapshots/cold-migration.md) — Cold / suspended-state migration: move a VM's full state (memory + disk) between nodes/clusters via an OCI registry (`swiftctl guest export`/`import`)
 - [snapshots/identity-regeneration.md](snapshots/identity-regeneration.md) — Regenerate a clone's identity in place (the in-guest vsock agent)
 - [snapshots/local-snapshots.md](snapshots/local-snapshots.md) — Tier B (local) memory snapshots
 - [snapshots/s3-snapshots.md](snapshots/s3-snapshots.md) — Tier C (S3) cluster-portable snapshots

--- a/docs/design/oras-cold-migration.md
+++ b/docs/design/oras-cold-migration.md
@@ -168,8 +168,16 @@ The runtime (CH `--restore`, launcher, resume) is **untouched**.
     the GPT would desync the memory image). Composes with the existing memory-download
     path in `prepareCloneFromSnapshot` (which pulls the memory artifact + requires the
     source spec) — the two artifacts are pulled independently, per §2.3.
-  - **Follow-ups:** `swiftctl guest export/import` + runbook; source-independent
-    (fully cross-cluster, source-gone) full-state clone.
+  - **PR 3 — `swiftctl guest export/import` + operator runbook (SHIPPED).**
+    `swiftctl guest export <guest> --to <repo>` creates the full-state oci
+    SwiftSnapshot; `swiftctl guest import <new> --from-snapshot <snap>
+    --target-node <node> --guest-class <class>` creates the cloneFromSnapshot
+    guest (both with `--wait`). Operator runbook:
+    [`docs/snapshots/cold-migration.md`](../snapshots/cold-migration.md).
+  - **Follow-ups:** source-independent (fully cross-cluster, source-gone)
+    full-state clone (capture enough of the source spec in the snapshot so import
+    no longer needs the live source); finding #2 (eager-vs-ondemand restore
+    fidelity); P5 edge-Zot profile.
 - **Cluster validation — DONE 2026-07-02, PASS** (dev cluster, `field-testing`,
   in-cluster Zot HTTP, controller+snapshot-oras `sha-a2edb7c`). Full
   suspend→registry→resume across nodes:

--- a/docs/snapshots/cold-migration.md
+++ b/docs/snapshots/cold-migration.md
@@ -1,0 +1,174 @@
+# Cold / suspended-state migration (via an OCI registry)
+
+Move a running VM's **full state — memory + disk — between nodes or clusters**
+through an OCI registry, and **resume it where it left off** (not a fresh boot).
+The source is suspended and its exact runtime state (RAM + disk) is pushed to a
+registry; a new guest elsewhere CH-restores that memory against a disk
+materialized from the registry.
+
+Use cold migration when:
+
+- You need to move a VM that **cannot live-migrate** (e.g. its state must cross a
+  cluster boundary, or there is no shared L2 / migration network between source
+  and target).
+- Seconds-to-minutes of downtime is acceptable (the VM is paused for the capture,
+  then resumes on the target).
+- You want the move to be **asynchronous and durable** — the registry is the seam,
+  so the source and target never talk directly and the artifact outlives either.
+
+For same-cluster, near-zero-downtime moves that preserve the IP, use **live
+migration** instead ([../migration/overview.md](../migration/overview.md)). For
+fanning out many *fresh* clones from one snapshot, use
+[clone-from-snapshot.md](clone-from-snapshot.md).
+
+> **Scope (v1):** the **import resolves the source guest's spec**, so the source
+> SwiftGuest object must still exist in the target namespace (same cluster today).
+> The disk and memory bytes travel through the registry; the *spec* does not yet.
+> Fully source-independent, cross-cluster import is a tracked follow-up. Same-node
+> and cross-node moves within a cluster work end-to-end today.
+
+## How it works
+
+Cold migration composes two shipped mechanisms — it adds no new runtime path:
+
+1. **Export** = a full-state `SwiftSnapshot` (`backend.type: oci`,
+   `includeMemory: true`, `includeDisk: true`). This is **capture-then-terminate**:
+
+   ```
+   Pending ──▶ Capturing ──▶ Uploading ──────────────────▶ Ready
+              (pause +        (STOP source → terminate       (status.oci: memory
+               snapshot        launcher → chunk the           + status.oci.disk)
+               memory,         frozen disk to oci → push
+               stay paused)    memory to oci)
+   ```
+
+   The guest is paused, its memory is snapshotted, the **source is stopped**
+   (`runPolicy: Stopped`) at the snapshot instant so the disk is coherent and no
+   split-brain is possible, and a memory + disk artifact pair is pushed to the
+   registry. The source stays down — this is a migration, not a backup.
+
+2. **Import** = a `SwiftGuest` with `cloneFromSnapshot` pointing at that snapshot.
+   The controller materializes the root disk from the snapshot's **OCI disk
+   artifact** (pinned by digest, into a fresh per-guest PVC) and the
+   restore-receive launcher CH-`--restore`s the captured memory against it, then
+   resumes. The guest continues from the exact point it was captured (same
+   `boot_id`, same in-RAM state).
+
+## Prerequisites
+
+- An OCI registry reachable from the cluster (ghcr.io, Harbor, a TLS-fronted or
+  in-cluster [Zot](https://zotregistry.dev/)). For a private registry, a
+  `kubernetes.io/dockerconfigjson` pull Secret in the guest's namespace.
+- The controller's `KUBESWIFT_SNAPSHOT_ORAS_IMAGE` set (the Helm chart sets it;
+  `make deploy` uses the pinned default).
+- The source guest running with a memory-snapshottable hypervisor (Cloud
+  Hypervisor). VFIO/GPU guests cannot be memory-snapshotted (webhook-rejected).
+
+## Quick start (swiftctl)
+
+```bash
+# Export a running guest's full state to the registry (source is stopped).
+swiftctl guest export db --to ghcr.io/acme/vm-snapshots --credentials-secret regcreds --wait
+# ... Ready. Artifacts:
+#   memory: ghcr.io/acme/vm-snapshots:default-db-export (sha256:...)
+#   disk:   ghcr.io/acme/vm-snapshots:default-db-export-disk (sha256:...)
+
+# Resume it as a new guest on another node.
+swiftctl guest import db2 --from-snapshot db-export --target-node boba --guest-class ft-small --wait
+# ... Running on boba (IP 192.168.99.x)
+```
+
+`--sign-key <secret>` on export cosign-signs the artifacts (supply-chain
+provenance — see [s3-snapshots.md](s3-snapshots.md) and the signing design). Use
+`--insecure` only for a plaintext in-cluster/test registry on a trusted network.
+
+## Equivalent YAML
+
+`swiftctl guest export db --to <repo>` creates:
+
+```yaml
+apiVersion: snapshot.kubeswift.io/v1alpha1
+kind: SwiftSnapshot
+metadata:
+  name: db-export
+spec:
+  guestRef: {name: db}
+  includeMemory: true
+  includeDisk: true          # full-state: pairs the disk with the memory
+  backend:
+    type: oci
+    oci:
+      repository: ghcr.io/acme/vm-snapshots
+      credentialsSecretRef: {name: regcreds}   # omit for anonymous
+      # insecure: true                         # plaintext registry only
+      # signingKeySecretRef: {name: cosign-key}
+```
+
+`swiftctl guest import db2 --from-snapshot db-export --target-node boba
+--guest-class ft-small` creates:
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: db2
+spec:
+  cloneFromSnapshot:
+    snapshotRef: {name: db-export}
+    targetNode: boba           # required for an oci snapshot
+  guestClassRef: {name: ft-small}  # required even for a clone (resources come
+  runPolicy: Running               # from the snapshot, but a class ref is mandatory)
+```
+
+## What resumes vs. what regenerates
+
+Because import **resumes** captured memory (it is not a fresh boot), the guest
+keeps the source's in-guest identity by default: `machine-id`, SSH host keys,
+hostname, and the guest-visible IP are inherited. Each imported guest gets a
+distinct **hypervisor-side** MAC and its own pod network namespace, so two
+imports of the same snapshot do not collide at L2.
+
+- To regenerate identity in place with no reboot, enable the in-guest vsock agent
+  on the source before export — see
+  [identity-regeneration.md](identity-regeneration.md).
+- The `cloneFromSnapshot.regenerate` list (hostname/machineId/sshHostKeys) fires
+  on the guest's first *reboot* via the seed bootcmd; note the CH v52 clone-reboot
+  caveat in [clone-from-snapshot.md](clone-from-snapshot.md).
+
+## Verifying a resume (not a reboot)
+
+```bash
+# On the source, before export — record the boot id:
+cat /proc/sys/kernel/random/boot_id
+# After import, on the resumed guest — it MATCHES (a reboot would change it):
+cat /proc/sys/kernel/random/boot_id
+journalctl --list-boots     # a single boot spanning source-capture → resume
+```
+
+## Cleanup
+
+The source is left `Stopped` after export (the workload has moved). Delete it once
+the import is healthy:
+
+```bash
+kubectl delete swiftguest db          # the stopped source
+kubectl delete swiftsnapshot db-export  # optional; oci objects are purged if
+                                        # deletionPolicy: Delete (the default)
+```
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| Export stuck in `Capturing`/`Uploading` | Check the snapshot's conditions (`swiftctl snapshot describe db-export`) and the `<snap>-oci-*` Job logs. A private registry needs `--credentials-secret`; a plaintext registry needs `--insecure`. |
+| Export `Failed: OCI disk chunk Job failed` | Registry auth/TLS, or the node ran out of space chunking the disk. Inspect the `<snap>-oci-disk` Job. |
+| Import guest stuck in `Scheduling` | The disk-from-oci download Job (`swiftguest-root-<guest>-oci-disk-dl`) is still pulling, or `--target-node` has no capacity. Check the Job + `kubectl describe swiftguest <guest>`. |
+| Import `Failed: source SwiftGuest ... no longer exists` | v1 needs the source spec — recreate the (stopped) source guest, or wait for source-independent import (tracked follow-up). |
+| Two copies running | Pre-fix behaviour; on current releases the source is stopped during export. If you manually restarted the source, stop it again. |
+
+## See also
+
+- [../design/oras-cold-migration.md](../design/oras-cold-migration.md) — design + decisions
+- [clone-from-snapshot.md](clone-from-snapshot.md) — fan out fresh clones from a snapshot
+- [s3-snapshots.md](s3-snapshots.md) — the S3 equivalent of the OCI backend
+- [../migration/overview.md](../migration/overview.md) — live migration (same-cluster, IP-preserving)


### PR DESCRIPTION
## What

The operator surface for cold / suspended-state migration (design §2.2) — two thin `swiftctl` commands over the shipped `SwiftSnapshot(oci, includeDisk)` + `cloneFromSnapshot` mechanism:

- **`swiftctl guest export <guest> --to <repo>`** `[--tag] [--insecure] [--credentials-secret] [--sign-key] [--name] [--wait]` — creates a full-state (memory + disk) oci `SwiftSnapshot`. Capture-then-terminate: the source is stopped at the snapshot instant and a memory + disk artifact pair is pushed to the registry.
- **`swiftctl guest import <new-guest> --from-snapshot <snap> --target-node <node> --guest-class <class>`** `[--wait]` — creates a `cloneFromSnapshot` guest that CH-restores the memory against a disk materialized from the oci disk artifact — resumes where the source left off.

`--wait` polls to Ready / Running and prints the artifact refs / node+IP.

## How

Spec construction is factored into `buildExportSnapshot` / `buildImportGuest` (pure, unit-tested); the run functions create + optionally poll. Registered under a new `guest` command group. No controller/runtime change — these commands create the exact resources #305–#308 already validated.

## Tests

Unit: full-state backend shape (oci + includeMemory + includeDisk), creds/sign/insecure/tag propagation, clone shape (cloneFromSnapshot set, no imageRef, guestClassRef required), terminal-condition message. `go build`/`go vet`/`gofmt`/`go test ./cmd/swiftctl/...` clean.

## Cluster-validated (2026-07-02)

Full CLI round-trip on the dev cluster (in-cluster Zot, controller with the source-stop fix):

```
$ swiftctl guest export cm3-src --to zot...:5000/vm-snapshots --insecure --name cm3-export --wait
Ready. Artifacts:
  memory: ...:field-testing-cm3-export (sha256:a38a98...)
  disk:   ...:field-testing-cm3-export-disk (sha256:f4bb82...)

$ swiftctl guest import cm3-clone --from-snapshot cm3-export --target-node boba --guest-class ft-small --wait
Running on boba
```

Final state: `cm3-src` → `Stopped` (source-stop fix engaged via the CLI-created snapshot too), `cm3-clone` → `Running` on boba (resumed cross-node). Both commands produced admissible resources that flowed end-to-end.

## Docs

Operator runbook `docs/snapshots/cold-migration.md` (how it works, the resume-not-reboot check, the same-cluster source-spec scope note, troubleshooting) + docs index + design §4 follow-up marked shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)