### PR TITLE
feat(sandbox): env + workingDir on sandbox exec (+ gate exec to sandboxes)

### DIFF
--- a/cmd/kubeswift-guest-agent/handler.go
+++ b/cmd/kubeswift-guest-agent/handler.go
@@ -19,12 +19,14 @@
 // Installing/starting it on the clone is impossible (nothing new starts on a
 // resume).
 //
-// SECURITY: the command surface is exactly two ops (ping, regenerate-identity)
-// with a fixed schema — NO exec, no path argument, no file transfer. Inputs
-// (MAC, hostname) are validated then passed as argv (never shell-interpolated).
-// The transport is vsock — host<->guest only, not network-reachable. An
-// attacker who somehow reached the port could only ask the guest to regenerate
-// its own identity (self-inflicted, non-escalating).
+// SECURITY: for identity guests the command surface is exactly two ops (ping,
+// regenerate-identity) with a fixed schema — inputs (MAC, hostname) are validated
+// then passed as argv (never shell-interpolated). The `exec` op (run an arbitrary
+// command in the guest) is ENABLED ONLY when the agent is started with --exec-root —
+// i.e. SwiftSandbox, which runs untrusted code the host already fully controls;
+// identity guests run WITHOUT --exec-root, so exec is unavailable there. The transport
+// is vsock — host<->guest only, not network-reachable — so only the (trusted) host can
+// reach any op.
 package main
 
 import (
@@ -74,6 +76,7 @@ type Request struct {
 	// exec op:
 	Argv []string `json:"argv,omitempty"`
 	Env  []string `json:"env,omitempty"`
+	Cwd  string   `json:"cwd,omitempty"`
 }
 
 // Response is the guest->host reply.
@@ -438,6 +441,12 @@ const execOutputCap = 1 << 20 // 1 MiB
 // stderr and exit code in one response. The command binary is resolved against a PATH
 // INSIDE the chroot — Go's LookPath would search the agent's own (initramfs) root.
 func (h *handler) exec(req Request) Response {
+	// exec is enabled ONLY when the agent was started with --exec-root (SwiftSandbox).
+	// Identity guests run without it, so they keep the minimal two-op surface — no
+	// arbitrary command execution, even over the host-only vsock.
+	if h.execRoot == "" {
+		return Response{OK: false, Error: "exec is disabled (no --exec-root; SwiftSandbox only)"}
+	}
 	if len(req.Argv) == 0 {
 		return Response{OK: false, Error: "exec: empty argv"}
 	}
@@ -453,10 +462,14 @@ func (h *handler) exec(req Request) Response {
 	}
 	cmd := exec.Command(prog, req.Argv[1:]...)
 	cmd.Path = prog // skip Go's parent-context LookPath (wrong filesystem)
+	dir := req.Cwd
 	if root != "" && root != "/" {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Chroot: root}
-		cmd.Dir = "/"
+		if dir == "" {
+			dir = "/" // cwd must exist in the new root; the chroot root always does
+		}
 	}
+	cmd.Dir = dir // "" inherits the agent's cwd (no-chroot case); otherwise relative to the chroot
 	cmd.Env = execEnv(req.Env)
 	stdout := &capBuffer{max: execOutputCap}
 	stderr := &capBuffer{max: execOutputCap}

--- a/cmd/kubeswift-guest-agent/handler_test.go
+++ b/cmd/kubeswift-guest-agent/handler_test.go
@@ -105,7 +105,12 @@ func TestUnknownOp(t *testing.T) {
 }
 
 func TestExec(t *testing.T) {
-	h, _ := newHandler() // execRoot="" -> no chroot; runs host commands in the test
+	h, _ := newHandler()
+	// exec is gated on --exec-root: disabled without it (identity-guest posture).
+	if r := decode(t, h.handle([]byte(`{"op":"exec","argv":["echo","hi"]}`))); r.OK || !strings.Contains(r.Error, "disabled") {
+		t.Errorf("exec must be disabled without --exec-root: %+v", r)
+	}
+	h.execRoot = "/" // enable exec; "/" means no chroot, so it runs host commands in the test
 	if r := decode(t, h.handle([]byte(`{"op":"exec"}`))); r.OK {
 		t.Errorf("empty argv should fail: %+v", r)
 	}
@@ -116,6 +121,11 @@ func TestExec(t *testing.T) {
 	r = decode(t, h.handle([]byte(`{"op":"exec","argv":["sh","-c","exit 3"]}`)))
 	if !r.OK || r.ExitCode == nil || *r.ExitCode != 3 {
 		t.Errorf("exit 3 should propagate: %+v", r)
+	}
+	// env + cwd are applied.
+	r = decode(t, h.handle([]byte(`{"op":"exec","argv":["sh","-c","echo $FOO; pwd"],"env":["FOO=bar"],"cwd":"/tmp"}`)))
+	if !r.OK || r.Stdout != "bar\n/tmp\n" {
+		t.Errorf("env+cwd: %+v", r)
 	}
 }
 

--- a/cmd/swiftctl/sandbox.go
+++ b/cmd/swiftctl/sandbox.go
@@ -58,8 +58,15 @@ stdout and stderr are returned and the command's exit code is propagated.`,
 	RunE:         runSandboxExec,
 }
 
+var (
+	sandboxExecEnv     []string
+	sandboxExecWorkdir string
+)
+
 func init() {
 	sandboxLogsCmd.Flags().BoolVarP(&sandboxLogsFollow, "follow", "f", false, "Follow the log output")
+	sandboxExecCmd.Flags().StringArrayVarP(&sandboxExecEnv, "env", "e", nil, "Environment variable KEY=VALUE (repeatable)")
+	sandboxExecCmd.Flags().StringVarP(&sandboxExecWorkdir, "workdir", "w", "", "Working directory inside the sandbox")
 	sandboxCmd.AddCommand(sandboxLogsCmd)
 	sandboxCmd.AddCommand(sandboxExecCmd)
 }
@@ -83,7 +90,14 @@ func runSandboxExec(cmd *cobra.Command, args []string) error {
 	}
 
 	vsockSock := "/var/lib/kubeswift/run/" + cli.GuestID(ns, name) + "/vsock.sock"
-	req, _ := json.Marshal(map[string]interface{}{"v": 1, "op": "exec", "argv": command})
+	reqObj := map[string]interface{}{"v": 1, "op": "exec", "argv": command}
+	if len(sandboxExecEnv) > 0 {
+		reqObj["env"] = sandboxExecEnv
+	}
+	if sandboxExecWorkdir != "" {
+		reqObj["cwd"] = sandboxExecWorkdir
+	}
+	req, _ := json.Marshal(reqObj)
 
 	resp, err := agentRequest(config, clientset, ns, name, vsockSock, req)
 	if err != nil {

--- a/config/samples/sandbox/README.md
+++ b/config/samples/sandbox/README.md
@@ -46,6 +46,8 @@ Notes:
   - `swiftctl sandbox logs <name>` (`-f` to follow) streams the workload console.
   - `swiftctl sandbox exec <name> -- cmd args...` runs a command inside the sandbox's
     OCI rootfs over a host↔guest vsock channel (an in-guest agent; non-interactive;
-    stdout/stderr returned, exit code propagated). Interactive `attach` is a follow-up.
+    stdout/stderr returned, exit code propagated). `-e KEY=VALUE` (repeatable) and
+    `-w DIR` set environment variables and the working directory. Interactive `attach`
+    is a follow-up.
 - `spec.timeout` force-terminates a runaway sandbox; `spec.ttl` deletes the
   finished record (and frees the node rootfs cache reference) after it elapses.

--- a/config/samples/sandbox/swiftkernel-sandbox.yaml
+++ b/config/samples/sandbox/swiftkernel-sandbox.yaml
@@ -14,6 +14,6 @@ metadata:
   namespace: default
 spec:
   ociRef:
-    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.5
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.6
   kernelCmdline: "console=ttyS0"
   profile: sandbox


### PR DESCRIPTION
`swiftctl sandbox exec` gains `-e/--env KEY=VALUE` (repeatable) + `-w/--workdir DIR`; the agent exec op applies them.

**Security**: exec is now enabled ONLY when the agent runs with `--exec-root` (SwiftSandbox). Identity guests (cloneFromSnapshot regen) run without it → they keep the minimal two-op surface, no arbitrary exec even over host-only vsock. Corrects the stale "NO exec" comment.

Cluster-validated: `exec -e X=yes -w /tmp -- sh -c 'echo $X; pwd; cat /etc/alpine-release'` → yes / /tmp / 3.20.10; exec disabled without --exec-root (unit test). Kernel `6.6.6`. First of the three exec/attach follow-ups (env/cwd → streaming → attach).