### PR TITLE
fix(chart): grant the hub SA services get,list for self Prometheus discovery

### DIFF
--- a/charts/kubeswift/templates/gateway/rbac.yaml
+++ b/charts/kubeswift/templates/gateway/rbac.yaml
@@ -80,6 +80,42 @@ subjects:
   - kind: ServiceAccount
     name: kubeswift-gateway
     namespace: {{ .Values.namespace }}
+{{- if eq (include "kubeswift.selfRegisterEnabled" .) "true" }}
+---
+# Self-registration: the gateway SA discovers the hub's OWN in-cluster Prometheus
+# for the spec.local self entry (Cluster.status.prometheusEndpoint). Read-only
+# Services list; gated on self-registration so a gateway that federates only
+# remote members never gets it. Independent of authMode — which Prometheus a
+# cluster has is a fleet fact, not a per-user view (mirrors the member-rbac
+# sample's discovery grant for remote members).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeswift-gateway-self-discovery
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: gateway
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeswift-gateway-self-discovery
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeswift-gateway-self-discovery
+subjects:
+  - kind: ServiceAccount
+    name: kubeswift-gateway
+    namespace: {{ .Values.namespace }}
+{{- end }}
 {{- if and (eq (include "kubeswift.selfRegisterEnabled" .) "true") (ne .Values.gateway.authMode "insecure") }}
 ---
 # Self-registration under auth-mode oidc/token: the hub federates ITSELF via the


### PR DESCRIPTION
Follow-up to the federation-UX arc (#335), found by **cluster-validating** it on the dev hub.

## Bug
A `federation.role=hub` self-registered (`spec.local: true`) entry resolved `PrometheusEndpointResolved=DiscoveryError`:
```
services "prometheus-operated" is forbidden: User "system:serviceaccount:kubeswift-system:kubeswift-gateway" cannot get resource "services" in namespace "monitoring"
```
The gateway discovers the **local** member's Prometheus via its own in-cluster SA, but the chart granted that SA no `services get,list`. (The design §5.5 / open-Q #7 called for this; #335 added the self-impersonator grant but missed the discovery one.)

## Fix
A `kubeswift-gateway-self-discovery` ClusterRole (`services get,list`) bound to the gateway SA, gated on `selfRegisterEnabled` only — independent of `authMode`, since which Prometheus a cluster has is a fleet fact, not a per-user view. Remote members already get this via `config/samples/gateway/member-rbac.yaml`.

## Cluster-validated
On the dev hub (arc images `sha-fa71b2f`), after the grant the self entry resolves `Discovered -> http://prometheus-operated.monitoring.svc:9090`; `dev`=Explicit, `sov`=NotFound — all correct. Chart-only, `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)