### PR TITLE
feat(chart): ingress tlsAuto — cert-manager TLS without hand-writing tls[]

### DIFF
--- a/charts/kubeswift/templates/_helpers.tpl
+++ b/charts/kubeswift/templates/_helpers.tpl
@@ -16,3 +16,48 @@ Override with controllerManager.image.tag / swiftletd.image.tag when using local
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+kubeswift.ingress.annotations — the merged annotation map for an Ingress: the
+raw .annotations, plus (when .tlsAuto.enabled) the cert-manager issuer
+annotation. Input: an ingress config dict (e.g. .Values.ui.ingress). Returns
+YAML for a map; the caller does `include ... | fromYaml` and guards emptiness so
+the `annotations:` key is omitted entirely when the map is empty.
+*/}}
+{{- define "kubeswift.ingress.annotations" -}}
+{{- $ing := . -}}
+{{- $ann := deepCopy (default (dict) $ing.annotations) -}}
+{{- $auto := default (dict) $ing.tlsAuto -}}
+{{- if $auto.enabled -}}
+  {{- if and $auto.clusterIssuer $auto.issuer -}}
+    {{- fail "ingress.tlsAuto: set only one of clusterIssuer or issuer, not both" -}}
+  {{- else if $auto.clusterIssuer -}}
+    {{- $_ := set $ann "cert-manager.io/cluster-issuer" $auto.clusterIssuer -}}
+  {{- else if $auto.issuer -}}
+    {{- $_ := set $ann "cert-manager.io/issuer" $auto.issuer -}}
+  {{- else -}}
+    {{- fail "ingress.tlsAuto.enabled=true requires clusterIssuer or issuer" -}}
+  {{- end -}}
+{{- end -}}
+{{- toYaml $ann -}}
+{{- end -}}
+
+{{/*
+kubeswift.ingress.tls — the tls[] list for an Ingress: derived from .tlsAuto
+when enabled (one host, cert-manager Secret named "<host>-tls" unless overridden),
+else the raw .tls escape-hatch list. Input: an ingress config dict. Returns YAML
+list items (empty string when neither is set). tlsAuto wins over a raw tls[].
+*/}}
+{{- define "kubeswift.ingress.tls" -}}
+{{- $ing := . -}}
+{{- $auto := default (dict) $ing.tlsAuto -}}
+{{- if $auto.enabled -}}
+- secretName: {{ default (printf "%s-tls" $ing.host) $auto.secretName }}
+  hosts:
+    - {{ $ing.host | quote }}
+{{- else -}}
+{{- with $ing.tls -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kubeswift/templates/gateway/ingress.yaml
+++ b/charts/kubeswift/templates/gateway/ingress.yaml
@@ -12,9 +12,10 @@ metadata:
   labels:
     app.kubernetes.io/name: kubeswift
     app.kubernetes.io/component: gateway
-  {{- with .Values.gateway.ingress.annotations }}
+  {{- $ann := include "kubeswift.ingress.annotations" .Values.gateway.ingress | fromYaml }}
+  {{- if $ann }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $ann | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.gateway.ingress.className }}
@@ -31,8 +32,9 @@ spec:
                 name: kubeswift-gateway
                 port:
                   name: http
-  {{- with .Values.gateway.ingress.tls }}
+  {{- $tls := include "kubeswift.ingress.tls" .Values.gateway.ingress }}
+  {{- if trim $tls }}
   tls:
-    {{- toYaml . | nindent 4 }}
+    {{- $tls | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/kubeswift/templates/ui/ingress.yaml
+++ b/charts/kubeswift/templates/ui/ingress.yaml
@@ -13,9 +13,10 @@ metadata:
   labels:
     app.kubernetes.io/name: kubeswift
     app.kubernetes.io/component: ui
-  {{- with .Values.ui.ingress.annotations }}
+  {{- $ann := include "kubeswift.ingress.annotations" .Values.ui.ingress | fromYaml }}
+  {{- if $ann }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $ann | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.ui.ingress.className }}
@@ -32,8 +33,9 @@ spec:
                 name: kubeswift-ui
                 port:
                   name: http
-  {{- with .Values.ui.ingress.tls }}
+  {{- $tls := include "kubeswift.ingress.tls" .Values.ui.ingress }}
+  {{- if trim $tls }}
   tls:
-    {{- toYaml . | nindent 4 }}
+    {{- $tls | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -164,8 +164,16 @@ gateway:
     enabled: false
     className: ""
     host: kubeswift-gateway.example.com
-    annotations: {}
-    tls: []
+    # TLS the easy way (cert-manager): set tlsAuto.enabled + ONE issuer, and the
+    # chart emits the tls[] block + the cert-manager annotation for you. Leave it
+    # off and hand-write annotations/tls[] below for full control.
+    tlsAuto:
+      enabled: false
+      clusterIssuer: "" # cert-manager ClusterIssuer name -> cert-manager.io/cluster-issuer
+      issuer: "" # namespaced Issuer name -> cert-manager.io/issuer (mutually exclusive with clusterIssuer)
+      secretName: "" # cert Secret name; defaults to "<host>-tls"
+    annotations: {} # advanced: extra ingress annotations (merged with tlsAuto's; tlsAuto wins on the issuer key)
+    tls: [] # advanced: raw tls[] escape hatch, honored only when tlsAuto.enabled=false
   resources:
     requests:
       cpu: 50m
@@ -228,8 +236,16 @@ ui:
     enabled: false
     className: ""
     host: kubeswift-ui.example.com
-    annotations: {}
-    tls: []
+    # TLS the easy way (cert-manager): set tlsAuto.enabled + ONE issuer, and the
+    # chart emits the tls[] block + the cert-manager annotation for you. Leave it
+    # off and hand-write annotations/tls[] below for full control.
+    tlsAuto:
+      enabled: false
+      clusterIssuer: "" # cert-manager ClusterIssuer name -> cert-manager.io/cluster-issuer
+      issuer: "" # namespaced Issuer name -> cert-manager.io/issuer (mutually exclusive with clusterIssuer)
+      secretName: "" # cert Secret name; defaults to "<host>-tls"
+    annotations: {} # advanced: extra ingress annotations (merged with tlsAuto's; tlsAuto wins on the issuer key)
+    tls: [] # advanced: raw tls[] escape hatch, honored only when tlsAuto.enabled=false
   resources:
     requests:
       cpu: 10m

--- a/docs/ui/gateway.md
+++ b/docs/ui/gateway.md
@@ -43,6 +43,13 @@ UI with `gateway.ingress.enabled=true` (+ `gateway.ingress.host`/`annotations`),
 or a Service of `type: LoadBalancer`. The gateway serves Connect/gRPC-Web over
 **h2c** — terminate TLS at the ingress and allow HTTP/2 to the backend.
 
+For cert-manager TLS without hand-writing the `tls[]` block, set
+`ingress.tlsAuto.enabled=true` + one of `ingress.tlsAuto.clusterIssuer` /
+`ingress.tlsAuto.issuer` (on either `ui.ingress` or `gateway.ingress`); the chart
+emits the `tls[]` entry (Secret `<host>-tls`, overridable) and the cert-manager
+annotation. The raw `annotations`/`tls[]` fields stay as escape hatches
+(`tlsAuto` wins on the issuer annotation when both are set).
+
 ## Register a member cluster
 
 For each member, create — **in the gateway's namespace** — a credential Secret


### PR DESCRIPTION
First PR of the federation-UX arc (design: internal). Chart-only, lowest-risk.

## What
Adds `ingress.tlsAuto.{enabled, clusterIssuer|issuer, secretName?}` to **both** `ui.ingress` and `gateway.ingress`. When enabled, the chart emits the `tls[]` block (Secret `<host>-tls`, overridable) + the `cert-manager.io/cluster-issuer` (or `cert-manager.io/issuer`) annotation — the common cert-manager case that previously meant hand-writing the tls array **and** the annotation.

## How
- Shared `kubeswift.ingress.{annotations,tls}` helpers render both ingress templates.
- Raw `annotations` + `tls[]` stay as advanced escape hatches; `tlsAuto` wins on the issuer annotation key when both are set (documented).
- Kept `tls` as the raw-array name (no type change) so existing `ui.ingress.tls: [{...}]` installs render **byte-identically**.
- `clusterIssuer` + `issuer` both set → loud `{{ fail }}`.

## Validation (`helm template` / `helm lint`)
- Backward-compat: default render = 0 Ingress objects; raw `tls[]` + `annotations` pass through unchanged.
- `tlsAuto` on ui + gateway → cert-manager annotation + derived `tls[]` for both `clusterIssuer` and `issuer`.
- both-issuers → loud fail. `helm lint` clean.

No Go / CRD / image changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)