### PR TITLE
feat(swiftctl): snapshot export-manifest / import-manifest — first-party cross-cluster object transfer

### DIFF
--- a/cmd/swiftctl/snapshot_manifest.go
+++ b/cmd/swiftctl/snapshot_manifest.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+)
+
+// Cross-cluster snapshot-object transfer (the cold-migration recipe in
+// docs/snapshots/cold-migration.md). A SwiftSnapshot's registry coordinates —
+// the oci artifact refs/digests and the captured launcher-sufficient surface —
+// live in STATUS, which `kubectl apply` cannot set. "export-manifest" emits a
+// portable JSON manifest of a Ready snapshot; "import-manifest" recreates it in
+// another cluster in two steps (create spec, then transplant status via the
+// status subresource) so a source-independent `swiftctl guest import` can run
+// there against the shared registry.
+
+var (
+	exportManifestOut         string
+	exportManifestKeepDelPol  bool
+	importManifestFile        string
+	importManifestToNamespace string
+)
+
+var snapshotExportManifestCmd = &cobra.Command{
+	Use:          "export-manifest [name]",
+	Short:        "Emit a portable manifest of a Ready SwiftSnapshot for another cluster",
+	SilenceUsage: true,
+	Long: `Emit a portable JSON manifest of a Ready SwiftSnapshot — spec plus the
+status the import side needs (oci artifact refs/digests + the captured guest
+surface). Feed it to "swiftctl snapshot import-manifest" against the target
+cluster; the artifacts themselves travel via the shared OCI registry.
+
+By default the emitted spec is rewritten to deletionPolicy: Retain — the copy
+must NOT own the shared registry artifacts' lifecycle (deleting a Delete-policy
+copy in the target cluster would purge artifacts other clusters still use).
+--keep-deletion-policy preserves the original value.`,
+	Example: `  swiftctl snapshot export-manifest db-export -o db-export.json
+  # then, against the target cluster:
+  swiftctl snapshot import-manifest -f db-export.json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSnapshotExportManifest,
+}
+
+var snapshotImportManifestCmd = &cobra.Command{
+	Use:          "import-manifest",
+	Short:        "Recreate an exported SwiftSnapshot (spec + status) in this cluster",
+	SilenceUsage: true,
+	Long: `Recreate a SwiftSnapshot from an export-manifest file: creates the object,
+then transplants the exported status via the status subresource (which kubectl
+apply cannot set). Run against the TARGET cluster's kubeconfig/context.
+
+For a full-state (cold-migration) snapshot, import it into a namespace with
+the SAME NAME as the source's original namespace — the captured memory's
+config.json records paths derived from it (see
+docs/snapshots/cold-migration.md).`,
+	Example: `  swiftctl snapshot import-manifest -f db-export.json
+  swiftctl snapshot import-manifest -f db-export.json -n team-a`,
+	RunE: runSnapshotImportManifest,
+}
+
+func init() {
+	snapshotExportManifestCmd.Flags().StringVarP(&exportManifestOut, "output", "o", "", "Write the manifest to this file (default: stdout)")
+	snapshotExportManifestCmd.Flags().BoolVar(&exportManifestKeepDelPol, "keep-deletion-policy", false, "Preserve the original spec.deletionPolicy instead of rewriting the copy to Retain")
+	snapshotImportManifestCmd.Flags().StringVarP(&importManifestFile, "file", "f", "", "Manifest file from export-manifest (required)")
+	_ = snapshotImportManifestCmd.MarkFlagRequired("file")
+
+	snapshotCmd.AddCommand(snapshotExportManifestCmd)
+	snapshotCmd.AddCommand(snapshotImportManifestCmd)
+}
+
+// portableSnapshotManifest strips cluster-local metadata (uid/resourceVersion/
+// timestamps/managedFields/finalizers/ownerRefs) so the object is creatable in
+// another cluster, keeps spec + status verbatim — except spec.deletionPolicy,
+// which is rewritten to Retain unless keepDeletionPolicy: the copy must not own
+// the shared registry artifacts' lifecycle (the target cluster's controller
+// re-adds the cleanup finalizer to any Ready snapshot, and a Delete-policy copy
+// would purge artifacts other clusters still use).
+func portableSnapshotManifest(snap *snapshotv1alpha1.SwiftSnapshot, keepDeletionPolicy bool) *snapshotv1alpha1.SwiftSnapshot {
+	out := &snapshotv1alpha1.SwiftSnapshot{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: snapshotv1alpha1.GroupName + "/" + snapshotv1alpha1.Version,
+			Kind:       "SwiftSnapshot",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        snap.Name,
+			Namespace:   snap.Namespace,
+			Labels:      snap.Labels,
+			Annotations: snap.Annotations,
+		},
+		Spec:   snap.Spec,
+		Status: snap.Status,
+	}
+	if !keepDeletionPolicy {
+		out.Spec.DeletionPolicy = snapshotv1alpha1.SnapshotDeletionPolicyRetain
+	}
+	return out
+}
+
+// importSnapshotManifest recreates the manifest's snapshot: Create with the
+// status stripped (the apiserver ignores status on create), then transplant the
+// exported status via the status subresource. Fails if the object already
+// exists — an existing snapshot may reference different artifacts, and silently
+// merging would be worse than asking the operator to resolve it.
+func importSnapshotManifest(ctx context.Context, c client.Client, manifest *snapshotv1alpha1.SwiftSnapshot) error {
+	obj := portableSnapshotManifest(manifest, true) // manifest spec is authoritative; re-clean metadata defensively
+	status := obj.Status
+	obj.Status = snapshotv1alpha1.SwiftSnapshotStatus{}
+	if err := c.Create(ctx, obj); err != nil {
+		if errors.IsAlreadyExists(err) {
+			return fmt.Errorf("SwiftSnapshot %s/%s already exists — delete it first (or import under a different name)", obj.Namespace, obj.Name)
+		}
+		return fmt.Errorf("create SwiftSnapshot: %w", err)
+	}
+	var created snapshotv1alpha1.SwiftSnapshot
+	if err := c.Get(ctx, client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}, &created); err != nil {
+		return err
+	}
+	created.Status = status
+	if err := c.Status().Update(ctx, &created); err != nil {
+		return fmt.Errorf("transplant status (subresource): %w", err)
+	}
+	return nil
+}
+
+func runSnapshotExportManifest(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	ns := getNamespace()
+	c, err := newSnapshotClient()
+	if err != nil {
+		return err
+	}
+	var snap snapshotv1alpha1.SwiftSnapshot
+	if err := c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: ns}, &snap); err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("SwiftSnapshot %s/%s not found", ns, name)
+		}
+		return err
+	}
+	if snap.Status.Phase != snapshotv1alpha1.SwiftSnapshotPhaseReady {
+		return fmt.Errorf("SwiftSnapshot %s/%s is %s, not Ready — export a Ready snapshot (the manifest must carry final artifact refs)", ns, name, snap.Status.Phase)
+	}
+	out := portableSnapshotManifest(&snap, exportManifestKeepDelPol)
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if exportManifestOut == "" {
+		_, err = cmd.OutOrStdout().Write(data)
+		return err
+	}
+	if err := os.WriteFile(exportManifestOut, data, 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s (SwiftSnapshot %s/%s", exportManifestOut, out.Namespace, out.Name)
+	if !exportManifestKeepDelPol && snap.Spec.DeletionPolicy != snapshotv1alpha1.SnapshotDeletionPolicyRetain {
+		fmt.Fprintf(cmd.OutOrStdout(), "; deletionPolicy rewritten to Retain for the copy")
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), ")\nImport on the target cluster: swiftctl snapshot import-manifest -f %s\n", exportManifestOut)
+	return nil
+}
+
+func runSnapshotImportManifest(cmd *cobra.Command, _ []string) error {
+	data, err := os.ReadFile(importManifestFile)
+	if err != nil {
+		return err
+	}
+	var manifest snapshotv1alpha1.SwiftSnapshot
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("parse %s: %w", importManifestFile, err)
+	}
+	if manifest.Name == "" {
+		return fmt.Errorf("%s carries no metadata.name — is this an export-manifest file?", importManifestFile)
+	}
+	// -n overrides the manifest's namespace (note the full-state same-name
+	// caveat in the long help).
+	if ns := getNamespace(); namespace != "" {
+		manifest.Namespace = ns
+	}
+	if manifest.Namespace == "" {
+		manifest.Namespace = getNamespace()
+	}
+	c, err := newSnapshotClient()
+	if err != nil {
+		return err
+	}
+	if err := importSnapshotManifest(context.Background(), c, &manifest); err != nil {
+		return err
+	}
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Imported SwiftSnapshot %s/%s (phase=%s", manifest.Namespace, manifest.Name, manifest.Status.Phase)
+	if manifest.Status.OCI != nil {
+		fmt.Fprintf(out, ", memory=%s", manifest.Status.OCI.ManifestDigest)
+		if manifest.Status.OCI.Disk != nil {
+			fmt.Fprintf(out, ", disk=%s", manifest.Status.OCI.Disk.ManifestDigest)
+		}
+	}
+	fmt.Fprintln(out, ")")
+	fmt.Fprintf(out, "Import a guest from it: swiftctl guest import <new-guest> --from-snapshot %s --target-node <node> --guest-class <class>\n", manifest.Name)
+	return nil
+}

--- a/cmd/swiftctl/snapshot_manifest_test.go
+++ b/cmd/swiftctl/snapshot_manifest_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+)
+
+func manifestTestSnap() *snapshotv1alpha1.SwiftSnapshot {
+	return &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "db-export",
+			Namespace:       "team-a",
+			UID:             types.UID("uid-123"),
+			ResourceVersion: "42",
+			Finalizers:      []string{"snapshot.kubeswift.io/s3-objects"},
+			Labels:          map[string]string{"demo": "coldmig"},
+		},
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			GuestRef:      snapshotv1alpha1.SwiftSnapshotGuestRef{Name: "db"},
+			IncludeMemory: true,
+			IncludeDisk:   true,
+			// Delete is the field default — the copy must NOT inherit it.
+			DeletionPolicy: snapshotv1alpha1.SnapshotDeletionPolicyDelete,
+			Backend: snapshotv1alpha1.SwiftSnapshotBackend{
+				Type: snapshotv1alpha1.SnapshotBackendOCI,
+				OCI:  &snapshotv1alpha1.OCIBackend{Repository: "hub.example.com/vm-snapshots"},
+			},
+		},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{
+			Phase: snapshotv1alpha1.SwiftSnapshotPhaseReady,
+			OCI: &snapshotv1alpha1.OCISnapshotStatus{
+				Reference:      "hub.example.com/vm-snapshots:team-a-db-export",
+				ManifestDigest: "sha256:mem123",
+				Disk:           &snapshotv1alpha1.OCIDiskArtifact{ManifestDigest: "sha256:disk123"},
+			},
+			GuestSpec: &snapshotv1alpha1.CapturedGuestSpec{
+				CPU: "2", MemoryMi: 2048,
+				Storage: &snapshotv1alpha1.CapturedStorage{AccessMode: "ReadWriteOnce", VolumeMode: "Filesystem"},
+			},
+		},
+	}
+}
+
+func TestPortableSnapshotManifest_StripsClusterLocalMetadata(t *testing.T) {
+	out := portableSnapshotManifest(manifestTestSnap(), false)
+	if out.UID != "" || out.ResourceVersion != "" || len(out.Finalizers) != 0 {
+		t.Errorf("cluster-local metadata must be stripped; got uid=%q rv=%q finalizers=%v",
+			out.UID, out.ResourceVersion, out.Finalizers)
+	}
+	if out.APIVersion != "snapshot.kubeswift.io/v1alpha1" || out.Kind != "SwiftSnapshot" {
+		t.Errorf("TypeMeta must be set for a standalone manifest; got %s/%s", out.APIVersion, out.Kind)
+	}
+	if out.Labels["demo"] != "coldmig" {
+		t.Errorf("labels must be preserved; got %v", out.Labels)
+	}
+	// Status carried verbatim — the whole point of the manifest.
+	if out.Status.Phase != snapshotv1alpha1.SwiftSnapshotPhaseReady ||
+		out.Status.OCI == nil || out.Status.OCI.Disk == nil ||
+		out.Status.OCI.Disk.ManifestDigest != "sha256:disk123" ||
+		out.Status.GuestSpec == nil || out.Status.GuestSpec.Storage == nil {
+		t.Errorf("status (oci refs + captured surface) must be carried; got %+v", out.Status)
+	}
+}
+
+func TestPortableSnapshotManifest_DeletionPolicyRetainForTheCopy(t *testing.T) {
+	// Default: the copy is rewritten to Retain — deleting a Delete-policy copy
+	// in the target cluster would purge registry artifacts other clusters use.
+	out := portableSnapshotManifest(manifestTestSnap(), false)
+	if out.Spec.DeletionPolicy != snapshotv1alpha1.SnapshotDeletionPolicyRetain {
+		t.Errorf("copy deletionPolicy = %q, want Retain", out.Spec.DeletionPolicy)
+	}
+	// --keep-deletion-policy preserves the original.
+	kept := portableSnapshotManifest(manifestTestSnap(), true)
+	if kept.Spec.DeletionPolicy != snapshotv1alpha1.SnapshotDeletionPolicyDelete {
+		t.Errorf("kept deletionPolicy = %q, want the original Delete", kept.Spec.DeletionPolicy)
+	}
+}
+
+func manifestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	gv := schema.GroupVersion{Group: snapshotv1alpha1.GroupName, Version: snapshotv1alpha1.Version}
+	s.AddKnownTypes(gv, &snapshotv1alpha1.SwiftSnapshot{}, &snapshotv1alpha1.SwiftSnapshotList{})
+	metav1.AddToGroupVersion(s, gv)
+	return s
+}
+
+func TestImportSnapshotManifest_CreatesSpecAndTransplantsStatus(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(manifestScheme(t)).
+		WithStatusSubresource(&snapshotv1alpha1.SwiftSnapshot{}).
+		Build()
+	manifest := portableSnapshotManifest(manifestTestSnap(), false)
+	if err := importSnapshotManifest(context.Background(), c, manifest); err != nil {
+		t.Fatalf("importSnapshotManifest: %v", err)
+	}
+	var got snapshotv1alpha1.SwiftSnapshot
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "db-export", Namespace: "team-a"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec.Backend.OCI == nil || got.Spec.Backend.OCI.Repository != "hub.example.com/vm-snapshots" {
+		t.Errorf("spec not created: %+v", got.Spec.Backend)
+	}
+	// The status subresource transplant is the load-bearing step.
+	if got.Status.Phase != snapshotv1alpha1.SwiftSnapshotPhaseReady ||
+		got.Status.OCI == nil || got.Status.OCI.ManifestDigest != "sha256:mem123" ||
+		got.Status.OCI.Disk == nil || got.Status.OCI.Disk.ManifestDigest != "sha256:disk123" ||
+		got.Status.GuestSpec == nil {
+		t.Errorf("status not transplanted: %+v", got.Status)
+	}
+}
+
+func TestImportSnapshotManifest_AlreadyExistsFailsLoudly(t *testing.T) {
+	existing := manifestTestSnap()
+	c := fake.NewClientBuilder().
+		WithScheme(manifestScheme(t)).
+		WithStatusSubresource(&snapshotv1alpha1.SwiftSnapshot{}).
+		WithObjects(existing).
+		Build()
+	err := importSnapshotManifest(context.Background(), c, portableSnapshotManifest(manifestTestSnap(), false))
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("importing over an existing snapshot must fail loudly; err=%v", err)
+	}
+}

--- a/docs/snapshots/cold-migration.md
+++ b/docs/snapshots/cold-migration.md
@@ -138,25 +138,36 @@ and seed profile) after export, and `swiftctl guest import` still works.
 **To move to a different cluster**, recreate the SwiftSnapshot object there
 (the artifacts are already in the shared registry; only the small object
 moves). Its oci refs + captured surface live in *status*, which `kubectl
-apply` cannot set — patch the status subresource after creating the spec:
+apply` cannot set — use the first-party pair:
 
 ```bash
-# In cluster A: dump the snapshot's spec and status.
-kubectl -n team-a get swiftsnapshot db-export -o json > snap.json
+# Against cluster A:
+swiftctl snapshot export-manifest db-export -o db-export.json
 
-# In cluster B: recreate the spec, then transplant the status.
-kubectl -n team-a apply -f <(jq 'del(.status, .metadata.uid, .metadata.resourceVersion,
-  .metadata.creationTimestamp, .metadata.generation, .metadata.finalizers,
-  .metadata.managedFields)' snap.json)
-kubectl -n team-a patch swiftsnapshot db-export --subresource=status \
-  --type=merge -p "$(jq '{status: .status}' snap.json)"
+# Against cluster B (same-name namespace — see the limits below):
+swiftctl snapshot import-manifest -f db-export.json
 
-# Then import as usual:
+# Then import the guest as usual:
 swiftctl guest import db2 --from-snapshot db-export --target-node <node> --guest-class <class>
 ```
 
-(A first-party `swiftctl snapshot export-manifest`-style helper is a tracked
-follow-up.)
+`export-manifest` rewrites the copy's `deletionPolicy` to **Retain** (pass
+`--keep-deletion-policy` to override): the target cluster's controller adds
+the cleanup finalizer to any Ready snapshot, and deleting a Delete-policy
+*copy* there would purge registry artifacts other clusters still use.
+
+<details><summary>Equivalent raw kubectl (no swiftctl)</summary>
+
+```bash
+kubectl -n team-a get swiftsnapshot db-export -o json > snap.json
+kubectl -n team-a apply -f <(jq 'del(.status, .metadata.uid, .metadata.resourceVersion,
+  .metadata.creationTimestamp, .metadata.generation, .metadata.finalizers,
+  .metadata.managedFields) | .spec.deletionPolicy="Retain"' snap.json)
+kubectl -n team-a patch swiftsnapshot db-export --subresource=status \
+  --type=merge -p "$(jq '{status: .status}' snap.json)"
+```
+
+</details>
 
 ### v1 requirements and limits
 


### PR DESCRIPTION
Replaces the jq + `kubectl patch --subresource=status` recipe for moving a SwiftSnapshot object between clusters (the cold-migration flow): the oci artifact refs/digests and the captured launcher-sufficient surface live in **status**, which `kubectl apply` cannot set.

## What

- **`swiftctl snapshot export-manifest <name> [-o file]`** — emits a portable JSON manifest of a Ready snapshot: cluster-local metadata stripped (uid/resourceVersion/timestamps/finalizers/ownerRefs), TypeMeta set, spec + status verbatim — **except `spec.deletionPolicy`, rewritten to `Retain` for the copy** (`--keep-deletion-policy` preserves the original). Rationale: the target cluster's controller re-adds the cleanup finalizer to any Ready snapshot, and deleting a Delete-policy *copy* there would purge registry artifacts other clusters still use. Refuses non-Ready snapshots.
- **`swiftctl snapshot import-manifest -f file [-n ns]`** — recreates it in the target cluster in two steps: Create (status stripped), then transplant the exported status via the **status subresource**. Fails loudly on already-exists.
- Runbook: the cross-cluster section leads with the pair; the raw kubectl recipe stays as a collapsed fallback (now also with the Retain rewrite).

## Tests

Unit: metadata stripping + TypeMeta; Retain-for-copy default + keep flag; fake-client create + status-transplant round-trip; already-exists failure.

## Cluster-validated (2026-07-02)

The full "cluster B" simulation:

```
$ swiftctl guest export cm7-src --name cm7-export --wait          # full-state, Ready
$ swiftctl snapshot export-manifest cm7-export -o cm7.json        # Retain rewrite confirmed in the file
# DELETED the snapshot object AND the source guest
#   (registry artifacts survived the Retain delete — HTTP 200 on the hub)
$ swiftctl snapshot import-manifest -f cm7.json
Imported SwiftSnapshot field-testing/cm7-export (phase=Ready, memory=sha256:2be32b…, disk=sha256:ce4ab4…)
$ swiftctl guest import cm7-clone --from-snapshot cm7-export --target-node boba --guest-class ft-small --wait
Running on boba
```

Proof on the clone: disk sentinel present + `boot_id` **identical** to the source (resume, not reboot) — the guest resumed entirely from a manifest-carried object + the registry.

`go build`/`vet`/`gofmt`/`go test ./cmd/swiftctl/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)