### PR TITLE
fix(ci): run Tier B local-snapshot e2e on the hosted nightly

### DIFF
--- a/.github/workflows/e2e-on-cluster.yaml
+++ b/.github/workflows/e2e-on-cluster.yaml
@@ -14,21 +14,26 @@ name: E2E (cluster)
 #     regressions within 24 hours.
 #
 # Hosted-runner `all` scope (nightly + default dispatch):
-#   The `all` scenario runs the disk-boot smoke PLUS the two Tier B local-*
-#   scenarios (local-roundtrip, local-clone-identity) — all runnable on a hosted
-#   ubuntu-latest runner under nested KVM. Disk-boot boots one real Cloud
-#   Hypervisor VM end-to-end; the Tier B scenarios then exercise the
-#   SwiftSnapshot / SwiftRestore / clone controller logic against on-node
-#   hostPath snapshots (no CSI driver needed). The Tier B tests SSH into the
+#   The `all` scenario runs the disk-boot smoke PLUS the Tier B local-roundtrip
+#   scenario — both runnable on a hosted ubuntu-latest runner under nested KVM.
+#   Disk-boot boots one real Cloud Hypervisor VM end-to-end; local-roundtrip then
+#   exercises the SwiftSnapshot / SwiftRestore memory round-trip (in-place restore)
+#   against an on-node hostPath snapshot (no CSI driver needed). It SSHes into the
 #   guest, so the job generates an ephemeral keypair and the scripts splice its
 #   pubkey into the seed's ssh_authorized_keys at apply time (see the
 #   "Generate ephemeral SSH keypair" step and apply_seed_profile in the scripts).
 #
-#   Still NOT hosted-runner-runnable, kept on workflow_dispatch (self-hosted):
-#   the Tier A CSI-snapshot scenarios need a real CSI driver (csi-hostpath
-#   times out snapshotting a VM disk — validated on the dev cluster's Longhorn),
-#   and the full five-guest smoke exhausts the runner disk. See the `all` case
-#   below for the full rationale.
+#   Still NOT hosted-runner-runnable, kept on workflow_dispatch:
+#   - Tier A CSI-snapshot scenarios need a real CSI driver (csi-hostpath times out
+#     snapshotting a VM disk — validated on the dev cluster's Longhorn).
+#   - local-clone-identity: a memory-resumed clone keeps the source's IP in RAM and
+#     never re-DHCPs, so kind's dnsmasq-lease discovery never reports the clone's
+#     status.network.primaryIP and the SSH-into-clone identity checks can't run. Its
+#     controller path (restore -> clone guest -> stager -> resume -> Ready) DOES run
+#     here; only the in-guest verify is gated. Needs the dev cluster's OVN-K path,
+#     where the controller derives the clone IP from k8s.ovn.org/pod-networks.
+#   - the full five-guest smoke exhausts the runner disk.
+#   See the `all` case below for the full rationale.
 #
 # NOT YET wired:
 #   - pull_request path-touch triggers. Hosted-runner KVM + cloud-image
@@ -250,11 +255,11 @@ jobs:
           # Default class (disk-boot smoke): cpu 2 -> 1.
           sed -i 's/cpu: "2"/cpu: "1"/' config/samples/shared/swiftguestclass-default.yaml
           grep -n 'cpu:' config/samples/shared/swiftguestclass-default.yaml
-          # Tier B local-snapshot class (snapshot-local-class): cpu 2 -> 1 and
-          # memory 2Gi -> 1Gi. local-clone-identity boots THREE guests at once
-          # (source + two clones, which copy the source's spec/class), so 3x cpu:1
-          # must fit the worker; the smaller memory also shrinks the RAM snapshot
-          # and the per-clone stager copies on the ~14 GB-free runner.
+          # Tier B local-snapshot class (snapshot-local-class): cpu 2 -> 1 (cpu:2
+          # does not schedule on the 4-vCPU worker, same as the default class) and
+          # memory 2Gi -> 1Gi (smaller RAM snapshot on the ~14 GB-free runner).
+          # Used by local-roundtrip in `all`, and by local-clone-identity when run
+          # via workflow_dispatch.
           sed -i -e 's/cpu: 2/cpu: 1/' -e 's/memory: "2Gi"/memory: "1Gi"/' \
             config/samples/local-snapshots/02-source-guest.yaml
           grep -nE 'cpu:|memory:' config/samples/local-snapshots/02-source-guest.yaml
@@ -298,22 +303,20 @@ jobs:
             local-roundtrip)     run_one local-roundtrip-test ;;
             local-clone-identity) run_one local-clone-identity-test ;;
             all)
-              # Hosted-runner nightly = disk-boot smoke FIRST, then the two Tier B
-              # local-snapshot scenarios. Disk-boot boots a real Cloud Hypervisor VM
-              # under nested KVM end-to-end (controller deploy -> SwiftImage
-              # qcow2->raw import -> SwiftGuest boot -> DHCP -> primaryIP), catching
-              # control-plane / import / boot regressions. The Tier B scenarios then
-              # exercise the SwiftSnapshot / SwiftRestore / clone controller logic
-              # against on-node hostPath snapshots (no CSI driver): local-roundtrip
-              # proves a memory snapshot round-trips (a tmpfs sentinel survives an
-              # in-place restore); local-clone-identity proves two clones from one
-              # snapshot get distinct machine-id / SSH host keys / hostname / MAC.
-              # Both SSH into the guest with the ephemeral key generated above,
-              # whose pubkey the scripts splice into the seed (apply_seed_profile).
+              # Hosted-runner nightly = disk-boot smoke FIRST, then Tier B
+              # local-roundtrip. Disk-boot boots a real Cloud Hypervisor VM under
+              # nested KVM end-to-end (controller deploy -> SwiftImage qcow2->raw
+              # import -> SwiftGuest boot -> DHCP -> primaryIP), catching
+              # control-plane / import / boot regressions. local-roundtrip then
+              # exercises the SwiftSnapshot / SwiftRestore memory round-trip against
+              # an on-node hostPath snapshot (no CSI driver): it plants a tmpfs
+              # sentinel, memory-snapshots, kills the pod, restores in-place, and
+              # verifies the sentinel survived. It SSHes into the guest with the
+              # ephemeral key generated above, whose pubkey the scripts splice into
+              # the seed (apply_seed_profile).
               #
               # Still NOT runnable on a hosted runner; each stays available via
-              # workflow_dispatch (self-hosted) and is validated on the dev cluster
-              # (Longhorn):
+              # workflow_dispatch and is validated on the dev cluster:
               #   - snapshot-test / clonestrategy=snapshot (Tier A CSI
               #     VolumeSnapshot): csi-hostpath is a REFERENCE driver whose
               #     CreateSnapshot copies the volume dir; it cannot snapshot a
@@ -321,12 +324,20 @@ jobs:
               #     disk/CPU-constrained runner ("rpc error: code = DeadlineExceeded").
               #     The guest boots fine on csi-hostpath — only the snapshot is
               #     infeasible. Needs a real CSI driver.
+              #   - local-clone-identity (Tier B clone identity-regen): the clones
+              #     RESUME from the memory snapshot and keep the source's IP in RAM
+              #     — they never re-DHCP, so kind's dnsmasq-lease discovery never
+              #     reports the clone's status.network.primaryIP and the test's
+              #     SSH-into-clone identity checks can't run. The clone CONTROLLER
+              #     path (restore -> clone guest -> stager -> resume -> Ready) DOES
+              #     run on a hosted runner; only the in-guest verify is gated. Needs
+              #     the dev cluster's OVN-K path, where the controller derives the
+              #     clone IP from the k8s.ovn.org/pod-networks annotation.
               #   - full `make smoke-test` (five guests): exhausts the runner disk.
               echo "::group::e2e: smoke (disk-boot only)"
               test/smoke/boot-test.sh --scenario disk-boot
               echo "::endgroup::"
               run_one local-roundtrip-test
-              run_one local-clone-identity-test
               ;;
             *)
               echo "::error::unknown scenario: $SCENARIO"

--- a/.github/workflows/e2e-on-cluster.yaml
+++ b/.github/workflows/e2e-on-cluster.yaml
@@ -14,15 +14,21 @@ name: E2E (cluster)
 #     regressions within 24 hours.
 #
 # Hosted-runner `all` scope (nightly + default dispatch):
-#   The `all` scenario runs the disk-boot smoke ONLY — the one scenario a hosted
-#   ubuntu-latest runner can do reliably (it boots a real Cloud Hypervisor VM
-#   under nested KVM end-to-end). The heavier scenarios are NOT hosted-runner-
-#   runnable and stay available via workflow_dispatch (self-hosted runner):
+#   The `all` scenario runs the disk-boot smoke PLUS the two Tier B local-*
+#   scenarios (local-roundtrip, local-clone-identity) — all runnable on a hosted
+#   ubuntu-latest runner under nested KVM. Disk-boot boots one real Cloud
+#   Hypervisor VM end-to-end; the Tier B scenarios then exercise the
+#   SwiftSnapshot / SwiftRestore / clone controller logic against on-node
+#   hostPath snapshots (no CSI driver needed). The Tier B tests SSH into the
+#   guest, so the job generates an ephemeral keypair and the scripts splice its
+#   pubkey into the seed's ssh_authorized_keys at apply time (see the
+#   "Generate ephemeral SSH keypair" step and apply_seed_profile in the scripts).
+#
+#   Still NOT hosted-runner-runnable, kept on workflow_dispatch (self-hosted):
 #   the Tier A CSI-snapshot scenarios need a real CSI driver (csi-hostpath
 #   times out snapshotting a VM disk — validated on the dev cluster's Longhorn),
-#   the Tier B local-* scenarios need the operator SSH key that matches the
-#   sample seed, and the full five-guest smoke exhausts the runner disk. See the
-#   `all` case below for the full rationale.
+#   and the full five-guest smoke exhausts the runner disk. See the `all` case
+#   below for the full rationale.
 #
 # NOT YET wired:
 #   - pull_request path-touch triggers. Hosted-runner KVM + cloud-image
@@ -235,14 +241,34 @@ jobs:
       # The default guest class is cpu:"2", which does NOT schedule on a
       # 4-vCPU kind worker already running kube-system + snapshot-controller
       # + csi-hostpath + the KubeSwift controller (the disk-boot guest sat
-      # Pending "Insufficient cpu"). Shrink the checked-out sample to cpu:"1"
-      # so the single smoke VM fits. boot-test.sh's apply_shared re-applies
-      # this file from disk, so the edit is honoured. Local to the runner
-      # checkout only — never committed.
-      - name: Shrink default guest class for hosted-runner capacity
+      # Pending "Insufficient cpu"). Shrink the checked-out samples to cpu:"1"
+      # so the VMs fit. boot-test.sh's apply_shared (default class) and the Tier B
+      # scripts (local class) re-apply these files from disk, so the edits are
+      # honoured. Local to the runner checkout only — never committed.
+      - name: Shrink guest classes for hosted-runner capacity
         run: |
+          # Default class (disk-boot smoke): cpu 2 -> 1.
           sed -i 's/cpu: "2"/cpu: "1"/' config/samples/shared/swiftguestclass-default.yaml
           grep -n 'cpu:' config/samples/shared/swiftguestclass-default.yaml
+          # Tier B local-snapshot class (snapshot-local-class): cpu 2 -> 1 and
+          # memory 2Gi -> 1Gi. local-clone-identity boots THREE guests at once
+          # (source + two clones, which copy the source's spec/class), so 3x cpu:1
+          # must fit the worker; the smaller memory also shrinks the RAM snapshot
+          # and the per-clone stager copies on the ~14 GB-free runner.
+          sed -i -e 's/cpu: 2/cpu: 1/' -e 's/memory: "2Gi"/memory: "1Gi"/' \
+            config/samples/local-snapshots/02-source-guest.yaml
+          grep -nE 'cpu:|memory:' config/samples/local-snapshots/02-source-guest.yaml
+
+      # The Tier B local-snapshot scenarios (local-roundtrip, local-clone-identity)
+      # SSH into the guest using $HOME/.ssh/id_ed25519. Generate an ephemeral
+      # keypair here; the scripts' apply_seed_profile splices its PUBLIC half into
+      # the seed's ssh_authorized_keys at apply time, so no pre-shared operator key
+      # is needed. Harmless for the other scenarios, which never read it.
+      - name: Generate ephemeral SSH keypair for Tier B local-snapshot e2e
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          ssh-keygen -t ed25519 -N '' -C 'kubeswift-e2e' -f ~/.ssh/id_ed25519
+          ls -l ~/.ssh/id_ed25519 ~/.ssh/id_ed25519.pub
 
       - name: Run e2e ${{ github.event.inputs.scenario || 'all' }}
         run: |
@@ -272,14 +298,22 @@ jobs:
             local-roundtrip)     run_one local-roundtrip-test ;;
             local-clone-identity) run_one local-clone-identity-test ;;
             all)
-              # Hosted-runner nightly = the disk-boot smoke ONLY. It boots a real
-              # Cloud Hypervisor VM under nested KVM end-to-end (controller deploy
-              # -> SwiftImage qcow2->raw import -> SwiftGuest boot -> DHCP ->
-              # primaryIP), so it catches control-plane / import / boot regressions.
+              # Hosted-runner nightly = disk-boot smoke FIRST, then the two Tier B
+              # local-snapshot scenarios. Disk-boot boots a real Cloud Hypervisor VM
+              # under nested KVM end-to-end (controller deploy -> SwiftImage
+              # qcow2->raw import -> SwiftGuest boot -> DHCP -> primaryIP), catching
+              # control-plane / import / boot regressions. The Tier B scenarios then
+              # exercise the SwiftSnapshot / SwiftRestore / clone controller logic
+              # against on-node hostPath snapshots (no CSI driver): local-roundtrip
+              # proves a memory snapshot round-trips (a tmpfs sentinel survives an
+              # in-place restore); local-clone-identity proves two clones from one
+              # snapshot get distinct machine-id / SSH host keys / hostname / MAC.
+              # Both SSH into the guest with the ephemeral key generated above,
+              # whose pubkey the scripts splice into the seed (apply_seed_profile).
               #
-              # Everything heavier is NOT runnable on a hosted runner. Each stays
-              # available via workflow_dispatch (point it at a self-hosted runner)
-              # and is validated on the dev cluster (Longhorn):
+              # Still NOT runnable on a hosted runner; each stays available via
+              # workflow_dispatch (self-hosted) and is validated on the dev cluster
+              # (Longhorn):
               #   - snapshot-test / clonestrategy=snapshot (Tier A CSI
               #     VolumeSnapshot): csi-hostpath is a REFERENCE driver whose
               #     CreateSnapshot copies the volume dir; it cannot snapshot a
@@ -287,16 +321,12 @@ jobs:
               #     disk/CPU-constrained runner ("rpc error: code = DeadlineExceeded").
               #     The guest boots fine on csi-hostpath — only the snapshot is
               #     infeasible. Needs a real CSI driver.
-              #   - local-roundtrip-test / local-clone-identity-test (Tier B): they
-              #     SSH into the guest and require the operator PRIVATE key matching
-              #     the sample seed's baked ssh_authorized_keys
-              #     (config/samples/local-snapshots/01-seed-profile.yaml); a hosted
-              #     runner has no such key. CI-enablement (generate a keypair +
-              #     inject its pubkey into the seed) is a tracked follow-up.
               #   - full `make smoke-test` (five guests): exhausts the runner disk.
               echo "::group::e2e: smoke (disk-boot only)"
               test/smoke/boot-test.sh --scenario disk-boot
               echo "::endgroup::"
+              run_one local-roundtrip-test
+              run_one local-clone-identity-test
               ;;
             *)
               echo "::error::unknown scenario: $SCENARIO"

--- a/test/snapshot/local-clone-identity-test.sh
+++ b/test/snapshot/local-clone-identity-test.sh
@@ -126,10 +126,32 @@ identity_of() {
 epoch_now() { date +%s; }
 elapsed_since() { echo $(($(epoch_now) - $1)); }
 
+# apply_seed_profile renders 01-seed-profile.yaml with THIS operator's SSH
+# public key spliced into ssh_authorized_keys, then applies it. The sample
+# ships a fixed pubkey; overriding it at apply time lets the test run with
+# ANY keypair — CI generates an ephemeral one, operators use their own —
+# instead of requiring the private key that matches the sample's baked-in
+# key. Prefer the .pub sidecar (needs no passphrase); fall back to deriving
+# the pubkey from the private $IDENTITY.
+apply_seed_profile() {
+  local pubkey
+  pubkey="$(cat "${IDENTITY}.pub" 2>/dev/null || ssh-keygen -y -f "$IDENTITY")"
+  # Keep only "type base64" (drop any trailing comment) so the value has no
+  # sed-special characters when spliced into the manifest.
+  pubkey="$(printf '%s' "$pubkey" | awk '{print $1, $2}')"
+  if [[ -z "$pubkey" ]]; then
+    echo "ERROR: could not derive an SSH public key from $IDENTITY" >&2
+    exit 2
+  fi
+  sed -E "s|^([[:space:]]*- )ssh-[^ ]+ .*|\1${pubkey}|" \
+    "$SAMPLES_DIR/01-seed-profile.yaml" \
+    | kubectl apply -n "$NAMESPACE" -f - >/dev/null
+}
+
 # 1. Source VM with the combined seed profile (kubeswift user for
 #    swiftctl ssh + clone-identity-regen bootcmd).
 echo "--- Step 1: Apply source manifests + seed profile ---"
-kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/01-seed-profile.yaml" >/dev/null
+apply_seed_profile
 kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/02-source-guest.yaml" >/dev/null
 
 if ! kubectl get swiftimage ubuntu-noble -n "$NAMESPACE" >/dev/null 2>&1; then
@@ -212,10 +234,17 @@ wait_guest_running() {
   return 1
 }
 
+# Map each clone to its numbered SwiftRestore manifest. The samples were
+# renamed swiftrestore-clone-{a,b}.yaml -> 0{5,6}-restore-clone-{a,b}.yaml
+# for the numbered walkthrough ordering; keep this map in step with them.
+declare -A RESTORE_MANIFEST=(
+  [snapshot-local-clone-a]=05-restore-clone-a.yaml
+  [snapshot-local-clone-b]=06-restore-clone-b.yaml
+)
 for clone in snapshot-local-clone-a snapshot-local-clone-b; do
   T_RESTORE_CREATED[$clone]=$(epoch_now)
   echo "  [$clone] Apply SwiftRestore (clone path)"
-  kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/swiftrestore-${clone#snapshot-local-}.yaml" >/dev/null
+  kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/${RESTORE_MANIFEST[$clone]}" >/dev/null
 done
 
 # Track each milestone independently.

--- a/test/snapshot/local-roundtrip-test.sh
+++ b/test/snapshot/local-roundtrip-test.sh
@@ -112,10 +112,32 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# apply_seed_profile renders 01-seed-profile.yaml with THIS operator's SSH
+# public key spliced into ssh_authorized_keys, then applies it. The sample
+# ships a fixed pubkey; overriding it at apply time lets the test run with
+# ANY keypair — CI generates an ephemeral one, operators use their own —
+# instead of requiring the private key that matches the sample's baked-in
+# key. Prefer the .pub sidecar (needs no passphrase); fall back to deriving
+# the pubkey from the private $IDENTITY.
+apply_seed_profile() {
+  local pubkey
+  pubkey="$(cat "${IDENTITY}.pub" 2>/dev/null || ssh-keygen -y -f "$IDENTITY")"
+  # Keep only "type base64" (drop any trailing comment) so the value has no
+  # sed-special characters when spliced into the manifest.
+  pubkey="$(printf '%s' "$pubkey" | awk '{print $1, $2}')"
+  if [[ -z "$pubkey" ]]; then
+    echo "ERROR: could not derive an SSH public key from $IDENTITY" >&2
+    exit 2
+  fi
+  sed -E "s|^([[:space:]]*- )ssh-[^ ]+ .*|\1${pubkey}|" \
+    "$SAMPLES_DIR/01-seed-profile.yaml" \
+    | kubectl apply -n "$NAMESPACE" -f - >/dev/null
+}
+
 # 1. Apply the combined seed profile (kubeswift user for swiftctl ssh +
 #    clone-identity-regen bootcmd) and the source SwiftGuest.
 echo "--- Step 1: Apply source manifests ---"
-kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/01-seed-profile.yaml" >/dev/null
+apply_seed_profile
 kubectl apply -n "$NAMESPACE" -f "$SAMPLES_DIR/02-source-guest.yaml" >/dev/null
 
 # Ensure Ubuntu Noble image is present (most clusters running these


### PR DESCRIPTION
## What

Restores real **SwiftSnapshot / SwiftRestore** controller coverage on the hosted-runner nightly. The `E2E (cluster)` `all` scenario goes from **disk-boot-only** (PR #326's red-nightly fix) to **disk-boot + Tier B `local-roundtrip`** — the full memory snapshot → in-place restore → tmpfs-sentinel round-trip, no CSI driver needed.

## How Tier B runs without a pre-shared key

The Tier B scripts SSH into the guest, which previously required the operator private key matching the sample seed's baked `ssh_authorized_keys` — a hosted runner has none (`SSH identity /home/runner/.ssh/id_ed25519 not readable`).

- **Scripts:** new `apply_seed_profile()` renders `01-seed-profile.yaml` with the run's *own* pubkey (from `$IDENTITY` — `.pub` sidecar, else `ssh-keygen -y`, normalized to `type base64`) spliced into `ssh_authorized_keys` at apply time. Works with any keypair — CI generates an ephemeral one, operators use their own.
- **Workflow:** generate an ephemeral ed25519 keypair before the e2e; add `local-roundtrip-test` to `all` after disk-boot.
- **Capacity:** shrink `snapshot-local-class` to cpu:1 / mem:1Gi for the 4-vCPU kind worker (cpu:2 won't schedule, same as the default class).

## Also fixed (pre-existing break)

`local-clone-identity-test.sh` still applied `swiftrestore-clone-{a,b}.yaml`, renamed to `0{5,6}-restore-clone-{a,b}.yaml` in `793235e` — so that test was broken **everywhere**, not just CI. Now maps clones to the numbered manifests.

## Why `local-clone-identity` stays on `workflow_dispatch`

Validation proved it can't complete on kind, for an environmental reason (not a bug in these changes): a memory-resumed clone keeps the source's IP in RAM and **never re-DHCPs**, so kind's dnsmasq-lease discovery never reports the clone's `status.network.primaryIP` and the SSH-into-clone identity checks have no IP to hit. Launcher logs are conclusive — the source `DHCPACK`s + `guest_ip_discovered`; the clones do neither. The clone **controller** path (restore → clone guest → stager → resume → Ready) *does* run on the hosted runner; only the in-guest verify is gated. It needs the dev cluster's OVN-K path (controller derives the clone IP from `k8s.ovn.org/pod-networks`). Gated alongside the Tier A CSI scenarios, with the root cause documented in-line.

## Validation

Dispatched `scenario=all` on this branch:

| Run | Result | Notes |
|---|---|---|
| [28665187854](https://github.com/kubeswift-io/kubeswift/actions/runs/28665187854) | diagnostic | disk-boot ✅, local-roundtrip ✅, clone-identity ❌ (root-caused above; all 3 code fixes proven correct — clones reached resume + Ready) |
| [28666754761](https://github.com/kubeswift-io/kubeswift/actions/runs/28666754761) | ✅ success | `all` = disk-boot + local-roundtrip, both PASS |

Tier A CSI-snapshot scenarios stay descoped (csi-hostpath can't snapshot a live VM disk on a hosted runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)