### PR TITLE
feat(gateway): auto-discover a member's Prometheus for telemetry

### DIFF
--- a/api/fleet/v1alpha1/cluster_types.go
+++ b/api/fleet/v1alpha1/cluster_types.go
@@ -67,6 +67,13 @@ const (
 	// the member is unreachable, so the UI surfaces a per-cluster error rather
 	// than failing the whole-fleet query (no silent failures).
 	ClusterConditionReachable = "Reachable"
+	// ClusterConditionPrometheusEndpointResolved reports how status.prometheusEndpoint
+	// was resolved: True with reason Explicit (operator-set spec.prometheusEndpoint)
+	// or Discovered (gateway found an in-cluster Prometheus on the member); False
+	// with reason NotFound (none found / discovery disabled / member down) or
+	// DiscoveryError (the member API errored). Surfaced so telemetry never fails
+	// on a silent guess (no silent failures).
+	ClusterConditionPrometheusEndpointResolved = "PrometheusEndpointResolved"
 )
 
 // ClusterStatus is populated by the kubeswift-gateway as it connects to and
@@ -85,6 +92,14 @@ type ClusterStatus struct {
 	// (e.g. "v1.34.3"), shown in the UI's cluster detail.
 	// +optional
 	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
+
+	// PrometheusEndpoint is the effective per-VM telemetry endpoint the gateway
+	// resolved for this member: spec.prometheusEndpoint when set, else a
+	// gateway-discovered in-cluster Prometheus, else empty. Read the
+	// PrometheusEndpointResolved condition for how it was derived. Surfaced so
+	// the UI and kubectl reflect the real derived state (never a silent guess).
+	// +optional
+	PrometheusEndpoint string `json:"prometheusEndpoint,omitempty"`
 
 	// GuestCount is the number of SwiftGuests observed on this member at the
 	// last sync — a cheap roll-up for the cluster selector. Omitted until the
@@ -106,6 +121,7 @@ type ClusterStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="K8s",type=string,JSONPath=`.status.kubernetesVersion`
 // +kubebuilder:printcolumn:name="Guests",type=integer,JSONPath=`.status.guestCount`
+// +kubebuilder:printcolumn:name="Prometheus",type=string,JSONPath=`.status.prometheusEndpoint`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/charts/kubeswift/crds/fleet.kubeswift.io_clusters.yaml
+++ b/charts/kubeswift/crds/fleet.kubeswift.io_clusters.yaml
@@ -29,6 +29,10 @@ spec:
     - jsonPath: .status.guestCount
       name: Guests
       type: integer
+    - jsonPath: .status.prometheusEndpoint
+      name: Prometheus
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -209,6 +213,14 @@ spec:
                   last reconciled.
                 format: int64
                 type: integer
+              prometheusEndpoint:
+                description: |-
+                  PrometheusEndpoint is the effective per-VM telemetry endpoint the gateway
+                  resolved for this member: spec.prometheusEndpoint when set, else a
+                  gateway-discovered in-cluster Prometheus, else empty. Read the
+                  PrometheusEndpointResolved condition for how it was derived. Surfaced so
+                  the UI and kubectl reflect the real derived state (never a silent guess).
+                type: string
             type: object
         type: object
     served: true

--- a/charts/kubeswift/templates/gateway/deployment.yaml
+++ b/charts/kubeswift/templates/gateway/deployment.yaml
@@ -36,6 +36,7 @@ spec:
             - --clusters-namespace={{ .Values.namespace }}
             - --auth-mode={{ .Values.gateway.authMode }}
             - --cors-allow-origin={{ .Values.gateway.corsAllowOrigin }}
+            - --prometheus-discovery-namespaces={{ join "," .Values.gateway.prometheusDiscovery.namespaces }}
             {{- if eq .Values.gateway.authMode "oidc" }}
             - --oidc-issuer-url={{ required "gateway.oidc.issuerURL is required when gateway.authMode=oidc" .Values.gateway.oidc.issuerURL }}
             - --oidc-client-id={{ required "gateway.oidc.clientID is required when gateway.authMode=oidc" .Values.gateway.oidc.clientID }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -157,6 +157,20 @@ gateway:
   # for a hardened install. With ui.gateway.mode=proxy the browser is same-origin,
   # so CORS does not apply.
   corsAllowOrigin: "*"
+  # Per-VM telemetry endpoint discovery. When a member's
+  # Cluster.spec.prometheusEndpoint is empty, the gateway scans these namespaces
+  # ON THAT MEMBER for an in-cluster Prometheus (the kube-prometheus-stack
+  # `prometheus-operated` Service or any Service labeled
+  # app.kubernetes.io/name=prometheus) and uses it; the result is published to
+  # Cluster.status.prometheusEndpoint + the PrometheusEndpointResolved condition.
+  # An explicit spec.prometheusEndpoint always wins. Set namespaces: [] to
+  # disable discovery (explicit endpoints only).
+  prometheusDiscovery:
+    namespaces:
+      - monitoring
+      - kube-prometheus-stack
+      - observability
+      - prometheus
   service:
     type: ClusterIP
     port: 8080

--- a/cmd/kubeswift-gateway/main.go
+++ b/cmd/kubeswift-gateway/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/kubernetes"
@@ -41,6 +42,7 @@ func main() {
 	oidcUsernamePrefix := flag.String("oidc-username-prefix", "", "prefix prepended to the OIDC username (mirrors apiserver --oidc-username-prefix)")
 	oidcGroupsPrefix := flag.String("oidc-groups-prefix", "", "prefix prepended to each OIDC group")
 	oidcCAFile := flag.String("oidc-ca-file", "", "PEM CA bundle to trust when fetching the OIDC issuer's discovery/JWKS (for a private-CA IdP, e.g. a self-signed Keycloak); empty = system roots")
+	promDiscoveryNS := flag.String("prometheus-discovery-namespaces", "monitoring,kube-prometheus-stack,observability,prometheus", "comma-separated namespaces scanned on each member for an in-cluster Prometheus when spec.prometheusEndpoint is empty; empty disables discovery")
 	klog.InitFlags(nil)
 	flag.Parse()
 
@@ -90,8 +92,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// The per-member client pool backing the guest read plane.
-	pool := gateway.NewClientPool(mgr.GetCache(), mgr.GetClient(), *clustersNS)
+	// The per-member client pool backing the guest read plane. It also resolves
+	// each member's telemetry endpoint, discovering an in-cluster Prometheus in
+	// the given namespaces when spec.prometheusEndpoint is empty.
+	pool := gateway.NewClientPool(mgr.GetCache(), mgr.GetClient(), *clustersNS, splitCSV(*promDiscoveryNS))
 	if err := mgr.Add(pool); err != nil {
 		log.Error(err, "unable to add client pool")
 		os.Exit(1)
@@ -163,6 +167,17 @@ func clustersNamespace() string {
 		return ns
 	}
 	return defaultClustersNamespace
+}
+
+// splitCSV parses a comma-separated flag into a trimmed, empty-dropped slice.
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // oidcOptions carries the auth-mode=oidc flags into buildAuthenticator.

--- a/config/crd/bases/fleet.kubeswift.io_clusters.yaml
+++ b/config/crd/bases/fleet.kubeswift.io_clusters.yaml
@@ -29,6 +29,10 @@ spec:
     - jsonPath: .status.guestCount
       name: Guests
       type: integer
+    - jsonPath: .status.prometheusEndpoint
+      name: Prometheus
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -209,6 +213,14 @@ spec:
                   last reconciled.
                 format: int64
                 type: integer
+              prometheusEndpoint:
+                description: |-
+                  PrometheusEndpoint is the effective per-VM telemetry endpoint the gateway
+                  resolved for this member: spec.prometheusEndpoint when set, else a
+                  gateway-discovered in-cluster Prometheus, else empty. Read the
+                  PrometheusEndpointResolved condition for how it was derived. Surfaced so
+                  the UI and kubectl reflect the real derived state (never a silent guess).
+                type: string
             type: object
         type: object
     served: true

--- a/config/samples/gateway/member-rbac.yaml
+++ b/config/samples/gateway/member-rbac.yaml
@@ -86,3 +86,36 @@ subjects:
   - kind: Group
     name: kubeswift-operators
     apiGroup: rbac.authorization.k8s.io
+---
+# 3) Let the gateway CREDENTIAL (the SA the kubeconfig authenticates as, NOT the
+#    impersonated user) discover this member's in-cluster Prometheus Service for
+#    per-VM telemetry — used when the member's Cluster.spec.prometheusEndpoint is
+#    empty. Read-only, low-sensitivity: a Prometheus Service is a fleet fact, not
+#    a user view (the telemetry data query itself still runs as the impersonated
+#    user). Omit this to require an explicit spec.prometheusEndpoint instead.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeswift-gateway-discovery
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
+  # Optional: derive the endpoint from the Prometheus CR when the operator CRDs
+  # are present. Drop this rule if monitoring.coreos.com is not installed.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["prometheuses"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeswift-gateway-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeswift-gateway-discovery
+subjects:
+  - kind: ServiceAccount
+    name: kubeswift-gateway
+    namespace: kubeswift-system

--- a/docs/ui/gateway.md
+++ b/docs/ui/gateway.md
@@ -75,12 +75,21 @@ spec:
   server: https://boba.example.com:6443       # optional if the kubeconfig has it
   credentialSecretRef:
     name: boba-kubeconfig
-  prometheusEndpoint: http://prometheus.monitoring.svc:9090   # optional (telemetry)
+  prometheusEndpoint: http://prometheus.monitoring.svc:9090   # optional (see below)
   displayName: Boba (lab)
 ```
 
 Alternatively the Secret may carry a `token` (+ optional `ca.crt`) instead of a
 `kubeconfig`, paired with `spec.server`.
+
+`prometheusEndpoint` is **optional**: leave it empty and the gateway discovers an
+in-cluster Prometheus on the member (the kube-prometheus-stack `prometheus-operated`
+Service or any Service labeled `app.kubernetes.io/name=prometheus`, scanned in
+`gateway.prometheusDiscovery.namespaces`) and publishes the result to
+`status.prometheusEndpoint` + the `PrometheusEndpointResolved` condition. An
+explicit `spec.prometheusEndpoint` always wins. Discovery needs the member
+credential to read Services (`config/samples/gateway/member-rbac.yaml` grants it);
+set `gateway.prometheusDiscovery.namespaces: []` to disable it.
 
 The gateway picks the member up immediately, probes it, and writes status:
 

--- a/internal/gateway/pool.go
+++ b/internal/gateway/pool.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
@@ -57,6 +61,11 @@ type ClientPool struct {
 	hub       client.Client // reads credential Secrets, writes Cluster status
 	namespace string
 
+	// discoveryNamespaces are scanned on each member for an in-cluster
+	// Prometheus when the Cluster's spec.prometheusEndpoint is empty. Empty
+	// slice = discovery disabled (only explicit endpoints resolve).
+	discoveryNamespaces []string
+
 	mu      sync.RWMutex
 	members map[string]*member
 }
@@ -67,9 +76,25 @@ type member struct {
 	prometheus string
 }
 
+// Prometheus endpoint resolution reasons — the reason on the
+// PrometheusEndpointResolved condition and the discriminator the telemetry
+// plane's degrade-vs-serve decision is derived from.
+const (
+	prometheusReasonExplicit       = "Explicit"       // operator-set spec.prometheusEndpoint
+	prometheusReasonDiscovered     = "Discovered"     // gateway found an in-cluster Prometheus
+	prometheusReasonNotFound       = "NotFound"       // none found / discovery disabled / member down
+	prometheusReasonDiscoveryError = "DiscoveryError" // the member API errored during discovery
+)
+
+// prometheusDefaultPort is the operated Service's web port when no named
+// web/http port is present.
+const prometheusDefaultPort int32 = 9090
+
 // NewClientPool builds the pool over the hub cache + a read/write hub client.
-func NewClientPool(c ctrlcache.Cache, hub client.Client, namespace string) *ClientPool {
-	return &ClientPool{cache: c, hub: hub, namespace: namespace, members: map[string]*member{}}
+// discoveryNamespaces are scanned per member for an in-cluster Prometheus when
+// the member's spec.prometheusEndpoint is empty (nil/empty disables discovery).
+func NewClientPool(c ctrlcache.Cache, hub client.Client, namespace string, discoveryNamespaces []string) *ClientPool {
+	return &ClientPool{cache: c, hub: hub, namespace: namespace, discoveryNamespaces: discoveryNamespaces, members: map[string]*member{}}
 }
 
 // NeedLeaderElection keeps the pool running on every replica.
@@ -102,23 +127,143 @@ func (p *ClientPool) upsert(ctx context.Context, obj any) {
 		p.mu.Lock()
 		delete(p.members, c.Name)
 		p.mu.Unlock()
-		p.setStatus(ctx, c, false, "", err.Error())
+		p.setStatus(ctx, c, false, "", err.Error(), "", prometheusReasonNotFound, "member credential invalid; telemetry endpoint unresolved")
 		return
 	}
 	p.mu.Lock()
 	p.members[c.Name] = &member{name: c.Name, config: cfg, prometheus: c.Spec.PrometheusEndpoint}
 	p.mu.Unlock()
 
-	// Probe reachability + version off the informer goroutine so a slow or
-	// unreachable member never stalls the shared handler.
+	// Probe reachability + version AND resolve the telemetry endpoint off the
+	// informer goroutine so a slow or unreachable member never stalls the
+	// shared handler.
 	cl := c.DeepCopy()
 	go func() {
-		if ver, perr := serverVersion(cfg); perr != nil {
-			p.setStatus(ctx, cl, false, "", perr.Error())
-		} else {
-			p.setStatus(ctx, cl, true, ver, "")
+		ver, verr := serverVersion(cfg)
+		reachable := verr == nil
+		reachMsg := ""
+		if verr != nil {
+			reachMsg = verr.Error()
 		}
+		endpoint, promReason, promMsg := p.resolvePrometheus(ctx, cfg, cl.Spec.PrometheusEndpoint, reachable)
+		p.mu.Lock()
+		if m := p.members[cl.Name]; m != nil {
+			m.prometheus = endpoint
+		}
+		p.mu.Unlock()
+		p.setStatus(ctx, cl, reachable, ver, reachMsg, endpoint, promReason, promMsg)
 	}()
+}
+
+// resolvePrometheus determines the member's effective telemetry endpoint:
+// an explicit spec.prometheusEndpoint always wins (reason Explicit); otherwise,
+// when the member is reachable and discovery is enabled, it scans the member for
+// an in-cluster Prometheus (reason Discovered); else empty (reason NotFound or
+// DiscoveryError). It never guesses silently — the reason + message are surfaced
+// on the Cluster's PrometheusEndpointResolved condition (Principle #6).
+func (p *ClientPool) resolvePrometheus(ctx context.Context, cfg *rest.Config, specEndpoint string, reachable bool) (endpoint, reason, msg string) {
+	if specEndpoint != "" {
+		return specEndpoint, prometheusReasonExplicit, "operator-set spec.prometheusEndpoint"
+	}
+	if !reachable {
+		return "", prometheusReasonNotFound, "member unreachable; Prometheus discovery skipped"
+	}
+	if len(p.discoveryNamespaces) == 0 {
+		return "", prometheusReasonNotFound, "spec.prometheusEndpoint empty and Prometheus discovery is disabled"
+	}
+	cs, cerr := kubernetes.NewForConfig(cfg)
+	if cerr != nil {
+		return "", prometheusReasonDiscoveryError, fmt.Sprintf("Prometheus discovery client: %v", cerr)
+	}
+	ep, detail, derr := discoverPrometheus(ctx, cs, p.discoveryNamespaces)
+	if derr != nil {
+		return "", prometheusReasonDiscoveryError, fmt.Sprintf("Prometheus discovery failed: %v", derr)
+	}
+	if ep == "" {
+		return "", prometheusReasonNotFound, fmt.Sprintf("no Prometheus Service found in namespaces %v", p.discoveryNamespaces)
+	}
+	return ep, prometheusReasonDiscovered, detail
+}
+
+// discoverPrometheus scans the given namespaces on the member (via the member
+// credential in cfg) for a kube-prometheus-stack Prometheus Service — the
+// governing "prometheus-operated" Service or any Service labeled
+// app.kubernetes.io/name=prometheus — and returns its base URL. The pick is
+// deterministic (namespace order, then Service name); when more than one is
+// found the detail names the others so an operator can override via
+// spec.prometheusEndpoint. Empty endpoint + nil error means none found.
+func discoverPrometheus(ctx context.Context, cs kubernetes.Interface, namespaces []string) (endpoint, detail string, err error) {
+	type cand struct {
+		ns, name string
+		port     int32
+	}
+	var cands []cand
+	seen := map[string]bool{}
+	add := func(s *corev1.Service) {
+		key := s.Namespace + "/" + s.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		cands = append(cands, cand{ns: s.Namespace, name: s.Name, port: prometheusServicePort(s)})
+	}
+	for _, ns := range namespaces {
+		// The operator's governing Service, stable across kps releases.
+		if s, gerr := cs.CoreV1().Services(ns).Get(ctx, "prometheus-operated", metav1.GetOptions{}); gerr == nil {
+			add(s)
+		} else if !apierrors.IsNotFound(gerr) {
+			return "", "", gerr
+		}
+		// Any Service the operator labels as a Prometheus (the *-kube-prometheus-
+		// prometheus ClusterIP Service and the operated Service both carry it).
+		list, lerr := cs.CoreV1().Services(ns).List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=prometheus"})
+		if lerr != nil {
+			return "", "", lerr
+		}
+		for i := range list.Items {
+			add(&list.Items[i])
+		}
+	}
+	if len(cands) == 0 {
+		return "", "", nil
+	}
+	nsIndex := map[string]int{}
+	for i, ns := range namespaces {
+		nsIndex[ns] = i
+	}
+	sort.SliceStable(cands, func(i, j int) bool {
+		if nsIndex[cands[i].ns] != nsIndex[cands[j].ns] {
+			return nsIndex[cands[i].ns] < nsIndex[cands[j].ns]
+		}
+		return cands[i].name < cands[j].name
+	})
+	pick := cands[0]
+	endpoint = fmt.Sprintf("http://%s.%s.svc:%d", pick.name, pick.ns, pick.port)
+	detail = fmt.Sprintf("discovered %s.%s:%d", pick.name, pick.ns, pick.port)
+	if len(cands) > 1 {
+		others := make([]string, 0, len(cands)-1)
+		for _, c := range cands[1:] {
+			others = append(others, fmt.Sprintf("%s.%s", c.name, c.ns))
+		}
+		detail += fmt.Sprintf(" (also saw %s; set spec.prometheusEndpoint to override)", strings.Join(others, ", "))
+	}
+	return endpoint, detail, nil
+}
+
+// prometheusServicePort returns the Service's web/http port, preferring a named
+// "web"/"http" port, then a 9090 port, else the 9090 default.
+func prometheusServicePort(s *corev1.Service) int32 {
+	for _, p := range s.Spec.Ports {
+		if p.Name == "web" || p.Name == "http" {
+			return p.Port
+		}
+	}
+	for _, p := range s.Spec.Ports {
+		if p.Port == prometheusDefaultPort {
+			return p.Port
+		}
+	}
+	return prometheusDefaultPort
 }
 
 func (p *ClientPool) remove(obj any) {
@@ -224,10 +369,12 @@ func serverVersion(cfg *rest.Config) (string, error) {
 	return v.GitVersion, nil
 }
 
-// setStatus best-effort patches the Cluster's Ready/Reachable conditions,
-// version, and lastConnected. It re-reads the object to avoid clobbering a
-// concurrent writer; failures are swallowed (status is advisory).
-func (p *ClientPool) setStatus(ctx context.Context, c *fleetv1alpha1.Cluster, reachable bool, version, msg string) {
+// setStatus best-effort patches the Cluster's Ready/Reachable conditions, the
+// resolved telemetry endpoint (spec/discovered/none) + its
+// PrometheusEndpointResolved condition, version, and lastConnected. It re-reads
+// the object to avoid clobbering a concurrent writer; failures are swallowed
+// (status is advisory).
+func (p *ClientPool) setStatus(ctx context.Context, c *fleetv1alpha1.Cluster, reachable bool, version, msg, promEndpoint, promReason, promMsg string) {
 	var cur fleetv1alpha1.Cluster
 	if err := p.hub.Get(ctx, types.NamespacedName{Namespace: c.Namespace, Name: c.Name}, &cur); err != nil {
 		return
@@ -236,6 +383,9 @@ func (p *ClientPool) setStatus(ctx context.Context, c *fleetv1alpha1.Cluster, re
 	now := metav1.Now()
 	setCondition(&cur.Status.Conditions, fleetv1alpha1.ClusterConditionReachable, reachable, "Reachable", "Unreachable", msg, now)
 	setCondition(&cur.Status.Conditions, fleetv1alpha1.ClusterConditionReady, reachable, "Ready", "NotReady", msg, now)
+	promOK := promReason == prometheusReasonExplicit || promReason == prometheusReasonDiscovered
+	setCondition(&cur.Status.Conditions, fleetv1alpha1.ClusterConditionPrometheusEndpointResolved, promOK, promReason, promReason, promMsg, now)
+	cur.Status.PrometheusEndpoint = promEndpoint
 	if version != "" {
 		cur.Status.KubernetesVersion = version
 	}

--- a/internal/gateway/pool_discovery_test.go
+++ b/internal/gateway/pool_discovery_test.go
@@ -1,0 +1,124 @@
+package gateway
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func mkSvc(ns, name string, labels map[string]string, ports ...corev1.ServicePort) *corev1.Service {
+	if len(ports) == 0 {
+		ports = []corev1.ServicePort{{Name: "web", Port: 9090}}
+	}
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: labels},
+		Spec:       corev1.ServiceSpec{Ports: ports},
+	}
+}
+
+func TestDiscoverPrometheus(t *testing.T) {
+	promLabel := map[string]string{"app.kubernetes.io/name": "prometheus"}
+	nss := []string{"monitoring", "kube-prometheus-stack", "observability", "prometheus"}
+
+	tests := []struct {
+		name      string
+		objs      []runtime.Object
+		wantEP    string
+		detailSub string // substring the detail must contain (skipped when empty)
+	}{
+		{
+			name:   "operated service found by well-known name",
+			objs:   []runtime.Object{mkSvc("monitoring", "prometheus-operated", nil)},
+			wantEP: "http://prometheus-operated.monitoring.svc:9090",
+		},
+		{
+			name:   "labeled ClusterIP service found by label",
+			objs:   []runtime.Object{mkSvc("monitoring", "kps-kube-prometheus-prometheus", promLabel)},
+			wantEP: "http://kps-kube-prometheus-prometheus.monitoring.svc:9090",
+		},
+		{
+			name:   "nothing found -> empty, no error",
+			objs:   nil,
+			wantEP: "",
+		},
+		{
+			name: "namespace order wins (earlier ns beats later)",
+			objs: []runtime.Object{
+				mkSvc("prometheus", "prometheus-operated", nil),
+				mkSvc("monitoring", "prometheus-operated", nil),
+			},
+			wantEP: "http://prometheus-operated.monitoring.svc:9090",
+		},
+		{
+			name: "multiple in a namespace -> lexicographic pick, reports the other",
+			objs: []runtime.Object{
+				mkSvc("monitoring", "z-prometheus", promLabel),
+				mkSvc("monitoring", "a-prometheus", promLabel),
+			},
+			wantEP:    "http://a-prometheus.monitoring.svc:9090",
+			detailSub: "also saw z-prometheus.monitoring",
+		},
+		{
+			name:   "web port honored on a non-9090 port",
+			objs:   []runtime.Object{mkSvc("monitoring", "prometheus-operated", nil, corev1.ServicePort{Name: "web", Port: 9091})},
+			wantEP: "http://prometheus-operated.monitoring.svc:9091",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := fake.NewSimpleClientset(tt.objs...)
+			ep, detail, err := discoverPrometheus(context.Background(), cs, nss)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ep != tt.wantEP {
+				t.Errorf("endpoint: got %q want %q", ep, tt.wantEP)
+			}
+			if tt.detailSub != "" && !strings.Contains(detail, tt.detailSub) {
+				t.Errorf("detail %q missing %q", detail, tt.detailSub)
+			}
+		})
+	}
+}
+
+func TestPrometheusServicePort(t *testing.T) {
+	cases := []struct {
+		name  string
+		ports []corev1.ServicePort
+		want  int32
+	}{
+		{"web named", []corev1.ServicePort{{Name: "web", Port: 9090}}, 9090},
+		{"http named on odd port", []corev1.ServicePort{{Name: "http", Port: 9091}}, 9091},
+		{"unnamed 9090 present", []corev1.ServicePort{{Name: "metrics", Port: 8080}, {Name: "x", Port: 9090}}, 9090},
+		{"no match -> default 9090", []corev1.ServicePort{{Name: "metrics", Port: 8080}}, 9090},
+		{"empty -> default 9090", nil, 9090},
+	}
+	for _, c := range cases {
+		got := prometheusServicePort(&corev1.Service{Spec: corev1.ServiceSpec{Ports: c.ports}})
+		if got != c.want {
+			t.Errorf("%s: got %d want %d", c.name, got, c.want)
+		}
+	}
+}
+
+// resolvePrometheus precedence: an explicit spec endpoint always wins (no
+// discovery attempted); an unreachable member or discovery-disabled pool resolve
+// to NotFound. These paths never touch cfg, so a nil cfg is safe.
+func TestResolvePrometheus_Precedence(t *testing.T) {
+	pEnabled := &ClientPool{discoveryNamespaces: []string{"monitoring"}}
+	if ep, reason, _ := pEnabled.resolvePrometheus(context.Background(), nil, "http://explicit:9090", true); ep != "http://explicit:9090" || reason != prometheusReasonExplicit {
+		t.Fatalf("explicit must win: ep=%q reason=%q", ep, reason)
+	}
+	if ep, reason, _ := pEnabled.resolvePrometheus(context.Background(), nil, "", false); ep != "" || reason != prometheusReasonNotFound {
+		t.Fatalf("unreachable must be NotFound (no discovery): ep=%q reason=%q", ep, reason)
+	}
+	pDisabled := &ClientPool{discoveryNamespaces: nil}
+	if ep, reason, _ := pDisabled.resolvePrometheus(context.Background(), nil, "", true); ep != "" || reason != prometheusReasonNotFound {
+		t.Fatalf("discovery-disabled must be NotFound: ep=%q reason=%q", ep, reason)
+	}
+}


### PR DESCRIPTION
Second PR of the federation-UX arc. **Stacked on #332** (base = `feat/chart-ingress-tlsauto`; GitHub retargets to `main` when #332 merges). Gateway Go + a status-only CRD field.

## What
When a fleet `Cluster`'s `spec.prometheusEndpoint` is empty, the gateway discovers an in-cluster Prometheus **on that member** and uses it for per-VM telemetry — fixing the "no prometheusEndpoint registered for this cluster" UI message for any cluster running kube-prometheus-stack, with no hand-typed endpoint.

## How
- **Resolution precedence:** explicit `spec.prometheusEndpoint` always wins (reason `Explicit`) → else discovered (`Discovered`) → else empty (`NotFound`/`DiscoveryError`).
- **Discovery:** the `prometheus-operated` Service or any Service labeled `app.kubernetes.io/name=prometheus`, scanned in `gateway.prometheusDiscovery.namespaces` (default `monitoring,kube-prometheus-stack,observability,prometheus`; `[]` disables). Deterministic pick (ns order, then name); >1 found names the others.
- **No silent guess:** the effective endpoint + how it was derived land in a new **status-only** `status.prometheusEndpoint` field + a `PrometheusEndpointResolved` condition (Principle #6).
- Runs off the existing informer-goroutine probe as the **member credential** (a fleet fact, not a user view — the telemetry *data* query still runs as the impersonated user, so per-user authz is unchanged).
- `member-rbac.yaml` sample gains a read-only `services get,list` grant on the credential.

## Validation
- `go build ./...` clean; `go test ./internal/gateway/...` green (discovery pick logic via fake clientset + resolve precedence).
- `make generate` → only the fleet CRD changed (status field + wide printcolumn), chart-synced; `gofmt -s` clean.
- Gateway deployment renders the flag.
- **Backward-compat:** an explicit `spec.prometheusEndpoint` short-circuits discovery entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)