### PR TITLE
feat(sandbox): capture the workload's exit code (batch lifecycle)

### DIFF
--- a/build/kernels/sandbox/rootfs-overlay/init
+++ b/build/kernels/sandbox/rootfs-overlay/init
@@ -72,11 +72,8 @@ mount -t overlay overlay \
 	-o lowerdir=/lower,upperdir=/over/up,workdir=/over/work /newroot \
 	|| fail "overlay mount failed (kernel lacks OVERLAY_FS?)"
 
-# The config disk (/dev/vdX) and /proc/net/pnp are read HERE — BEFORE the pseudo-
-# filesystems are moved into /newroot below. After the move they are gone from this
-# root, so reading them afterwards silently fails and the exec falls back to
-# /sbin/init (the config disk is never applied). /newroot (the overlay) is already
-# mounted, so writes into it work now.
+# The config disk (/dev/vdX) and /proc/net/pnp are read HERE, after the overlay is
+# mounted (so writes into /newroot land) and while the bridge still owns /dev + /proc.
 
 # --- guest resolver: kernel ip=dhcp autoconfig sets the IP but NOT the userspace
 # /etc/resolv.conf, so a workload can't resolve names without this. /proc/net/pnp
@@ -120,11 +117,14 @@ if [ -n "$CONFIG_DEV" ] && [ -r "$CONFIG_DEV" ]; then
 	IFS=$oldifs
 fi
 
-# carry the pseudo-filesystems into the new root (AFTER the reads above)
+# Mount the pseudo-filesystems INSIDE the new root for the workload. We do NOT
+# `mount --move` them out of the bridge's root — the bridge stays PID 1 (see below)
+# and needs to keep its own /dev/console + /proc to report the exit code and power
+# the VM off after the workload exits.
 mkdir -p /newroot/proc /newroot/sys /newroot/dev
-mount --move /proc /newroot/proc 2>/dev/null || mount -t proc none /newroot/proc
-mount --move /sys  /newroot/sys  2>/dev/null || mount -t sysfs none /newroot/sys
-mount --move /dev  /newroot/dev  2>/dev/null || mount -t devtmpfs none /newroot/dev
+mount -t proc     none /newroot/proc 2>/dev/null || true
+mount -t sysfs    none /newroot/sys  2>/dev/null || true
+mount -t devtmpfs none /newroot/dev  2>/dev/null || mount --bind /dev /newroot/dev
 
 if [ "$#" -eq 0 ]; then
 	if [ -n "$ENTRYPOINT" ]; then set -- "$ENTRYPOINT"
@@ -132,7 +132,26 @@ if [ "$#" -eq 0 ]; then
 	else set -- /bin/sh; fi
 fi
 
-echo "sandbox-bridge: OCI rootfs ($ROOTFS_KIND) + tmpfs overlay; exec $1 ($# arg(s))"
-# NOTE: spec.workingDir is NOT honored in v1 — switch_root resets cwd to /, and a
-# shell wrapper to chdir is unreliable across images. The workload starts in /.
-exec switch_root /newroot "$@"
+# Supervise the workload instead of `exec switch_root`-ing it as PID 1. If the
+# workload were PID 1, its exit would panic the kernel ("Attempted to kill init")
+# and CH would keep running — the sandbox would sit "Running" forever with no exit
+# status. Instead the bridge stays PID 1 and runs the workload chrooted into the OCI
+# overlay as a FOREGROUND child (so it keeps the console tty — interactive + batch
+# both work; chroot execs the binary directly, so distroless images work with no
+# shell). When it exits we capture its code, emit it on the console for swiftletd to
+# read, and power the VM off so CH exits and the launcher pod reaches a terminal state.
+# NOTE: spec.workingDir is NOT honored in v1 — chroot starts the workload at / and a
+# chdir wrapper needs a guest shell (deferred). The workload starts in /.
+echo "sandbox-bridge: OCI rootfs ($ROOTFS_KIND) + tmpfs overlay; run $1 ($# arg(s))"
+chroot /newroot "$@"
+code=$?
+printf 'KUBESWIFT-EXIT-CODE=%s\n' "$code" >/dev/console 2>/dev/null
+# Let CH flush the exit line to the host console file before we power off (swiftletd
+# reads it after CH exits to recover the workload's exit code).
+sleep 1
+# Power the guest off (reboot syscall) so CH exits and the pod terminates. Fall back
+# through progressively harder stops; never return (we are PID 1).
+poweroff -f 2>/dev/null
+halt -f 2>/dev/null
+echo o >/proc/sysrq-trigger 2>/dev/null
+while :; do sleep 1; done

--- a/config/samples/sandbox/README.md
+++ b/config/samples/sandbox/README.md
@@ -32,8 +32,12 @@ Notes:
   semantics (command overrides the image ENTRYPOINT, args the CMD, env is merged
   over the image env), delivered to the guest on a per-sandbox read-only config
   disk — never the kernel cmdline, so env stays out of `/proc/cmdline` and the
-  host's `ps`/logs. A bare image runs its own entrypoint. (`workingDir` is
-  best-effort in v1: honored when the image has a shell, else the workload starts
-  in `/`.)
+  host's `ps`/logs. A bare image runs its own entrypoint. (`workingDir` is not
+  honored in v1 — the workload starts in `/`.)
+- **Exit status**: the workload runs as a supervised child, so its real exit code
+  is surfaced as `status.exitCode` — a non-zero exit terminates the sandbox `Failed`,
+  zero terminates it `Completed`. The guest console (workload stdout/stderr) is
+  written to a host file, not an interactive socket; live exec/attach is a vsock
+  follow-up.
 - `spec.timeout` force-terminates a runaway sandbox; `spec.ttl` deletes the
   finished record (and frees the node rootfs cache reference) after it elapses.

--- a/config/samples/sandbox/swiftkernel-sandbox.yaml
+++ b/config/samples/sandbox/swiftkernel-sandbox.yaml
@@ -14,6 +14,6 @@ metadata:
   namespace: default
 spec:
   ociRef:
-    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.1
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.3
   kernelCmdline: "console=ttyS0"
   profile: sandbox

--- a/internal/controller/swiftsandbox/controller.go
+++ b/internal/controller/swiftsandbox/controller.go
@@ -131,10 +131,8 @@ func (r *SwiftSandboxReconciler) reconcilePodState(ctx context.Context, sb *sand
 	}
 
 	switch pod.Status.Phase {
-	case corev1.PodSucceeded:
-		return r.finishTerminal(ctx, sb, pod, sandboxv1alpha1.SwiftSandboxCompleted, "Completed", "workload exited")
-	case corev1.PodFailed:
-		return r.finishTerminal(ctx, sb, pod, sandboxv1alpha1.SwiftSandboxFailed, "GuestFailed", podFailureMessage(pod))
+	case corev1.PodSucceeded, corev1.PodFailed:
+		return r.finishTerminal(ctx, sb, pod)
 	}
 
 	// Materialize init failure (before the launcher starts) is an honest, specific
@@ -166,13 +164,28 @@ func (r *SwiftSandboxReconciler) reconcilePodState(ctx context.Context, sb *sand
 	return r.setPhase(ctx, sb, sandboxv1alpha1.SwiftSandboxMaterializing, "materializing rootfs")
 }
 
-// finishTerminal maps a terminal pod to Completed/Failed with the launcher exit code.
-func (r *SwiftSandboxReconciler) finishTerminal(ctx context.Context, sb *sandboxv1alpha1.SwiftSandbox, pod *corev1.Pod, phase sandboxv1alpha1.SwiftSandboxPhase, reason, msg string) (ctrl.Result, error) {
+// finishTerminal maps a terminated launcher pod to Completed/Failed. It prefers the
+// WORKLOAD's exit code — swiftletd writes it to kubeswift.io/sandbox-exit-code from the
+// guest console's KUBESWIFT-EXIT-CODE marker — because CH/the launcher exit 0 on a
+// clean power-off regardless of what the workload returned. When the marker is absent
+// (e.g. the guest died before the bridge emitted it), it falls back to the pod phase +
+// the launcher container's exit code.
+func (r *SwiftSandboxReconciler) finishTerminal(ctx context.Context, sb *sandboxv1alpha1.SwiftSandbox, pod *corev1.Pod) (ctrl.Result, error) {
+	applyMaterializeResult(sb, pod)
+	if code, ok := sandboxWorkloadExitCode(pod); ok {
+		sb.Status.ExitCode = &code
+		if code == 0 {
+			return r.terminal(ctx, sb, sandboxv1alpha1.SwiftSandboxCompleted, "Completed", "workload exited 0")
+		}
+		return r.terminal(ctx, sb, sandboxv1alpha1.SwiftSandboxFailed, "WorkloadFailed", fmt.Sprintf("workload exited %d", code))
+	}
 	if code, ok := launcherExitCode(pod); ok {
 		sb.Status.ExitCode = &code
 	}
-	applyMaterializeResult(sb, pod)
-	return r.terminal(ctx, sb, phase, reason, msg)
+	if pod.Status.Phase == corev1.PodFailed {
+		return r.terminal(ctx, sb, sandboxv1alpha1.SwiftSandboxFailed, "GuestFailed", podFailureMessage(pod))
+	}
+	return r.terminal(ctx, sb, sandboxv1alpha1.SwiftSandboxCompleted, "Completed", "workload exited")
 }
 
 func (r *SwiftSandboxReconciler) fail(ctx context.Context, sb *sandboxv1alpha1.SwiftSandbox, reason, msg string) (ctrl.Result, error) {
@@ -258,6 +271,24 @@ func launcherExitCode(pod *corev1.Pod) (int32, bool) {
 		}
 	}
 	return 0, false
+}
+
+// annSandboxExitCode carries the workload's real exit code, written by swiftletd from
+// the guest console's KUBESWIFT-EXIT-CODE marker (see rust/swiftletd/src/report.rs).
+const annSandboxExitCode = "kubeswift.io/sandbox-exit-code"
+
+// sandboxWorkloadExitCode reads the workload exit code swiftletd recorded on the
+// launcher pod. Absent when the guest died before the bridge-init could emit it.
+func sandboxWorkloadExitCode(pod *corev1.Pod) (int32, bool) {
+	v := pod.Annotations[annSandboxExitCode]
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(v, 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return int32(n), true
 }
 
 func podFailureMessage(pod *corev1.Pod) string {

--- a/rust/swift-ch-client/src/config.rs
+++ b/rust/swift-ch-client/src/config.rs
@@ -300,10 +300,20 @@ impl VmConfig {
         }
 
         if let Some(ref path) = self.serial_socket_path {
-            // Serial socket: bidirectional; connect with socat for interactive console.
-            // Kernel cmdline comes from disk GRUB (patched during SwiftImage import for console=ttyS0).
             args.push("--serial".to_string());
-            args.push(format!("socket={}", path));
+            if self.sandbox_rootfs.is_some() {
+                // Sandbox: write the guest console to a FILE, not an interactive socket.
+                // The workload is a batch job — swiftletd reads this file after CH exits
+                // to recover the workload's exit code (the bridge-init emits a trailing
+                // `KUBESWIFT-EXIT-CODE=<n>`), and it doubles as the sandbox log. CH also
+                // drops serial-socket output emitted before a client connects, which
+                // would lose the exit line. (Interactive exec/attach is a vsock follow-up.)
+                args.push(format!("file={}.log", path));
+            } else {
+                // Serial socket: bidirectional; connect with socat for interactive console.
+                // Kernel cmdline comes from disk GRUB (patched during SwiftImage import for console=ttyS0).
+                args.push(format!("socket={}", path));
+            }
             // Disable virtio-console; serial is the interactive console.
             args.push("--console".to_string());
             args.push("off".to_string());
@@ -769,6 +779,19 @@ mod tests {
             "sandbox rootfs must be the first disk (/dev/vda); args: {:?}",
             args
         );
+        // Sandbox serial goes to a FILE (batch console + exit-code recovery), not an
+        // interactive socket — swiftletd reads the file after CH exits.
+        assert!(
+            joined.contains("--serial file=/tmp/serial.sock.log"),
+            "sandbox serial must be a file: {}",
+            joined
+        );
+        assert!(
+            !joined.contains("--serial socket="),
+            "sandbox must not use an interactive serial socket: {}",
+            joined
+        );
+
         // A normal faas kernel boot (no sandbox_rootfs, no seed/data) emits NO --disk.
         let mut faas = make_disk_boot_config();
         faas.kernel_path = Some("/k/bzImage".to_string());

--- a/rust/swiftletd/src/main.rs
+++ b/rust/swiftletd/src/main.rs
@@ -391,7 +391,47 @@ fn main() {
                 }
             }
             match result {
-                Ok((exit_status, _pid, _serial_socket_path)) => {
+                Ok((exit_status, _pid, serial_socket_path)) => {
+                    // Sandbox: recover the workload's exit code from the console file
+                    // (the bridge-init emits `KUBESWIFT-EXIT-CODE=<n>` before powering
+                    // off — CH has exited now, so the file is complete) and write it to
+                    // a pod annotation for the SwiftSandbox controller. Best-effort: a
+                    // missing marker leaves status.exitCode unset, not wrong.
+                    if intent.sandbox_rootfs_path().is_some() {
+                        if let (Some(ref ns), Some(ref n)) = (&namespace, &name) {
+                            let console = format!("{}.log", serial_socket_path);
+                            match std::fs::read_to_string(&console) {
+                                Ok(text) => match report::parse_sandbox_exit_code(&text) {
+                                    Some(code) => rt.block_on(async {
+                                        match kube_client::create_client().await {
+                                            Ok(client) => {
+                                                if let Err(e) = report::report_sandbox_exit(
+                                                    &client, ns, n, code,
+                                                )
+                                                .await
+                                                {
+                                                    log::error!("report_sandbox_exit_failed: {}", e);
+                                                } else {
+                                                    log::info!("sandbox_exit_reported code={}", code);
+                                                }
+                                            }
+                                            Err(e) => log::warn!(
+                                                "kube client unavailable ({}); skipping sandbox exit report",
+                                                e
+                                            ),
+                                        }
+                                    }),
+                                    None => log::warn!(
+                                        "sandbox_exit_code_marker_not_found in {}",
+                                        console
+                                    ),
+                                },
+                                Err(e) => {
+                                    log::warn!("sandbox console read failed {}: {}", console, e)
+                                }
+                            }
+                        }
+                    }
                     if exit_status.success() {
                         // W22 (PR #46 follow-up cluster re-walkthrough):
                         // when CH exits cleanly because vm.send-migration

--- a/rust/swiftletd/src/report.rs
+++ b/rust/swiftletd/src/report.rs
@@ -87,6 +87,41 @@ pub async fn report_guest_runtime(
     Ok(())
 }
 
+/// Writes the sandbox workload's exit code to a launcher pod annotation, for the
+/// SwiftSandbox controller to map to `status.exitCode` + a terminal phase. The
+/// bridge-init emits a trailing `KUBESWIFT-EXIT-CODE=<n>` on the console after the
+/// workload exits; swiftletd extracts it from the sandbox console file once CH exits.
+pub async fn report_sandbox_exit(
+    client: &Client,
+    namespace: &str,
+    name: &str,
+    exit_code: i32,
+) -> Result<(), kube::Error> {
+    let api: Api<k8s_openapi::api::core::v1::Pod> = Api::namespaced(client.clone(), namespace);
+    let patch = json!({
+        "metadata": {
+            "annotations": {
+                "kubeswift.io/sandbox-exit-code": exit_code.to_string(),
+            }
+        }
+    });
+    let pp = PatchParams::default();
+    api.patch(name, &pp, &Patch::Merge(&patch)).await?;
+    Ok(())
+}
+
+/// Parses the LAST `KUBESWIFT-EXIT-CODE=<n>` line from the sandbox console text. The
+/// bridge-init emits it once, after the workload exits, so it is the workload's exit
+/// code. Taking the LAST match is robust against a workload that printed a look-alike
+/// line before exiting (all of its output precedes the bridge's line).
+pub fn parse_sandbox_exit_code(console: &str) -> Option<i32> {
+    console
+        .lines()
+        .rev()
+        .find_map(|l| l.trim().strip_prefix("KUBESWIFT-EXIT-CODE="))
+        .and_then(|v| v.trim().parse::<i32>().ok())
+}
+
 /// Whether swiftletd should patch a SwiftGuest CR's GuestRunning condition
 /// (`report_guest_running`). Default true — the SwiftGuest launch path is
 /// unchanged. A SwiftSandbox launcher sets `KUBESWIFT_REPORT_GUEST_CR=false`:
@@ -106,7 +141,29 @@ pub fn report_guest_cr_enabled(v: Option<&str>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::report_guest_cr_enabled;
+    use super::{parse_sandbox_exit_code, report_guest_cr_enabled};
+
+    #[test]
+    fn sandbox_exit_code_parsing() {
+        assert_eq!(
+            parse_sandbox_exit_code("hello\nKUBESWIFT-EXIT-CODE=0\n"),
+            Some(0)
+        );
+        assert_eq!(
+            parse_sandbox_exit_code("out\r\nKUBESWIFT-EXIT-CODE=7\r\n"),
+            Some(7)
+        );
+        // Last match wins (workload printed a look-alike before the bridge's real line).
+        assert_eq!(
+            parse_sandbox_exit_code("KUBESWIFT-EXIT-CODE=99\nwork\nKUBESWIFT-EXIT-CODE=3\n"),
+            Some(3)
+        );
+        assert_eq!(parse_sandbox_exit_code("no marker here\n"), None);
+        assert_eq!(
+            parse_sandbox_exit_code("KUBESWIFT-EXIT-CODE=notanint\n"),
+            None
+        );
+    }
 
     #[test]
     fn cr_report_defaults_on() {


### PR DESCRIPTION
## What

A SwiftSandbox workload used to run as **PID 1** (via `exec switch_root`), so when it
exited the guest kernel panicked (`Attempted to kill init`) and CH kept running — the
sandbox sat `Running` forever with no exit status. Useless for CI/batch jobs.

Now the bridge-init **stays PID 1 and supervises** the workload: runs it `chroot`ed
into the OCI overlay as a foreground child (keeps the console tty; `chroot` execs the
binary directly, so distroless images work with no shell), captures its exit code,
emits `KUBESWIFT-EXIT-CODE=<n>` on the console, and powers the VM off (ACPI) so CH
exits and the pod terminates.

The code is read back and surfaced:
- **swift-ch-client**: a sandbox's serial goes to a **file** (`--serial file=`), not an
  interactive socket — CH drops socket output before a client connects (which would
  lose the exit line), and the file doubles as the sandbox log.
- **swiftletd**: after CH exits, parse the last `KUBESWIFT-EXIT-CODE=<n>` from the
  console file → `kubeswift.io/sandbox-exit-code` pod annotation.
- **controller**: `finishTerminal` prefers that code over the launcher/CH exit code
  (0 on a clean power-off regardless of the workload) — non-zero → `Failed`, zero →
  `Completed`.

## Validation (cluster)

| workload | before | after |
|---|---|---|
| `exit 0` | stuck `Running` | **`Completed`, exitCode 0** |
| `exit 7` | stuck `Running` | **`Failed`, exitCode 7** |

Kernel bumped to `kernels/sandbox:6.6.3` (the supervisor bridge; sample updated).

## Follow-ups

- The sandbox serial is now output-only, so interactive exec/attach and honoring
  `workingDir` are **vsock** work.
- A run-to-completion sandbox whose guest dies before the marker is emitted falls back
  to the pod phase + launcher exit code.
