### PR TITLE
feat(sandbox): restricted-egress hardening for SwiftSandbox

### DIFF
--- a/api/sandbox/v1alpha1/swiftsandbox_types.go
+++ b/api/sandbox/v1alpha1/swiftsandbox_types.go
@@ -76,13 +76,19 @@ type SwiftSandboxSpec struct {
 }
 
 // SandboxNetworkMode selects the sandbox connectivity posture.
-// +kubebuilder:validation:Enum=restricted;none
+// +kubebuilder:validation:Enum=restricted;open;none
 type SandboxNetworkMode string
 
 const (
-	// SandboxNetworkRestricted attaches the pod network with a deny-ingress /
-	// limited-egress posture (the default).
+	// SandboxNetworkRestricted (the default) attaches the pod network with a
+	// deny-ingress posture AND hardened egress: the guest reaches DNS + the public
+	// internet but CANNOT reach cluster-internal pods/services or the cloud metadata
+	// endpoint (169.254.169.254). The right posture for untrusted code.
 	SandboxNetworkRestricted SandboxNetworkMode = "restricted"
+	// SandboxNetworkOpen attaches the pod network with deny-ingress but unrestricted
+	// egress (the guest can reach the whole cluster + internet). Opt-in for trusted
+	// workloads that must talk to in-cluster services; NOT for untrusted code.
+	SandboxNetworkOpen SandboxNetworkMode = "open"
 	// SandboxNetworkNone attaches no network (detonation / pure compute).
 	SandboxNetworkNone SandboxNetworkMode = "none"
 )

--- a/charts/kubeswift/crds/sandbox.kubeswift.io_swiftsandboxes.yaml
+++ b/charts/kubeswift/crds/sandbox.kubeswift.io_swiftsandboxes.yaml
@@ -283,6 +283,7 @@ spec:
                     description: Mode is "restricted" (default) or "none".
                     enum:
                     - restricted
+                    - open
                     - none
                     type: string
                 type: object

--- a/config/crd/bases/sandbox.kubeswift.io_swiftsandboxes.yaml
+++ b/config/crd/bases/sandbox.kubeswift.io_swiftsandboxes.yaml
@@ -283,6 +283,7 @@ spec:
                     description: Mode is "restricted" (default) or "none".
                     enum:
                     - restricted
+                    - open
                     - none
                     type: string
                 type: object

--- a/config/samples/sandbox/README.md
+++ b/config/samples/sandbox/README.md
@@ -18,8 +18,16 @@ kubectl get sbox -w
 ```
 
 Notes:
-- `network.mode: restricted` (default) attaches the pod network with a
-  deny-ingress NetworkPolicy; `none` attaches no network.
+- `network.mode`:
+  - `restricted` (default) — deny-ingress (nothing reaches the sandbox) **and**
+    hardened egress: the guest reaches DNS + the public internet but **cannot** reach
+    cluster-internal pods/services or the cloud metadata endpoint
+    (`169.254.169.254`). The posture for untrusted code. Enforced by in-pod iptables
+    on the VM's forwarded traffic (not a NetworkPolicy — that would also cut
+    swiftletd's own status reporting).
+  - `open` — deny-ingress but unrestricted egress (guest can reach the whole cluster
+    + internet). Opt-in for trusted workloads that must talk to in-cluster services.
+  - `none` — no network at all (detonation / pure compute).
 - `spec.command` overrides the image entrypoint (single path in v1; a bare image
   runs its own entrypoint).
 - `spec.timeout` force-terminates a runaway sandbox; `spec.ttl` deletes the

--- a/internal/controller/swiftsandbox/egress_test.go
+++ b/internal/controller/swiftsandbox/egress_test.go
@@ -1,0 +1,66 @@
+package swiftsandbox
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
+)
+
+func egSandbox(mode sandboxv1alpha1.SandboxNetworkMode) *sandboxv1alpha1.SwiftSandbox {
+	return &sandboxv1alpha1.SwiftSandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: sandboxv1alpha1.SwiftSandboxSpec{
+			Image:   "alpine:3.20",
+			Network: sandboxv1alpha1.SandboxNetwork{Mode: mode},
+		},
+	}
+}
+
+func TestEgressMode(t *testing.T) {
+	// The default (unset) posture is the secure one — restricted.
+	if got := egressMode(egSandbox("")); got != sandboxv1alpha1.SandboxNetworkRestricted {
+		t.Errorf("default -> %q, want restricted", got)
+	}
+	if got := egressMode(egSandbox(sandboxv1alpha1.SandboxNetworkRestricted)); got != sandboxv1alpha1.SandboxNetworkRestricted {
+		t.Errorf("restricted -> %q", got)
+	}
+	if got := egressMode(egSandbox(sandboxv1alpha1.SandboxNetworkOpen)); got != sandboxv1alpha1.SandboxNetworkOpen {
+		t.Errorf("open -> %q, want open", got)
+	}
+}
+
+// networkInitEgressEnv returns (KUBESWIFT_SANDBOX_EGRESS, network-init-present).
+func networkInitEgressEnv(pod *corev1.Pod) (string, bool) {
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name != "network-init" {
+			continue
+		}
+		for _, e := range pod.Spec.InitContainers[i].Env {
+			if e.Name == "KUBESWIFT_SANDBOX_EGRESS" {
+				return e.Value, true
+			}
+		}
+		return "", true // network-init present but env missing
+	}
+	return "", false
+}
+
+func TestBuildPod_EgressEnv(t *testing.T) {
+	// restricted (default): network-init carries the restricted signal.
+	if v, ok := networkInitEgressEnv(buildPod(egSandbox(""), "sandbox")); !ok || v != "restricted" {
+		t.Errorf("default egress env = %q (network-init present=%v), want restricted", v, ok)
+	}
+	// open: network-init carries open (so the script installs no egress DROP rules).
+	if v, ok := networkInitEgressEnv(buildPod(egSandbox(sandboxv1alpha1.SandboxNetworkOpen), "sandbox")); !ok || v != "open" {
+		t.Errorf("open egress env = %q (network-init present=%v), want open", v, ok)
+	}
+	// none: no network-init container at all (no pod network).
+	for i := range buildPod(egSandbox(sandboxv1alpha1.SandboxNetworkNone), "sandbox").Spec.InitContainers {
+		if buildPod(egSandbox(sandboxv1alpha1.SandboxNetworkNone), "sandbox").Spec.InitContainers[i].Name == "network-init" {
+			t.Error("network:none must not get a network-init container")
+		}
+	}
+}

--- a/internal/controller/swiftsandbox/netpol.go
+++ b/internal/controller/swiftsandbox/netpol.go
@@ -7,11 +7,19 @@ import (
 	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
 )
 
-// buildNetworkPolicy builds the "restricted" NetworkPolicy for a networked
-// sandbox: deny ALL ingress to the launcher pod (nothing on the cluster can reach
-// the sandbox) while allowing egress (a CI/agent sandbox's outbound is the point).
-// mode=none has no pod network at all, so no policy is created there. Narrowing
-// egress to specific destinations is a follow-up; deny-ingress is the v1 floor.
+// buildNetworkPolicy builds the deny-ingress NetworkPolicy for a networked sandbox:
+// nothing on the cluster can reach the sandbox. Egress is left allow-all HERE on
+// purpose — the VM's egress hardening is done in-pod (the restricted-egress FORWARD
+// iptables in network-init.sh), NOT in this NetworkPolicy.
+//
+// Why not the NetworkPolicy: it applies to the whole launcher pod, and after
+// MASQUERADE the VM's traffic and swiftletd's own API-server traffic both source
+// from the pod IP — a NetworkPolicy that blocked cluster egress would also cut
+// swiftletd's status reporting (#347). Only the FORWARD chain can match the VM's
+// pre-NAT source (bridge subnet) and filter the VM alone. So this policy owns
+// ingress isolation; the iptables owns egress. mode=none has no pod network at all,
+// so no policy is created. Same policy for restricted and open (both deny-ingress);
+// the restricted/open difference is entirely the in-pod egress rules.
 func buildNetworkPolicy(sb *sandboxv1alpha1.SwiftSandbox) *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/swiftsandbox/pod.go
+++ b/internal/controller/swiftsandbox/pod.go
@@ -35,6 +35,15 @@ func networked(sb *sandboxv1alpha1.SwiftSandbox) bool {
 	return sb.Spec.Network.Mode != sandboxv1alpha1.SandboxNetworkNone
 }
 
+// egressMode is the effective egress posture for a networked sandbox. The CRD
+// default is restricted; the fallthrough also covers a pre-admission empty value.
+func egressMode(sb *sandboxv1alpha1.SwiftSandbox) sandboxv1alpha1.SandboxNetworkMode {
+	if sb.Spec.Network.Mode == sandboxv1alpha1.SandboxNetworkOpen {
+		return sandboxv1alpha1.SandboxNetworkOpen
+	}
+	return sandboxv1alpha1.SandboxNetworkRestricted
+}
+
 // buildIntent constructs the mode-3 sandbox RuntimeIntent: kernel boot + the RO
 // OCI rootfs disk + the bridge cmdline (rootfs selector + entrypoint).
 func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath, entrypoint string) *runtimeintent.RuntimeIntent {
@@ -117,8 +126,16 @@ func buildPod(sb *sandboxv1alpha1.SwiftSandbox, kernelName string) *corev1.Pod {
 	}}
 	if networked(sb) {
 		// network-init (br0/tap0/dnsmasq) runs first; it mounts the same
-		// runtime-intent + run volumes the launcher uses.
-		initContainers = append([]corev1.Container{swiftguest.NetworkInitContainer()}, initContainers...)
+		// runtime-intent + run volumes the launcher uses. KUBESWIFT_SANDBOX_EGRESS
+		// tells it whether to install the restricted-egress FORWARD iptables. This is
+		// the ONLY layer that can filter the VM's egress precisely: a pod-level
+		// NetworkPolicy can't, because after MASQUERADE the VM's traffic and
+		// swiftletd's own API-server traffic share the pod IP — a NetworkPolicy that
+		// blocked cluster egress would also cut swiftletd's status reporting (#347).
+		// The FORWARD chain matches the VM's pre-NAT source (bridge subnet) only.
+		ni := swiftguest.NetworkInitContainer()
+		ni.Env = append(ni.Env, corev1.EnvVar{Name: "KUBESWIFT_SANDBOX_EGRESS", Value: string(egressMode(sb))})
+		initContainers = append([]corev1.Container{ni}, initContainers...)
 	}
 
 	dirCreate := corev1.HostPathDirectoryOrCreate

--- a/rust/swiftletd/scripts/network-init.sh
+++ b/rust/swiftletd/scripts/network-init.sh
@@ -23,6 +23,42 @@ guest_run_dir() {
     echo "$RUN_DIR/$(echo "$gid" | tr '/' '-')"
 }
 
+# apply_restricted_egress hardens a sandbox guest's outbound traffic (untrusted
+# code). Gated on KUBESWIFT_SANDBOX_EGRESS=restricted (set only by the SwiftSandbox
+# pod builder -- SwiftGuests never set it, so their egress is untouched).
+#
+# The guest's traffic is FORWARDed (VM -> br0 -> eth0, MASQUERADEd), so a FORWARD
+# filter is the precise, CNI-independent hard control (a NetworkPolicy is only
+# enforced if the CNI supports egress policy -- silent no-op otherwise). Rules live
+# in a dedicated chain jumped to from the TOP of FORWARD (before any CNI ACCEPT) for
+# VM-sourced traffic only:
+#   - ESTABLISHED/RELATED return traffic and DNS to the cluster resolver(s) RETURN
+#     (allowed) -- the guest queries kube-dns directly (dnsmasq hands it as the
+#     resolver), so :53 must be punched through the cluster block or DNS breaks;
+#   - 169.254.0.0/16 (cloud metadata -> node creds) and RFC1918 (pod + service
+#     CIDRs -> lateral movement) DROP;
+#   - everything else (public internet) falls through -> ACCEPT -> MASQUERADE.
+# Node public IPs are NOT blocked (same exposure as any pod); documented.
+apply_restricted_egress() {
+    src_net="$1"
+    [ "${KUBESWIFT_SANDBOX_EGRESS:-}" = "restricted" ] || return 0
+    chain="KUBESWIFT_SBX_EGRESS"
+    iptables -N "$chain" 2>/dev/null || iptables -F "$chain"
+    iptables -A "$chain" -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN
+    for d in $(grep '^nameserver ' /etc/resolv.conf 2>/dev/null | awk '{print $2}'); do
+        iptables -A "$chain" -d "$d" -p udp --dport 53 -j RETURN
+        iptables -A "$chain" -d "$d" -p tcp --dport 53 -j RETURN
+    done
+    iptables -A "$chain" -d 169.254.0.0/16 -j DROP
+    iptables -A "$chain" -d 10.0.0.0/8     -j DROP
+    iptables -A "$chain" -d 172.16.0.0/12  -j DROP
+    iptables -A "$chain" -d 192.168.0.0/16 -j DROP
+    # Idempotent jump at the top of FORWARD for the VM subnet.
+    iptables -C FORWARD -s "$src_net" -j "$chain" 2>/dev/null \
+        || iptables -I FORWARD 1 -s "$src_net" -j "$chain"
+    echo "Restricted egress: $src_net -> DNS + internet; DROP 169.254/16 + RFC1918 (chain $chain)"
+}
+
 setup_primary_nic() {
     local bridge="$1" tap="$2"
 
@@ -67,6 +103,9 @@ setup_primary_nic() {
     # Source/exclude derive from bridge_ip so any operator override
     # via BRIDGE_IP env stays internally consistent.
     iptables -t nat -A POSTROUTING -s "$bridge_net" ! -d "$bridge_net" -j MASQUERADE
+
+    # Sandbox restricted-egress hardening (no-op unless KUBESWIFT_SANDBOX_EGRESS=restricted).
+    apply_restricted_egress "$bridge_net"
 
     echo "Primary NIC: $bridge ($bridge_ip, net $bridge_net) with $tap"
 }


### PR DESCRIPTION
A SwiftSandbox runs untrusted code, but "restricted" only enforced deny-ingress —
egress was allow-all, so the guest could reach the cloud metadata endpoint
(`169.254.169.254` → the node's cloud credentials) and cluster-internal
pods/services (lateral movement). This hardens the default posture.

## Changes

- `network.mode` gains **`open`** (deny-ingress + allow-all egress, opt-in for
  trusted workloads that must reach in-cluster services). **`restricted`** (default)
  now also restricts egress; **`none`** is unchanged.
- `network-init.sh` installs a FORWARD iptables chain (gated on
  `KUBESWIFT_SANDBOX_EGRESS=restricted`, set only by the sandbox pod builder — a
  SwiftGuest never sets it) that DROPs the VM's traffic to `169.254.0.0/16` +
  RFC1918 (pod + service CIDRs), while allowing DNS (RETURN to the resolv.conf
  nameservers, which the guest queries directly) + the public internet. Jumped to
  from the **top** of FORWARD for the VM's bridge subnet, so it fires before any
  CNI rule.

## Why in-pod iptables, not a NetworkPolicy

After MASQUERADE the VM's traffic and swiftletd's own API-server traffic share the
pod IP, so a pod-level NetworkPolicy that blocked cluster egress would also cut
swiftletd's status reporting (#347). Only the FORWARD chain can match the VM's
pre-NAT source (bridge subnet) and filter the VM alone. The NetworkPolicy keeps
owning deny-ingress; the iptables owns egress. It's also CNI-independent — a
NetworkPolicy is a silent no-op if the CNI doesn't enforce egress policy.

A VM (unlike a container) never exposes the launcher pod's service-account
token/filesystem to the workload, so the network was the main remaining exposure.

## Cluster-validated (restricted alpine sandbox)

| check | result |
|---|---|
| chain + FORWARD jump installed | ✓ (`network-init` log + `iptables -S`) |
| metadata `169.254.169.254` blocked | ✓ DROP counter 6 pkts |
| cluster `10.0.0.0/8` blocked | ✓ DROP counter 8 pkts |
| raw internet (`ping 1.1.1.1`) | ✓ `INTERNET_IP_OK` |
| DNS to resolver (`nslookup @10.96.0.10`) | ✓ RETURN counter 2 pkts |

## Known gap (separate, tracked)

The guest's `/etc/resolv.conf` is **empty**, so name resolution fails unless an
explicit resolver is given — a pre-existing `#350` `ip=dhcp` limitation (the kernel
autoconfigures the IP but not the userspace resolver), NOT an egress issue (egress
correctly allows DNS; DNS-to-resolver + internet-by-IP both work). The fix is a
bridge-init change (`cat /proc/net/pnp > /etc/resolv.conf`) that lands with the next
PR (config-disk exec), which rebuilds the bridge-init/kernel artifact anyway.

Also documented in code: node public IPs stay reachable (same exposure as any pod).

Node opt-in, tests: `egressMode` default/open + the per-mode network-init env +
no network-init for `network:none`.
