### PR TITLE
feat(resolved): FromCapturedSpec — resolve a source-independent full-state clone (SI PR2)

### DIFF
--- a/internal/resolved/captured.go
+++ b/internal/resolved/captured.go
@@ -1,0 +1,78 @@
+package resolved
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+)
+
+// CapturedInput is the launcher-sufficient surface a source-independent
+// full-state clone needs, mapped from a SwiftSnapshot's status.capturedGuestSpec
+// by the caller (so this package stays free of the snapshot API). It is the
+// resume-specific configuration that overrides the guestClass shell in
+// FromCapturedSpec. See docs/design/oras-cold-migration-source-independent.md.
+type CapturedInput struct {
+	CPU              int // cores (from the captured/resumed VM, not the clone's class)
+	MemoryMi         int // MiB
+	RootDiskSize     string
+	AccessMode       string
+	VolumeMode       string
+	StorageClassName string
+	Network          bool
+	OSType           string
+	InterfaceNames   []string
+}
+
+// FromCapturedSpec builds a ResolvedGuest for a source-independent (fully
+// cross-cluster) full-state clone — one whose source SwiftGuest / SwiftImage /
+// SwiftSeedProfile are all gone, so the effective-spec resolve path
+// (resolveDiskBoot) can't run.
+//
+// It reuses Merge (with a nil image + nil seedProfile) for the system-default
+// shell — GuestSettings, Lifecycle, Networks, Meta, CoreScheduling — from the
+// clone's OWN guestClass, then overrides the resume-specific fields from the
+// captured surface: the disk is materialized from the OCI artifact (RootDisk
+// .FromOCI, raw), and the resumed VM's actual resources/storage/os/interfaces
+// come from the snapshot, not the clone's class (CH --restore uses the captured
+// config.json; the class exists only to satisfy the guestClassRef requirement).
+//
+// PreparedImage is left empty (no image) — the controller runs
+// EnsureRootDiskClone on RootDisk.FromOCI (→ maybeRootDiskFromOCI) to supply the
+// disk. Pure: no client, no I/O — the caller fetches the guestClass.
+//
+// Same-cluster clones are unaffected: they keep resolving via the effective-spec
+// path (source guest present). This constructor fires only when the source is
+// gone AND the snapshot carries a populated captured surface.
+func FromCapturedSpec(guest *swiftv1alpha1.SwiftGuest, guestClass *swiftv1alpha1.SwiftGuestClass, c CapturedInput) *ResolvedGuest {
+	rg := Merge(guest, guestClass, nil, nil)
+
+	// Resume-specific overrides (the captured/resumed VM's real config).
+	rg.Resources = Resources{CPU: c.CPU, Memory: c.MemoryMi}
+	if c.RootDiskSize != "" {
+		if q, err := resource.ParseQuantity(c.RootDiskSize); err == nil {
+			rg.RootDisk.Size = q
+		}
+	}
+	rg.RootDisk.Format = "raw"
+	rg.RootDisk.FromOCI = true
+	rg.Storage = Storage{
+		AccessMode:       c.AccessMode,
+		VolumeMode:       c.VolumeMode,
+		StorageClassName: c.StorageClassName,
+	}
+	rg.Network = c.Network
+	if c.OSType != "" {
+		rg.OSType = c.OSType
+	}
+	// Interface names only — enough for the launcher's default per-NIC setup and
+	// for deterministic per-clone MAC rewrites (the source MACs are irrelevant;
+	// the clone re-derives them). Multi-NIC with secondary NADs is a documented
+	// v1 limitation (the NADs must also exist in the target cluster).
+	if len(c.InterfaceNames) > 0 {
+		rg.Interfaces = make([]swiftv1alpha1.GuestInterface, 0, len(c.InterfaceNames))
+		for _, n := range c.InterfaceNames {
+			rg.Interfaces = append(rg.Interfaces, swiftv1alpha1.GuestInterface{Name: n})
+		}
+	}
+	return rg
+}

--- a/internal/resolved/captured_test.go
+++ b/internal/resolved/captured_test.go
@@ -1,0 +1,66 @@
+package resolved
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+)
+
+func TestFromCapturedSpec(t *testing.T) {
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-a", Namespace: "team-a"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			GuestClassRef: corev1.LocalObjectReference{Name: "ft-small"},
+		},
+	}
+	// A minimal class shell: its values are overridden by the captured surface,
+	// but Merge parses them, so keep them valid.
+	class := &swiftv1alpha1.SwiftGuestClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "ft-small"},
+		Spec: swiftv1alpha1.SwiftGuestClassSpec{
+			CPU:      resource.MustParse("1"),
+			Memory:   resource.MustParse("1Gi"),
+			RootDisk: swiftv1alpha1.RootDiskSpec{Size: resource.MustParse("10Gi")},
+		},
+	}
+	c := CapturedInput{
+		CPU: 2, MemoryMi: 2048, RootDiskSize: "40Gi",
+		AccessMode: "ReadWriteMany", VolumeMode: "Block", StorageClassName: "longhorn-migratable",
+		Network: true, OSType: "linux", InterfaceNames: []string{"eth0", "data"},
+	}
+
+	rg := FromCapturedSpec(guest, class, c)
+
+	// Resume-specific fields come from the captured surface, not the class.
+	if rg.Resources.CPU != 2 || rg.Resources.Memory != 2048 {
+		t.Errorf("resources = %+v, want cpu 2 / mem 2048 (from captured, not class)", rg.Resources)
+	}
+	if rg.RootDisk.Size.String() != "40Gi" || rg.RootDisk.Format != "raw" || !rg.RootDisk.FromOCI {
+		t.Errorf("rootDisk = %+v, want 40Gi/raw/FromOCI", rg.RootDisk)
+	}
+	if rg.Storage.AccessMode != "ReadWriteMany" || rg.Storage.VolumeMode != "Block" ||
+		rg.Storage.StorageClassName != "longhorn-migratable" {
+		t.Errorf("storage = %+v", rg.Storage)
+	}
+	if !rg.Network || rg.OSType != "linux" {
+		t.Errorf("network=%v osType=%q, want true/linux", rg.Network, rg.OSType)
+	}
+	if len(rg.Interfaces) != 2 || rg.Interfaces[0].Name != "eth0" || rg.Interfaces[1].Name != "data" {
+		t.Errorf("interfaces = %+v, want [eth0 data]", rg.Interfaces)
+	}
+	// No image was resolved — the disk comes from oci.
+	if rg.PreparedImage.Ready || rg.PreparedImage.PVCName != "" {
+		t.Errorf("PreparedImage must be empty for a source-independent clone; got %+v", rg.PreparedImage)
+	}
+	// The system-default shell still comes through Merge.
+	if rg.GuestSettings.Firmware != DefaultFirmware || rg.GuestSettings.Bus != DefaultBus {
+		t.Errorf("GuestSettings shell not filled from Merge: %+v", rg.GuestSettings)
+	}
+	if rg.Meta.Name != "clone-a" || rg.Meta.Namespace != "team-a" {
+		t.Errorf("Meta = %+v, want clone-a/team-a", rg.Meta)
+	}
+}

--- a/internal/resolved/types.go
+++ b/internal/resolved/types.go
@@ -104,6 +104,12 @@ type Resources struct {
 type RootDisk struct {
 	Size   resource.Quantity `json:"size"`
 	Format string            `json:"format"` // raw or qcow2
+	// FromOCI marks a root disk that is materialized from a snapshot's OCI disk
+	// artifact rather than cloned from a base SwiftImage — a source-independent
+	// full-state clone (FromCapturedSpec). The controller runs EnsureRootDiskClone
+	// (→ maybeRootDiskFromOCI) on this even though PreparedImage is empty (no
+	// image was resolved). See docs/design/oras-cold-migration-source-independent.md.
+	FromOCI bool `json:"fromOCI,omitempty"`
 }
 
 // Storage is the post-merge effective storage spec for controller-created


### PR DESCRIPTION
Second PR of the **source-independent (cross-cluster) full-state clone** arc — design [#310](https://github.com/kubeswift-io/kubeswift/pull/310), capture surface [#311](https://github.com/kubeswift-io/kubeswift/pull/311).

## Why

The resolver is image-oriented: `resolveDiskBoot` Gets the SwiftImage and needs it `Ready`. For a true cross-cluster clone the source's SwiftGuest/SwiftImage/SwiftSeedProfile are all gone, so that path can't run. This PR adds the parallel resolver path fed from the captured surface.

## What

- **`resolved.FromCapturedSpec(guest, guestClass, CapturedInput)`** — reuses `Merge` (nil image + nil seedProfile) for the system-default shell (GuestSettings / Lifecycle / Networks / Meta / CoreScheduling from the clone's own guestClass), then overrides the resume-specific fields from the captured surface (resources / rootDiskSize / storage / network / osType / interface-names), since CH `--restore` uses the captured `config.json`, not the clone's class. **Pure** (no client); the caller maps the snapshot's `CapturedGuestSpec` → `resolved.CapturedInput` (keeps `resolved` snapshot-API-free).
- **`resolved.RootDisk.FromOCI`** — marks a disk materialized from the oci disk artifact (`PreparedImage` empty, no image resolved). SI PR3 wires the controller to run `EnsureRootDiskClone` on `FromOCI` → `maybeRootDiskFromOCI` supplies the disk.
- Unit test: captured overrides win over the class; `FromOCI`/raw; no `PreparedImage`; the `Merge` shell (GuestSettings/Meta) comes through.

## Scope

Reuses `Merge` deliberately to **minimize drift** from the real resolver (design Risk #1 — the shell fields can't diverge). Inert until SI PR3 wires it in; same-cluster clones keep the effective-spec path unchanged.

`go build`/`go test ./internal/resolved/...`/`gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)