### PR TITLE
feat(sandbox): swiftctl sandbox exec over an in-guest vsock agent

### DIFF
--- a/build/kernels/sandbox/.gitignore
+++ b/build/kernels/sandbox/.gitignore
@@ -1,2 +1,3 @@
 /buildroot/
 /output/
+/rootfs-overlay/usr/local/bin/kubeswift-guest-agent

--- a/build/kernels/sandbox/Makefile
+++ b/build/kernels/sandbox/Makefile
@@ -26,7 +26,19 @@ setup:
 		echo "buildroot already present at $(BUILDROOT_DIR)"; \
 	fi
 
-build: setup
+# The in-guest vsock control agent (swiftctl sandbox exec/attach) is baked into the
+# initramfs via the buildroot rootfs-overlay. Built static from source here (a build
+# artifact — gitignored, never committed). The bridge-init runs it in the background.
+REPO_ROOT := $(CURDIR)/../../..
+AGENT_BIN  := $(CURDIR)/rootfs-overlay/usr/local/bin/kubeswift-guest-agent
+
+agent:
+	@mkdir -p $(dir $(AGENT_BIN))
+	cd $(REPO_ROOT) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+		go build -ldflags="-s -w" -o $(AGENT_BIN) ./cmd/kubeswift-guest-agent
+	@echo "  guest-agent: $(AGENT_BIN) ($$(du -h $(AGENT_BIN) | cut -f1))"
+
+build: setup agent
 	$(MAKE) -C $(BUILDROOT_DIR) \
 		BR2_EXTERNAL=$(EXTERNAL) \
 		O=$(OUTPUT_DIR) \

--- a/build/kernels/sandbox/rootfs-overlay/init
+++ b/build/kernels/sandbox/rootfs-overlay/init
@@ -154,6 +154,15 @@ fi
 # read, and power the VM off so CH exits and the launcher pod reaches a terminal state.
 # NOTE: spec.workingDir is NOT honored in v1 — chroot starts the workload at / and a
 # chdir wrapper needs a guest shell (deferred). The workload starts in /.
+# Start the vsock control agent (swiftctl sandbox exec/attach) in the background if it
+# was baked into the initramfs. It runs in the initramfs context (has AF_VSOCK) and
+# chroots into /newroot per exec request. Best-effort — a missing agent just means no
+# exec. Logs go to /dev/kmsg (kernel log) so they don't interleave the workload console
+# that swiftletd captures as the sandbox log.
+if [ -x /usr/local/bin/kubeswift-guest-agent ]; then
+	/usr/local/bin/kubeswift-guest-agent --exec-root=/newroot >/dev/kmsg 2>&1 &
+fi
+
 echo "sandbox-bridge: OCI rootfs ($ROOTFS_KIND) + tmpfs overlay; run $1 ($# arg(s))"
 chroot /newroot "$@"
 code=$?

--- a/cmd/kubeswift-guest-agent/handler.go
+++ b/cmd/kubeswift-guest-agent/handler.go
@@ -28,7 +28,9 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -36,6 +38,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -68,6 +71,9 @@ type Request struct {
 	MAC        string   `json:"mac,omitempty"`
 	Hostname   string   `json:"hostname,omitempty"`
 	RenewLease bool     `json:"renewLease,omitempty"`
+	// exec op:
+	Argv []string `json:"argv,omitempty"`
+	Env  []string `json:"env,omitempty"`
 }
 
 // Response is the guest->host reply.
@@ -83,6 +89,10 @@ type Response struct {
 	MAC          string   `json:"mac,omitempty"`
 	IP           string   `json:"ip,omitempty"`
 	Error        string   `json:"error,omitempty"`
+	// exec op:
+	Stdout   string `json:"stdout,omitempty"`
+	Stderr   string `json:"stderr,omitempty"`
+	ExitCode *int   `json:"exitCode,omitempty"`
 }
 
 var (
@@ -105,6 +115,10 @@ type system interface {
 type handler struct {
 	sys     system
 	version string
+	// execRoot is the chroot dir for the exec op (empty = run in the agent's own root).
+	// SwiftSandbox passes /newroot (the OCI overlay) so exec runs in the workload's
+	// filesystem; identity guests leave it empty.
+	execRoot string
 }
 
 // handle parses one request, dispatches it, and returns the JSON response bytes.
@@ -122,6 +136,8 @@ func (h *handler) handle(raw []byte) []byte {
 		resp = h.status()
 	case "regenerate-identity":
 		resp = h.regenerate(req)
+	case "exec":
+		resp = h.exec(req)
 	default:
 		resp = Response{OK: false, Error: "unknown op: " + req.Op}
 	}
@@ -410,3 +426,72 @@ func (realSystem) writeFile(p string, data []byte, perm os.FileMode) error {
 func (realSystem) remove(p string) error           { return os.Remove(p) }
 func (realSystem) glob(p string) ([]string, error) { return filepath.Glob(p) }
 func (realSystem) hostname() (string, error)       { return os.Hostname() }
+
+// execPathDirs is the PATH searched (inside the chroot) for a bare command name.
+var execPathDirs = []string{"/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"}
+
+// execOutputCap bounds each of stdout/stderr for the non-streaming exec op. Large or
+// long-running output is a streaming follow-up.
+const execOutputCap = 1 << 20 // 1 MiB
+
+// exec runs argv chrooted into the sandbox root (h.execRoot) and returns its stdout,
+// stderr and exit code in one response. The command binary is resolved against a PATH
+// INSIDE the chroot — Go's LookPath would search the agent's own (initramfs) root.
+func (h *handler) exec(req Request) Response {
+	if len(req.Argv) == 0 {
+		return Response{OK: false, Error: "exec: empty argv"}
+	}
+	root := h.execRoot
+	prog := req.Argv[0]
+	if !strings.Contains(prog, "/") {
+		for _, dir := range execPathDirs {
+			if fi, err := os.Stat(root + dir + "/" + prog); err == nil && !fi.IsDir() {
+				prog = dir + "/" + prog
+				break
+			}
+		}
+	}
+	cmd := exec.Command(prog, req.Argv[1:]...)
+	cmd.Path = prog // skip Go's parent-context LookPath (wrong filesystem)
+	if root != "" && root != "/" {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Chroot: root}
+		cmd.Dir = "/"
+	}
+	cmd.Env = execEnv(req.Env)
+	stdout := &capBuffer{max: execOutputCap}
+	stderr := &capBuffer{max: execOutputCap}
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	code := 0
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			code = ee.ExitCode()
+		} else {
+			return Response{OK: false, Error: "exec: " + err.Error()}
+		}
+	}
+	return Response{OK: true, Stdout: stdout.buf.String(), Stderr: stderr.buf.String(), ExitCode: &code}
+}
+
+func execEnv(reqEnv []string) []string {
+	env := []string{"PATH=" + strings.Join(execPathDirs, ":"), "HOME=/", "TERM=xterm"}
+	return append(env, reqEnv...)
+}
+
+// capBuffer accumulates up to max bytes then silently drops the rest, so a runaway
+// command can't OOM the agent while still running to completion.
+type capBuffer struct {
+	buf bytes.Buffer
+	max int
+}
+
+func (c *capBuffer) Write(p []byte) (int, error) {
+	if rem := c.max - c.buf.Len(); rem > 0 {
+		if len(p) > rem {
+			c.buf.Write(p[:rem])
+		} else {
+			c.buf.Write(p)
+		}
+	}
+	return len(p), nil
+}

--- a/cmd/kubeswift-guest-agent/handler_test.go
+++ b/cmd/kubeswift-guest-agent/handler_test.go
@@ -98,9 +98,24 @@ func TestPingReportsIdentity(t *testing.T) {
 
 func TestUnknownOp(t *testing.T) {
 	h, _ := newHandler()
-	r := decode(t, h.handle([]byte(`{"op":"exec","cmd":"rm -rf /"}`)))
+	r := decode(t, h.handle([]byte(`{"op":"bogus-op"}`)))
 	if r.OK || !strings.Contains(r.Error, "unknown op") {
 		t.Fatalf("unknown op should fail loudly: %+v", r)
+	}
+}
+
+func TestExec(t *testing.T) {
+	h, _ := newHandler() // execRoot="" -> no chroot; runs host commands in the test
+	if r := decode(t, h.handle([]byte(`{"op":"exec"}`))); r.OK {
+		t.Errorf("empty argv should fail: %+v", r)
+	}
+	r := decode(t, h.handle([]byte(`{"op":"exec","argv":["echo","hi"]}`)))
+	if !r.OK || r.Stdout != "hi\n" || r.ExitCode == nil || *r.ExitCode != 0 {
+		t.Errorf("echo: %+v", r)
+	}
+	r = decode(t, h.handle([]byte(`{"op":"exec","argv":["sh","-c","exit 3"]}`)))
+	if !r.OK || r.ExitCode == nil || *r.ExitCode != 3 {
+		t.Errorf("exit 3 should propagate: %+v", r)
 	}
 }
 

--- a/cmd/kubeswift-guest-agent/main.go
+++ b/cmd/kubeswift-guest-agent/main.go
@@ -20,6 +20,7 @@ const (
 
 func main() {
 	port := flag.Int("port", DefaultPort, "AF_VSOCK port to listen on")
+	execRoot := flag.String("exec-root", "", "chroot dir for the exec op (empty = agent's own root; SwiftSandbox passes /newroot)")
 	flag.Parse()
 	if env := os.Getenv("KUBESWIFT_GUEST_AGENT_PORT"); env != "" {
 		if p, err := strconv.Atoi(env); err == nil {
@@ -27,7 +28,7 @@ func main() {
 		}
 	}
 
-	h := &handler{sys: realSystem{}, version: version}
+	h := &handler{sys: realSystem{}, version: version, execRoot: *execRoot}
 
 	lfd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
 	if err != nil {

--- a/cmd/swiftctl/sandbox.go
+++ b/cmd/swiftctl/sandbox.go
@@ -1,19 +1,28 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/kubeswift-io/kubeswift/internal/cli"
 
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
+
+// agentVsockPort is the AF_VSOCK port the in-guest agent listens on (matches
+// cmd/kubeswift-guest-agent DefaultPort and swift-vsock-client).
+const agentVsockPort = 1024
 
 var sandboxCmd = &cobra.Command{
 	Use:          "sandbox",
@@ -36,9 +45,130 @@ host file by swiftletd — by exec-ing into the launcher pod. Use -f to follow.`
 	RunE:         runSandboxLogs,
 }
 
+var sandboxExecCmd = &cobra.Command{
+	Use:   "exec [sandbox-name] -- command [args...]",
+	Short: "Run a command inside a running sandbox (over vsock)",
+	Long: `Runs a command inside a running SwiftSandbox via the in-guest agent over vsock. The
+command runs in the sandbox's OCI root filesystem. Non-interactive (no stdin/TTY);
+stdout and stderr are returned and the command's exit code is propagated.`,
+	Example: `  swiftctl sandbox exec my-job -- ls -la /
+  swiftctl -n ci sandbox exec my-job -- cat /etc/os-release`,
+	Args:         cobra.MinimumNArgs(2),
+	SilenceUsage: true,
+	RunE:         runSandboxExec,
+}
+
 func init() {
 	sandboxLogsCmd.Flags().BoolVarP(&sandboxLogsFollow, "follow", "f", false, "Follow the log output")
 	sandboxCmd.AddCommand(sandboxLogsCmd)
+	sandboxCmd.AddCommand(sandboxExecCmd)
+}
+
+func runSandboxExec(cmd *cobra.Command, args []string) error {
+	dash := cmd.ArgsLenAtDash()
+	if dash != 1 || dash >= len(args) {
+		return fmt.Errorf("usage: swiftctl sandbox exec <name> -- command [args...]")
+	}
+	name := args[0]
+	command := args[dash:]
+	ns := getNamespace()
+
+	config, err := kubeConfig.ToRESTConfig()
+	if err != nil {
+		return fmt.Errorf("kubeconfig: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("create clientset: %w", err)
+	}
+
+	vsockSock := "/var/lib/kubeswift/run/" + cli.GuestID(ns, name) + "/vsock.sock"
+	req, _ := json.Marshal(map[string]interface{}{"v": 1, "op": "exec", "argv": command})
+
+	resp, err := agentRequest(config, clientset, ns, name, vsockSock, req)
+	if err != nil {
+		return err
+	}
+	if resp.Stdout != "" {
+		fmt.Fprint(os.Stdout, resp.Stdout)
+	}
+	if resp.Stderr != "" {
+		fmt.Fprint(os.Stderr, resp.Stderr)
+	}
+	if !resp.OK {
+		return fmt.Errorf("agent exec failed: %s", resp.Error)
+	}
+	if resp.ExitCode != nil && *resp.ExitCode != 0 {
+		os.Exit(*resp.ExitCode)
+	}
+	return nil
+}
+
+// agentResponse is the subset of the guest agent's reply swiftctl needs.
+type agentResponse struct {
+	OK       bool   `json:"ok"`
+	Error    string `json:"error"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	ExitCode *int   `json:"exitCode"`
+}
+
+// agentRequest execs socat in the launcher pod (a raw pipe to CH's vsock unix socket),
+// performs CH's hybrid-vsock CONNECT handshake, sends one JSON request to the in-guest
+// agent on agentVsockPort, and returns the parsed JSON response. The request must be
+// sent AFTER the "OK" line, so swiftctl drives the protocol over the exec stdin/stdout.
+func agentRequest(config *rest.Config, clientset *kubernetes.Clientset, ns, pod, vsockSock string, req []byte) (*agentResponse, error) {
+	waitAndSocat := fmt.Sprintf("for i in $(seq 1 10); do test -S %q && break; sleep 1; done; exec socat -t10 - UNIX-CONNECT:%s", vsockSock, vsockSock)
+	execReq := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").Namespace(ns).Name(pod).SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: cli.LauncherContainer,
+			Command:   []string{"sh", "-c", waitAndSocat},
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    true,
+		}, clientgoscheme.ParameterCodec)
+	executor, err := remotecommand.NewSPDYExecutor(config, "POST", execReq.URL())
+	if err != nil {
+		return nil, fmt.Errorf("exec setup: %w", err)
+	}
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		done <- executor.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+			Stdin: inR, Stdout: outW, Stderr: os.Stderr,
+		})
+		outW.Close()
+	}()
+
+	br := bufio.NewReader(outR)
+	if _, err := io.WriteString(inW, fmt.Sprintf("CONNECT %d\n", agentVsockPort)); err != nil {
+		return nil, fmt.Errorf("vsock connect: %w", err)
+	}
+	okLine, err := br.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("vsock handshake (is the sandbox running with an agent?): %w", err)
+	}
+	if !strings.HasPrefix(okLine, "OK ") {
+		return nil, fmt.Errorf("vsock handshake failed: %q", strings.TrimSpace(okLine))
+	}
+	if _, err := inW.Write(append(req, '\n')); err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	respLine, err := br.ReadString('\n')
+	if err != nil && respLine == "" {
+		return nil, fmt.Errorf("read agent response: %w", err)
+	}
+	inW.Close()
+	<-done
+
+	var resp agentResponse
+	if err := json.Unmarshal([]byte(strings.TrimSpace(respLine)), &resp); err != nil {
+		return nil, fmt.Errorf("parse agent response %q: %w", strings.TrimSpace(respLine), err)
+	}
+	return &resp, nil
 }
 
 func runSandboxLogs(cmd *cobra.Command, args []string) error {

--- a/config/samples/sandbox/README.md
+++ b/config/samples/sandbox/README.md
@@ -41,8 +41,11 @@ Notes:
   honored in v1 — the workload starts in `/`.)
 - **Exit status**: the workload runs as a supervised child, so its real exit code
   is surfaced as `status.exitCode` — a non-zero exit terminates the sandbox `Failed`,
-  zero terminates it `Completed`. The guest console (workload stdout/stderr) is
-  written to a host file, not an interactive socket; live exec/attach is a vsock
-  follow-up.
+  zero terminates it `Completed`.
+- **Interacting** with a running sandbox:
+  - `swiftctl sandbox logs <name>` (`-f` to follow) streams the workload console.
+  - `swiftctl sandbox exec <name> -- cmd args...` runs a command inside the sandbox's
+    OCI rootfs over a host↔guest vsock channel (an in-guest agent; non-interactive;
+    stdout/stderr returned, exit code propagated). Interactive `attach` is a follow-up.
 - `spec.timeout` force-terminates a runaway sandbox; `spec.ttl` deletes the
   finished record (and frees the node rootfs cache reference) after it elapses.

--- a/config/samples/sandbox/swiftkernel-sandbox.yaml
+++ b/config/samples/sandbox/swiftkernel-sandbox.yaml
@@ -14,6 +14,6 @@ metadata:
   namespace: default
 spec:
   ociRef:
-    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.4
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.5
   kernelCmdline: "console=ttyS0"
   profile: sandbox

--- a/internal/controller/swiftsandbox/pod.go
+++ b/internal/controller/swiftsandbox/pod.go
@@ -102,6 +102,11 @@ func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath string
 		// the "restricted" posture (built by the controller).
 		Network:    networked(sb),
 		Hypervisor: "cloud-hypervisor",
+		// vsock control channel for the in-guest agent (swiftctl sandbox exec/attach).
+		// The agent is baked into the sandbox initramfs and the bridge runs it; the host
+		// reaches it through CH's vsock unix socket. Always wired for sandboxes — vsock
+		// is host<->guest only (not network-reachable), so it costs nothing to have.
+		Vsock: &runtimeintent.VsockIntent{CID: runtimeintent.DeriveVsockCID(sb.Namespace, sb.Name)},
 	}
 }
 


### PR DESCRIPTION
Run a command inside a running SwiftSandbox — `swiftctl sandbox exec <name> -- cmd args...` — over a host↔guest **vsock** control channel. The command runs in the sandbox's OCI rootfs; stdout/stderr returned, exit code propagated (non-interactive v1).

- **controller**: wire a vsock device on every sandbox (`intent.Vsock`, `DeriveVsockCID`) → CH `--vsock cid,socket`.
- **agent**: the static `kubeswift-guest-agent` is baked into the sandbox initramfs (built from source by the sandbox Makefile, gitignored); the bridge runs it in the background before the workload. New `exec` op: chroot `/newroot`, resolve the command against a PATH inside the chroot, run it, return stdout/stderr (1 MiB cap) + exit code.
- **swiftctl**: `sandbox exec` execs socat in the launcher (raw pipe to CH's vsock socket), drives CH's hybrid-vsock `CONNECT` handshake, sends the request after `OK`, prints output, propagates the exit code.

**Cluster-validated**: `exec -- id` → uid=0; `-- cat /etc/alpine-release` → 3.20.10 (the OCI rootfs); `-- uname -a` → 6.6.44; `-- sh -c 'exit 7'` → swiftctl exits 7. Kernel bumped `6.6.5` (agent baked in, initramfs ~1.7 MB).

Second half of #6 (first half = `sandbox logs` #356). Follow-ups: interactive attach (stdin/TTY), streaming exec, env/cwd on exec.