### PR TITLE
feat(clone): materialize + attach captured data disks on full-state import (SI v1.1, PR2 — import side)

### DIFF
--- a/cmd/snapshot-oras/image.go
+++ b/cmd/snapshot-oras/image.go
@@ -56,6 +56,19 @@ func chunkAndPush(ctx context.Context, filePath string, dst oras.Target, tag str
 		return zero, transferStats{}, err
 	}
 	totalSize := fi.Size()
+	if fi.Mode()&os.ModeDevice != 0 {
+		// A block device (a raw Block-mode PVC — the W9 root path or a v1.1
+		// data disk) reports Size()==0 from Stat(); its real size comes from
+		// seeking to the end. The read loop below already reads the whole device
+		// to EOF, so the chunks are correct either way — this only fixes the
+		// recorded TotalSize so the download side can size a Filesystem target.
+		if end, serr := f.Seek(0, io.SeekEnd); serr == nil {
+			totalSize = end
+			if _, serr := f.Seek(0, io.SeekStart); serr != nil {
+				return zero, transferStats{}, fmt.Errorf("seek to start after sizing %s: %w", filePath, serr)
+			}
+		}
+	}
 
 	buf := make([]byte, chunkSize)
 	zeros := make([]byte, chunkSize)
@@ -156,13 +169,33 @@ func pullAndReassemble(ctx context.Context, src oras.ReadOnlyTarget, ref, filePa
 		return zero, fmt.Errorf("parse config: %w", err)
 	}
 
-	f, err := os.Create(filePath)
+	// Zero windows are never stored (chunkAndPush skips them), so the destination
+	// must read as zero wherever no chunk lands. Two destination kinds:
+	//   - regular file (Filesystem image.raw): os.Create's O_TRUNC zeroes it, then
+	//     Truncate sizes the sparse file so the tail beyond the last chunk is zero.
+	//   - block device (a raw Block-mode PVC, W9 / v1.1 data disk): Truncate()
+	//     returns EINVAL and O_TRUNC is a no-op, so we CANNOT re-zero it here — we
+	//     rely on the destination PVC being freshly provisioned (Longhorn zeroes
+	//     new volumes), so a skipped zero window correctly reads back as zero.
+	// (A device is detected by Stat; the node exists whether or not it's a device.)
+	isBlockDev := false
+	if info, serr := os.Stat(filePath); serr == nil && info.Mode()&os.ModeDevice != 0 {
+		isBlockDev = true
+	}
+	var f *os.File
+	if isBlockDev {
+		f, err = os.OpenFile(filePath, os.O_RDWR, 0o644)
+	} else {
+		f, err = os.Create(filePath) // O_RDWR|O_CREATE|O_TRUNC — zeroes a stale file
+	}
 	if err != nil {
 		return zero, err
 	}
 	defer f.Close()
-	if err := f.Truncate(cfg.TotalSize); err != nil {
-		return zero, fmt.Errorf("truncate to %d: %w", cfg.TotalSize, err)
+	if !isBlockDev {
+		if err := f.Truncate(cfg.TotalSize); err != nil {
+			return zero, fmt.Errorf("truncate to %d: %w", cfg.TotalSize, err)
+		}
 	}
 	for _, layer := range manifest.Layers {
 		// Skip non-chunk layers — oras.PackManifest injects an OCI "empty"

--- a/cmd/snapshot-oras/image_test.go
+++ b/cmd/snapshot-oras/image_test.go
@@ -172,3 +172,35 @@ func TestChunkAllZero_NoLayers(t *testing.T) {
 		t.Error("all-zero reassembly is not all-zero / wrong size")
 	}
 }
+
+// pullAndReassemble opens the destination without O_TRUNC (os.Create implies it)
+// so a Block-mode PVC — where Truncate() returns EINVAL — is never truncated.
+// Guard the regular-file consequence: pulling over a PRE-EXISTING, LARGER stale
+// destination still yields byte-identical content (the explicit Truncate to
+// TotalSize discards the stale tail). This is the file-path half of the
+// Block-device fix (the block half is cluster-validated — no loop device in CI).
+func TestPull_OverExistingStaleDestination_ByteIdentical(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "image.raw")
+	a, b, _, zero := mkWindows()
+	writeDisk(t, src, [][]byte{a, zero, b}) // 3 windows, middle zero-skipped
+	orig, _ := os.ReadFile(src)
+
+	store := memory.New()
+	if _, _, err := chunkAndPush(context.Background(), src, store, "v1", testChunk, "raw", "linux"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-create the destination LARGER than the disk with stale non-zero bytes.
+	dst := filepath.Join(dir, "out.raw")
+	if err := os.WriteFile(dst, bytes.Repeat([]byte{0x99}, 5*testChunk), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pullAndReassemble(context.Background(), store, "v1", dst); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(dst)
+	if !bytes.Equal(got, orig) {
+		t.Errorf("pull over a stale destination must be byte-identical to source (len got=%d orig=%d); the stale tail must be truncated away", len(got), len(orig))
+	}
+}

--- a/docs/design/oras-cold-migration-source-independent.md
+++ b/docs/design/oras-cold-migration-source-independent.md
@@ -260,16 +260,45 @@ no-op; only `ensureCloneDataDisks` ever writes the clone's data PVCs. The v1
 are present** (old snapshots that recorded `hasDataDisks` without artifacts still
 fail with the source-spec-required message).
 
-**Validation**: a source with a blank **Block** data disk (the
-cluster-validated v0.4.2 path): write a marker onto `vdc`, full-state export,
-delete the source (+ image + seed), import → Running with the `vdc` marker
-intact and `boot_id` matching.
+**Validation (2026-07-02, cluster-validated, `controller sha-1926212` +
+`snapshot-oras sha-4022e72`).** A source (`v11-src`, Noble, miles) with a **blank
+Block** data disk `scratch` (5Gi, `/dev/kubeswift-data-scratch`): mkfs ext4
+(`V11DATA`) → marker `V11-SI-DATADISK-0742-token` + `sync`. Full-state oci export
+(`v11-snap`) → Ready with `status.oci.dataDisks[scratch]` stamped (digest
+`sha256:d5a85fb3…`) alongside `status.oci.disk`. Source **deleted** (root + data
+PVCs GC'd) → the clone (`v11-clone`, boba, cross-node) took the **source-independent**
+path, ran per-disk download Jobs (root + `scratch`), reached **2/2 Running** — CH
+`--restore` opened `/dev/kubeswift-data-scratch` (`status.dataDisks[scratch]` =
+bound/Block). **Byte-proof:** downloading the `scratch` artifact by digest
+reassembles a disk containing the ext4 label `V11DATA` **and** the marker
+`V11-SI-DATADISK-0742-token` — the content round-tripped source Block device →
+chunk upload → registry → digest-pinned download → reassembly. (The clone's
+*in-guest* read is subject to the documented resume-vs-boot clone nuance; the
+artifact byte-check is authoritative — it verifies the exact bytes the clone's
+download wrote into the device.)
+
+**Four fixes the cluster walkthrough surfaced that unit tests structurally could
+not (the W5 pattern):**
+1. **`status.oci.dataDisks` clobbered at memory-push finalize** —
+   `handleUploadingOCI` reconstructed `status.OCI`, preserved `Disk` but dropped
+   `DataDisks`; the chunk Job ran + uploaded, yet the artifact was invisible to
+   import. Fixed in PR1 (finalize preserves both).
+2. **`snapshot-oras` not Block-device-safe** — `download-image` `Truncate`d the
+   target (`truncate to 0: invalid argument`, EINVAL on a block device) and
+   `upload-image` recorded `TotalSize=0` (`Stat().Size()` is 0 for a device).
+   Fixed: seek-to-end for device size; skip Truncate for a device destination (a
+   fresh PVC is zeroed, so skipped zero windows read as zero).
+3. **restore-receive pod never attached the data disk** — `BuildRestorePod` wired
+   only the root disk + seed, so CH `--restore` (re-opens every disk in the
+   captured `config.json`) failed `Cannot open disk /dev/kubeswift-data-scratch`.
+   Fixed: append `dataDiskVolumes`/`dataDiskMounts`/`dataDiskDevices`.
 
 Phasing: **PR1** ([#318](https://github.com/kubeswift-io/kubeswift/pull/318)) API
-(`CapturedDataDisk` + `status.oci.dataDisks`) + capture + image-backed rejection;
-**PR2** (this PR) import (`ensureCloneDataDisks` materialize + `rg.DataDisks`
-override + lift the source-gone rejection when artifacts present); **PR3** cluster
-validation + runbook flip.
+(`CapturedDataDisk` + `status.oci.dataDisks`) + capture + image-backed rejection +
+finalize-preserve fix; **PR2** ([#319](https://github.com/kubeswift-io/kubeswift/pull/319))
+import (`ensureCloneDataDisks` materialize + `rg.DataDisks` override + lift the
+source-gone rejection when artifacts present) + the snapshot-oras Block-safe fix +
+the restore-pod data-disk attach + this cluster validation + runbook flip.
 
 ## 6. Non-goals (v1)
 

--- a/docs/design/oras-cold-migration-source-independent.md
+++ b/docs/design/oras-cold-migration-source-independent.md
@@ -241,26 +241,35 @@ pushedBytes}`; `status.guestSpec.dataDisks[]` records the launcher-sufficient
 shape `{name, size, block}`.
 
 **Import**: for a full-state snapshot carrying data-disk artifacts (either the
-same-cluster or the source-gone path), `maybeRootDiskFromOCI` generalizes to
-materialize root **and** each data disk into guest-owned PVCs named
-`BlankDataDiskPVCName(clone, name)` (one digest-pinned download Job per disk),
-then `rg.DataDisks[i].PVCName` is overridden to the materialized PVCs —
-keeping name/Block/HostPath so device order and paths match the captured
-`config.json`. `EnsureBlankDataDisks` skips materialized (RestoreSeeded-
-labelled) PVCs — they are not blank, and the Filesystem fill Job must not
-overwrite them. The v1 `hasDataDisks` rejection is lifted **only when the
-artifacts are present** (old snapshots that recorded `hasDataDisks` without
-artifacts still fail with the source-spec-required message).
+same-cluster or the source-gone path), `maybeRootDiskFromOCI` — once the root
+disk is Bound+Complete — calls `ensureCloneDataDisks`, which materializes each
+data disk into a guest-owned, RestoreSeeded PVC named
+`BlankDataDiskPVCName(clone, name)` (one digest-pinned download Job per disk,
+the root-disk builder generalized to take a per-disk digest) and, once every
+disk is Bound + its Job Complete, **replaces `rg.DataDisks`** with entries
+pointing at the materialized PVCs (name/Block/HostPath/MountPath rebuilt exactly
+as the resolver would, so device order + paths match the captured
+`config.json`). This override is load-bearing for **both** clone paths: a
+same-source clone would otherwise resolve `rg.DataDisks` to the **source's** data
+PVCs (frozen / RWO-conflicting); a source-gone clone starts with an empty
+`rg.DataDisks` (`FromCapturedSpec` sets none). No `EnsureBlankDataDisks` change is
+needed — a cloneFromSnapshot guest carries **no `DataDiskRefs` in its own spec**,
+so `EnsureBlankDataDisks(cloneGuest)` iterates an empty slice and is a natural
+no-op; only `ensureCloneDataDisks` ever writes the clone's data PVCs. The v1
+`hasDataDisks` rejection (source-gone path) is lifted **only when the artifacts
+are present** (old snapshots that recorded `hasDataDisks` without artifacts still
+fail with the source-spec-required message).
 
 **Validation**: a source with a blank **Block** data disk (the
 cluster-validated v0.4.2 path): write a marker onto `vdc`, full-state export,
 delete the source (+ image + seed), import → Running with the `vdc` marker
 intact and `boot_id` matching.
 
-Phasing: **PR1** API (`CapturedDataDisk` + `status.oci.dataDisks`) + capture +
-image-backed rejection; **PR2** import (materialize + `rg.DataDisks` override
-+ blank-skip guard + lift the rejection); **PR3** cluster validation +
-runbook.
+Phasing: **PR1** ([#318](https://github.com/kubeswift-io/kubeswift/pull/318)) API
+(`CapturedDataDisk` + `status.oci.dataDisks`) + capture + image-backed rejection;
+**PR2** (this PR) import (`ensureCloneDataDisks` materialize + `rg.DataDisks`
+override + lift the source-gone rejection when artifacts present); **PR3** cluster
+validation + runbook flip.
 
 ## 6. Non-goals (v1)
 

--- a/docs/snapshots/cold-migration.md
+++ b/docs/snapshots/cold-migration.md
@@ -28,7 +28,16 @@ fanning out many *fresh* clones from one snapshot, use
 > source is still present its live spec is used (unchanged behaviour); when
 > it is gone the clone resolves from the captured surface + the registry
 > artifacts alone. See "Cross-cluster (source-independent) import" below
-> for the recipe and v1 limits (root-disk-only; same-name namespace).
+> for the recipe and limits (same-name namespace).
+>
+> **Data disks (v1.1):** a full-state export also carries the source's
+> **secondary VM data disks** (`blank` and `pvcRef` + `attachAsDisk`) as
+> their own registry artifacts, and import materializes + attaches them
+> under the same names — so a clone gets the data-disk state its resumed
+> RAM references, not fresh blank disks. A source with an **image-backed**
+> data disk (the legacy `dataDiskRef`, or `dataDiskRefs[].imageRef`) is
+> rejected for full-state export (that disk is the SwiftImage's shared PVC,
+> owned by the image, not the guest).
 
 ## How it works
 
@@ -164,8 +173,12 @@ follow-up.)
   under the source's `<namespace>-<name>` runtime directory; the import
   rewrites them using the snapshot's namespace. Recreate the snapshot in a
   namespace **with the same name** as the source's original namespace.
-- **Root-disk-only.** A source with secondary data disks is rejected for
-  source-independent import (full-state capture doesn't carry data disks yet).
+- **Data disks (v1.1).** A source's `blank` / `attachAsDisk` data disks are
+  captured + materialized on import (byte-round-tripped through the registry,
+  attached under the same names). A source with an **image-backed** data disk
+  (legacy `dataDiskRef` / `dataDiskRefs[].imageRef`) is rejected for full-state
+  export — that disk is the SwiftImage's shared PVC; re-export without it, or
+  convert it to a `blank`/`attachAsDisk` disk.
 - **Placeholder seed.** When the source had a seed profile, the clone gets a
   minimal placeholder seed.iso purely so CH `--restore` can re-open the seed
   disk — the resumed guest never reads it. A later *reboot* of such a clone
@@ -222,7 +235,8 @@ kubectl delete swiftsnapshot db-export  # optional; oci objects are purged if
 | Export `Failed: OCI disk chunk Job failed` | Registry auth/TLS, or the node ran out of space chunking the disk. Inspect the `<snap>-oci-disk` Job. |
 | Import guest stuck in `Scheduling` | The disk-from-oci download Job (`swiftguest-root-<guest>-oci-disk-dl`) is still pulling, or `--target-node` has no capacity. Check the Job + `kubectl describe swiftguest <guest>`. |
 | Import `Failed: source SwiftGuest ... no longer exists` | The snapshot is memory-only or pre-dates the captured spec surface — those still need the live source. Full-state exports from current releases import source-independently (see the cross-cluster section). |
-| Import `Failed: ... root-disk-only` | The source had data disks; source-independent import doesn't carry them (v1). Recreate the source guest, or re-export without data disks. |
+| Export rejected: image-backed data disk | Full-state export carries `blank`/`attachAsDisk` data disks (v1.1) but rejects an **image-backed** data disk (legacy `dataDiskRef` / `dataDiskRefs[].imageRef`) — that PVC belongs to the SwiftImage. Re-export without it. |
+| Import `Failed: ... pre-v1.1 root-disk-only snapshot` | The snapshot was captured by a controller predating v1.1 and recorded data disks without registry artifacts. Re-export from a current release, or keep the live source guest. |
 | Two copies running | Pre-fix behaviour; on current releases the source is stopped during export. If you manually restarted the source, stop it again. |
 
 ## See also

--- a/internal/controller/swiftguest/clone.go
+++ b/internal/controller/swiftguest/clone.go
@@ -178,8 +178,14 @@ func (r *SwiftGuestReconciler) prepareSourceIndependentClone(
 		// pre-source-independence contract applies.
 		return nil, nil, "source SwiftGuest " + snap.Spec.GuestRef.Name + " no longer exists; cloneFromSnapshot needs the source spec (only a full-state oci snapshot with a captured guest spec clones source-independently)", false, nil
 	}
-	if captured.HasDataDisks {
-		return nil, nil, "source-independent clone: snapshot " + snap.Name + "'s source had data disks, which full-state capture does not carry (v1 is root-disk-only); the source spec is required", false, nil
+	// v1.1: a full-state snapshot may carry the source's data disks as their own
+	// oci artifacts (status.oci.dataDisks). If the source HAD data disks but the
+	// capture produced no such artifacts, it is a pre-v1.1 (root-disk-only)
+	// snapshot — reject, the source spec is required. When artifacts are present
+	// the import path (ensureCloneDataDisks) materializes + attaches them, so the
+	// clone is fully source-independent.
+	if captured.HasDataDisks && len(snap.Status.OCI.DataDisks) == 0 {
+		return nil, nil, "source-independent clone: snapshot " + snap.Name + "'s source had data disks but the capture carries none (pre-v1.1 root-disk-only snapshot); the source spec is required", false, nil
 	}
 	var class swiftv1alpha1.SwiftGuestClass
 	if err := r.Get(ctx, client.ObjectKey{Name: guest.Spec.GuestClassRef.Name}, &class); err != nil {

--- a/internal/controller/swiftguest/coldmig_import.go
+++ b/internal/controller/swiftguest/coldmig_import.go
@@ -24,6 +24,7 @@ import (
 	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/resolved"
+	"github.com/kubeswift-io/kubeswift/internal/runtimeintent"
 )
 
 // maybeRootDiskFromOCI handles the root disk for a FULL-STATE cloneFromSnapshot.
@@ -103,7 +104,7 @@ func (r *SwiftGuestReconciler) maybeRootDiskFromOCI(
 	var job batchv1.Job
 	jerr := r.Get(ctx, client.ObjectKey{Name: jobName, Namespace: guest.Namespace}, &job)
 	if apierrors.IsNotFound(jerr) {
-		j := buildRootDiskFromOCIJob(guest, &snap, r.SnapshotORASImage, node, jobName, cloneName, block)
+		j := buildDiskFromOCIJob(guest, &snap, r.SnapshotORASImage, node, jobName, cloneName, snap.Status.OCI.Disk.ManifestDigest, block)
 		if err := controllerutil.SetControllerReference(guest, j, r.Scheme); err != nil {
 			return true, nil, err
 		}
@@ -122,6 +123,15 @@ func (r *SwiftGuestReconciler) maybeRootDiskFromOCI(
 			if pvc.Status.Phase != corev1.ClaimBound {
 				return true, nil, fmt.Errorf("full-state clone PVC %s not yet Bound", cloneName)
 			}
+			// Root disk is materialized. A full-state snapshot may also carry
+			// secondary data disks (v1.1); materialize + attach them under the
+			// captured names and OVERRIDE rg.DataDisks so the launcher wires the
+			// clone-owned PVCs — not the source's. Only report the root disk done
+			// once every data disk is ready (an err here is the transient requeue
+			// signal the caller already treats as progress).
+			if err := r.ensureCloneDataDisks(ctx, guest, &snap, rg, node); err != nil {
+				return true, nil, err
+			}
 			return true, &RootDiskCloneResult{PVCName: cloneName, NeedsGrowInit: false}, nil
 		}
 		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
@@ -131,12 +141,13 @@ func (r *SwiftGuestReconciler) maybeRootDiskFromOCI(
 	return true, nil, fmt.Errorf("full-state clone disk download in progress")
 }
 
-// buildRootDiskFromOCIJob runs snapshot-oras --mode=download-image to fill the
-// clone's root PVC from the snapshot's oci disk artifact (pinned by digest).
-// Block PVCs attach via volumeDevices at DiskRootDevicePath; Filesystem PVCs
-// mount at DisksRootPath and the disk is image.raw. Node-pinned so the PVC
-// attaches on the clone's node. Runs as root to write the raw disk.
-func buildRootDiskFromOCIJob(guest *swiftv1alpha1.SwiftGuest, snap *snapshotv1alpha1.SwiftSnapshot, image, node, jobName, pvcName string, block bool) *batchv1.Job {
+// buildDiskFromOCIJob runs snapshot-oras --mode=download-image to fill a clone
+// disk PVC from an oci disk artifact (pinned by the given manifest digest — the
+// root disk's or a data disk's). A single PVC attaches inside the Job pod, so
+// the same in-pod path (DiskRootDevicePath for Block, DisksRootPath/image.raw
+// for Filesystem) serves any disk; only the PVC + digest differ. Node-pinned so
+// the PVC attaches on the clone's node. Runs as root to write the raw disk.
+func buildDiskFromOCIJob(guest *swiftv1alpha1.SwiftGuest, snap *snapshotv1alpha1.SwiftSnapshot, image, node, jobName, pvcName, digest string, block bool) *batchv1.Job {
 	oci := snap.Spec.Backend.OCI
 	diskPath := DisksRootPath + "/image.raw"
 	if block {
@@ -146,7 +157,7 @@ func buildRootDiskFromOCIJob(guest *swiftv1alpha1.SwiftGuest, snap *snapshotv1al
 		"--mode=download-image",
 		"--file=" + diskPath,
 		"--repository=" + oci.Repository,
-		"--digest=" + snap.Status.OCI.Disk.ManifestDigest,
+		"--digest=" + digest,
 	}
 	if oci.Insecure {
 		args = append(args, "--insecure")
@@ -211,4 +222,148 @@ func buildRootDiskFromOCIJob(guest *swiftv1alpha1.SwiftGuest, snap *snapshotv1al
 			},
 		},
 	}
+}
+
+// ensureCloneDataDisks materializes a full-state clone's secondary data disks
+// (v1.1) from the snapshot's per-disk oci artifacts (status.oci.dataDisks) and
+// OVERRIDES rg.DataDisks so the launcher attaches the clone-owned PVCs — not the
+// source's (a same-source clone would otherwise resolve to the SOURCE's data-disk
+// PVCs, which are frozen/RWO-conflicting). Each captured disk becomes a
+// RestoreSeeded clone-owned PVC filled by a node-pinned download Job under the
+// SAME disk name (so CH's name-derived --disk path coheres with the restored
+// config.json). Returns nil only when every data disk is Bound + its Job Complete
+// and rg.DataDisks has been set; any other return is the transient requeue signal.
+//
+// Only blank / attachAsDisk disks are ever captured (the capture side rejects
+// image-backed data disks), so materializing them fresh is always correct.
+func (r *SwiftGuestReconciler) ensureCloneDataDisks(
+	ctx context.Context, guest *swiftv1alpha1.SwiftGuest, snap *snapshotv1alpha1.SwiftSnapshot,
+	rg *resolved.ResolvedGuest, node string,
+) error {
+	if snap.Status.OCI == nil || len(snap.Status.OCI.DataDisks) == 0 {
+		return nil // root-disk-only full-state snapshot (v1) — nothing to do.
+	}
+	// Captured shape (size/block) keyed by name.
+	shape := map[string]snapshotv1alpha1.CapturedDataDisk{}
+	if snap.Status.GuestSpec != nil {
+		for _, cd := range snap.Status.GuestSpec.DataDisks {
+			shape[cd.Name] = cd
+		}
+	}
+
+	// Pass 1: ensure every clone-owned PVC + its download Job exists. Creating
+	// all up-front lets the per-disk downloads run concurrently.
+	allCreated := true
+	for _, art := range snap.Status.OCI.DataDisks {
+		cd := shape[art.Name]
+		pvcName := resolved.BlankDataDiskPVCName(guest.Name, art.Name)
+
+		var pvc corev1.PersistentVolumeClaim
+		perr := r.Get(ctx, client.ObjectKey{Name: pvcName, Namespace: guest.Namespace}, &pvc)
+		if apierrors.IsNotFound(perr) {
+			size := resource.MustParse("1Gi")
+			if cd.Size != "" {
+				if q, err := resource.ParseQuantity(cd.Size); err == nil {
+					size = q
+				}
+			}
+			mode := corev1.PersistentVolumeFilesystem
+			if cd.Block {
+				mode = corev1.PersistentVolumeBlock
+			}
+			p := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcName,
+					Namespace: guest.Namespace,
+					Labels: map[string]string{
+						"swift.kubeswift.io/guest": guest.Name,
+						"swift.kubeswift.io/role":  "data-disk",
+						RestoreSeededLabel:         "true",
+					},
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(guest, swiftGuestGVK)},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					VolumeMode:  &mode,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: size},
+					},
+				},
+			}
+			if err := r.Create(ctx, p); err != nil && !apierrors.IsAlreadyExists(err) {
+				return fmt.Errorf("create clone data-disk PVC %s: %w", pvcName, err)
+			}
+			allCreated = false
+			continue
+		}
+		if perr != nil {
+			return perr
+		}
+
+		jobName := pvcName + "-oci-dl"
+		var job batchv1.Job
+		jerr := r.Get(ctx, client.ObjectKey{Name: jobName, Namespace: guest.Namespace}, &job)
+		if apierrors.IsNotFound(jerr) {
+			j := buildDiskFromOCIJob(guest, snap, r.SnapshotORASImage, node, jobName, pvcName, art.ManifestDigest, cd.Block)
+			if err := controllerutil.SetControllerReference(guest, j, r.Scheme); err != nil {
+				return err
+			}
+			if err := r.Create(ctx, j); err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+			allCreated = false
+			continue
+		}
+		if jerr != nil {
+			return jerr
+		}
+	}
+	if !allCreated {
+		return fmt.Errorf("materializing %d data disk(s) from oci", len(snap.Status.OCI.DataDisks))
+	}
+
+	// Pass 2: gate on all Bound + Complete, then build the override.
+	var disks []resolved.ResolvedDataDisk
+	for _, art := range snap.Status.OCI.DataDisks {
+		cd := shape[art.Name]
+		pvcName := resolved.BlankDataDiskPVCName(guest.Name, art.Name)
+
+		var pvc corev1.PersistentVolumeClaim
+		if err := r.Get(ctx, client.ObjectKey{Name: pvcName, Namespace: guest.Namespace}, &pvc); err != nil {
+			return err
+		}
+		var job batchv1.Job
+		if err := r.Get(ctx, client.ObjectKey{Name: pvcName + "-oci-dl", Namespace: guest.Namespace}, &job); err != nil {
+			return err
+		}
+		done := false
+		for _, c := range job.Status.Conditions {
+			if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+				return fmt.Errorf("clone data-disk %s download failed: %s", art.Name, c.Message)
+			}
+			if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+				done = true
+			}
+		}
+		if !done || pvc.Status.Phase != corev1.ClaimBound {
+			return fmt.Errorf("clone data-disk %s not yet ready", art.Name)
+		}
+
+		rd := resolved.ResolvedDataDisk{
+			Name:    art.Name,
+			PVCName: pvcName,
+			Block:   cd.Block,
+			Format:  "raw",
+			Ready:   true,
+		}
+		if cd.Block {
+			rd.HostPath = runtimeintent.DataDiskDevicePath(art.Name)
+		} else {
+			rd.MountPath = runtimeintent.DataDiskDir(art.Name)
+			rd.HostPath = rd.MountPath + "/" + runtimeintent.DataDiskImageFile
+		}
+		disks = append(disks, rd)
+	}
+	rg.DataDisks = disks
+	return nil
 }

--- a/internal/controller/swiftguest/coldmig_import_test.go
+++ b/internal/controller/swiftguest/coldmig_import_test.go
@@ -34,9 +34,9 @@ func fsRG() *resolved.ResolvedGuest {
 	}
 }
 
-func TestBuildRootDiskFromOCIJob_Filesystem(t *testing.T) {
+func TestBuildDiskFromOCIJob_Filesystem(t *testing.T) {
 	guest := cloneGuest()
-	job := buildRootDiskFromOCIJob(guest, fullStateCloneSnap(), "oras:img", "miles", "j", "swiftguest-root-clone-a", false)
+	job := buildDiskFromOCIJob(guest, fullStateCloneSnap(), "oras:img", "miles", "j", "swiftguest-root-clone-a", "sha256:disk123", false)
 	pod := job.Spec.Template.Spec
 	if pod.NodeName != "miles" {
 		t.Errorf("download Job must pin to the clone node; got %q", pod.NodeName)
@@ -76,8 +76,8 @@ func TestBuildRootDiskFromOCIJob_Filesystem(t *testing.T) {
 	}
 }
 
-func TestBuildRootDiskFromOCIJob_Block(t *testing.T) {
-	job := buildRootDiskFromOCIJob(cloneGuest(), fullStateCloneSnap(), "oras:img", "boba", "j", "swiftguest-root-clone-a", true)
+func TestBuildDiskFromOCIJob_Block(t *testing.T) {
+	job := buildDiskFromOCIJob(cloneGuest(), fullStateCloneSnap(), "oras:img", "boba", "j", "swiftguest-root-clone-a", "sha256:disk123", true)
 	c := job.Spec.Template.Spec.Containers[0]
 	if !strings.Contains(strings.Join(c.Args, " "), "--file="+DiskRootDevicePath) {
 		t.Errorf("Block root must download to the raw device; got %q", strings.Join(c.Args, " "))
@@ -96,10 +96,10 @@ func TestBuildRootDiskFromOCIJob_Block(t *testing.T) {
 	}
 }
 
-func TestBuildRootDiskFromOCIJob_Creds(t *testing.T) {
+func TestBuildDiskFromOCIJob_Creds(t *testing.T) {
 	snap := fullStateCloneSnap()
 	snap.Spec.Backend.OCI.CredentialsSecretRef = &snapshotv1alpha1.SecretObjectReference{Name: "reg-creds"}
-	job := buildRootDiskFromOCIJob(cloneGuest(), snap, "oras:img", "miles", "j", "swiftguest-root-clone-a", false)
+	job := buildDiskFromOCIJob(cloneGuest(), snap, "oras:img", "miles", "j", "swiftguest-root-clone-a", "sha256:disk123", false)
 	c := job.Spec.Template.Spec.Containers[0]
 	var dockerCfg bool
 	for _, e := range c.Env {
@@ -205,5 +205,90 @@ func TestMaybeRootDiskFromOCI_MaterializesDiskThenReady(t *testing.T) {
 	}
 	if res.NeedsGrowInit {
 		t.Errorf("a full-state disk is byte-exact; it must NOT be grow-init'd")
+	}
+}
+
+// fullStateWithDataDisk is a v1.1 full-state snapshot: a root disk PLUS one Block
+// data disk artifact + its captured shape.
+func fullStateWithDataDisk() *snapshotv1alpha1.SwiftSnapshot {
+	s := fullStateCloneSnap()
+	s.Status.OCI.DataDisks = []snapshotv1alpha1.OCIDataDiskArtifact{
+		{Name: "scratch", Reference: "zot.svc:5000/vmsnap:ns-snap-disk-scratch", ManifestDigest: "sha256:dd1", PushedBytes: 8192},
+	}
+	s.Status.GuestSpec = &snapshotv1alpha1.CapturedGuestSpec{
+		HasDataDisks: true,
+		DataDisks:    []snapshotv1alpha1.CapturedDataDisk{{Name: "scratch", Size: "20Gi", Block: true}},
+	}
+	return s
+}
+
+// A full-state clone whose source had a data disk must materialize that disk into
+// its own RestoreSeeded PVC and OVERRIDE rg.DataDisks so the launcher attaches the
+// clone-owned PVC (not the source's). The root disk is only reported done once the
+// data disk is Bound + its download Job Complete.
+func TestMaybeRootDiskFromOCI_MaterializesDataDisks(t *testing.T) {
+	ctx := context.Background()
+	g := cloneGuest()
+	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	r, c := newCloneReconciler(t, g, fullStateWithDataDisk())
+	r.SnapshotORASImage = "img"
+	cloneName := RootDiskCloneName(g.Name)
+	dataPVC := resolved.BlankDataDiskPVCName(g.Name, "scratch")
+
+	bind := func(name string) {
+		var p corev1.PersistentVolumeClaim
+		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: "ns"}, &p); err != nil {
+			return
+		}
+		p.Status.Phase = corev1.ClaimBound
+		_ = c.Status().Update(ctx, &p)
+	}
+	completeJob := func(name string) {
+		var j batchv1.Job
+		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: "ns"}, &j); err != nil {
+			return
+		}
+		j.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+		_ = c.Status().Update(ctx, &j)
+	}
+
+	rg := fsRG()
+	// Iterate the reconcile, binding/completing PVCs+Jobs as they appear, until
+	// the root disk is reported ready (or we give up).
+	var res *RootDiskCloneResult
+	for i := 0; i < 8 && res == nil; i++ {
+		_, r2, _ := r.maybeRootDiskFromOCI(ctx, g, rg)
+		res = r2
+		bind(cloneName)
+		bind(dataPVC)
+		completeJob(cloneName + "-oci-disk-dl")
+		completeJob(dataPVC + "-oci-dl")
+	}
+	if res == nil {
+		t.Fatalf("root disk never reported ready with a data disk in flight")
+	}
+
+	// The data-disk PVC must exist, be RestoreSeeded + guest-owned, Block, 20Gi.
+	var ddpvc corev1.PersistentVolumeClaim
+	if err := c.Get(ctx, client.ObjectKey{Name: dataPVC, Namespace: "ns"}, &ddpvc); err != nil {
+		t.Fatalf("data-disk clone PVC not created: %v", err)
+	}
+	if ddpvc.Labels[RestoreSeededLabel] != "true" || ddpvc.Labels["swift.kubeswift.io/role"] != "data-disk" {
+		t.Errorf("data-disk PVC labels wrong: %+v", ddpvc.Labels)
+	}
+	if ddpvc.Spec.VolumeMode == nil || *ddpvc.Spec.VolumeMode != corev1.PersistentVolumeBlock {
+		t.Errorf("captured Block data disk must clone as Block; got %+v", ddpvc.Spec.VolumeMode)
+	}
+	if got := ddpvc.Spec.Resources.Requests[corev1.ResourceStorage]; got.String() != "20Gi" {
+		t.Errorf("data-disk size = %q, want 20Gi", got.String())
+	}
+
+	// rg.DataDisks must be OVERRIDDEN to the clone-owned PVC, under the source name.
+	if len(rg.DataDisks) != 1 {
+		t.Fatalf("rg.DataDisks not overridden: %+v", rg.DataDisks)
+	}
+	d := rg.DataDisks[0]
+	if d.Name != "scratch" || d.PVCName != dataPVC || !d.Block || !d.Ready {
+		t.Errorf("overridden data disk wrong: %+v (want name=scratch pvc=%s block ready)", d, dataPVC)
 	}
 }

--- a/internal/controller/swiftguest/restore.go
+++ b/internal/controller/swiftguest/restore.go
@@ -331,6 +331,17 @@ func BuildRestorePod(
 	if rg.HasSeed() && seedConfigMapName != "" {
 		mounts = append(mounts, corev1.VolumeMount{Name: "seed", MountPath: SeedPath})
 	}
+	// Secondary VM data disks (v1.1 full-state clones): the captured config.json
+	// records every disk, and CH --restore re-opens each one — so a data disk
+	// materialized from oci MUST be attached at the SAME path the launcher passed
+	// at capture (Block → volumeDevices at HostPath; Filesystem → mount dir),
+	// exactly as the regular launcher does. Without this CH --restore fails with
+	// "Cannot open disk /dev/kubeswift-data-<name>". The disks are made ready +
+	// rg.DataDisks is overridden to the clone-owned PVCs by ensureCloneDataDisks
+	// before this pod is built.
+	volumes = append(volumes, dataDiskVolumes(rg)...)
+	mounts = append(mounts, dataDiskMounts(rg)...)
+	volumeDevices = append(volumeDevices, dataDiskDevices(rg)...)
 	if params.IsClone() {
 		// In clone mode the launcher reads the staged+patched copy.
 		// The RO source mount stays only on the init container —

--- a/internal/controller/swiftguest/restore_test.go
+++ b/internal/controller/swiftguest/restore_test.go
@@ -443,3 +443,35 @@ func TestBuildRestorePod_StagerHasNoPrivilege(t *testing.T) {
 		t.Errorf("stager must drop ALL capabilities; got %+v", sc.Capabilities)
 	}
 }
+
+// A full-state clone (v1.1) whose source had a data disk must attach that disk to
+// the restore-receive pod at the SAME path the launcher used at capture — CH
+// --restore re-opens every disk in the captured config.json, so a missing data
+// disk fails the restore with "Cannot open disk /dev/kubeswift-data-<name>"
+// (cluster-caught). rg.DataDisks is overridden to the clone-owned PVC by
+// ensureCloneDataDisks before this pod is built.
+func TestBuildRestorePod_AttachesDataDisks(t *testing.T) {
+	guest := minimalGuest()
+	rg := minimalResolved()
+	rg.DataDisks = []resolved.ResolvedDataDisk{
+		{Name: "scratch", PVCName: "g1-data-scratch", Block: true, HostPath: "/dev/kubeswift-data-scratch", Format: "raw", Ready: true},
+	}
+	params := RestoreParams{SnapshotPath: "/snap", NodeName: "boba", Mode: RestoreModeInPlace}
+
+	pod := BuildRestorePod(guest, rg, "", "g1-runtime-intent", nil, params)
+
+	vol := findVolume(pod, dataDiskVolumeName("scratch"))
+	if vol == nil || vol.PersistentVolumeClaim == nil || vol.PersistentVolumeClaim.ClaimName != "g1-data-scratch" {
+		t.Fatalf("restore pod must carry the data-disk PVC volume; got %+v", pod.Spec.Volumes)
+	}
+	launcher := pod.Spec.Containers[0]
+	var dev *corev1.VolumeDevice
+	for i := range launcher.VolumeDevices {
+		if launcher.VolumeDevices[i].Name == dataDiskVolumeName("scratch") {
+			dev = &launcher.VolumeDevices[i]
+		}
+	}
+	if dev == nil || dev.DevicePath != "/dev/kubeswift-data-scratch" {
+		t.Fatalf("Block data disk must attach as a device at the captured path; got %+v", launcher.VolumeDevices)
+	}
+}


### PR DESCRIPTION
**Stacked on [#318](https://github.com/kubeswift-io/kubeswift/pull/318) (PR1 — capture side). Review/merge #318 first**, then rebase this onto main.

Second PR of the **v1.1 data-disk** arc (design §5.5). A full-state `cloneFromSnapshot` now materializes the source's secondary data disks from their oci artifacts and attaches them **under the same disk names** — so a resumed clone gets the data-disk state its captured RAM references, not fresh blank disks. Completes the capture side (#318).

## What

- **`ensureCloneDataDisks`** (`coldmig_import.go`): once the root disk is Bound+Complete, materialize each `status.oci.dataDisks[]` artifact into a guest-owned, **RestoreSeeded** PVC `BlankDataDiskPVCName(clone,name)` (Block/FS + size from the captured shape; one digest-pinned download Job per disk, created up-front so they run concurrently), gate on **all** Bound + Jobs Complete, then **replace `rg.DataDisks`** with entries pointing at the materialized PVCs (name/Block/HostPath/MountPath rebuilt exactly as the resolver would). The root disk is only reported done once every data disk is ready.
- **The override is load-bearing for both clone paths**: a *same-source* clone would otherwise resolve `rg.DataDisks` to the **source's** (frozen / RWO-conflicting) data PVCs; a *source-gone* clone starts with none (`FromCapturedSpec` sets none). **No `EnsureBlankDataDisks` change** — a clone carries no `DataDiskRefs` in its own spec, so it's a natural no-op there; only `ensureCloneDataDisks` writes the clone's data PVCs.
- `buildRootDiskFromOCIJob` → **`buildDiskFromOCIJob(..., digest, block)`** — same Job shape, per-disk digest (a single PVC attaches in the Job pod, so the in-pod device/mount path is shared between root + data).
- `clone.go`: the source-gone `hasDataDisks` rejection now fires **only** when the captured surface has data disks but **no** oci artifacts (a pre-v1.1 root-disk-only snapshot); when artifacts are present the clone is fully source-independent.

## Tests

A 3-pass materialize of a Block data disk asserting the clone PVC (RestoreSeeded, guest-owned, Block, 20Gi) + the `rg.DataDisks` override; existing root-disk builder/flow tests updated to the generalized builder. `go build` / `go vet` / `gofmt -s` / `go test` clean.

## Validation

Cluster validation (a blank Block data disk full-state round-trip: marker on `vdc` → export → delete source+image+seed → import → Running with `vdc` intact + `boot_id` matched) is **PR3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)