### PR TITLE
feat(sandbox): deliver workload exec via a per-sandbox config disk

### DIFF
--- a/build/kernels/sandbox/configs/sandbox-linux.config
+++ b/build/kernels/sandbox/configs/sandbox-linux.config
@@ -21,10 +21,24 @@ CONFIG_SERIAL_8250=y
 CONFIG_SERIAL_8250_CONSOLE=y
 CONFIG_SERIAL_8250_NR_UARTS=4
 CONFIG_SERIAL_8250_RUNTIME_UARTS=4
+# PCI is the virtio transport. VIRTIO_PCI *depends on* PCI, so without an explicit
+# CONFIG_PCI=y olddefconfig drops VIRTIO_PCI and the guest gets NO virtio-blk/net at
+# all (cluster-observed: "/dev/vda: Can't lookup blockdev" -> kernel panic; no /dev/vd*
+# and no eth0 ever enumerate). PCI_MSI gives each virtio device its own MSI-X vector
+# (INTx-shared multi-device is fragile). Both are present in the faas base this derives
+# from; they were dropped when this config was hand-written.
+CONFIG_PCI=y
+CONFIG_PCI_MSI=y
 CONFIG_VIRTIO=y
 CONFIG_VIRTIO_PCI=y
 CONFIG_VIRTIO_PCI_LEGACY=y
 CONFIG_VIRTIO_BLK=y
+# VIRTIO_NET depends on NETDEVICES + NET_CORE (same dropped-dependency trap as
+# VIRTIO_PCI/PCI above): without them olddefconfig drops VIRTIO_NET and the guest
+# gets no eth0 (networked sandboxes never DHCP an IP). Present in the faas base.
+CONFIG_NETDEVICES=y
+CONFIG_NET_CORE=y
+CONFIG_ETHERNET=y
 CONFIG_VIRTIO_NET=y
 CONFIG_VIRTIO_CONSOLE=y
 CONFIG_HW_RANDOM_VIRTIO=y

--- a/build/kernels/sandbox/rootfs-overlay/init
+++ b/build/kernels/sandbox/rootfs-overlay/init
@@ -24,12 +24,17 @@ mkdir -p /dev/pts
 mount -t devpts   none /dev/pts 2>/dev/null || true
 
 # --- parse kernel cmdline ---
+# kubeswift.config=/dev/vdX points at the per-sandbox config disk carrying the full
+# workload exec (argv/env/cwd, base64-encoded values). kubeswift.entrypoint is the
+# legacy single-path fallback (a current controller emits kubeswift.config instead).
 ROOTFS_KIND=block
 ENTRYPOINT=""
+CONFIG_DEV=""
 for arg in $(cat /proc/cmdline); do
 	case "$arg" in
 		kubeswift.rootfs=*)     ROOTFS_KIND="${arg#kubeswift.rootfs=}" ;;
 		kubeswift.entrypoint=*) ENTRYPOINT="${arg#kubeswift.entrypoint=}" ;;
+		kubeswift.config=*)     CONFIG_DEV="${arg#kubeswift.config=}" ;;
 	esac
 done
 
@@ -42,10 +47,17 @@ fail() {
 mkdir -p /lower /over /newroot
 
 # --- mount the OCI rootfs READ-ONLY as the overlay lower ---
+# The virtio-blk probe is asynchronous and can lag PID 1, so an immediate mount of
+# /dev/vda can fail ("Can't lookup blockdev") before the device node appears. Retry
+# the mount (bounded) until the block device enumerates, rather than mounting once.
 case "$ROOTFS_KIND" in
 	block)
-		mount -o ro -t ext4 /dev/vda /lower \
-			|| fail "cannot mount /dev/vda (OCI ext4) read-only" ;;
+		n=0
+		until mount -o ro -t ext4 /dev/vda /lower 2>/dev/null; do
+			n=$((n + 1))
+			[ "$n" -ge 30 ] && fail "cannot mount /dev/vda (OCI ext4) read-only after ${n}s"
+			sleep 1
+		done ;;
 	virtiofs)
 		mount -t virtiofs sandboxroot /lower \
 			|| fail "cannot mount virtio-fs tag 'sandboxroot'" ;;
@@ -60,17 +72,67 @@ mount -t overlay overlay \
 	-o lowerdir=/lower,upperdir=/over/up,workdir=/over/work /newroot \
 	|| fail "overlay mount failed (kernel lacks OVERLAY_FS?)"
 
-# carry the pseudo-filesystems into the new root
+# The config disk (/dev/vdX) and /proc/net/pnp are read HERE — BEFORE the pseudo-
+# filesystems are moved into /newroot below. After the move they are gone from this
+# root, so reading them afterwards silently fails and the exec falls back to
+# /sbin/init (the config disk is never applied). /newroot (the overlay) is already
+# mounted, so writes into it work now.
+
+# --- guest resolver: kernel ip=dhcp autoconfig sets the IP but NOT the userspace
+# /etc/resolv.conf, so a workload can't resolve names without this. /proc/net/pnp
+# carries the DHCP-provided nameserver(s); write the resolver directives into the
+# guest (the tmpfs overlay upper is writable, so the signed image is untouched).
+mkdir -p /newroot/etc
+if [ -r /proc/net/pnp ]; then
+	grep -E '^(nameserver|domain|search)' /proc/net/pnp > /newroot/etc/resolv.conf 2>/dev/null || true
+fi
+
+# --- resolve the workload exec ---
+# Primary: the config disk (kubeswift.config) carries the full argv/env/cwd with
+# base64-encoded values (so a multi-line `sh -c` script survives). Fall back to the
+# legacy single entrypoint, then /sbin/init, then /bin/sh.
+set --                         # positional params accumulate argv
+if [ -n "$CONFIG_DEV" ]; then
+	# Wait (bounded) for the config-disk node — same async virtio-blk enumeration as
+	# the rootfs above.
+	n=0
+	while [ ! -b "$CONFIG_DEV" ] && [ "$n" -lt 30 ]; do
+		n=$((n + 1)); sleep 1
+	done
+fi
+if [ -n "$CONFIG_DEV" ] && [ -r "$CONFIG_DEV" ]; then
+	# Slurp the whole config disk (a small raw blob padded with NULs) in ONE read and
+	# strip the padding, then parse the lines. Reading a block device line-by-line
+	# with `read` hangs (device EOF/size semantics differ from a regular file).
+	blob=$(dd if="$CONFIG_DEV" bs=65536 count=1 2>/dev/null | tr -d '\000')
+	oldifs=$IFS
+	IFS='
+'
+	for line in $blob; do
+		key=${line%%	*}    # up to the first tab
+		val=${line#*	}     # after the first tab
+		case "$key" in
+			KUBESWIFT-EXEC-END) break ;;
+			ARGV) set -- "$@" "$(printf '%s' "$val" | base64 -d 2>/dev/null)" ;;
+			ENV)  export "$(printf '%s' "$val" | base64 -d 2>/dev/null)" 2>/dev/null || true ;;
+		esac
+	done
+	IFS=$oldifs
+fi
+
+# carry the pseudo-filesystems into the new root (AFTER the reads above)
 mkdir -p /newroot/proc /newroot/sys /newroot/dev
 mount --move /proc /newroot/proc 2>/dev/null || mount -t proc none /newroot/proc
 mount --move /sys  /newroot/sys  2>/dev/null || mount -t sysfs none /newroot/sys
 mount --move /dev  /newroot/dev  2>/dev/null || mount -t devtmpfs none /newroot/dev
 
-# --- resolve entrypoint and hand off ---
-if [ -z "$ENTRYPOINT" ]; then
-	if [ -x /newroot/sbin/init ]; then ENTRYPOINT=/sbin/init
-	else ENTRYPOINT=/bin/sh; fi
+if [ "$#" -eq 0 ]; then
+	if [ -n "$ENTRYPOINT" ]; then set -- "$ENTRYPOINT"
+	elif [ -x /newroot/sbin/init ]; then set -- /sbin/init
+	else set -- /bin/sh; fi
 fi
 
-echo "sandbox-bridge: OCI rootfs ($ROOTFS_KIND) mounted RO + tmpfs overlay; exec $ENTRYPOINT"
-exec switch_root /newroot "$ENTRYPOINT"
+echo "sandbox-bridge: OCI rootfs ($ROOTFS_KIND) + tmpfs overlay; exec $1 ($# arg(s))"
+# NOTE: spec.workingDir is NOT honored in v1 — switch_root resets cwd to /, and a
+# shell wrapper to chdir is unreliable across images. The workload starts in /.
+exec switch_root /newroot "$@"

--- a/config/samples/sandbox/README.md
+++ b/config/samples/sandbox/README.md
@@ -28,7 +28,12 @@ Notes:
   - `open` — deny-ingress but unrestricted egress (guest can reach the whole cluster
     + internet). Opt-in for trusted workloads that must talk to in-cluster services.
   - `none` — no network at all (detonation / pure compute).
-- `spec.command` overrides the image entrypoint (single path in v1; a bare image
-  runs its own entrypoint).
+- `spec.command` / `spec.args` / `spec.env` / `spec.workingDir` follow k8s/OCI
+  semantics (command overrides the image ENTRYPOINT, args the CMD, env is merged
+  over the image env), delivered to the guest on a per-sandbox read-only config
+  disk — never the kernel cmdline, so env stays out of `/proc/cmdline` and the
+  host's `ps`/logs. A bare image runs its own entrypoint. (`workingDir` is
+  best-effort in v1: honored when the image has a shell, else the workload starts
+  in `/`.)
 - `spec.timeout` force-terminates a runaway sandbox; `spec.ttl` deletes the
   finished record (and frees the node rootfs cache reference) after it elapses.

--- a/internal/controller/swiftsandbox/controller.go
+++ b/internal/controller/swiftsandbox/controller.go
@@ -86,7 +86,7 @@ func (r *SwiftSandboxReconciler) createLaunch(ctx context.Context, sb *sandboxv1
 	if err != nil {
 		return r.fail(ctx, sb, "ImageResolveFailed", err.Error())
 	}
-	intent := buildIntent(sb, kernelName, ri.RootfsPath, ri.Entrypoint)
+	intent := buildIntent(sb, kernelName, ri.RootfsPath, ri.Exec)
 	intentJSON, err := runtimeintent.Serialize(intent)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/swiftsandbox/controller_test.go
+++ b/internal/controller/swiftsandbox/controller_test.go
@@ -12,24 +12,41 @@ import (
 	"github.com/kubeswift-io/kubeswift/internal/sandbox/materialize"
 )
 
-func TestResolveEntrypoint(t *testing.T) {
-	cfg := materialize.ImageConfig{Entrypoint: []string{"/ep"}, Cmd: []string{"/cmd"}}
-	// spec.command wins (only [0]; v1 limitation).
-	sb := &sandboxv1alpha1.SwiftSandbox{Spec: sandboxv1alpha1.SwiftSandboxSpec{Command: []string{"/mine", "arg"}}}
-	if got := resolveEntrypoint(sb, cfg); got != "/mine" {
-		t.Errorf("command should win: %q", got)
+func TestResolveExec(t *testing.T) {
+	cfg := materialize.ImageConfig{
+		Entrypoint: []string{"/ep"}, Cmd: []string{"--serve"},
+		Env: []string{"PATH=/bin", "A=1"}, WorkingDir: "/img",
 	}
-	// else image entrypoint.
-	if got := resolveEntrypoint(&sandboxv1alpha1.SwiftSandbox{}, cfg); got != "/ep" {
-		t.Errorf("entrypoint: %q", got)
+	// spec.command overrides ENTRYPOINT, spec.args overrides CMD, spec.env overrides
+	// by key + appends, spec.workingDir wins.
+	sb := &sandboxv1alpha1.SwiftSandbox{Spec: sandboxv1alpha1.SwiftSandboxSpec{
+		Command:    []string{"/bin/sh", "-c"},
+		Args:       []string{"echo hi"},
+		Env:        []corev1.EnvVar{{Name: "A", Value: "2"}, {Name: "B", Value: "3"}},
+		WorkingDir: "/work",
+	}}
+	e := resolveExec(sb, cfg)
+	if strings.Join(e.Argv, " ") != "/bin/sh -c echo hi" {
+		t.Errorf("argv = %v", e.Argv)
 	}
-	// else image cmd.
-	if got := resolveEntrypoint(&sandboxv1alpha1.SwiftSandbox{}, materialize.ImageConfig{Cmd: []string{"/cmd"}}); got != "/cmd" {
-		t.Errorf("cmd: %q", got)
+	if e.Cwd != "/work" {
+		t.Errorf("cwd = %q", e.Cwd)
 	}
-	// else empty (bridge default /sbin/init -> /bin/sh).
-	if got := resolveEntrypoint(&sandboxv1alpha1.SwiftSandbox{}, materialize.ImageConfig{}); got != "" {
-		t.Errorf("empty: %q", got)
+	envs := strings.Join(e.Env, ",")
+	if !strings.Contains(envs, "PATH=/bin") || !strings.Contains(envs, "A=2") || !strings.Contains(envs, "B=3") {
+		t.Errorf("env = %v (want PATH kept, A overridden to 2, B appended)", e.Env)
+	}
+	// No spec command: image ENTRYPOINT + CMD; image cwd.
+	if e2 := resolveExec(&sandboxv1alpha1.SwiftSandbox{}, cfg); strings.Join(e2.Argv, " ") != "/ep --serve" || e2.Cwd != "/img" {
+		t.Errorf("image defaults: argv=%v cwd=%q", e2.Argv, e2.Cwd)
+	}
+	// command set, no args: the image CMD is suppressed (k8s rule).
+	if e3 := resolveExec(&sandboxv1alpha1.SwiftSandbox{Spec: sandboxv1alpha1.SwiftSandboxSpec{Command: []string{"/only"}}}, cfg); strings.Join(e3.Argv, " ") != "/only" {
+		t.Errorf("command should suppress image CMD: %v", e3.Argv)
+	}
+	// bare image, no overrides: empty argv+env+cwd -> not worth a config disk.
+	if bare := resolveExec(&sandboxv1alpha1.SwiftSandbox{}, materialize.ImageConfig{}); bare.nonTrivial() {
+		t.Errorf("bare spec should be trivial: %+v", bare)
 	}
 }
 
@@ -38,7 +55,7 @@ func TestBuildIntent(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "sbx", Namespace: "default"},
 		Spec:       sandboxv1alpha1.SwiftSandboxSpec{CPU: 2, Memory: resource.MustParse("1Gi")},
 	}
-	intent := buildIntent(sb, "sandbox", "/var/lib/kubeswift/sandbox-rootfs/sha256-abc.ext4", "/bin/sh")
+	intent := buildIntent(sb, "sandbox", "/var/lib/kubeswift/sandbox-rootfs/sha256-abc.ext4", execSpec{Argv: []string{"/bin/sh"}})
 	if intent.KernelBoot == nil {
 		t.Fatal("kernelBoot nil")
 	}
@@ -46,9 +63,14 @@ func TestBuildIntent(t *testing.T) {
 		!strings.HasSuffix(intent.KernelBoot.InitramfsPath, "/rootfs.cpio.gz") {
 		t.Errorf("kernel paths: %s / %s", intent.KernelBoot.KernelPath, intent.KernelBoot.InitramfsPath)
 	}
+	// The exec spec rides the config disk: cmdline points the bridge at it (no argv
+	// on the cmdline), and intent.SandboxExec carries the argv.
 	if !strings.Contains(intent.KernelBoot.Cmdline, "kubeswift.rootfs=block") ||
-		!strings.Contains(intent.KernelBoot.Cmdline, "kubeswift.entrypoint=/bin/sh") {
+		!strings.Contains(intent.KernelBoot.Cmdline, "kubeswift.config=/dev/vdb") {
 		t.Errorf("cmdline: %s", intent.KernelBoot.Cmdline)
+	}
+	if intent.SandboxExec == nil || strings.Join(intent.SandboxExec.Argv, " ") != "/bin/sh" {
+		t.Errorf("sandboxExec: %+v", intent.SandboxExec)
 	}
 	// A networked sandbox gets kernel IP autoconfig so the guest actually DHCPs.
 	if !strings.Contains(intent.KernelBoot.Cmdline, "ip=dhcp") {
@@ -63,7 +85,7 @@ func TestBuildIntent(t *testing.T) {
 	}
 	sbNone := sb.DeepCopy()
 	sbNone.Spec.Network.Mode = sandboxv1alpha1.SandboxNetworkNone
-	iNone := buildIntent(sbNone, "sandbox", "/x.ext4", "")
+	iNone := buildIntent(sbNone, "sandbox", "/x.ext4", execSpec{Argv: []string{"/bin/sh"}})
 	if iNone.Network {
 		t.Error("mode=none sandbox must be network-isolated")
 	}
@@ -77,10 +99,10 @@ func TestBuildIntent(t *testing.T) {
 	if intent.Hypervisor != "cloud-hypervisor" {
 		t.Errorf("hypervisor: %s", intent.Hypervisor)
 	}
-	// No entrypoint -> the cmdline omits kubeswift.entrypoint (bridge default).
-	i2 := buildIntent(sb, "sandbox", "/x.ext4", "")
-	if strings.Contains(i2.KernelBoot.Cmdline, "kubeswift.entrypoint") {
-		t.Errorf("empty entrypoint should omit the arg: %s", i2.KernelBoot.Cmdline)
+	// Trivial exec (bare image, no overrides) -> no config disk, no SandboxExec.
+	i2 := buildIntent(sb, "sandbox", "/x.ext4", execSpec{})
+	if strings.Contains(i2.KernelBoot.Cmdline, "kubeswift.config") || i2.SandboxExec != nil {
+		t.Errorf("trivial exec should omit the config disk: cmdline=%s exec=%+v", i2.KernelBoot.Cmdline, i2.SandboxExec)
 	}
 }
 

--- a/internal/controller/swiftsandbox/image.go
+++ b/internal/controller/swiftsandbox/image.go
@@ -2,6 +2,9 @@ package swiftsandbox
 
 import (
 	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
 
 	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/sandbox/materialize"
@@ -30,7 +33,23 @@ func SandboxMaterializeImage() string {
 type resolvedImage struct {
 	Digest     string
 	RootfsPath string // <cache>/<digest>.ext4 — deterministic, matches what the init produces
-	Entrypoint string // resolved single entrypoint path (v1: [0] only; see note below)
+	Exec       execSpec
+}
+
+// execSpec is the full workload exec (argv + env + cwd), delivered to the guest
+// via the per-sandbox config disk (NOT the kernel cmdline — that would leak env to
+// /proc/cmdline + the host's ps/logs and cap at ~2-4KB).
+type execSpec struct {
+	Argv []string // full argv (command/args merged over the image entrypoint/cmd)
+	Env  []string // "KEY=VAL", image env overlaid by spec.env
+	Cwd  string   // working dir (v1: best-effort; the bridge defaults to /)
+}
+
+// nonTrivial reports whether the exec spec carries anything worth a config disk.
+// A bare scratch image with no overrides yields an empty spec — the bridge then
+// falls back to /sbin/init -> /bin/sh with no config disk.
+func (e execSpec) nonTrivial() bool {
+	return len(e.Argv) > 0 || len(e.Env) > 0 || e.Cwd != ""
 }
 
 // resolveImage does a cheap registry resolve (manifest + config, no layers) so
@@ -50,25 +69,64 @@ func resolveImage(sb *sandboxv1alpha1.SwiftSandbox) (resolvedImage, error) {
 	return resolvedImage{
 		Digest:     digest,
 		RootfsPath: materialize.CachePathFor(rootfsCacheDir, digest, materialize.ModeBlock),
-		Entrypoint: resolveEntrypoint(sb, cfg),
+		Exec:       resolveExec(sb, cfg),
 	}, nil
 }
 
-// resolveEntrypoint picks the entrypoint path the bridge-initramfs execs.
+// resolveExec computes the full workload exec spec using k8s/OCI semantics, the
+// SwiftSandbox spec merged over the image config:
 //
-// v1 limitation: the bridge execs a single path (switch_root <root> <entrypoint>),
-// so only the first token is passed; args beyond it (e.g. an image CMD after its
-// ENTRYPOINT) are not yet threaded through the cmdline. spec.command[0] wins;
-// else the image ENTRYPOINT[0]/CMD[0]; else empty (the bridge falls back to
-// /sbin/init then /bin/sh). Passing a full command line is a follow-up.
-func resolveEntrypoint(sb *sandboxv1alpha1.SwiftSandbox, cfg materialize.ImageConfig) string {
-	switch {
-	case len(sb.Spec.Command) > 0:
-		return sb.Spec.Command[0]
-	case len(cfg.Entrypoint) > 0:
-		return cfg.Entrypoint[0]
-	case len(cfg.Cmd) > 0:
-		return cfg.Cmd[0]
+//   - argv: spec.command overrides the image ENTRYPOINT; spec.args overrides the
+//     image CMD. Per the k8s rule, setting command suppresses the image CMD unless
+//     args are also given.
+//   - env: the image env, then spec.env overrides by key (v1: literal Value only —
+//     ValueFrom needs a downward-API/secret path not available in a microVM).
+//   - cwd: spec.workingDir, else the image WorkingDir.
+func resolveExec(sb *sandboxv1alpha1.SwiftSandbox, cfg materialize.ImageConfig) execSpec {
+	var argv []string
+	if len(sb.Spec.Command) > 0 {
+		argv = append(argv, sb.Spec.Command...)
+		argv = append(argv, sb.Spec.Args...)
+	} else {
+		argv = append(argv, cfg.Entrypoint...)
+		if len(sb.Spec.Args) > 0 {
+			argv = append(argv, sb.Spec.Args...)
+		} else {
+			argv = append(argv, cfg.Cmd...)
+		}
 	}
-	return ""
+	cwd := sb.Spec.WorkingDir
+	if cwd == "" {
+		cwd = cfg.WorkingDir
+	}
+	return execSpec{Argv: argv, Env: mergeEnv(cfg.Env, sb.Spec.Env), Cwd: cwd}
+}
+
+// mergeEnv overlays spec.env (literal values) onto the image env, preserving the
+// image order and appending new keys. Both are "KEY=VAL" on output.
+func mergeEnv(imageEnv []string, specEnv []corev1.EnvVar) []string {
+	val := map[string]string{}
+	var order []string
+	seen := func(k string) bool { _, ok := val[k]; return ok }
+	for _, e := range imageEnv {
+		k, v, ok := strings.Cut(e, "=")
+		if !ok {
+			continue
+		}
+		if !seen(k) {
+			order = append(order, k)
+		}
+		val[k] = v
+	}
+	for _, e := range specEnv {
+		if !seen(e.Name) {
+			order = append(order, e.Name)
+		}
+		val[e.Name] = e.Value
+	}
+	out := make([]string, 0, len(order))
+	for _, k := range order {
+		out = append(out, k+"="+val[k])
+	}
+	return out
 }

--- a/internal/controller/swiftsandbox/pod.go
+++ b/internal/controller/swiftsandbox/pod.go
@@ -44,9 +44,15 @@ func egressMode(sb *sandboxv1alpha1.SwiftSandbox) sandboxv1alpha1.SandboxNetwork
 	return sandboxv1alpha1.SandboxNetworkRestricted
 }
 
+// sandboxConfigDevice is where the bridge-initramfs reads the workload exec spec.
+// swiftletd emits the config disk right after the rootfs (/dev/vda), and a sandbox
+// carries no seed/data disks, so it enumerates as /dev/vdb.
+const sandboxConfigDevice = "/dev/vdb"
+
 // buildIntent constructs the mode-3 sandbox RuntimeIntent: kernel boot + the RO
-// OCI rootfs disk + the bridge cmdline (rootfs selector + entrypoint).
-func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath, entrypoint string) *runtimeintent.RuntimeIntent {
+// OCI rootfs disk + (when the workload has a defined exec) the config disk + the
+// bridge cmdline.
+func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath string, exec execSpec) *runtimeintent.RuntimeIntent {
 	kernelDir := kernelv1alpha1.KernelLocalPath(sb.Namespace, kernelName)
 	cmdline := "console=ttyS0 kubeswift.rootfs=block"
 	if networked(sb) {
@@ -58,8 +64,12 @@ func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath, entry
 		// so kernel DHCP would only stall the boot.
 		cmdline += " ip=dhcp"
 	}
-	if entrypoint != "" {
-		cmdline += " kubeswift.entrypoint=" + entrypoint
+	var sandboxExec *runtimeintent.SandboxExecSpec
+	if exec.nonTrivial() {
+		// The workload argv/env/cwd ride the config disk (kubeswift.config points the
+		// bridge at it) — never the cmdline, so env stays out of /proc/cmdline + logs.
+		cmdline += " kubeswift.config=" + sandboxConfigDevice
+		sandboxExec = &runtimeintent.SandboxExecSpec{Argv: exec.Argv, Env: exec.Env, Cwd: exec.Cwd}
 	}
 	cpu := int(sb.Spec.CPU)
 	if cpu < 1 {
@@ -76,6 +86,7 @@ func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath, entry
 			Cmdline:       cmdline,
 		},
 		SandboxRootfs: &runtimeintent.SandboxRootfsSpec{Path: rootfsPath},
+		SandboxExec:   sandboxExec,
 		CPU:           cpu,
 		Memory:        memMiB,
 		Lifecycle:     "start",

--- a/internal/runtimeintent/types.go
+++ b/internal/runtimeintent/types.go
@@ -78,6 +78,14 @@ type RuntimeIntent struct {
 	// path only (a virtio-fs sandbox rootfs rides Filesystems). Set by the
 	// SwiftSandbox controller; the SwiftGuest path always leaves it nil.
 	SandboxRootfs *SandboxRootfsSpec `json:"sandboxRootfs,omitempty"`
+
+	// SandboxExec, when set, is the mode-3 workload exec spec (full argv + env +
+	// cwd). swiftletd serializes it to a per-sandbox READ-ONLY config disk (emitted
+	// right after SandboxRootfs, so /dev/vdb) that the bridge-initramfs reads to exec
+	// the workload. It rides a DISK, never the kernel cmdline — so env (secrets)
+	// never reach /proc/cmdline or the host's ps/logs. Set by the SwiftSandbox
+	// controller; nil on the SwiftGuest path.
+	SandboxExec *SandboxExecSpec `json:"sandboxExec,omitempty"`
 }
 
 // VsockIntent is the vsock device for the in-guest identity agent.
@@ -211,6 +219,16 @@ type RootDiskSpec struct {
 // or a block device — the W9 opacity contract).
 type SandboxRootfsSpec struct {
 	Path string `json:"path"`
+}
+
+// SandboxExecSpec is the workload exec for a mode-3 sandbox: the full argv, the
+// merged env ("KEY=VAL"), and the working directory. swiftletd writes it to the
+// per-sandbox config disk in the bridge's line format; the bridge execs argv with
+// env exported (cwd is best-effort in v1).
+type SandboxExecSpec struct {
+	Argv []string `json:"argv,omitempty"`
+	Env  []string `json:"env,omitempty"`
+	Cwd  string   `json:"cwd,omitempty"`
 }
 
 // DataDiskSpec specifies one secondary VM disk for swiftletd. Path is opaque

--- a/rust/swift-ch-client/src/config.rs
+++ b/rust/swift-ch-client/src/config.rs
@@ -79,6 +79,12 @@ pub struct VmConfig {
     /// co-located sandboxes of the same image share the host page cache), so it
     /// is /dev/vda for the bridge-initramfs to mount RO under a tmpfs overlay.
     pub sandbox_rootfs: Option<String>,
+    /// Mode-3 sandbox config disk: the workload exec spec (argv/env/cwd) blob.
+    /// Emitted as a read-only raw disk immediately AFTER sandbox_rootfs (before any
+    /// seed/data disk), so it is /dev/vdb — the bridge-initramfs reads it (pointed
+    /// there by the `kubeswift.config=/dev/vdb` cmdline) to exec the workload. Path
+    /// is opaque (a node-local blob file swiftletd wrote). None = no config disk.
+    pub sandbox_config: Option<String>,
     /// Secondary data disk paths, in order. Empty = no data disks. Each
     /// produces a `--disk path=<p>,image_type=raw,direct=on` argument
     /// after the root (and seed) disk, appearing as the next virtio-blk
@@ -205,30 +211,44 @@ impl VmConfig {
                 }
             }
 
-            // Mode-3 sandbox: the OCI image as the READ-ONLY root disk. Emitted
-            // FIRST so it is /dev/vda (the bridge-initramfs mounts it as the
-            // overlay lower). Buffered (no direct=on) so co-located sandboxes of
-            // the same image share the host page cache for the RO base; the
-            // bridge layers a tmpfs upper so the signed image is never mutated.
+            // Mode-3 sandbox disks. CH's `--disk` takes MULTIPLE values under a single
+            // flag (`--disk path=A path=B ...`); a REPEATED `--disk` flag does NOT
+            // append — CH keeps only one value and silently drops the rest (confirmed
+            // on cluster: a repeated form attached only 1 of 2 disks). Collect every
+            // sandbox disk and emit them as ONE multi-value `--disk`, in enumeration
+            // order (vda, vdb, ...). Mirrors the disk-boot branch below.
+            let mut sandbox_disks: Vec<String> = Vec::new();
+
+            // OCI image as the READ-ONLY root disk (/dev/vda) — the bridge-initramfs
+            // mounts it as the overlay lower. Buffered (no direct=on) so co-located
+            // sandboxes of the same image share the host page cache for the RO base;
+            // the bridge layers a tmpfs upper so the signed image is never mutated.
             if let Some(ref rp) = self.sandbox_rootfs {
-                args.push("--disk".to_string());
-                args.push(format!("path={},readonly=on,image_type=raw", rp));
+                sandbox_disks.push(format!("path={},readonly=on,image_type=raw", rp));
+            }
+
+            // Config disk (/dev/vdb): the workload exec blob (argv/env/cwd). The
+            // bridge-initramfs reads it via the kubeswift.config=/dev/vdb cmdline.
+            if let Some(ref cp) = self.sandbox_config {
+                sandbox_disks.push(format!("path={},readonly=on,image_type=raw", cp));
             }
 
             if !self.seed_path.is_empty() {
                 // No direct=on: emptyDir/tmpfs-backed; tmpfs rejects O_DIRECT.
-                args.push("--disk".to_string());
-                args.push(format!("path={},image_type=raw", self.seed_path));
+                sandbox_disks.push(format!("path={},image_type=raw", self.seed_path));
             }
             // direct=on: PVC-backed data disks, O_DIRECT-capable (see the
             // disk-boot branch comment for why root/data bypass the cache).
-            // One --disk per data disk, in order.
             for p in &self.data_disk_paths {
                 if p.is_empty() {
                     continue;
                 }
+                sandbox_disks.push(format!("path={},image_type=raw,direct=on", p));
+            }
+
+            if !sandbox_disks.is_empty() {
                 args.push("--disk".to_string());
-                args.push(format!("path={},image_type=raw,direct=on", p));
+                args.extend(sandbox_disks);
             }
         } else {
             // --kernel (CLOUDHV.fd UEFI firmware) required for disk boot.
@@ -385,6 +405,7 @@ mod tests {
             initramfs_path: None,
             kernel_cmdline: None,
             sandbox_rootfs: None,
+            sandbox_config: None,
             data_disk_paths: vec![],
             vfio_devices: vec![],
             fs_mounts: vec![],
@@ -757,6 +778,44 @@ mod tests {
         assert!(
             !faas.to_args().iter().any(|a| a == "--disk"),
             "faas kernel boot without sandbox_rootfs must emit no --disk"
+        );
+    }
+
+    #[test]
+    fn test_kernel_boot_sandbox_config_disk_is_vdb() {
+        let mut cfg = make_disk_boot_config();
+        cfg.kernel_path = Some("/k/bzImage".to_string());
+        cfg.initramfs_path = Some("/k/rootfs.cpio.gz".to_string());
+        cfg.firmware_path = None;
+        cfg.seed_path = String::new();
+        cfg.sandbox_rootfs = Some("/cache/x.ext4".to_string());
+        cfg.sandbox_config = Some("/run/exec.config".to_string());
+        let args = cfg.to_args();
+        // CH keeps only one disk from a REPEATED --disk flag, so all sandbox disks
+        // must ride a SINGLE multi-value --disk: exactly one --disk token, then the
+        // rootfs (/dev/vda) and the config (/dev/vdb) as consecutive path= values.
+        assert_eq!(
+            args.iter().filter(|a| *a == "--disk").count(),
+            1,
+            "sandbox disks must be ONE multi-value --disk (repeated --disk drops disks in CH): {:?}",
+            args
+        );
+        let disk_idx = args
+            .iter()
+            .position(|a| a == "--disk")
+            .expect("--disk missing");
+        let disks: Vec<&String> = args[disk_idx + 1..]
+            .iter()
+            .take_while(|a| a.starts_with("path="))
+            .collect();
+        assert_eq!(
+            disks,
+            vec![
+                "path=/cache/x.ext4,readonly=on,image_type=raw",
+                "path=/run/exec.config,readonly=on,image_type=raw",
+            ],
+            "config disk must be the 2nd disk (/dev/vdb), after the rootfs: {:?}",
+            args
         );
     }
 

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -31,6 +31,13 @@ pub struct RuntimeIntent {
     /// tmpfs upper. Block path only. None for a normal SwiftGuest kernel boot.
     #[serde(default)]
     pub sandbox_rootfs: Option<SandboxRootfs>,
+    /// Set alongside `sandbox_rootfs` for a mode-3 sandbox: the workload exec spec
+    /// (argv + env + cwd). swiftletd serializes it to a per-sandbox read-only config
+    /// disk (emitted right after the rootfs, so /dev/vdb) that the bridge-initramfs
+    /// reads to exec the workload. Rides a DISK, never the cmdline — env stays off
+    /// /proc/cmdline + the host's ps/logs. None for a SwiftGuest.
+    #[serde(default)]
+    pub sandbox_exec: Option<SandboxExec>,
     /// Hypervisor to use: "cloud-hypervisor" (default) or "qemu".
     /// Empty or absent means Cloud Hypervisor.
     #[serde(default)]
@@ -446,6 +453,74 @@ pub struct SandboxRootfs {
     pub path: String,
 }
 
+/// The mode-3 workload exec: full argv, merged env ("KEY=VAL"), and working dir.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxExec {
+    #[serde(default)]
+    pub argv: Vec<String>,
+    #[serde(default)]
+    pub env: Vec<String>,
+    #[serde(default)]
+    pub cwd: String,
+}
+
+const B64_ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+// Standard base64 (with '=' padding). Values are base64-encoded on the config disk
+// so argv/env may contain spaces, tabs, or newlines (e.g. a multi-line `sh -c`
+// script) without breaking the line-based blob; the bridge decodes with `base64 -d`.
+fn base64_encode(data: &[u8]) -> String {
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = *chunk.get(1).unwrap_or(&0);
+        let b2 = *chunk.get(2).unwrap_or(&0);
+        let n = ((b0 as u32) << 16) | ((b1 as u32) << 8) | (b2 as u32);
+        out.push(B64_ALPHABET[((n >> 18) & 63) as usize] as char);
+        out.push(B64_ALPHABET[((n >> 12) & 63) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            B64_ALPHABET[((n >> 6) & 63) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            B64_ALPHABET[(n & 63) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+impl SandboxExec {
+    /// Serializes to the bridge's config-disk blob: the `KUBESWIFT-EXEC-V1` magic,
+    /// TAB-separated `CWD`/`ARGV`/`ENV` lines (values base64-encoded), and the
+    /// `KUBESWIFT-EXEC-END` sentinel — padded to a 512-byte sector (virtio-blk).
+    pub fn to_config_blob(&self) -> Vec<u8> {
+        let mut s = String::from("KUBESWIFT-EXEC-V1\n");
+        if !self.cwd.is_empty() {
+            s.push_str(&format!("CWD\t{}\n", base64_encode(self.cwd.as_bytes())));
+        }
+        for a in &self.argv {
+            s.push_str(&format!("ARGV\t{}\n", base64_encode(a.as_bytes())));
+        }
+        for e in &self.env {
+            s.push_str(&format!("ENV\t{}\n", base64_encode(e.as_bytes())));
+        }
+        s.push_str("KUBESWIFT-EXEC-END\n");
+        let mut b = s.into_bytes();
+        // Pad to at least 1 MiB (a multiple of 512, the virtio-blk logical block size).
+        // The exec blob is small (a few hundred bytes); 1 MiB just gives the config disk
+        // a conventional, non-degenerate size (avoids a 1-sector disk) and is negligible
+        // — sparse on the host, and the guest bridge reads only the first 64 KiB.
+        const MIN_CONFIG_DISK: usize = 1024 * 1024;
+        let rounded = b.len().div_ceil(512) * 512;
+        b.resize(rounded.max(MIN_CONFIG_DISK), 0u8);
+        b
+    }
+}
+
 impl RuntimeIntent {
     /// Returns the disk path from intent (no hardcoded path).
     pub fn disk_path(&self) -> &str {
@@ -476,6 +551,11 @@ impl RuntimeIntent {
     /// an OCI rootfs), else None.
     pub fn sandbox_rootfs_path(&self) -> Option<&str> {
         self.sandbox_rootfs.as_ref().map(|s| s.path.as_str())
+    }
+
+    /// Returns the mode-3 sandbox workload exec spec when set.
+    pub fn sandbox_exec(&self) -> Option<&SandboxExec> {
+        self.sandbox_exec.as_ref()
     }
 
     /// Returns the ordered list of secondary data-disk paths.
@@ -626,6 +706,44 @@ pub fn load_intent(path: &str) -> Result<RuntimeIntent, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_base64_encode_known_vectors() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"test123"), "dGVzdDEyMw==");
+    }
+
+    #[test]
+    fn test_sandbox_exec_config_blob() {
+        let e = SandboxExec {
+            // A multi-line arg (a `sh -c` script) must survive — that's why values
+            // are base64-encoded rather than written raw into the line format.
+            argv: vec!["/bin/sh".into(), "-c".into(), "echo hi\nline2".into()],
+            env: vec!["PATH=/usr/bin:/bin".into()],
+            cwd: "/work".into(),
+        };
+        let blob = e.to_config_blob();
+        assert_eq!(blob.len() % 512, 0, "blob must be sector-padded");
+        assert!(
+            blob.len() >= 1024 * 1024,
+            "blob must be padded to >= 1 MiB so it enumerates as a virtio-blk device \
+             (a 1-sector disk breaks guest virtio-blk enumeration); got {}",
+            blob.len()
+        );
+        let text = String::from_utf8_lossy(&blob);
+        assert!(text.starts_with("KUBESWIFT-EXEC-V1\n"));
+        assert!(text.contains("KUBESWIFT-EXEC-END\n"));
+        assert!(text.contains(&format!("CWD\t{}\n", base64_encode(b"/work"))));
+        assert!(text.contains(&format!("ARGV\t{}\n", base64_encode(b"echo hi\nline2"))));
+        assert!(text.contains(&format!("ENV\t{}\n", base64_encode(b"PATH=/usr/bin:/bin"))));
+        // No raw newline leaked from the multi-line arg into the line structure:
+        // exactly the magic + CWD + 3 ARGV + 1 ENV + END = 7 content lines.
+        let content_lines = text.trim_end_matches('\u{0}').lines().count();
+        assert_eq!(content_lines, 7, "unexpected line count: {text:?}");
+    }
 
     #[test]
     fn test_intent_os_type_windows() {

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -387,6 +387,22 @@ where
             .to_string(),
     });
 
+    // Mode-3 sandbox: serialize the workload exec (argv/env/cwd) to a per-sandbox
+    // read-only config disk (emitted right after the rootfs, so /dev/vdb). It rides a
+    // disk, never the cmdline, so env stays off /proc/cmdline + the host's ps/logs. On
+    // a write failure we leave it unset — the bridge finds no config device and falls
+    // back to /sbin/init -> /bin/sh (a loud degrade, not a crash).
+    let sandbox_config_path = intent.sandbox_exec().and_then(|e| {
+        let path = runtime_dir.root().join("exec.config");
+        match std::fs::write(&path, e.to_config_blob()) {
+            Ok(()) => Some(path.to_string_lossy().to_string()),
+            Err(err) => {
+                log::error!("sandbox exec config write failed: {}", err);
+                None
+            }
+        }
+    });
+
     let config = if intent.has_kernel() {
         let kb = intent.kernel_boot.as_ref().unwrap();
         VmConfig {
@@ -408,6 +424,7 @@ where
             initramfs_path: Some(kb.initramfs_path.clone()),
             kernel_cmdline: Some(kb.cmdline.clone()),
             sandbox_rootfs: intent.sandbox_rootfs_path().map(|s| s.to_string()),
+            sandbox_config: sandbox_config_path.clone(),
             data_disk_paths: data_disk_paths.clone(),
             vfio_devices,
             fs_mounts,
@@ -435,6 +452,7 @@ where
             initramfs_path: None,
             kernel_cmdline: None,
             sandbox_rootfs: None,
+            sandbox_config: None,
             data_disk_paths: data_disk_paths.clone(),
             vfio_devices,
             fs_mounts,


### PR DESCRIPTION
## What

Delivers a SwiftSandbox workload's `command`/`args`/`env` on a per-sandbox
**read-only config disk** (`/dev/vdb`, right after the rootfs) instead of the
kernel cmdline — so env/secrets never reach `/proc/cmdline` or the host
`ps`/logs, and there is no cmdline size cap.

Blob format: `KUBESWIFT-EXEC-V1` magic + TAB-separated `ARGV`/`ENV` lines with
base64-encoded values (a multi-line `sh -c` script survives), padded to ≥1 MiB.

- **controller** (`image.go`): `resolveExec` merges the k8s spec over the OCI
  image config (`command||Entrypoint`, `args||Cmd`, `env`, `WorkingDir`);
  `buildIntent` sets `kubeswift.config=/dev/vdb` only when the exec is non-trivial.
- **swiftletd / swift-ch-client**: serialize the exec to the blob and emit it as
  the 2nd RO raw `--disk`.
- **bridge-init**: reads `/dev/vdb` (dd-slurp), decodes argv/env, execs via
  `switch_root`. The config disk and `/proc/net/pnp` are read **before** the
  `/proc,/dev` pseudo-fs are moved into `/newroot`. Also seeds
  `/etc/resolv.conf` from `/proc/net/pnp` (kernel `ip=dhcp` sets the IP, not the
  resolver).

## Two prerequisite fixes surfaced by cluster validation

- **`fix(sandbox kernel)`** — the committed `sandbox-linux.config` set
  `VIRTIO_PCI=y` / `VIRTIO_NET=y` but omitted their dependencies (`CONFIG_PCI`,
  `CONFIG_PCI_MSI`, `CONFIG_NETDEVICES`, `CONFIG_NET_CORE`, `CONFIG_ETHERNET`).
  As a `USE_CUSTOM_CONFIG` whole-config, `olddefconfig` then **dropped**
  `VIRTIO_PCI`/`VIRTIO_NET`, so a freshly rebuilt sandbox kernel had **no virtio
  transport at all** (no `/dev/vd*`, no `eth0` → `"/dev/vda: Can't lookup
  blockdev"` → panic). Added the missing deps (all present in the faas base this
  derives from). The shipped artifact was fine — built from a good config during
  the P1 spike — but any fresh rebuild was broken.
- **`fix(sandbox)`** — CH keeps only **one** value from a *repeated* `--disk`
  flag, so all sandbox disks now ride a **single multi-value** `--disk`
  (mirrors the disk-boot branch).

## Validation (cluster)

- config-disk exec delivers argv + env for `network: none` and networked
  sandboxes (workload prints the injected env value).
- both virtio-blk disks (`vda` rootfs + `vdb` config), virtio-net, and `eth0`
  DHCP IP all enumerate; networked sandbox reports `status.network.primaryIP`.

## Not in v1

- `workingDir` is not honored (`switch_root` resets cwd to `/`).
- a run-to-completion workload panics the guest as PID 1 — exit-code capture is
  a separate batch-lifecycle follow-up.
