### PR TITLE
fix(clone): memory-clone root disk from the SOURCE's disk, not the pristine image (fixes clone-reboot hang)

### DIFF
--- a/docs/design/known-issues-clone-reboot-firmware-hang.md
+++ b/docs/design/known-issues-clone-reboot-firmware-hang.md
@@ -1,15 +1,107 @@
-# Known issue — cloneFromSnapshot guests hang in firmware on reboot (CH v52)
+# Known issue — cloneFromSnapshot guests fail to reboot (root-disk geometry, NOT a firmware hang)
 
-> Status: OPEN. Surfaced 2026-06-15 validating demo 06 (instant clones) on the
-> v0.4.2 cluster. An off-cluster reproduction attempt (2026-07-03, see
-> "Off-cluster investigation" below) was **inconclusive** — restore/resume is
-> solid but a deterministic reboot-hang could not be reproduced, and it produced
-> one correction to the diagnosis. Severity: MEDIUM (blocks identity/IP
-> divergence for memory-snapshot clones; does not affect normal guests or the
-> source) — but effectively **mitigated** by the shipped in-guest vsock identity
-> agent (v0.4.4), which regenerates identity + re-DHCPs with no reboot.
-> Layer: **Cloud Hypervisor v52 `--restore` + guest reboot + EDK2 firmware** —
-> NOT KubeSwift Go/Rust code.
+> Status: **RESOLVED (2026-07-03).** Root cause was cluster-reproduced with a
+> deterministic signal (the "CH v52 firmware hang" title/framing was a
+> **MISDIAGNOSIS** — see "ROOT CAUSE" below), and the fix
+> (`maybeRootDiskFromSourceClone`, PR #323) is **cluster-validated**. The real
+> fault was a KubeSwift **clone root-disk geometry bug**
+> (`internal/controller/swiftguest/rootdisk.go`), not EDK2/Cloud Hypervisor.
+> Severity was MEDIUM (a memory-snapshot clone could not reboot; unaffected:
+> normal guests + the source). This PR supersedes the diagnosis-only PR #322.
+
+## ROOT CAUSE (2026-07-03, cluster-reproduced, deterministic)
+
+A `cloneFromSnapshot` clone's root disk was **cloned from the pristine SwiftImage**
+(`EnsureRootDiskClone` → `sourcePVC := rg.PreparedImage.PVCName`; `createCloneJob`
+does `cp image.raw` + `qemu-img resize` + `sgdisk -e` — **no `growpart` /
+`resize2fs`**). On a *normal* guest that is correct: cloud-init `growpart` grows
+the partition + `resize2fs` grows the filesystem on **first boot**. But a clone
+**RESUMES** captured RAM — **cloud-init never re-runs** — so the on-disk partition
+stays at the pristine image size while the resumed guest's in-RAM ext4 is the
+**source's already-grown** filesystem. The resumed guest syncs that grown
+superblock onto the small-partition clone disk, leaving it internally
+inconsistent: **filesystem size > partition size**.
+
+It works while running (the mount lives in the captured RAM). It only breaks on
+the **next reboot**, when the initramfs re-reads the disk and ext4 refuses:
+
+```
+EXT4-fs (vda1): bad geometry: block count 2359035 exceeds size of device (655099 blocks)
+```
+
+→ the guest drops to the **initramfs emergency shell**, never reaches systemd,
+never re-DHCPs, and is unreachable — which the operator saw as a "hang".
+
+**Cluster reproduction (2026-07-03, field-testing, boba, CH v52.0, deterministic
+`DHCPACK`+`boot_id` signal):**
+
+| Guest | root disk | partition `vda1` | ext4 superblock | reboot result |
+|---|---|---|---|---|
+| `rh-src` (normal source) | grown on first boot | 18,872,287 sec ≈ 9.66 GB | 2,359,035 blk ≈ 9.66 GB (**match**) | **rebooted cleanly in ~15 s** (new boot_id, 2×DHCPACK) |
+| `rh-clone` (pre-fix clone) | pristine image copy | 5,240,799 sec ≈ 2.68 GB | 2,359,035 blk ≈ 9.66 GB (**fs > part**) | **initramfs; no DHCP; unreachable 4.3+ min** |
+
+The two corrections from the earlier off-cluster attempt hold and explain why it
+looked like firmware: (1) `MpInitChangeApLoopCallback() done!` is the firmware's
+*normal* hand-off point (the debug port goes quiet there on every boot as the
+kernel takes the console) — it is **not** an AP-init hang; the guest is past
+firmware, in the kernel's initramfs. (2) the serial console is an unreliable
+verdict tool; the deterministic signal is the launcher `DHCPACK` (as the
+original 2026-06-15 `ft-golden` vs `ft-clone-a` observation already used).
+
+## Fix (PR #323) — clone the root disk from the SOURCE's disk, not the pristine image
+
+A new `maybeRootDiskFromSourceClone` (in
+[`internal/controller/swiftguest/clone.go`](../../internal/controller/swiftguest/clone.go)),
+called from `EnsureRootDiskClone` right after `maybeRootDiskFromOCI` and **before**
+the pristine-image copy path. For a **memory-only** clone (Tier B local / Tier C
+s3 without `includeDisk`) it materializes the clone's root PVC as a **CSI clone
+(`spec.dataSource`) of the SOURCE guest's live root PVC** — matching size, class,
+and volume mode. Because it is a byte copy of the source's disk, the on-disk
+partition+filesystem geometry (**and the real data**) match the resumed RAM, so
+the next reboot's initramfs finds a consistent disk. The clone PVC is
+`RestoreSeeded`-labelled (so the image-copy path skips it) and `NeedsGrowInit`
+is **false** (growing it would re-desync partition-vs-resumed-fs). Longhorn clones
+an attached source volume without detaching it, so the running source is
+undisturbed.
+
+- **Source root PVC gone → fail loud.** A memory-only clone genuinely needs the
+  source's disk; there is no correct silent fall-through. (The source-independent
+  path is a **full-state `includeDisk` OCI snapshot**, which carries the grown
+  disk in the artifact and is handled first by `maybeRootDiskFromOCI` — the
+  source-clone path declines those.)
+- **Secondary data bug also fixed.** Before this change a memory-only clone was
+  actually running on the *pristine image's* disk content (masked by the resumed
+  page cache until a reboot). It now carries the source's real disk.
+
+**Cluster validation (2026-07-03, field-testing, boba, CH v52.0, controller
+`sha-54fbd8d`):** source `rf-src` → memory snapshot `rf-snap` → clone `rf-clone`.
+The clone's root PVC had `dataSource: {kind: PersistentVolumeClaim, name:
+swiftguest-root-rf-src}` (a CSI clone of the source disk, **not** the pristine
+image). Geometry post-materialize **and** post-reboot: partition 18,872,287 sec ==
+fs 2,359,035 blk (both ≈9.66 GB, matching the source). Driving `sudo reboot`:
+
+| Clone | root disk geometry | reboot verdict |
+|---|---|---|
+| `rh-clone` (pre-fix, pristine image) | fs 9.66 GB > partition 2.68 GB | initramfs "bad geometry"; no DHCP; unreachable 4.3+ min |
+| **`rf-clone` (post-fix, source-cloned)** | partition == fs (both 9.66 GB) | **new boot_id `19a67802` (≠ resumed `fcf7f42e` — proof of a real reboot); `DHCPACK(br0) 192.168.99.17`; `login:` prompt; `status.network.primaryIP` populated** |
+
+The reboot-to-regenerate-identity + get-a-fresh-IP path (the reason clones reboot
+at all) now works — the clone re-DHCP'd to a fresh IP with a per-clone MAC.
+Regression tests in
+[`rootdisk_source_clone_test.go`](../../internal/controller/swiftguest/rootdisk_source_clone_test.go):
+CSI-clones the source PVC (dataSource + RestoreSeeded + matching size/class, no
+grow-init); source-gone fails loud; a full-state oci-disk snapshot is declined.
+
+> The in-guest **vsock identity agent** (v0.4.4) remains the *preferred* way to
+> give a clone its own identity + IP — it regenerates in place with **no reboot**,
+> so it never touches this disk-geometry path. This fix makes the *reboot* path
+> (kernel updates, operator reboots, the legacy `kubeswift.clone=true` bootcmd)
+> correct as well.
+
+---
+
+Everything below this line is the **original (superseded) firmware-hang
+hypothesis**, kept for history.
 
 ## Symptom
 
@@ -39,7 +131,10 @@ So the hang is **specific to restored guests**. The differentiators ruled OUT:
   `boot_vcpus: 2`, guest config intact). It is the *guest firmware* that wedges,
   not the VMM.
 
-The only remaining differentiator is the `--restore` path itself.
+The only remaining differentiator is the `--restore` path itself. *(In hindsight:
+the restored guest is past firmware and stuck in the initramfs on the
+bad-geometry disk — see "ROOT CAUSE" above. The "specific to restored guests"
+observation was right; the "firmware" attribution was wrong.)*
 
 ## Evidence pointing at the EDK2 S3-resume / AP-init path
 
@@ -50,7 +145,8 @@ the kernel. Reading: on a warm reset the restored guest's firmware enters an
 **S3 (suspend-to-RAM) resume** code path — plausibly because the snapshot froze
 ACPI/firmware state that makes EDK2 believe it is resuming from S3 — and then
 **hangs bringing the APs back up**. CLOUDHV.fd (rust-hypervisor-firmware / EDK2)
-+ CH v52 + restored memory state is the suspect surface.
++ CH v52 + restored memory state is the suspect surface. *(Superseded: this line
+is the normal firmware→kernel hand-off; the stall is later, in the initramfs.)*
 
 ## Impact
 
@@ -66,7 +162,7 @@ ACPI/firmware state that makes EDK2 believe it is resuming from S3 — and then
   restore guests, so the IP **would** surface automatically the moment a clone
   re-DHCPs — it just never gets the chance while the reboot is wedged.
 
-## Hypotheses (original; see "Off-cluster investigation" below for what the 2026-07-03 attempt found)
+## Hypotheses (original; superseded by the ROOT CAUSE above)
 
 1. **Disable guest S3 / ACPI sleep so the warm reset takes the cold-boot path.**
    Investigate whether CH or the firmware can be told the guest has no S3 (e.g. a
@@ -99,49 +195,36 @@ An off-cluster reproduction harness was built with the **real CH v52.0 binary +
   produced a full boot — 19 `Reached target` lines on the guest serial); others
   looked wedged. **The same configuration produced both "rebooted" and "hung"
   verdicts on different runs**, so the result is measurement-limited, not a clean
-  repro. Root cause off-cluster is **unconfirmed**.
+  repro. *(Explained by the ROOT CAUSE: the off-cluster Noble guest booted from a
+  disk whose partition already matched its fs — no growpart delta — so it had no
+  geometry inconsistency to trip over. The cluster clone tripped because its
+  pristine-image disk had a small partition vs the source's grown fs.)*
 - **Methodology caveat (why the verdicts are noisy):** observing reboot outcome
   over a `--serial socket=` connection is unreliable — the guest resets the
   serial device on warm reset, so a held connection goes silent (looks hung) and
   intermittent fresh probes race the boot. A trustworthy repro needs a
-  **connection-independent liveness signal** — the **vsock agent ping** (responds
-  only once the guest reaches multi-user) is the right instrument; the serial
-  console is not.
+  **connection-independent liveness signal** — the launcher `DHCPACK` (or the
+  vsock agent ping) is the right instrument; the serial console is not.
 
 **Correction to the diagnosis above:** the "froze after
 `MpInitChangeApLoopCallback() done!`" evidence was over-read. In the off-cluster
 harness that line is the firmware's **normal** hand-off point — the firmware
 debug port goes quiet there on **every** boot (successful or not) because the
 kernel takes over the console. So "last line is `MpInit...done`" is **not**, by
-itself, evidence of an AP-init firmware hang; the true stall point (when the
-hang does occur on the cluster) is at or after the firmware→kernel hand-off and
-remains unconfirmed. The "Evidence pointing at the EDK2 S3-resume / AP-init path"
-section above should be read as a *hypothesis*, not a conclusion.
-
-**Recommendation / next steps (revised):**
-1. **Reproduce on the cluster** (where it was actually observed) using the
-   **vsock agent ping** as the boot-completion signal — the only reliable way to
-   separate "hung" from "slow/at-an-unresponsive-prompt".
-2. **CH version bisect (v52 → v53+)** against a cluster repro; the intermittency
-   is most consistent with a timing-sensitive upstream firmware/KVM interaction,
-   not KubeSwift code — so this is the strongest lead for a real fix.
-3. **Accept the in-guest vsock identity agent (shipped v0.4.4) as the resolution
-   for the primary need.** It regenerates identity + renews DHCP *in place, no
-   reboot*, so the reboot path is unnecessary for clone identity/IP. The
-   reboot-hang then only affects *other* reboots (kernel updates, etc.) of a
-   restored clone — a lower-severity, upstream-watch item.
-
-The single-vCPU (Lead 2) and S3-disable (Lead 1) experiments were **not run to a
-firm conclusion** — they depend on a reliable repro, which the off-cluster
-harness could not provide.
+itself, evidence of an AP-init firmware hang; the true stall point is the kernel
+initramfs on the bad-geometry disk (see "ROOT CAUSE").
 
 ## Related
 
+- The fix: `maybeRootDiskFromSourceClone` in
+  [`internal/controller/swiftguest/clone.go`](../../internal/controller/swiftguest/clone.go)
+  (PR #323).
 - The lease-poller-stays-alive fix (v0.4.3): `rust/swiftletd/src/lease.rs`
-  (`LEASE_POLL_ATTEMPTS_RESTORE`). Correct and necessary, but cannot deliver a
-  clone IP while the reboot is wedged.
+  (`LEASE_POLL_ATTEMPTS_RESTORE`). Correct and necessary; now the clone actually
+  re-DHCPs on reboot so the poller has something to surface.
 - Operator runbook caveat:
   [`docs/snapshots/clone-from-snapshot.md`](../snapshots/clone-from-snapshot.md)
-  "Known limitation on Cloud Hypervisor v52".
+  "Known limitation on Cloud Hypervisor v52" — update to reflect the fix.
 - The resume-vs-boot identity-inheritance rule (Snapshot Phase 2) is the root
-  reason a reboot is needed at all.
+  reason a reboot is needed at all; the in-guest vsock identity agent (v0.4.4)
+  removes the need to reboot for identity.

--- a/internal/controller/swiftguest/clone.go
+++ b/internal/controller/swiftguest/clone.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"strconv"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -492,4 +493,110 @@ func cloneOCITag(snap *snapshotv1alpha1.SwiftSnapshot) string {
 		return snap.Spec.Backend.OCI.Tag
 	}
 	return snap.Namespace + "-" + snap.Name
+}
+
+// maybeRootDiskFromSourceClone materializes the root disk for a MEMORY-ONLY
+// cloneFromSnapshot (Tier B local, or Tier C s3 without includeDisk) as a CSI
+// clone (spec.dataSource) of the SOURCE guest's live root PVC — a byte copy of
+// the source's actual disk, so its on-disk partition+filesystem geometry (and
+// data) match the RAM the clone resumes.
+//
+// Returns (handled, result, err), mirroring maybeRootDiskFromOCI:
+//   - handled=false  → not a memory-only clone (no cloneFromSnapshot, or a
+//     full-state oci clone maybeRootDiskFromOCI already took); the caller falls
+//     through to the image-clone paths.
+//   - handled=true, err=nil, result set → the CSI clone is Bound and ready.
+//   - handled=true, err!=nil → transient "requeue and retry" progress signal
+//     (PVC just created / not yet Bound) OR a terminal failure (source disk gone).
+//
+// WHY (the bug this fixes): the legacy path copies the pristine SwiftImage, whose
+// partition is the original (small) cloud-image size. A normal guest grows it via
+// cloud-init growpart/resize2fs on FIRST BOOT — but a clone RESUMES captured RAM,
+// so cloud-init never re-runs. The resumed guest's in-RAM ext4 is the source's
+// already-grown filesystem; synced onto the small-partition image copy it leaves
+// fs > partition, which the next reboot's initramfs rejects ("EXT4-fs: bad
+// geometry"), dropping the guest to the emergency shell (looked like a firmware
+// hang). Cloning the source's real disk keeps geometry consistent. See
+// docs/design/known-issues-clone-reboot-firmware-hang.md.
+func (r *SwiftGuestReconciler) maybeRootDiskFromSourceClone(
+	ctx context.Context, guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGuest,
+) (bool, *RootDiskCloneResult, error) {
+	if guest.Spec.CloneFromSnapshot == nil {
+		return false, nil, nil
+	}
+	var snap snapshotv1alpha1.SwiftSnapshot
+	if err := r.Get(ctx, client.ObjectKey{Name: guest.Spec.CloneFromSnapshot.SnapshotRef.Name, Namespace: guest.Namespace}, &snap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil, nil // prepareCloneFromSnapshot surfaces the missing snapshot
+		}
+		return true, nil, err
+	}
+	// Full-state (includeDisk oci) clones carry their disk in the registry and are
+	// handled by maybeRootDiskFromOCI (called before this). Only memory-only
+	// snapshots reach here needing the source guest's disk.
+	if snap.Status.OCI != nil && snap.Status.OCI.Disk != nil && snap.Status.OCI.Disk.ManifestDigest != "" {
+		return false, nil, nil
+	}
+
+	sourceRootPVC := RootDiskCloneName(snap.Spec.GuestRef.Name)
+	cloneName := RootDiskCloneName(guest.Name)
+
+	// The source guest's root PVC supplies the disk. A memory-only clone is
+	// same-cluster and needs the live source (its RAM references that disk). If it
+	// is gone, we cannot build a consistent disk — fail loudly (Principle #6).
+	var srcPVC corev1.PersistentVolumeClaim
+	if err := r.Get(ctx, client.ObjectKey{Name: sourceRootPVC, Namespace: guest.Namespace}, &srcPVC); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil, fmt.Errorf("cloneFromSnapshot: source root PVC %s not found — a memory-only clone needs the source guest's disk (use a full-state includeDisk snapshot for source-independent clones)", sourceRootPVC)
+		}
+		return true, nil, err
+	}
+
+	var pvc corev1.PersistentVolumeClaim
+	perr := r.Get(ctx, client.ObjectKey{Name: cloneName, Namespace: guest.Namespace}, &pvc)
+	if apierrors.IsNotFound(perr) {
+		// CSI-clone the source's live disk. Same size/class/mode as the source so
+		// it is a byte clone (CSI cloning requires matching capacity + class);
+		// Longhorn clones an attached source volume without detaching it.
+		// RestoreSeeded so the copy path (ensureRootDiskCloneFromCopy) skips it.
+		newPVC := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cloneName,
+				Namespace: guest.Namespace,
+				Labels: map[string]string{
+					"swift.kubeswift.io/guest": guest.Name,
+					"swift.kubeswift.io/role":  "root-disk",
+					RestoreSeededLabel:         "true",
+				},
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(guest, swiftGuestGVK)},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      srcPVC.Spec.AccessModes,
+				VolumeMode:       srcPVC.Spec.VolumeMode,
+				StorageClassName: srcPVC.Spec.StorageClassName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: srcPVC.Spec.Resources.Requests[corev1.ResourceStorage],
+					},
+				},
+				DataSource: &corev1.TypedLocalObjectReference{
+					Kind: "PersistentVolumeClaim",
+					Name: sourceRootPVC,
+				},
+			},
+		}
+		if err := r.Create(ctx, newPVC); err != nil && !apierrors.IsAlreadyExists(err) {
+			return true, nil, fmt.Errorf("create clone-from-source PVC %s: %w", cloneName, err)
+		}
+		return true, nil, fmt.Errorf("clone-from-source PVC %s created (CSI clone of %s), waiting for Bound", cloneName, sourceRootPVC)
+	}
+	if perr != nil {
+		return true, nil, perr
+	}
+	if pvc.Status.Phase != corev1.ClaimBound {
+		return true, nil, fmt.Errorf("clone-from-source PVC %s not yet Bound (phase=%s)", cloneName, pvc.Status.Phase)
+	}
+	// Byte clone of the source's already-grown disk → geometry is consistent;
+	// never grow-init (that would desync partition vs the resumed fs).
+	return true, &RootDiskCloneResult{PVCName: cloneName, NeedsGrowInit: false}, nil
 }

--- a/internal/controller/swiftguest/rootdisk.go
+++ b/internal/controller/swiftguest/rootdisk.go
@@ -103,6 +103,18 @@ func (r *SwiftGuestReconciler) EnsureRootDiskClone(
 		return res, err
 	}
 
+	// Memory-only cloneFromSnapshot (Tier B local / Tier C s3 without includeDisk):
+	// the disk is NOT in the snapshot, so the clone must be a copy of the SOURCE
+	// guest's actual root disk (grown partition+fs + real data matching the
+	// resumed RAM), NOT the pristine SwiftImage. Copying the image gives the clone
+	// a small (original-image) partition while the resumed guest's in-RAM ext4 is
+	// the source's grown fs — fs > partition — which reboots straight into the
+	// initramfs ("EXT4-fs: bad geometry"). See
+	// docs/design/known-issues-clone-reboot-firmware-hang.md.
+	if handled, res, err := r.maybeRootDiskFromSourceClone(ctx, guest, rg); handled {
+		return res, err
+	}
+
 	cloneName := RootDiskCloneName(guest.Name)
 	sourcePVC := rg.PreparedImage.PVCName
 	targetSize := rg.RootDisk.Size

--- a/internal/controller/swiftguest/rootdisk_source_clone_test.go
+++ b/internal/controller/swiftguest/rootdisk_source_clone_test.go
@@ -1,0 +1,128 @@
+package swiftguest
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/resolved"
+)
+
+// localCloneSnap is a Tier-B (local) memory snapshot — no oci disk, so a clone's
+// root disk must come from the SOURCE guest's disk, not the pristine image.
+func localCloneSnap() *snapshotv1alpha1.SwiftSnapshot {
+	return &snapshotv1alpha1.SwiftSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "snap", Namespace: "ns"},
+		Spec: snapshotv1alpha1.SwiftSnapshotSpec{
+			GuestRef: snapshotv1alpha1.SwiftSnapshotGuestRef{Name: "src"},
+			Backend: snapshotv1alpha1.SwiftSnapshotBackend{
+				Type:  snapshotv1alpha1.SnapshotBackendLocal,
+				Local: &snapshotv1alpha1.LocalBackend{HostPath: "/var/lib/kubeswift/snapshots/"},
+			},
+		},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{
+			Phase:    snapshotv1alpha1.SwiftSnapshotPhaseReady,
+			NodeName: "boba",
+		},
+	}
+}
+
+func sourceRootPVCObj() *corev1.PersistentVolumeClaim {
+	fs := corev1.PersistentVolumeFilesystem
+	sc := "longhorn"
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: RootDiskCloneName("src"), Namespace: "ns"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			VolumeMode:       &fs,
+			StorageClassName: &sc,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+}
+
+// A memory-only cloneFromSnapshot clone must CSI-clone the SOURCE's root PVC
+// (grown geometry + real data), NOT copy the pristine SwiftImage — the fix for
+// the clone-reboot "bad geometry" initramfs drop.
+func TestMaybeRootDiskFromSourceClone_CSIClonesSourcePVC(t *testing.T) {
+	ctx := context.Background()
+	g := cloneGuest()
+	r, c := newCloneReconciler(t, g, localCloneSnap(), sourceRootPVCObj())
+
+	// Pass 1: creates the clone PVC as a CSI clone of the source root PVC, requeues.
+	handled, res, err := r.maybeRootDiskFromSourceClone(ctx, g, &resolved.ResolvedGuest{})
+	if !handled || res != nil || err == nil {
+		t.Fatalf("memory-only clone must be handled + requeue on PVC create; handled=%v res=%v err=%v", handled, res, err)
+	}
+	var pvc corev1.PersistentVolumeClaim
+	if err := c.Get(ctx, client.ObjectKey{Name: RootDiskCloneName("clone-a"), Namespace: "ns"}, &pvc); err != nil {
+		t.Fatalf("clone PVC not created: %v", err)
+	}
+	// dataSource = the SOURCE's root PVC (NOT a copy Job from the image).
+	if pvc.Spec.DataSource == nil || pvc.Spec.DataSource.Kind != "PersistentVolumeClaim" ||
+		pvc.Spec.DataSource.Name != RootDiskCloneName("src") {
+		t.Fatalf("clone PVC must dataSource-clone the source root PVC; got %+v", pvc.Spec.DataSource)
+	}
+	// RestoreSeeded so the image copy path skips it; owned by the clone guest.
+	if pvc.Labels[RestoreSeededLabel] != "true" {
+		t.Errorf("clone PVC must be RestoreSeeded; labels=%+v", pvc.Labels)
+	}
+	if len(pvc.OwnerReferences) == 0 || pvc.OwnerReferences[0].Name != "clone-a" {
+		t.Errorf("clone PVC must be owned by the clone guest; ownerRefs=%+v", pvc.OwnerReferences)
+	}
+	// Same size/class as the source (CSI clone requires an exact match).
+	if got := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; got.String() != "10Gi" {
+		t.Errorf("clone PVC size = %q, want 10Gi (match the source)", got.String())
+	}
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != "longhorn" {
+		t.Errorf("clone PVC class must match the source; got %v", pvc.Spec.StorageClassName)
+	}
+
+	// Pass 2: PVC Bound → returns the materialized root disk, never grow-init.
+	pvc.Status.Phase = corev1.ClaimBound
+	if err := c.Status().Update(ctx, &pvc); err != nil {
+		t.Fatal(err)
+	}
+	handled, res, err = r.maybeRootDiskFromSourceClone(ctx, g, &resolved.ResolvedGuest{})
+	if !handled || err != nil || res == nil {
+		t.Fatalf("Bound clone PVC should return the root disk; handled=%v res=%v err=%v", handled, res, err)
+	}
+	if res.PVCName != RootDiskCloneName("clone-a") {
+		t.Errorf("result PVC = %q, want %q", res.PVCName, RootDiskCloneName("clone-a"))
+	}
+	if res.NeedsGrowInit {
+		t.Errorf("a byte-clone of the source disk must NOT be grow-init'd (would desync partition vs the resumed fs)")
+	}
+}
+
+// Source root PVC gone → a memory-only clone cannot build a consistent disk;
+// fail loudly (no silent fall-through to a pristine-image copy).
+func TestMaybeRootDiskFromSourceClone_SourceGone_FailsLoud(t *testing.T) {
+	g := cloneGuest()
+	r, _ := newCloneReconciler(t, g, localCloneSnap()) // no source root PVC
+	handled, res, err := r.maybeRootDiskFromSourceClone(context.Background(), g, &resolved.ResolvedGuest{})
+	if !handled || res != nil || err == nil {
+		t.Fatalf("missing source disk must be handled + error, not a silent fall-through; handled=%v res=%v err=%v", handled, res, err)
+	}
+}
+
+// A full-state (oci disk) snapshot is handled by maybeRootDiskFromOCI — the
+// source-clone path must decline it (handled=false).
+func TestMaybeRootDiskFromSourceClone_DeclinesOCIDiskSnapshot(t *testing.T) {
+	g := cloneGuest()
+	snap := ociCloneSnap()
+	snap.Status.OCI.Disk = &snapshotv1alpha1.OCIDiskArtifact{Reference: "r:t-disk", ManifestDigest: "sha256:disk"}
+	r, _ := newCloneReconciler(t, g, snap)
+	handled, _, _ := r.maybeRootDiskFromSourceClone(context.Background(), g, &resolved.ResolvedGuest{})
+	if handled {
+		t.Fatal("a full-state oci-disk clone must be left to maybeRootDiskFromOCI (handled=false)")
+	}
+}


### PR DESCRIPTION
Fixes the cloneFromSnapshot reboot failure diagnosed in [#322](https://github.com/kubeswift-io/kubeswift/pull/322) (the "CH v52 firmware hang" was a misdiagnosis). **Cluster-validated end-to-end.**

## Root cause (recap)
A memory-only cloneFromSnapshot clone copied its root disk from the **pristine SwiftImage** (small original partition). A normal guest grows partition+fs via cloud-init on first boot; a clone **RESUMES** captured RAM, so cloud-init never re-runs. The resumed guest's in-RAM ext4 is the source's already-grown fs, synced onto the small-partition image copy → **fs > partition** → the next reboot's initramfs rejects it (`EXT4-fs: bad geometry`) → emergency shell, no re-DHCP = the "hang".

## Fix
New `maybeRootDiskFromSourceClone` (sibling of `maybeRootDiskFromOCI`, called before the image-clone paths in `EnsureRootDiskClone`). For a memory-only clone (Tier B local / Tier C s3 without includeDisk) it materializes the clone root PVC as a **CSI clone (`spec.dataSource`) of the SOURCE guest's live root PVC** — a byte copy with matching size/class/mode, so the on-disk partition+fs geometry **and data** match the resumed RAM. `RestoreSeeded` so the copy path skips it; `NeedsGrowInit=false`. Longhorn clones an attached source volume without detaching it. Source disk gone = fail loud (a memory-only clone needs the source's disk; full-state `includeDisk` oci is the source-independent path). Full-state oci-disk clones are unchanged (`maybeRootDiskFromOCI` runs first).

Also corrects a latent data bug: memory-only clones were running on the *pristine image's* disk content (masked by the resumed page cache until reboot); they now carry the source's real disk.

## Cluster validation (field-testing, boba, CH v52.0, controller `sha-54fbd8d`)
Source → memory snapshot → clone (root PVC `dataSource: swiftguest-root-<source>` ✓) → reboot the clone:

| | root disk geometry | reboot verdict (DHCPACK + boot_id) |
|---|---|---|
| before the fix | fs 9.66 GB > partition 2.68 GB | initramfs "bad geometry"; no DHCP; unreachable 4.3+ min |
| **after the fix** | partition == fs (both 9.66 GB) | **new boot_id `19a67802`; DHCPACK→192.168.99.17; login prompt** |

The reboot-to-regenerate-identity + get-a-fresh-IP path now works (clone re-DHCP'd with a per-clone MAC). `go build`/`vet`/`test`/`gofmt` clean; 3 regression tests (CSI-clones the source PVC; source-gone fails loud; oci-disk declined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)