### PR TITLE
feat(sandbox): resolve cluster + external DNS names in the guest

### DIFF
--- a/build/kernels/sandbox/rootfs-overlay/init
+++ b/build/kernels/sandbox/rootfs-overlay/init
@@ -30,11 +30,13 @@ mount -t devpts   none /dev/pts 2>/dev/null || true
 ROOTFS_KIND=block
 ENTRYPOINT=""
 CONFIG_DEV=""
+DNS_SEARCH=""
 for arg in $(cat /proc/cmdline); do
 	case "$arg" in
 		kubeswift.rootfs=*)     ROOTFS_KIND="${arg#kubeswift.rootfs=}" ;;
 		kubeswift.entrypoint=*) ENTRYPOINT="${arg#kubeswift.entrypoint=}" ;;
 		kubeswift.config=*)     CONFIG_DEV="${arg#kubeswift.config=}" ;;
+		kubeswift.dns-search=*) DNS_SEARCH="${arg#kubeswift.dns-search=}" ;;
 	esac
 done
 
@@ -81,7 +83,17 @@ mount -t overlay overlay \
 # guest (the tmpfs overlay upper is writable, so the signed image is untouched).
 mkdir -p /newroot/etc
 if [ -r /proc/net/pnp ]; then
-	grep -E '^(nameserver|domain|search)' /proc/net/pnp > /newroot/etc/resolv.conf 2>/dev/null || true
+	grep -E '^(nameserver|domain)' /proc/net/pnp > /newroot/etc/resolv.conf 2>/dev/null || true
+fi
+# ip=dhcp captures the nameserver but not the DHCP search list, so cluster-internal
+# SHORT names (kubernetes.default) would NXDOMAIN. Add the k8s search domains the
+# controller passed on the cmdline (kubeswift.dns-search=, comma-separated).
+if [ -n "$DNS_SEARCH" ]; then
+	echo "search $(echo "$DNS_SEARCH" | tr ',' ' ')" >> /newroot/etc/resolv.conf
+	# Match the Kubernetes pod resolver: ndots:5 so a partially-qualified name like
+	# `svc.namespace` (1 dot) is tried against the search domains, not resolved absolute-
+	# only. Without it musl/glibc only search-expand names with fewer dots than ndots (1).
+	echo "options ndots:5" >> /newroot/etc/resolv.conf
 fi
 
 # --- resolve the workload exec ---

--- a/config/samples/sandbox/README.md
+++ b/config/samples/sandbox/README.md
@@ -28,6 +28,11 @@ Notes:
   - `open` — deny-ingress but unrestricted egress (guest can reach the whole cluster
     + internet). Opt-in for trusted workloads that must talk to in-cluster services.
   - `none` — no network at all (detonation / pure compute).
+- **DNS**: a networked guest resolves cluster service names (`kubernetes`, `svc.ns`,
+  FQDNs) *and* external names — the controller injects the namespace search domains +
+  `ndots:5` (matching a Kubernetes pod's resolver; `ip=dhcp` alone captures the
+  nameserver but not the search list). `restricted` still blocks *connecting* to
+  cluster IPs — names resolve, the egress rules decide reachability.
 - `spec.command` / `spec.args` / `spec.env` / `spec.workingDir` follow k8s/OCI
   semantics (command overrides the image ENTRYPOINT, args the CMD, env is merged
   over the image env), delivered to the guest on a per-sandbox read-only config

--- a/config/samples/sandbox/swiftkernel-sandbox.yaml
+++ b/config/samples/sandbox/swiftkernel-sandbox.yaml
@@ -14,6 +14,6 @@ metadata:
   namespace: default
 spec:
   ociRef:
-    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.3
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.4
   kernelCmdline: "console=ttyS0"
   profile: sandbox

--- a/internal/controller/swiftsandbox/controller_test.go
+++ b/internal/controller/swiftsandbox/controller_test.go
@@ -76,6 +76,11 @@ func TestBuildIntent(t *testing.T) {
 	if !strings.Contains(intent.KernelBoot.Cmdline, "ip=dhcp") {
 		t.Errorf("networked sandbox cmdline should include ip=dhcp: %s", intent.KernelBoot.Cmdline)
 	}
+	// ...and the k8s search domains for its namespace (ip=dhcp doesn't capture the
+	// DHCP search list, so cluster-internal short names would otherwise NXDOMAIN).
+	if !strings.Contains(intent.KernelBoot.Cmdline, "kubeswift.dns-search=default.svc.cluster.local,svc.cluster.local,cluster.local") {
+		t.Errorf("networked sandbox cmdline should include the namespace search domains: %s", intent.KernelBoot.Cmdline)
+	}
 	if intent.SandboxRootfs == nil || intent.SandboxRootfs.Path != "/var/lib/kubeswift/sandbox-rootfs/sha256-abc.ext4" {
 		t.Errorf("sandboxRootfs: %+v", intent.SandboxRootfs)
 	}
@@ -89,8 +94,9 @@ func TestBuildIntent(t *testing.T) {
 	if iNone.Network {
 		t.Error("mode=none sandbox must be network-isolated")
 	}
-	// network:none has no dnsmasq -> ip=dhcp would only stall the boot; it must be absent.
-	if strings.Contains(iNone.KernelBoot.Cmdline, "ip=dhcp") {
+	// network:none has no dnsmasq -> ip=dhcp (and the DNS search domains) would only
+	// stall the boot / be meaningless; both must be absent.
+	if strings.Contains(iNone.KernelBoot.Cmdline, "ip=dhcp") || strings.Contains(iNone.KernelBoot.Cmdline, "kubeswift.dns-search=") {
 		t.Errorf("network:none must omit ip=dhcp: %s", iNone.KernelBoot.Cmdline)
 	}
 	if intent.CPU != 2 || intent.Memory != 1024 {

--- a/internal/controller/swiftsandbox/pod.go
+++ b/internal/controller/swiftsandbox/pod.go
@@ -63,6 +63,12 @@ func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath string
 		// kernel DHCP eth0 at boot. Omitted for network:none — there is no dnsmasq,
 		// so kernel DHCP would only stall the boot.
 		cmdline += " ip=dhcp"
+		// The kernel ip=dhcp path captures the DHCP nameserver but NOT the search list
+		// (DHCP option 119), so cluster-internal SHORT names (e.g. kubernetes.default)
+		// would NXDOMAIN. Pass the standard k8s search domains for the sandbox's
+		// namespace; the bridge-init writes them into the guest's /etc/resolv.conf.
+		// (Cluster domain assumed cluster.local — the near-universal default.)
+		cmdline += " kubeswift.dns-search=" + sb.Namespace + ".svc.cluster.local,svc.cluster.local,cluster.local"
 	}
 	var sandboxExec *runtimeintent.SandboxExecSpec
 	if exec.nonTrivial() {


### PR DESCRIPTION
A networked sandbox already got the kube-dns nameserver via `ip=dhcp` (external + cluster FQDNs resolved), but the kernel ip=dhcp path doesn't capture the DHCP **search list** (option 119), so cluster-internal SHORT names (`kubernetes.default`, `kubernetes`) NXDOMAIN'd.

Give the guest the same resolver config a k8s pod gets:
- **controller**: inject `kubeswift.dns-search=<ns>.svc.cluster.local,svc.cluster.local,cluster.local` on the cmdline for networked sandboxes.
- **bridge-init**: write `search <domains>` + `options ndots:5` into the guest resolv.conf (ndots:5 so a 1-dot name like `svc.ns` is search-expanded, not resolved absolute-only).

Cluster domain assumed `cluster.local` (near-universal default).

**Cluster-validated**: `getent hosts kubernetes` → 10.96.0.1, `getent hosts kubernetes.default` → 10.96.0.1, external names still resolve. (`restricted` still blocks *connecting* to cluster IPs — names resolve, egress decides reachability.) Kernel bumped to `6.6.4`.

Note: this was smaller than the original 'DNS-by-name fails' framing — external DNS already worked; this closes the cluster-short-name gap.