### PR TITLE
docs(known-issue): the clone-reboot 'hang' is a root-disk geometry bug, not a firmware hang (cluster-reproduced)

### DIFF
--- a/docs/design/known-issues-clone-reboot-firmware-hang.md
+++ b/docs/design/known-issues-clone-reboot-firmware-hang.md
@@ -1,8 +1,13 @@
 # Known issue — cloneFromSnapshot guests hang in firmware on reboot (CH v52)
 
-> Status: OPEN (investigation). Surfaced 2026-06-15 validating demo 06 (instant
-> clones) on the v0.4.2 cluster. Severity: MEDIUM (blocks identity/IP divergence
-> for memory-snapshot clones; does not affect normal guests or the source).
+> Status: OPEN. Surfaced 2026-06-15 validating demo 06 (instant clones) on the
+> v0.4.2 cluster. An off-cluster reproduction attempt (2026-07-03, see
+> "Off-cluster investigation" below) was **inconclusive** — restore/resume is
+> solid but a deterministic reboot-hang could not be reproduced, and it produced
+> one correction to the diagnosis. Severity: MEDIUM (blocks identity/IP
+> divergence for memory-snapshot clones; does not affect normal guests or the
+> source) — but effectively **mitigated** by the shipped in-guest vsock identity
+> agent (v0.4.4), which regenerates identity + re-DHCPs with no reboot.
 > Layer: **Cloud Hypervisor v52 `--restore` + guest reboot + EDK2 firmware** —
 > NOT KubeSwift Go/Rust code.
 
@@ -61,7 +66,7 @@ ACPI/firmware state that makes EDK2 believe it is resuming from S3 — and then
   restore guests, so the IP **would** surface automatically the moment a clone
   re-DHCPs — it just never gets the chance while the reboot is wedged.
 
-## Hypotheses / next steps (not yet attempted)
+## Hypotheses (original; see "Off-cluster investigation" below for what the 2026-07-03 attempt found)
 
 1. **Disable guest S3 / ACPI sleep so the warm reset takes the cold-boot path.**
    Investigate whether CH or the firmware can be told the guest has no S3 (e.g. a
@@ -77,6 +82,58 @@ ACPI/firmware state that makes EDK2 believe it is resuming from S3 — and then
    agent** regenerates machine-id / SSH keys / hostname and renews DHCP *without*
    a reboot. That is the real fix for clone identity/IP and makes the reboot path
    unnecessary; prioritize it over chasing the firmware hang.
+
+## Off-cluster investigation (2026-07-03) — inconclusive; two corrections
+
+An off-cluster reproduction harness was built with the **real CH v52.0 binary +
+`CLOUDHV.fd`** (extracted from the `swiftletd` image) and a Noble guest, driving
+`boot → snapshot → --restore (resume) → reboot` directly. Findings:
+
+- **Restore + resume is rock-solid.** Every `--restore` (eager and `ondemand`/
+  userfaultfd) reached `state=Running`; the vsock-agent-survives-restore property
+  (PR-0 spike) holds.
+- **A deterministic hang could NOT be reproduced.** Restored clones were driven
+  through `sudo reboot` and CH `vm.reboot` dozens of times across
+  eager/`ondemand` restore modes, with and without a virtio-net device. Some
+  trials clearly rebooted to multi-user (e.g. `vm.reboot` on a no-net clone
+  produced a full boot — 19 `Reached target` lines on the guest serial); others
+  looked wedged. **The same configuration produced both "rebooted" and "hung"
+  verdicts on different runs**, so the result is measurement-limited, not a clean
+  repro. Root cause off-cluster is **unconfirmed**.
+- **Methodology caveat (why the verdicts are noisy):** observing reboot outcome
+  over a `--serial socket=` connection is unreliable — the guest resets the
+  serial device on warm reset, so a held connection goes silent (looks hung) and
+  intermittent fresh probes race the boot. A trustworthy repro needs a
+  **connection-independent liveness signal** — the **vsock agent ping** (responds
+  only once the guest reaches multi-user) is the right instrument; the serial
+  console is not.
+
+**Correction to the diagnosis above:** the "froze after
+`MpInitChangeApLoopCallback() done!`" evidence was over-read. In the off-cluster
+harness that line is the firmware's **normal** hand-off point — the firmware
+debug port goes quiet there on **every** boot (successful or not) because the
+kernel takes over the console. So "last line is `MpInit...done`" is **not**, by
+itself, evidence of an AP-init firmware hang; the true stall point (when the
+hang does occur on the cluster) is at or after the firmware→kernel hand-off and
+remains unconfirmed. The "Evidence pointing at the EDK2 S3-resume / AP-init path"
+section above should be read as a *hypothesis*, not a conclusion.
+
+**Recommendation / next steps (revised):**
+1. **Reproduce on the cluster** (where it was actually observed) using the
+   **vsock agent ping** as the boot-completion signal — the only reliable way to
+   separate "hung" from "slow/at-an-unresponsive-prompt".
+2. **CH version bisect (v52 → v53+)** against a cluster repro; the intermittency
+   is most consistent with a timing-sensitive upstream firmware/KVM interaction,
+   not KubeSwift code — so this is the strongest lead for a real fix.
+3. **Accept the in-guest vsock identity agent (shipped v0.4.4) as the resolution
+   for the primary need.** It regenerates identity + renews DHCP *in place, no
+   reboot*, so the reboot path is unnecessary for clone identity/IP. The
+   reboot-hang then only affects *other* reboots (kernel updates, etc.) of a
+   restored clone — a lower-severity, upstream-watch item.
+
+The single-vCPU (Lead 2) and S3-disable (Lead 1) experiments were **not run to a
+firm conclusion** — they depend on a reliable repro, which the off-cluster
+harness could not provide.
 
 ## Related
 

--- a/docs/design/known-issues-clone-reboot-firmware-hang.md
+++ b/docs/design/known-issues-clone-reboot-firmware-hang.md
@@ -1,15 +1,63 @@
-# Known issue — cloneFromSnapshot guests hang in firmware on reboot (CH v52)
+# Known issue — cloneFromSnapshot guests fail to reboot (root-disk geometry, NOT a firmware hang)
 
-> Status: OPEN. Surfaced 2026-06-15 validating demo 06 (instant clones) on the
-> v0.4.2 cluster. An off-cluster reproduction attempt (2026-07-03, see
-> "Off-cluster investigation" below) was **inconclusive** — restore/resume is
-> solid but a deterministic reboot-hang could not be reproduced, and it produced
-> one correction to the diagnosis. Severity: MEDIUM (blocks identity/IP
-> divergence for memory-snapshot clones; does not affect normal guests or the
-> source) — but effectively **mitigated** by the shipped in-guest vsock identity
-> agent (v0.4.4), which regenerates identity + re-DHCPs with no reboot.
-> Layer: **Cloud Hypervisor v52 `--restore` + guest reboot + EDK2 firmware** —
-> NOT KubeSwift Go/Rust code.
+> Status: **ROOT CAUSE IDENTIFIED (2026-07-03, cluster-reproduced with a
+> deterministic signal). The "CH v52 firmware hang" title/framing was a
+> MISDIAGNOSIS** — see "ROOT CAUSE" immediately below. The real fault is a
+> KubeSwift **clone root-disk geometry bug** (`internal/controller/swiftguest/rootdisk.go`),
+> not EDK2/Cloud Hypervisor. Severity: MEDIUM (a memory-snapshot clone cannot
+> reboot; unaffected: normal guests + the source). Effectively **mitigated** for
+> the primary need by the shipped in-guest vsock identity agent (v0.4.4), which
+> regenerates identity + re-DHCPs with no reboot.
+
+## ROOT CAUSE (2026-07-03, cluster-reproduced, deterministic)
+
+A `cloneFromSnapshot` clone's root disk is **cloned from the pristine SwiftImage**
+(`EnsureRootDiskClone` → `sourcePVC := rg.PreparedImage.PVCName`; `createCloneJob`
+does `cp image.raw` + `qemu-img resize` + `sgdisk -e` — **no `growpart` /
+`resize2fs`**). On a *normal* guest that is correct: cloud-init `growpart` grows
+the partition + `resize2fs` grows the filesystem on **first boot**. But a clone
+**RESUMES** captured RAM — **cloud-init never re-runs** — so the on-disk partition
+stays at the pristine image size while the resumed guest's in-RAM ext4 is the
+**source's already-grown** filesystem. The resumed guest syncs that grown
+superblock onto the small-partition clone disk, leaving it internally
+inconsistent: **filesystem size > partition size**.
+
+It works while running (the mount lives in the captured RAM). It only breaks on
+the **next reboot**, when the initramfs re-reads the disk and ext4 refuses:
+
+```
+EXT4-fs (vda1): bad geometry: block count 2359035 exceeds size of device (655099 blocks)
+```
+
+→ the guest drops to the **initramfs emergency shell**, never reaches systemd,
+never re-DHCPs, and is unreachable — which the operator saw as a "hang".
+
+**Cluster reproduction (2026-07-03, field-testing, boba, CH v52.0, deterministic
+`DHCPACK`+`boot_id` signal):**
+
+| Guest | root disk | partition `vda1` | ext4 superblock | reboot result |
+|---|---|---|---|---|
+| `rh-src` (normal source) | grown on first boot | 18,872,287 sec ≈ 9.66 GB | 2,359,035 blk ≈ 9.66 GB (**match**) | **rebooted cleanly in ~15 s** (new boot_id, 2×DHCPACK) |
+| `rh-clone` (cloneFromSnapshot) | pristine image copy | 5,240,799 sec ≈ 2.68 GB | 2,359,035 blk ≈ 9.66 GB (**fs > part**) | **initramfs; no DHCP; unreachable 4.3+ min** |
+
+The two corrections from the earlier off-cluster attempt hold and explain why it
+looked like firmware: (1) `MpInitChangeApLoopCallback() done!` is the firmware's
+*normal* hand-off point (the debug port goes quiet there on every boot as the
+kernel takes the console) — it is **not** an AP-init hang; the guest is past
+firmware, in the kernel's initramfs. (2) the serial console is an unreliable
+verdict tool; the deterministic signal is the launcher `DHCPACK` (as the
+original 2026-06-15 `ft-golden` vs `ft-clone-a` observation already used).
+
+**Fix direction:** a memory-snapshot clone must get a root disk whose on-disk
+geometry (and data) matches the resumed RAM — i.e. **clone the disk from the
+SOURCE's actual root PVC** (grown partition+fs), not from the pristine SwiftImage.
+(Equivalently: grow the clone disk's partition+fs to the source's geometry before
+resume — but cloning the source's disk is the clean fix and also gives the clone
+the source's real disk content, not the pristine image's.) Scope: the
+`cloneFromSnapshot` branch of `EnsureRootDiskClone`. Everything below this line is
+the **original (superseded) firmware-hang hypothesis**, kept for history.
+
+---
 
 ## Symptom
 


### PR DESCRIPTION
Follow-up to [#321](https://github.com/kubeswift-io/kubeswift/pull/321). The on-cluster reproduction (which #321 recommended) **succeeded with a deterministic signal** and found the real root cause — the "CH v52 firmware hang" framing was a **misdiagnosis**.

## Root cause
A `cloneFromSnapshot` clone's root disk is cloned from the **pristine SwiftImage** (`EnsureRootDiskClone` → `rg.PreparedImage.PVCName`; `createCloneJob` does `cp image.raw` + `qemu-img resize` + `sgdisk -e` — **no `growpart`/`resize2fs`**). For a normal guest that's correct (cloud-init `growpart`+`resize2fs` runs on first boot). But a clone **RESUMES** captured RAM — cloud-init never re-runs — so the on-disk partition stays pristine-sized while the resumed guest's in-RAM ext4 is the source's **already-grown** filesystem. The resumed guest syncs the grown superblock onto the small-partition disk → **fs size > partition size**. It runs fine (mount lives in RAM); the next **reboot's initramfs** re-reads the disk and ext4 refuses:

```
EXT4-fs (vda1): bad geometry: block count 2359035 exceeds size of device (655099 blocks)
```

→ initramfs emergency shell → never reaches systemd, never re-DHCPs = the "hang".

## Deterministic reproduction (field-testing, boba, CH v52.0)
Signal = launcher `DHCPACK` + `boot_id` change (the original `ft-golden` vs `ft-clone-a` signal), not the serial console.

| Guest | partition `vda1` | ext4 superblock | reboot |
|---|---|---|---|
| source (normal) | ≈ 9.66 GB | ≈ 9.66 GB (match) | **clean, ~15 s** (new boot_id, 2×DHCPACK) |
| clone (cloneFromSnapshot) | ≈ 2.68 GB (pristine image) | ≈ 9.66 GB (**fs > part**) | **initramfs; no DHCP; unreachable 4.3+ min** |

Confirms #321's two corrections: `MpInitChangeApLoopCallback done` is the firmware's *normal* hand-off point (the guest is past firmware, in the kernel's initramfs — not an AP-init hang); serial is an unreliable verdict tool.

## Fix direction (not in this PR — docs only)
A memory-snapshot clone must get a root disk whose geometry **and data** match the resumed RAM → **clone the disk from the SOURCE's actual root PVC** (grown partition+fs), not the pristine SwiftImage. Scope: the `cloneFromSnapshot` branch of `EnsureRootDiskClone`. (This also means today's clones carry the *pristine image's* disk content, masked by the resumed page cache until a reboot — worth confirming when the fix lands.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)