### PR TITLE
fix(restore): clone target must not inherit a stopped source's runPolicy; resolve finding #2 (RemoveIPC)

### DIFF
--- a/docs/design/oras-cold-migration.md
+++ b/docs/design/oras-cold-migration.md
@@ -219,16 +219,29 @@ The runtime (CH `--restore`, launcher, resume) is **untouched**.
      `src.runPolicy=Stopped` + `launcher=NONE` through the entire Uploading→Ready
      window (no resurrection), vs the pre-fix run where the source came back 2/2
      Running mid-capture; both artifacts still pushed.
-  2. **RAM-only tmpfs token missing on the resumed clone — narrow fidelity
-     curiosity, LOW.** The `/dev/shm/cm-ram-token` written before the snapshot is
-     absent on the clone, while `boot_id` (kernel RAM) and all other resume
-     witnesses survive and `/dev/shm`'s dir mtime is unchanged (nothing deleted it
-     post-restore). Hypothesis: the cloneFromSnapshot restore uses
-     `memoryMode: ondemand` (userfaultfd demand-paging) for fast pool scale-up; a
-     tmpfs/anonymous-page fault-in nuance is the likely cause. Does not affect disk
-     content or core guest state (cloud-init done, machine-id, processes intact).
-     Investigate whether cold-migration full-state clones should default to
-     **eager** restore rather than ondemand.
+  2. **RAM-only tmpfs token missing on the resumed clone — RESOLVED
+     (2026-07-02): NOT a restore-fidelity issue; root cause is in-guest
+     systemd-logind `RemoveIPC=yes`.** A controlled experiment (same Tier B
+     snapshot → a `cloneFromSnapshot` clone with `memory_restore_mode=ondemand`
+     AND a SwiftRestore clone with `copy`/eager) showed **both** modes "lose" the
+     `/dev/shm` probes identically while `boot_id`/journal/disk survive — refuting
+     the userfaultfd hypothesis. The decisive follow-up (no snapshot involved): on
+     a live guest, a user-owned `/dev/shm` file written over SSH is **deleted by
+     systemd-logind seconds after the user's last session ends**
+     (`RemoveIPC=yes`, the systemd/Ubuntu default for non-system users; a
+     root-owned file survives; the logind journal shows the session GC). The probe
+     files were therefore removed **on the source before the capture** — every
+     restore mode faithfully reproduced a memory image in which they were already
+     gone. **CH v52 restore fidelity (eager AND ondemand) is exonerated;
+     `ondemand` stays the cloneFromSnapshot default.** Operator note: write
+     resume-witness files as root (or outside `/dev/shm`) when probing.
+     The experiment also surfaced a real incidental bug — the SwiftRestore clone
+     target inherited the SOURCE's `runPolicy` (`ensureCloneTargetGuest`
+     `Spec: source.Spec`), so restoring from a **stopped** source (the natural DR
+     flow) created a Stopped target with no launcher and wedged the restore in
+     `Restoring` forever. Fixed: the target's runPolicy is target-owned
+     (Running, or Stopped only for `resumeAfterRestore: false`), mirroring
+     clone.go's "runPolicy is clone-owned" rule.
 
 ## 5. Non-goals (P4 v1)
 

--- a/internal/controller/swiftrestore/local.go
+++ b/internal/controller/swiftrestore/local.go
@@ -681,6 +681,14 @@ func (r *SwiftRestoreReconciler) ensureCloneTargetGuest(
 		},
 		Spec: source.Spec,
 	}
+	// runPolicy is TARGET-owned, not inherited: a restore's whole point is a
+	// RUNNING restored guest, and the natural DR flow restores FROM a stopped
+	// source — inheriting the source's Stopped would leave the target with no
+	// launcher pod and wedge this restore in Restoring ("waiting for ... CH
+	// socket") forever. Mirrors the cloneFromSnapshot rule in
+	// swiftguest/clone.go ("runPolicy is clone-owned"). Surfaced by the F2
+	// investigation (2026-07-02).
+	target.Spec.RunPolicy = swiftv1alpha1.RunPolicyRunning
 	if !restore.Spec.ResumeAfterRestore {
 		// Caller asked the restored VM be left Paused. With Tier B
 		// the launcher pod is what gets paused (CH stays paused

--- a/internal/controller/swiftrestore/local_test.go
+++ b/internal/controller/swiftrestore/local_test.go
@@ -1,10 +1,13 @@
 package swiftrestore
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
@@ -418,4 +421,70 @@ func TestRuntimeDirPrefix_FormatMatchesSwiftRuntime(t *testing.T) {
 // here but the call site reads better with the local name.
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
+}
+
+// A clone target must NOT inherit the source's runPolicy: the natural DR flow
+// restores FROM a stopped source, and an inherited Stopped leaves the target
+// with no launcher pod — wedging the restore in Restoring forever. runPolicy is
+// target-owned: Running by default, Stopped only when the operator asked for
+// resumeAfterRestore=false. (F2 investigation, 2026-07-02.)
+func TestEnsureCloneTargetGuest_StoppedSource_TargetRuns(t *testing.T) {
+	source := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: "ns"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef:      &corev1.LocalObjectReference{Name: "img"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "cls"},
+			RunPolicy:     swiftv1alpha1.RunPolicyStopped, // stopped source (the DR case)
+		},
+	}
+	restore := &snapshotv1alpha1.SwiftRestore{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "ns"},
+		Spec: snapshotv1alpha1.SwiftRestoreSpec{
+			SnapshotRef:        snapshotv1alpha1.SwiftRestoreSnapshotRef{Name: "snap"},
+			TargetGuest:        snapshotv1alpha1.SwiftRestoreTarget{Name: "clone"},
+			ResumeAfterRestore: true,
+		},
+	}
+	r, c := newReconciler(t, source, restore)
+	got, err := r.ensureCloneTargetGuest(context.Background(), restore, source, map[string]string{"a": "b"})
+	if err != nil {
+		t.Fatalf("ensureCloneTargetGuest: %v", err)
+	}
+	if got.Spec.RunPolicy != swiftv1alpha1.RunPolicyRunning {
+		t.Errorf("target runPolicy = %q, want Running (must not inherit the stopped source's)", got.Spec.RunPolicy)
+	}
+	var stored swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "clone", Namespace: "ns"}, &stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored.Spec.RunPolicy != swiftv1alpha1.RunPolicyRunning {
+		t.Errorf("stored target runPolicy = %q, want Running", stored.Spec.RunPolicy)
+	}
+}
+
+// resumeAfterRestore=false still yields a Stopped target (the explicit ask).
+func TestEnsureCloneTargetGuest_NoResume_TargetStopped(t *testing.T) {
+	source := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: "ns"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef:  &corev1.LocalObjectReference{Name: "img"},
+			RunPolicy: swiftv1alpha1.RunPolicyRunning,
+		},
+	}
+	restore := &snapshotv1alpha1.SwiftRestore{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "ns"},
+		Spec: snapshotv1alpha1.SwiftRestoreSpec{
+			SnapshotRef: snapshotv1alpha1.SwiftRestoreSnapshotRef{Name: "snap"},
+			TargetGuest: snapshotv1alpha1.SwiftRestoreTarget{Name: "clone"},
+			// ResumeAfterRestore false (zero value)
+		},
+	}
+	r, _ := newReconciler(t, source, restore)
+	got, err := r.ensureCloneTargetGuest(context.Background(), restore, source, nil)
+	if err != nil {
+		t.Fatalf("ensureCloneTargetGuest: %v", err)
+	}
+	if got.Spec.RunPolicy != swiftv1alpha1.RunPolicyStopped {
+		t.Errorf("target runPolicy = %q, want Stopped (resumeAfterRestore=false)", got.Spec.RunPolicy)
+	}
 }


### PR DESCRIPTION
Two outcomes of the finding-#2 (tmpfs-fidelity) investigation from [#307](https://github.com/kubeswift-io/kubeswift/pull/307)'s validation.

## 1. Finding #2 RESOLVED — not a restore bug (docs)

Controlled experiment on the dev cluster: the **same** Tier B snapshot restored two ways — a `cloneFromSnapshot` clone (`memory_restore_mode=ondemand`) and a SwiftRestore clone (`copy`/eager). **Both** modes "lost" the `/dev/shm` probes identically (small token + 8MB blob) while `boot_id`/journal/disk-sentinel survived — refuting the userfaultfd hypothesis.

The decisive follow-up needed **no snapshot at all**: on a live guest, a user-owned `/dev/shm` file written over SSH is deleted by **systemd-logind `RemoveIPC=yes`** (the systemd/Ubuntu default for non-system users) seconds after the user's last session ends; a root-owned file survives; the logind journal shows the session GC. The probe files were removed **on the source before capture** — every restore mode faithfully reproduced a memory image in which they were already gone.

**CH v52 restore fidelity (eager and ondemand) is exonerated; `ondemand` stays the cloneFromSnapshot default.** Operator note added: write resume-witness probes as root (or outside `/dev/shm`).

## 2. Real incidental bug fixed (code)

`ensureCloneTargetGuest` created the clone target with `Spec: source.Spec` verbatim — **inheriting the source's `runPolicy`**. Restoring from a **stopped** source (the natural DR flow — the source being down is *why* you restore) produced a Stopped target with no launcher pod, wedging the SwiftRestore in `Restoring: waiting for ... CH socket` **forever**. Hit live during the experiment after stopping the source to free node CPU.

Fix: the target's runPolicy is **target-owned** — `Running`, or `Stopped` only when the operator asked for `resumeAfterRestore: false` — mirroring `swiftguest/clone.go`'s "runPolicy is clone-owned" rule. Regression tests cover both branches (stopped-source → Running target; `resumeAfterRestore: false` → Stopped target).

`go build`/`vet`/`gofmt`/`go test ./internal/controller/swiftrestore/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)