### PR TITLE
feat(clone): source-independent full-state import — resolve from the captured surface (SI PR3)

### DIFF
--- a/docs/design/oras-cold-migration-source-independent.md
+++ b/docs/design/oras-cold-migration-source-independent.md
@@ -151,14 +151,27 @@ smaller change). The vsock identity agent path is unchanged.
 
 ## 4. Phasing
 
-- **PR 1 — capture surface:** expand `CapturedGuestSpec` (D1) + populate it at
-  capture from the resolved source guest; `make generate` + chart sync. Additive;
-  no behaviour change.
-- **PR 2 — resolver path:** `resolved.FromCapturedSpec` (D2) + unit tests (pure).
-- **PR 3 — import fallback:** `prepareCloneFromSnapshot` source-gone branch (D5) +
-  minimal-seed launcher path (D3) + MAC-from-names (D6) + webhook rejects
-  source-gone-with-data-disks (D4).
-- **PR 4 — CLI + validation:** `swiftctl guest import` works with the source (and
+- **PR 1 — capture surface (SHIPPED #311):** expand `CapturedGuestSpec` (D1) +
+  populate it at capture from the resolved source guest; `make generate` + chart
+  sync. Additive; no behaviour change.
+- **PR 2 — resolver path (SHIPPED #312):** `resolved.FromCapturedSpec` (D2) +
+  `RootDisk.FromOCI` sentinel + unit tests (pure).
+- **PR 3 — import fallback (this PR):** `prepareCloneFromSnapshot` dispatches a
+  source-gone clone to `prepareSourceIndependentClone` (D5): guards full-state +
+  captured surface (else the pre-SI needs-the-source-spec message) and rejects
+  captured `hasDataDisks` (D4, controller-side — races-immune vs an
+  admission-time check); builds `rg` via `FromCapturedSpec` from the clone's own
+  guestClass + the captured surface; a `placeholderSeed` (minimal NoCloud) rides
+  the EXISTING seed-ConfigMap + launcher ISO machinery so CH `--restore` can
+  re-open the config.json seed disk with zero Rust change (D3); a
+  `stubSourceFromCaptured` (identity + interface names + agent opt-in) feeds the
+  shared `cloneRestoreAnnotations` builder so MAC rewrites/runtime-dir
+  prefixes/agent-enable derive from the captured surface (D6). The controller
+  consumes the pre-resolved `rg` (skipping the image-oriented resolver) and the
+  root-disk gate also fires on `RootDisk.FromOCI` so `maybeRootDiskFromOCI`
+  materializes the disk. Same-cluster clones are byte-identical in behaviour
+  (source-present keeps the effective-spec path).
+- **PR 4 — validation:** `swiftctl guest import` works with the source (and
   its SwiftImage + seedProfile) deleted; cluster-validate by simulating
   cross-cluster (below). Runbook update (drop the same-cluster scope note).
 

--- a/internal/controller/swiftguest/clone.go
+++ b/internal/controller/swiftguest/clone.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"strconv"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/metrics"
+	"github.com/kubeswift-io/kubeswift/internal/resolved"
 	"github.com/kubeswift-io/kubeswift/internal/snapshot/clonecommon"
 )
 
@@ -27,30 +30,35 @@ import (
 // overlaid (for resolution); the real guest keeps its identity
 // (name/namespace/annotations) and is used everywhere else.
 //
-// Returns (effective, failReason, requeue, err):
-//   - effective != nil  → resolve THIS instead of the real guest.
-//   - failReason != ""  → set Resolved=False / phase=Failed (terminal).
-//   - requeue           → snapshot not Ready yet; re-reconcile.
+// Returns (effective, preResolved, failReason, requeue, err):
+//   - effective != nil   → resolve THIS instead of the real guest.
+//   - preResolved != nil → skip the resolver entirely and use THIS ResolvedGuest
+//     (the source-independent path — the source guest/image/seedProfile are gone
+//     and rg is built from the snapshot's captured surface via FromCapturedSpec).
+//   - failReason != ""   → set Resolved=False / phase=Failed (terminal).
+//   - requeue            → snapshot not Ready yet; re-reconcile.
 //
-// PR 3a handles Tier B (local, same-node) snapshots. Tier C (s3) needs the
-// download path (PR 3b); the source guest must be live (the snapshot's
-// CapturedGuestSpec is validation-only — cross-cluster/source-gone clones are a
-// future enhancement).
+// PR 3a handles Tier B (local, same-node) snapshots; Tier C (s3/oci) adds the
+// download path. When the source guest still exists its live spec is used (the
+// validated same-cluster path). When it is GONE and the snapshot is a full-state
+// oci snapshot carrying the captured launcher-sufficient surface (SI PR1), the
+// clone resolves source-independently — the fully cross-cluster path
+// (docs/design/oras-cold-migration-source-independent.md).
 func (r *SwiftGuestReconciler) prepareCloneFromSnapshot(
 	ctx context.Context, guest *swiftv1alpha1.SwiftGuest,
-) (*swiftv1alpha1.SwiftGuest, string, bool, error) {
+) (*swiftv1alpha1.SwiftGuest, *resolved.ResolvedGuest, string, bool, error) {
 	src := guest.Spec.CloneFromSnapshot
 
 	var snap snapshotv1alpha1.SwiftSnapshot
 	if err := r.Get(ctx, client.ObjectKey{Name: src.SnapshotRef.Name, Namespace: guest.Namespace}, &snap); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, "SwiftSnapshot " + src.SnapshotRef.Name + " not found", false, nil
+			return nil, nil, "SwiftSnapshot " + src.SnapshotRef.Name + " not found", false, nil
 		}
-		return nil, "", false, err
+		return nil, nil, "", false, err
 	}
 	if snap.Status.Phase != snapshotv1alpha1.SwiftSnapshotPhaseReady {
 		// Transient — the snapshot may still be Capturing/Uploading.
-		return nil, "", true, nil
+		return nil, nil, "", true, nil
 	}
 
 	// Resolve the on-node snapshot directory + the node the clone runs on.
@@ -63,81 +71,72 @@ func (r *SwiftGuestReconciler) prepareCloneFromSnapshot(
 	switch snap.Spec.Backend.Type {
 	case snapshotv1alpha1.SnapshotBackendLocal:
 		if snap.Status.NodeName == "" || snap.Spec.Backend.Local == nil || snap.Spec.Backend.Local.HostPath == "" {
-			return nil, "SwiftSnapshot " + snap.Name + " is missing status.nodeName or backend.local.hostPath", false, nil
+			return nil, nil, "SwiftSnapshot " + snap.Name + " is missing status.nodeName or backend.local.hostPath", false, nil
 		}
 		snapshotPath, node = snap.Spec.Backend.Local.HostPath, snap.Status.NodeName
 	case snapshotv1alpha1.SnapshotBackendS3:
 		node = src.TargetNode
 		if node == "" {
-			return nil, "cloneFromSnapshot from a Tier C (s3) snapshot requires spec.cloneFromSnapshot.targetNode", false, nil
+			return nil, nil, "cloneFromSnapshot from a Tier C (s3) snapshot requires spec.cloneFromSnapshot.targetNode", false, nil
 		}
 		if snap.Status.S3 == nil || snap.Status.S3.Location == "" {
-			return nil, "SwiftSnapshot " + snap.Name + " has no status.s3 — its upload is not complete", false, nil
+			return nil, nil, "SwiftSnapshot " + snap.Name + " has no status.s3 — its upload is not complete", false, nil
 		}
 		done, failReason, derr := r.ensureCloneDownloadJob(ctx, guest, &snap, node)
 		if derr != nil {
-			return nil, "", false, derr
+			return nil, nil, "", false, derr
 		}
 		if failReason != "" {
-			return nil, failReason, false, nil
+			return nil, nil, failReason, false, nil
 		}
 		if !done {
 			// Still downloading the snapshot artifacts onto the target node.
-			return nil, "", true, nil
+			return nil, nil, "", true, nil
 		}
 		snapshotPath = clonecommon.S3LocalDir(&snap)
 	case snapshotv1alpha1.SnapshotBackendOCI:
 		node = src.TargetNode
 		if node == "" {
-			return nil, "cloneFromSnapshot from an oci snapshot requires spec.cloneFromSnapshot.targetNode", false, nil
+			return nil, nil, "cloneFromSnapshot from an oci snapshot requires spec.cloneFromSnapshot.targetNode", false, nil
 		}
 		if snap.Status.OCI == nil || snap.Status.OCI.ManifestDigest == "" {
-			return nil, "SwiftSnapshot " + snap.Name + " has no status.oci — its push is not complete", false, nil
+			return nil, nil, "SwiftSnapshot " + snap.Name + " has no status.oci — its push is not complete", false, nil
 		}
 		done, failReason, derr := r.ensureCloneDownloadJob(ctx, guest, &snap, node)
 		if derr != nil {
-			return nil, "", false, derr
+			return nil, nil, "", false, derr
 		}
 		if failReason != "" {
-			return nil, failReason, false, nil
+			return nil, nil, failReason, false, nil
 		}
 		if !done {
 			// Still pulling the snapshot artifacts onto the target node.
-			return nil, "", true, nil
+			return nil, nil, "", true, nil
 		}
 		snapshotPath = clonecommon.S3LocalDir(&snap)
 	default:
-		return nil, "cloneFromSnapshot requires a memory snapshot (backend.type: local, s3, or oci); got " + string(snap.Spec.Backend.Type), false, nil
+		return nil, nil, "cloneFromSnapshot requires a memory snapshot (backend.type: local, s3, or oci); got " + string(snap.Spec.Backend.Type), false, nil
 	}
 
-	// The clone needs the source guest's full spec (image/seed/class) to build
+	// The clone prefers the source guest's full spec (image/seed/class) to build
 	// the launcher pod — a fresh disk from the source image plus the restored
-	// memory. The snapshot's CapturedGuestSpec is insufficient (CPU/mem/image
-	// name only), so the source guest must still exist.
+	// memory. When the source is GONE, a full-state oci snapshot carrying the
+	// captured launcher-sufficient surface (SI PR1) can still clone
+	// source-independently — the disk comes from the oci disk artifact and rg is
+	// built from the captured surface instead of a live spec.
 	var source swiftv1alpha1.SwiftGuest
 	if err := r.Get(ctx, client.ObjectKey{Name: snap.Spec.GuestRef.Name, Namespace: guest.Namespace}, &source); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, "source SwiftGuest " + snap.Spec.GuestRef.Name + " no longer exists; cloneFromSnapshot needs the source spec", false, nil
+			return r.prepareSourceIndependentClone(ctx, guest, &snap, snapshotPath, node)
 		}
-		return nil, "", false, err
+		return nil, nil, "", false, err
 	}
 
 	// Self-stamp the clone-mode restore annotations (mirrors what the
 	// SwiftRestore controller stamps on its clone targets) if not already set.
 	annos := cloneRestoreAnnotations(guest, &snap, &source, snapshotPath, node)
-	if !cloneAnnotationsMatch(guest.Annotations, annos) {
-		patched := guest.DeepCopy()
-		if patched.Annotations == nil {
-			patched.Annotations = map[string]string{}
-		}
-		for k, v := range annos {
-			patched.Annotations[k] = v
-		}
-		if err := r.Patch(ctx, patched, client.MergeFrom(guest)); err != nil {
-			return nil, "", false, err
-		}
-		// Reflect the stamp in-memory so the rest of this reconcile sees it.
-		guest.Annotations = patched.Annotations
+	if err := r.stampCloneAnnotations(ctx, guest, annos); err != nil {
+		return nil, nil, "", false, err
 	}
 
 	// Effective guest: the real guest's identity (name/namespace/annotations/
@@ -148,7 +147,131 @@ func (r *SwiftGuestReconciler) prepareCloneFromSnapshot(
 	clonePolicy := guest.Spec.RunPolicy
 	effective.Spec = source.Spec
 	effective.Spec.RunPolicy = clonePolicy
-	return effective, "", false, nil
+	return effective, nil, "", false, nil
+}
+
+// prepareSourceIndependentClone handles a cloneFromSnapshot whose SOURCE guest no
+// longer exists — the fully cross-cluster path
+// (docs/design/oras-cold-migration-source-independent.md). It requires a
+// FULL-STATE oci snapshot (status.oci.disk — the frozen runtime disk is in the
+// registry, so no SwiftImage is needed) carrying the captured
+// launcher-sufficient surface (status.guestSpec.storage — SI PR1); anything else
+// genuinely needs the live source spec and fails with the pre-SI message.
+//
+// The returned ResolvedGuest is built by resolved.FromCapturedSpec: the clone's
+// own guestClass supplies the system-default shell, the captured surface
+// supplies the resume-specific config, RootDisk.FromOCI routes the root disk to
+// maybeRootDiskFromOCI, and — when the source had a seedProfile — a minimal
+// placeholder NoCloud seed satisfies CH --restore's re-open of the seed.iso
+// disk recorded in config.json (a resume never reads seed content; see design
+// D3 — a later reboot has no real seed, the vsock agent is the identity path).
+func (r *SwiftGuestReconciler) prepareSourceIndependentClone(
+	ctx context.Context,
+	guest *swiftv1alpha1.SwiftGuest,
+	snap *snapshotv1alpha1.SwiftSnapshot,
+	snapshotPath, node string,
+) (*swiftv1alpha1.SwiftGuest, *resolved.ResolvedGuest, string, bool, error) {
+	captured := snap.Status.GuestSpec
+	if snap.Status.OCI == nil || snap.Status.OCI.Disk == nil || snap.Status.OCI.Disk.ManifestDigest == "" ||
+		captured == nil || captured.Storage == nil {
+		// Not a full-state snapshot with the captured surface — the
+		// pre-source-independence contract applies.
+		return nil, nil, "source SwiftGuest " + snap.Spec.GuestRef.Name + " no longer exists; cloneFromSnapshot needs the source spec (only a full-state oci snapshot with a captured guest spec clones source-independently)", false, nil
+	}
+	if captured.HasDataDisks {
+		return nil, nil, "source-independent clone: snapshot " + snap.Name + "'s source had data disks, which full-state capture does not carry (v1 is root-disk-only); the source spec is required", false, nil
+	}
+	var class swiftv1alpha1.SwiftGuestClass
+	if err := r.Get(ctx, client.ObjectKey{Name: guest.Spec.GuestClassRef.Name}, &class); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil, "SwiftGuestClass " + guest.Spec.GuestClassRef.Name + " not found", false, nil
+		}
+		return nil, nil, "", false, err
+	}
+
+	cpu, _ := strconv.Atoi(captured.CPU) // "" → 0; FromCapturedSpec output feeds pod limits only (CH --restore uses config.json)
+	in := resolved.CapturedInput{
+		CPU:              cpu,
+		MemoryMi:         int(captured.MemoryMi),
+		RootDiskSize:     captured.RootDiskSize,
+		AccessMode:       captured.Storage.AccessMode,
+		VolumeMode:       captured.Storage.VolumeMode,
+		StorageClassName: captured.Storage.StorageClassName,
+		Network:          captured.Network,
+		OSType:           captured.OSType,
+		InterfaceNames:   captured.InterfaceNames,
+	}
+	rg := resolved.FromCapturedSpec(guest, &class, in)
+	if captured.HasSeed {
+		rg.Seed = placeholderSeed(guest.Name)
+	}
+
+	// A stub source (identity + the captured interface names + agent opt-in)
+	// makes the shared annotation builder work unchanged: MAC rewrites seed from
+	// interface names, the runtime-dir FROM prefix derives from the source's
+	// ns/name — which config.json records — and agent-enablement carries over.
+	// Cross-cluster note: the FROM prefix uses snap.Namespace, so the snapshot
+	// must be recreated in a namespace with the SAME NAME as the source's
+	// original namespace (documented in the runbook).
+	stub := stubSourceFromCaptured(snap, captured)
+	annos := cloneRestoreAnnotations(guest, snap, stub, snapshotPath, node)
+	if err := r.stampCloneAnnotations(ctx, guest, annos); err != nil {
+		return nil, nil, "", false, err
+	}
+	return nil, rg, "", false, nil
+}
+
+// stampCloneAnnotations idempotently patches the clone-mode restore annotations
+// onto the real guest (in-cluster + in-memory).
+func (r *SwiftGuestReconciler) stampCloneAnnotations(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, annos map[string]string) error {
+	if cloneAnnotationsMatch(guest.Annotations, annos) {
+		return nil
+	}
+	patched := guest.DeepCopy()
+	if patched.Annotations == nil {
+		patched.Annotations = map[string]string{}
+	}
+	for k, v := range annos {
+		patched.Annotations[k] = v
+	}
+	if err := r.Patch(ctx, patched, client.MergeFrom(guest)); err != nil {
+		return err
+	}
+	// Reflect the stamp in-memory so the rest of this reconcile sees it.
+	guest.Annotations = patched.Annotations
+	return nil
+}
+
+// stubSourceFromCaptured synthesizes a minimal source SwiftGuest from the
+// snapshot's captured surface, carrying exactly what cloneRestoreAnnotations
+// consumes: identity (ns/name → runtime-dir FROM prefix), interface names (MAC
+// rewrites), and the guest-agent opt-in.
+func stubSourceFromCaptured(snap *snapshotv1alpha1.SwiftSnapshot, captured *snapshotv1alpha1.CapturedGuestSpec) *swiftv1alpha1.SwiftGuest {
+	stub := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: snap.Spec.GuestRef.Name, Namespace: snap.Namespace},
+	}
+	for _, n := range captured.InterfaceNames {
+		stub.Spec.Interfaces = append(stub.Spec.Interfaces, swiftv1alpha1.GuestInterface{Name: n})
+	}
+	if captured.GuestAgent {
+		stub.Spec.GuestAgent = &swiftv1alpha1.GuestAgentSpec{Enabled: true}
+	}
+	return stub
+}
+
+// placeholderSeed is the minimal NoCloud seed for a source-independent clone
+// whose source had a seedProfile. CH --restore re-opens the seed.iso disk path
+// recorded in config.json and refuses to restore when the file is missing; the
+// launcher rebuilds seed.iso from the seed ConfigMap, so giving rg a minimal
+// seed makes the existing ConfigMap + ISO machinery produce a file at the right
+// path. The resumed guest never reads it (cloud-init already ran in the
+// captured state). Content is deliberately inert.
+func placeholderSeed(cloneName string) *resolved.Seed {
+	return &resolved.Seed{
+		Datasource: "NoCloud",
+		MetaData:   "instance-id: " + cloneName + "\nlocal-hostname: " + cloneName + "\n",
+		UserData:   "#cloud-config\n# Placeholder seed for a source-independent full-state clone.\n# The resumed guest never reads this (cloud-init already ran before capture).\n",
+	}
 }
 
 // cloneRestoreAnnotations builds the clone-mode restore-receive annotations for

--- a/internal/controller/swiftguest/clone_test.go
+++ b/internal/controller/swiftguest/clone_test.go
@@ -7,6 +7,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -25,7 +26,10 @@ func cloneScheme(t *testing.T) *runtime.Scheme {
 		t.Fatalf("clientgoscheme: %v", err)
 	}
 	gvSwift := schema.GroupVersion{Group: "swift.kubeswift.io", Version: "v1alpha1"}
-	s.AddKnownTypes(gvSwift, &swiftv1alpha1.SwiftGuest{}, &swiftv1alpha1.SwiftGuestList{})
+	s.AddKnownTypes(gvSwift,
+		&swiftv1alpha1.SwiftGuest{}, &swiftv1alpha1.SwiftGuestList{},
+		&swiftv1alpha1.SwiftGuestClass{}, &swiftv1alpha1.SwiftGuestClassList{},
+	)
 	metav1.AddToGroupVersion(s, gvSwift)
 	gvSnap := schema.GroupVersion{Group: "snapshot.kubeswift.io", Version: "v1alpha1"}
 	s.AddKnownTypes(gvSnap, &snapshotv1alpha1.SwiftSnapshot{}, &snapshotv1alpha1.SwiftSnapshotList{})
@@ -79,7 +83,7 @@ func newCloneReconciler(t *testing.T, objs ...client.Object) (*SwiftGuestReconci
 func TestPrepareCloneFromSnapshot_TierB(t *testing.T) {
 	g := cloneGuest()
 	r, c := newCloneReconciler(t, g, sourceGuest(), localSnap(snapshotv1alpha1.SwiftSnapshotPhaseReady))
-	eff, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	eff, _, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
 	if err != nil || fail != "" || requeue {
 		t.Fatalf("expected success; fail=%q requeue=%v err=%v", fail, requeue, err)
 	}
@@ -111,7 +115,7 @@ func TestPrepareCloneFromSnapshot_TierB(t *testing.T) {
 func TestPrepareCloneFromSnapshot_NotReady(t *testing.T) {
 	g := cloneGuest()
 	r, _ := newCloneReconciler(t, g, sourceGuest(), localSnap(snapshotv1alpha1.SwiftSnapshotPhaseCapturing))
-	_, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	_, _, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
 	if err != nil || fail != "" || !requeue {
 		t.Fatalf("not-Ready snapshot should requeue; fail=%q requeue=%v err=%v", fail, requeue, err)
 	}
@@ -138,7 +142,7 @@ func TestPrepareCloneFromSnapshot_TierC_RequiresTargetNode(t *testing.T) {
 	g := cloneGuest() // no targetNode
 	r, _ := newCloneReconciler(t, g, sourceGuest(), s3CloneSnap())
 	r.SnapshotS3Image = "img"
-	_, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	_, _, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
 	if err != nil || !strings.Contains(fail, "requires spec.cloneFromSnapshot.targetNode") {
 		t.Fatalf("Tier C without targetNode should fail; fail=%q err=%v", fail, err)
 	}
@@ -151,7 +155,7 @@ func TestPrepareCloneFromSnapshot_TierC_DownloadsThenProceeds(t *testing.T) {
 	r.SnapshotS3Image = "img"
 
 	// First pass: creates the download Job + requeues (not yet complete).
-	_, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	_, _, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
 	if err != nil || fail != "" || !requeue {
 		t.Fatalf("first pass should create the download Job + requeue; fail=%q requeue=%v err=%v", fail, requeue, err)
 	}
@@ -173,7 +177,7 @@ func TestPrepareCloneFromSnapshot_TierC_DownloadsThenProceeds(t *testing.T) {
 	if err := c.Status().Update(context.Background(), &job); err != nil {
 		t.Fatal(err)
 	}
-	eff, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	eff, _, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
 	if err != nil || fail != "" || requeue || eff == nil {
 		t.Fatalf("after download completes, should proceed; fail=%q requeue=%v err=%v", fail, requeue, err)
 	}
@@ -210,7 +214,7 @@ func TestPrepareCloneFromSnapshot_OCI_RequiresTargetNode(t *testing.T) {
 	g := cloneGuest() // no targetNode
 	r, _ := newCloneReconciler(t, g, sourceGuest(), ociCloneSnap())
 	r.SnapshotORASImage = "img"
-	_, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	_, _, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
 	if err != nil || !strings.Contains(fail, "requires spec.cloneFromSnapshot.targetNode") {
 		t.Fatalf("oci clone without targetNode should fail; fail=%q err=%v", fail, err)
 	}
@@ -223,7 +227,7 @@ func TestPrepareCloneFromSnapshot_OCI_DownloadsThenProceeds(t *testing.T) {
 	r.SnapshotORASImage = "img"
 
 	// First pass: creates the oci download Job + requeues (not yet complete).
-	_, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	_, _, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
 	if err != nil || fail != "" || !requeue {
 		t.Fatalf("first pass should create the oci download Job + requeue; fail=%q requeue=%v err=%v", fail, requeue, err)
 	}
@@ -245,7 +249,7 @@ func TestPrepareCloneFromSnapshot_OCI_DownloadsThenProceeds(t *testing.T) {
 	if err := c.Status().Update(context.Background(), &job); err != nil {
 		t.Fatal(err)
 	}
-	eff, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	eff, _, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
 	if err != nil || fail != "" || requeue || eff == nil {
 		t.Fatalf("after oci download completes, should proceed; fail=%q requeue=%v err=%v", fail, requeue, err)
 	}
@@ -330,7 +334,7 @@ func jobNames(l batchv1.JobList) []string {
 func TestPrepareCloneFromSnapshot_SourceGone(t *testing.T) {
 	g := cloneGuest()
 	r, _ := newCloneReconciler(t, g, localSnap(snapshotv1alpha1.SwiftSnapshotPhaseReady)) // no source guest
-	_, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	_, _, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
 	if err != nil || !strings.Contains(fail, "no longer exists") {
 		t.Fatalf("missing source should fail; fail=%q err=%v", fail, err)
 	}
@@ -385,4 +389,157 @@ func poolCloneReconciler(t *testing.T, objs ...client.Object) *SwiftGuestReconci
 	s := cloneScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
 	return &SwiftGuestReconciler{Client: c, Scheme: s}
+}
+
+// ── Source-independent (cross-cluster) full-state clone ──────────────────────
+// docs/design/oras-cold-migration-source-independent.md: when the SOURCE guest
+// is gone, a full-state oci snapshot carrying the captured launcher-sufficient
+// surface resolves via FromCapturedSpec instead of the live source spec.
+
+func fullStateSnap() *snapshotv1alpha1.SwiftSnapshot {
+	s := ociCloneSnap() // ns/snap, guestRef src, repo zot.svc:5000/vmsnap
+	s.Status.OCI.Disk = &snapshotv1alpha1.OCIDiskArtifact{
+		Reference:      "zot.svc:5000/vmsnap:ns-snap-disk",
+		ManifestDigest: "sha256:disk123",
+	}
+	s.Status.GuestSpec = &snapshotv1alpha1.CapturedGuestSpec{
+		CPU: "2", MemoryMi: 2048, ImageName: "rocky9",
+		Storage:        &snapshotv1alpha1.CapturedStorage{AccessMode: "ReadWriteOnce", VolumeMode: "Filesystem", StorageClassName: "longhorn"},
+		RootDiskSize:   "40Gi",
+		Network:        true,
+		InterfaceNames: []string{"eth0"},
+		OSType:         "linux",
+		HasSeed:        true,
+	}
+	return s
+}
+
+func testGuestClass() *swiftv1alpha1.SwiftGuestClass {
+	return &swiftv1alpha1.SwiftGuestClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cls"},
+		Spec: swiftv1alpha1.SwiftGuestClassSpec{
+			CPU:      resource.MustParse("1"),
+			Memory:   resource.MustParse("1Gi"),
+			RootDisk: swiftv1alpha1.RootDiskSpec{Size: resource.MustParse("10Gi")},
+		},
+	}
+}
+
+// completeCloneDownload drives the first prepare pass (which creates the oci
+// download Job) and marks the Job Complete, so the next pass reaches the
+// source-guest resolution step.
+func completeCloneDownload(t *testing.T, r *SwiftGuestReconciler, c client.Client, g *swiftv1alpha1.SwiftGuest, snap *snapshotv1alpha1.SwiftSnapshot) {
+	t.Helper()
+	_, _, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || fail != "" || !requeue {
+		t.Fatalf("first pass should create the oci download Job + requeue; fail=%q requeue=%v err=%v", fail, requeue, err)
+	}
+	var job batchv1.Job
+	if err := c.Get(context.Background(), client.ObjectKey{Name: cloneDownloadJobName(snap, "boba"), Namespace: "ns"}, &job); err != nil {
+		t.Fatalf("oci download Job not created: %v", err)
+	}
+	job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+	if err := c.Status().Update(context.Background(), &job); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPrepareCloneFromSnapshot_SourceGone_FullState_ResolvesFromCaptured(t *testing.T) {
+	g := cloneGuest()
+	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	g.Spec.GuestClassRef = corev1.LocalObjectReference{Name: "cls"}
+	snap := fullStateSnap()
+	// NO source guest in the cluster — the source-independent path must fire.
+	r, c := newCloneReconciler(t, g, snap, testGuestClass())
+	r.SnapshotORASImage = "img"
+	completeCloneDownload(t, r, c, g, snap)
+
+	eff, rg, fail, requeue, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || fail != "" || requeue {
+		t.Fatalf("source-gone full-state clone should resolve; fail=%q requeue=%v err=%v", fail, requeue, err)
+	}
+	if eff != nil {
+		t.Errorf("source-independent path must not return an effective guest (nothing to resolve); got %v", eff.Name)
+	}
+	if rg == nil {
+		t.Fatal("source-independent path must return a pre-resolved rg")
+	}
+	if !rg.RootDisk.FromOCI || rg.RootDisk.Size.String() != "40Gi" {
+		t.Errorf("rootDisk = %+v, want FromOCI + 40Gi", rg.RootDisk)
+	}
+	if rg.Storage.StorageClassName != "longhorn" || rg.Storage.AccessMode != "ReadWriteOnce" {
+		t.Errorf("storage not from captured surface: %+v", rg.Storage)
+	}
+	if rg.Resources.CPU != 2 || rg.Resources.Memory != 2048 {
+		t.Errorf("resources = %+v, want captured 2/2048 (not the class's 1/1024)", rg.Resources)
+	}
+	// hasSeed → placeholder NoCloud seed so CH --restore can re-open seed.iso.
+	if !rg.HasSeed() || rg.Seed.Datasource != "NoCloud" {
+		t.Errorf("captured hasSeed must yield a placeholder NoCloud seed; got %+v", rg.Seed)
+	}
+	// Clone restore annotations stamped, with MAC rewrites seeded from the
+	// captured interface names and the FROM prefix from the source ns/name.
+	var got swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "clone-a", Namespace: "ns"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Annotations[AnnotationRestoreMode] != RestoreModeClone ||
+		got.Annotations[AnnotationRestoreMACRewrites] == "" ||
+		!strings.Contains(got.Annotations[AnnotationRestoreRuntimeDirFromPrefix], "src") {
+		t.Errorf("clone restore annotations not stamped from the captured surface: %+v", got.Annotations)
+	}
+}
+
+func TestPrepareCloneFromSnapshot_SourceGone_MemoryOnly_Fails(t *testing.T) {
+	g := cloneGuest()
+	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	snap := ociCloneSnap() // memory-only: no status.oci.disk, no captured surface
+	r, c := newCloneReconciler(t, g, snap)
+	r.SnapshotORASImage = "img"
+	completeCloneDownload(t, r, c, g, snap)
+
+	_, rg, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || rg != nil {
+		t.Fatalf("memory-only source-gone must not resolve; rg=%v err=%v", rg, err)
+	}
+	if !strings.Contains(fail, "needs the source spec") {
+		t.Errorf("fail = %q, want the pre-SI needs-the-source-spec message", fail)
+	}
+}
+
+func TestPrepareCloneFromSnapshot_SourceGone_DataDisks_Fails(t *testing.T) {
+	g := cloneGuest()
+	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	g.Spec.GuestClassRef = corev1.LocalObjectReference{Name: "cls"}
+	snap := fullStateSnap()
+	snap.Status.GuestSpec.HasDataDisks = true
+	r, c := newCloneReconciler(t, g, snap, testGuestClass())
+	r.SnapshotORASImage = "img"
+	completeCloneDownload(t, r, c, g, snap)
+
+	_, rg, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || rg != nil {
+		t.Fatalf("data-disk source-gone must not resolve; rg=%v err=%v", rg, err)
+	}
+	if !strings.Contains(fail, "root-disk-only") {
+		t.Errorf("fail = %q, want the v1 root-disk-only rejection", fail)
+	}
+}
+
+func TestPrepareCloneFromSnapshot_SourceGone_NoGuestClass_Fails(t *testing.T) {
+	g := cloneGuest()
+	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	g.Spec.GuestClassRef = corev1.LocalObjectReference{Name: "missing-cls"}
+	snap := fullStateSnap()
+	r, c := newCloneReconciler(t, g, snap) // class NOT in the cluster
+	r.SnapshotORASImage = "img"
+	completeCloneDownload(t, r, c, g, snap)
+
+	_, rg, fail, _, err := r.prepareCloneFromSnapshot(context.Background(), g)
+	if err != nil || rg != nil {
+		t.Fatalf("missing guestClass must not resolve; rg=%v err=%v", rg, err)
+	}
+	if !strings.Contains(fail, "SwiftGuestClass") {
+		t.Errorf("fail = %q, want a SwiftGuestClass-not-found message", fail)
+	}
 }

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -118,8 +118,9 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// resolution (seed/intent/rootdisk/pod) runs unchanged off the now-stamped
 	// restore annotations + the source-resolved rg.
 	guestForResolve := &guest
+	var rg *resolved.ResolvedGuest
 	if guest.UsesCloneFromSnapshot() {
-		effective, failReason, requeue, perr := r.prepareCloneFromSnapshot(ctx, &guest)
+		effective, preResolved, failReason, requeue, perr := r.prepareCloneFromSnapshot(ctx, &guest)
 		if perr != nil {
 			return ctrl.Result{}, perr
 		}
@@ -143,26 +144,38 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
-		guestForResolve = effective
+		if preResolved != nil {
+			// Source-independent full-state clone: the source guest (and its
+			// SwiftImage/seedProfile) are gone; rg was built from the snapshot's
+			// captured surface (FromCapturedSpec). Skip the resolver — its
+			// image-oriented path cannot run and is not needed (the disk comes
+			// from the oci artifact via RootDisk.FromOCI).
+			rg = preResolved
+		} else {
+			guestForResolve = effective
+		}
 	}
 
-	res := resolved.NewResolver(r.Client)
-	rg, err := res.Resolve(ctx, guestForResolve)
-	if err != nil {
-		var re *resolved.ResolutionError
-		if errors.As(err, &re) {
-			// Set Resolved=False, phase=Failed; do not create pod
-			status := guest.Status.DeepCopy()
-			SetResolvedCondition(status, false, re.Reason)
-			status.Phase = swiftv1alpha1.SwiftGuestPhaseFailed
-			recordGuestMetrics(&guest, &guest.Status, status, nil)
-			if err := r.patchStatus(ctx, &guest, status); err != nil {
-				return ctrl.Result{}, err
+	if rg == nil {
+		res := resolved.NewResolver(r.Client)
+		var err error
+		rg, err = res.Resolve(ctx, guestForResolve)
+		if err != nil {
+			var re *resolved.ResolutionError
+			if errors.As(err, &re) {
+				// Set Resolved=False, phase=Failed; do not create pod
+				status := guest.Status.DeepCopy()
+				SetResolvedCondition(status, false, re.Reason)
+				status.Phase = swiftv1alpha1.SwiftGuestPhaseFailed
+				recordGuestMetrics(&guest, &guest.Status, status, nil)
+				if err := r.patchStatus(ctx, &guest, status); err != nil {
+					return ctrl.Result{}, err
+				}
+				logger.Info("resolution failed", "reason", re.Reason, "resource", re.AffectedResource)
+				return ctrl.Result{}, nil
 			}
-			logger.Info("resolution failed", "reason", re.Reason, "resource", re.AffectedResource)
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, err
 	}
 
 	// Set Resolved=True
@@ -421,8 +434,11 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// (status-only, not load-bearing for the runtime). Design doc §A2/§A6.
 
 	// For disk boot, ensure per-guest root disk clone exists and is ready.
+	// RootDisk.FromOCI (a source-independent full-state clone) has NO prepared
+	// image — its disk is materialized from the snapshot's oci disk artifact
+	// inside EnsureRootDiskClone (maybeRootDiskFromOCI), so it enters here too.
 	var rootDiskClone *RootDiskCloneResult
-	if rg.PreparedImage.PVCName != "" && !rg.HasKernel() {
+	if (rg.PreparedImage.PVCName != "" || rg.RootDisk.FromOCI) && !rg.HasKernel() {
 		res, err := r.EnsureRootDiskClone(ctx, &guest, rg)
 		if err != nil {
 			// Clone not ready — requeue


### PR DESCRIPTION
Third PR of the **source-independent (cross-cluster) full-state clone** arc — design [#310](https://github.com/kubeswift-io/kubeswift/pull/310), capture surface [#311](https://github.com/kubeswift-io/kubeswift/pull/311), resolver path [#312](https://github.com/kubeswift-io/kubeswift/pull/312).

## What

A `cloneFromSnapshot` whose **source guest is gone** now resolves from the snapshot's captured launcher-sufficient surface instead of failing — removing all three live-source dependencies (source SwiftGuest spec, source SwiftImage, source SwiftSeedProfile) for full-state oci snapshots. This is the wiring that makes the cross-cluster path real.

## How

- **`prepareCloneFromSnapshot` gains a `preResolved` return**: on source-`NotFound` it dispatches to `prepareSourceIndependentClone`, which:
  - guards **full-state** (`status.oci.disk`) + **captured surface** (`status.guestSpec.storage`) — anything else keeps the pre-SI "needs the source spec" failure;
  - rejects captured `hasDataDisks` (**v1 root-disk-only**, controller-side → immune to admission-time races);
  - builds `rg` via **`resolved.FromCapturedSpec`** from the clone's *own* guestClass (system-default shell) + the captured surface (the resumed VM's real resources/storage/os/interfaces).
- **The controller consumes the pre-resolved `rg`** and skips the image-oriented resolver; the **root-disk gate also fires on `rg.RootDisk.FromOCI`** (no prepared image) so `EnsureRootDiskClone` → `maybeRootDiskFromOCI` materializes the disk from the oci artifact.
- **`placeholderSeed`** (design D3): when the source had a seedProfile, a minimal NoCloud seed rides the **existing** seed-ConfigMap + launcher ISO machinery, so CH `--restore` can re-open the seed.iso disk recorded in `config.json` — **zero Rust change**; a resume never reads seed content.
- **`stubSourceFromCaptured`** (design D6) feeds the shared `cloneRestoreAnnotations` builder: MAC rewrites seed from captured interface names, the runtime-dir FROM prefix from the source ns/name (cross-cluster: recreate the snapshot in a namespace with the same *name* — runbook note lands in PR 4), agent-enable carries over.
- `stampCloneAnnotations` extracted (shared by both paths).

## Behaviour containment

**Same-cluster clones are unchanged** — a present source keeps the validated effective-spec path byte-for-byte; the new branch fires only on source-`NotFound` + full-state + captured surface.

## Tests

- Source-gone full-state resolves: `FromOCI` + captured storage/resources win over the class + placeholder NoCloud seed + stamped clone annotations (MAC rewrites, FROM prefix).
- Memory-only / missing-captured-surface → pre-SI failure preserved.
- Captured `hasDataDisks` → v1 root-disk-only rejection.
- Missing guestClass → clean failure.
- All existing clone tests green (mechanical 5-tuple widening only).

`go build` / `go vet` / `gofmt -s` / `go test ./...` all clean.

## Next

SI PR4 cluster-validates by the source-deletion simulation (export → **delete source guest + SwiftImage + seedProfile** → import must reach Running from the registry + captured spec alone, sentinel + `boot_id` proof) + runbook update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)