### PR TITLE
feat(sandbox): stream sandbox exec output live (framed vsock protocol)

### DIFF
--- a/cmd/kubeswift-guest-agent/handler.go
+++ b/cmd/kubeswift-guest-agent/handler.go
@@ -74,9 +74,10 @@ type Request struct {
 	Hostname   string   `json:"hostname,omitempty"`
 	RenewLease bool     `json:"renewLease,omitempty"`
 	// exec op:
-	Argv []string `json:"argv,omitempty"`
-	Env  []string `json:"env,omitempty"`
-	Cwd  string   `json:"cwd,omitempty"`
+	Argv   []string `json:"argv,omitempty"`
+	Env    []string `json:"env,omitempty"`
+	Cwd    string   `json:"cwd,omitempty"`
+	Stream bool     `json:"stream,omitempty"` // stream stdout/stderr/exit as frames (see internal/guestagent); dispatched in serve(), not handle()
 }
 
 // Response is the guest->host reply.
@@ -437,18 +438,20 @@ var execPathDirs = []string{"/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/
 // long-running output is a streaming follow-up.
 const execOutputCap = 1 << 20 // 1 MiB
 
-// exec runs argv chrooted into the sandbox root (h.execRoot) and returns its stdout,
-// stderr and exit code in one response. The command binary is resolved against a PATH
-// INSIDE the chroot — Go's LookPath would search the agent's own (initramfs) root.
-func (h *handler) exec(req Request) Response {
+// buildExecCmd resolves argv + chroot + cwd + env into an *exec.Cmd, shared by the
+// single-shot exec (buffered response) and execStream (framed) paths. The command
+// binary is resolved against a PATH INSIDE the chroot — Go's LookPath would search
+// the agent's own (initramfs) root. It returns an error (never runs) when exec is
+// disabled or argv is empty.
+func (h *handler) buildExecCmd(req Request) (*exec.Cmd, error) {
 	// exec is enabled ONLY when the agent was started with --exec-root (SwiftSandbox).
 	// Identity guests run without it, so they keep the minimal two-op surface — no
 	// arbitrary command execution, even over the host-only vsock.
 	if h.execRoot == "" {
-		return Response{OK: false, Error: "exec is disabled (no --exec-root; SwiftSandbox only)"}
+		return nil, fmt.Errorf("exec is disabled (no --exec-root; SwiftSandbox only)")
 	}
 	if len(req.Argv) == 0 {
-		return Response{OK: false, Error: "exec: empty argv"}
+		return nil, fmt.Errorf("exec: empty argv")
 	}
 	root := h.execRoot
 	prog := req.Argv[0]
@@ -471,6 +474,16 @@ func (h *handler) exec(req Request) Response {
 	}
 	cmd.Dir = dir // "" inherits the agent's cwd (no-chroot case); otherwise relative to the chroot
 	cmd.Env = execEnv(req.Env)
+	return cmd, nil
+}
+
+// exec runs argv chrooted into the sandbox root (h.execRoot) and returns its stdout,
+// stderr and exit code in one response.
+func (h *handler) exec(req Request) Response {
+	cmd, err := h.buildExecCmd(req)
+	if err != nil {
+		return Response{OK: false, Error: err.Error()}
+	}
 	stdout := &capBuffer{max: execOutputCap}
 	stderr := &capBuffer{max: execOutputCap}
 	cmd.Stdout, cmd.Stderr = stdout, stderr

--- a/cmd/kubeswift-guest-agent/handler_test.go
+++ b/cmd/kubeswift-guest-agent/handler_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/kubeswift-io/kubeswift/internal/guestagent"
 )
 
 // fakeSys records run() invocations and serves canned file/glob/hostname data so
@@ -127,6 +130,61 @@ func TestExec(t *testing.T) {
 	if !r.OK || r.Stdout != "bar\n/tmp\n" {
 		t.Errorf("env+cwd: %+v", r)
 	}
+}
+
+func TestExecStream(t *testing.T) {
+	h, _ := newHandler()
+	// streaming exec is gated the same way: no --exec-root => a stderr frame + non-zero exit.
+	var off bytes.Buffer
+	h.execStream(&off, Request{Op: "exec", Stream: true, Argv: []string{"echo", "hi"}})
+	if _, _, code := drainFrames(t, &off); code != 255 {
+		t.Fatalf("stream exec must be disabled without --exec-root (exit 255), got %d", code)
+	}
+
+	h.execRoot = "/" // enable (no chroot in the test)
+	var buf bytes.Buffer
+	h.execStream(&buf, Request{Op: "exec", Stream: true,
+		Argv: []string{"sh", "-c", "echo out; echo err 1>&2; exit 5"}})
+	stdout, stderr, code := drainFrames(t, &buf)
+	if stdout != "out\n" {
+		t.Errorf("stdout=%q", stdout)
+	}
+	if !strings.Contains(stderr, "err") {
+		t.Errorf("stderr=%q", stderr)
+	}
+	if code != 5 {
+		t.Errorf("exit code=%d, want 5", code)
+	}
+
+	// env + cwd flow through the same buildExecCmd path.
+	var buf2 bytes.Buffer
+	h.execStream(&buf2, Request{Op: "exec", Stream: true,
+		Argv: []string{"sh", "-c", "echo $FOO; pwd"}, Env: []string{"FOO=bar"}, Cwd: "/tmp"})
+	if out, _, _ := drainFrames(t, &buf2); out != "bar\n/tmp\n" {
+		t.Errorf("env+cwd stream stdout=%q", out)
+	}
+}
+
+// drainFrames reads a completed execStream buffer into (stdout, stderr, exitCode).
+func drainFrames(t *testing.T, r *bytes.Buffer) (string, string, int) {
+	t.Helper()
+	var out, errb strings.Builder
+	code := -1
+	for {
+		typ, pay, err := guestagent.ReadFrame(r)
+		if err != nil {
+			break
+		}
+		switch typ {
+		case guestagent.FrameStdout:
+			out.Write(pay)
+		case guestagent.FrameStderr:
+			errb.Write(pay)
+		case guestagent.FrameExit:
+			code = guestagent.DecodeExitCode(pay)
+		}
+	}
+	return out.String(), errb.String(), code
 }
 
 func TestBadJSON(t *testing.T) {

--- a/cmd/kubeswift-guest-agent/main.go
+++ b/cmd/kubeswift-guest-agent/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"log"
 	"os"
@@ -56,14 +57,32 @@ func main() {
 	}
 }
 
-// serve reads one newline-delimited JSON request, dispatches it, writes the JSON
-// response, and closes the connection (one request/response per connection).
+// serve reads one newline-delimited JSON request and dispatches it. Single-shot ops
+// write one JSON response and close. A streaming exec (op=exec, stream=true) hands the
+// connection to execStream, which writes framed stdout/stderr/exit for the command's
+// lifetime (see internal/guestagent).
 func serve(h *handler, nfd int) {
 	defer unix.Close(nfd)
-	// bound the connection so a stuck/hostile client cannot pin a goroutine
+	// bound the request read so a stuck/hostile client cannot pin a goroutine
 	tv := unix.Timeval{Sec: recvTimeoutSecs}
 	_ = unix.SetsockoptTimeval(nfd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &tv)
 
+	buf := readRequestLine(nfd)
+
+	var req Request
+	if json.Unmarshal(buf, &req) == nil && req.Op == "exec" && req.Stream {
+		// clear the read deadline — a streamed command may run far longer than the
+		// request-read timeout, and (for attach) the host keeps sending stdin frames.
+		_ = unix.SetsockoptTimeval(nfd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{})
+		h.execStream(fdWriter{fd: nfd}, req)
+		return
+	}
+
+	writeAll(nfd, h.handle(buf))
+}
+
+// readRequestLine reads one newline-delimited request (bounded by maxRequestBytes).
+func readRequestLine(nfd int) []byte {
 	var buf []byte
 	tmp := make([]byte, 4096)
 	for len(buf) < maxRequestBytes {
@@ -71,16 +90,17 @@ func serve(h *handler, nfd int) {
 		if n > 0 {
 			buf = append(buf, tmp[:n]...)
 			if i := bytes.IndexByte(buf, '\n'); i >= 0 {
-				buf = buf[:i]
-				break
+				return buf[:i]
 			}
 		}
 		if err != nil || n == 0 {
 			break
 		}
 	}
+	return buf
+}
 
-	resp := h.handle(buf)
+func writeAll(nfd int, resp []byte) {
 	for len(resp) > 0 {
 		n, err := unix.Write(nfd, resp)
 		if n > 0 {

--- a/cmd/kubeswift-guest-agent/stream.go
+++ b/cmd/kubeswift-guest-agent/stream.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os/exec"
+	"sync"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/kubeswift-io/kubeswift/internal/guestagent"
+)
+
+// execStream runs argv (chrooted into the sandbox root, with env + cwd) and streams
+// its stdout/stderr to w as frames LIVE, then a terminal Exit frame with the code —
+// unbounded output, no 1 MiB cap. Used by `swiftctl sandbox exec` and the foundation
+// interactive attach builds on. w is the (frame-serialized) connection back to the host.
+func (h *handler) execStream(w io.Writer, req Request) {
+	fc := &frameConn{w: w}
+	cmd, err := h.buildExecCmd(req)
+	if err != nil {
+		fc.exitErr(err.Error())
+		return
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		fc.exitErr("stdout pipe: " + err.Error())
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		fc.exitErr("stderr pipe: " + err.Error())
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		fc.exitErr("exec: " + err.Error())
+		return
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go pumpFrames(fc, guestagent.FrameStdout, stdout, &wg)
+	go pumpFrames(fc, guestagent.FrameStderr, stderr, &wg)
+	wg.Wait() // both pipes drained (EOF) => the process has closed its outputs
+
+	code := 0
+	if err := cmd.Wait(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			code = ee.ExitCode()
+		} else {
+			_ = fc.write(guestagent.FrameStderr, []byte("kubeswift-guest-agent: exec: "+err.Error()+"\n"))
+			code = 255
+		}
+	}
+	fc.exit(code)
+}
+
+// frameConn serializes frame writes across the two output pumps so a reader always
+// sees whole frames on the shared connection.
+type frameConn struct {
+	w  io.Writer
+	mu sync.Mutex
+}
+
+func (c *frameConn) write(typ byte, payload []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return guestagent.WriteFrame(c.w, typ, payload)
+}
+
+func (c *frameConn) exit(code int) { _ = c.write(guestagent.FrameExit, guestagent.ExitCode(code)) }
+
+// exitErr surfaces a pre-run failure (exec disabled, empty argv, spawn error) on the
+// stream: a stderr frame plus a non-zero Exit frame, so the host prints it and exits
+// non-zero — never a silent stall.
+func (c *frameConn) exitErr(msg string) {
+	_ = c.write(guestagent.FrameStderr, []byte("kubeswift-guest-agent: "+msg+"\n"))
+	c.exit(255)
+}
+
+// pumpFrames copies r into typ-tagged frames until EOF.
+func pumpFrames(fc *frameConn, typ byte, r io.Reader, wg *sync.WaitGroup) {
+	defer wg.Done()
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			if werr := fc.write(typ, buf[:n]); werr != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// fdWriter adapts a raw vsock fd to io.Writer, retrying short writes.
+type fdWriter struct{ fd int }
+
+func (w fdWriter) Write(p []byte) (int, error) {
+	total := 0
+	for total < len(p) {
+		n, err := unix.Write(w.fd, p[total:])
+		if n > 0 {
+			total += n
+		}
+		if err != nil {
+			return total, err
+		}
+		if n == 0 {
+			return total, io.ErrShortWrite
+		}
+	}
+	return total, nil
+}

--- a/cmd/swiftctl/sandbox.go
+++ b/cmd/swiftctl/sandbox.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/kubeswift-io/kubeswift/internal/cli"
+	"github.com/kubeswift-io/kubeswift/internal/guestagent"
 
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -49,8 +50,8 @@ var sandboxExecCmd = &cobra.Command{
 	Use:   "exec [sandbox-name] -- command [args...]",
 	Short: "Run a command inside a running sandbox (over vsock)",
 	Long: `Runs a command inside a running SwiftSandbox via the in-guest agent over vsock. The
-command runs in the sandbox's OCI root filesystem. Non-interactive (no stdin/TTY);
-stdout and stderr are returned and the command's exit code is propagated.`,
+command runs in the sandbox's OCI root filesystem. stdout and stderr stream back LIVE
+and the command's exit code is propagated. Non-interactive (no stdin/TTY yet).`,
 	Example: `  swiftctl sandbox exec my-job -- ls -la /
   swiftctl -n ci sandbox exec my-job -- cat /etc/os-release`,
 	Args:         cobra.MinimumNArgs(2),
@@ -90,7 +91,7 @@ func runSandboxExec(cmd *cobra.Command, args []string) error {
 	}
 
 	vsockSock := "/var/lib/kubeswift/run/" + cli.GuestID(ns, name) + "/vsock.sock"
-	reqObj := map[string]interface{}{"v": 1, "op": "exec", "argv": command}
+	reqObj := map[string]interface{}{"v": 1, "op": "exec", "argv": command, "stream": true}
 	if len(sandboxExecEnv) > 0 {
 		reqObj["env"] = sandboxExecEnv
 	}
@@ -99,39 +100,21 @@ func runSandboxExec(cmd *cobra.Command, args []string) error {
 	}
 	req, _ := json.Marshal(reqObj)
 
-	resp, err := agentRequest(config, clientset, ns, name, vsockSock, req)
+	code, err := agentExecStream(config, clientset, ns, name, vsockSock, req)
 	if err != nil {
 		return err
 	}
-	if resp.Stdout != "" {
-		fmt.Fprint(os.Stdout, resp.Stdout)
-	}
-	if resp.Stderr != "" {
-		fmt.Fprint(os.Stderr, resp.Stderr)
-	}
-	if !resp.OK {
-		return fmt.Errorf("agent exec failed: %s", resp.Error)
-	}
-	if resp.ExitCode != nil && *resp.ExitCode != 0 {
-		os.Exit(*resp.ExitCode)
+	if code != 0 {
+		os.Exit(code)
 	}
 	return nil
 }
 
-// agentResponse is the subset of the guest agent's reply swiftctl needs.
-type agentResponse struct {
-	OK       bool   `json:"ok"`
-	Error    string `json:"error"`
-	Stdout   string `json:"stdout"`
-	Stderr   string `json:"stderr"`
-	ExitCode *int   `json:"exitCode"`
-}
-
-// agentRequest execs socat in the launcher pod (a raw pipe to CH's vsock unix socket),
-// performs CH's hybrid-vsock CONNECT handshake, sends one JSON request to the in-guest
-// agent on agentVsockPort, and returns the parsed JSON response. The request must be
-// sent AFTER the "OK" line, so swiftctl drives the protocol over the exec stdin/stdout.
-func agentRequest(config *rest.Config, clientset *kubernetes.Clientset, ns, pod, vsockSock string, req []byte) (*agentResponse, error) {
+// dialAgent execs socat in the launcher pod (a raw pipe to CH's vsock unix socket) and
+// performs CH's hybrid-vsock CONNECT handshake to the in-guest agent on agentVsockPort.
+// It returns a reader over the agent stream, a writer to it, and the executor's done
+// channel; the request must be written AFTER the returned handshake succeeds.
+func dialAgent(config *rest.Config, clientset *kubernetes.Clientset, ns, pod, vsockSock string) (*bufio.Reader, *io.PipeWriter, chan error, error) {
 	waitAndSocat := fmt.Sprintf("for i in $(seq 1 10); do test -S %q && break; sleep 1; done; exec socat -t10 - UNIX-CONNECT:%s", vsockSock, vsockSock)
 	execReq := clientset.CoreV1().RESTClient().Post().
 		Resource("pods").Namespace(ns).Name(pod).SubResource("exec").
@@ -144,7 +127,7 @@ func agentRequest(config *rest.Config, clientset *kubernetes.Clientset, ns, pod,
 		}, clientgoscheme.ParameterCodec)
 	executor, err := remotecommand.NewSPDYExecutor(config, "POST", execReq.URL())
 	if err != nil {
-		return nil, fmt.Errorf("exec setup: %w", err)
+		return nil, nil, nil, fmt.Errorf("exec setup: %w", err)
 	}
 
 	inR, inW := io.Pipe()
@@ -159,30 +142,48 @@ func agentRequest(config *rest.Config, clientset *kubernetes.Clientset, ns, pod,
 
 	br := bufio.NewReader(outR)
 	if _, err := io.WriteString(inW, fmt.Sprintf("CONNECT %d\n", agentVsockPort)); err != nil {
-		return nil, fmt.Errorf("vsock connect: %w", err)
+		return nil, nil, nil, fmt.Errorf("vsock connect: %w", err)
 	}
 	okLine, err := br.ReadString('\n')
 	if err != nil {
-		return nil, fmt.Errorf("vsock handshake (is the sandbox running with an agent?): %w", err)
+		return nil, nil, nil, fmt.Errorf("vsock handshake (is the sandbox running with an agent?): %w", err)
 	}
 	if !strings.HasPrefix(okLine, "OK ") {
-		return nil, fmt.Errorf("vsock handshake failed: %q", strings.TrimSpace(okLine))
+		return nil, nil, nil, fmt.Errorf("vsock handshake failed: %q", strings.TrimSpace(okLine))
 	}
-	if _, err := inW.Write(append(req, '\n')); err != nil {
-		return nil, fmt.Errorf("send request: %w", err)
-	}
-	respLine, err := br.ReadString('\n')
-	if err != nil && respLine == "" {
-		return nil, fmt.Errorf("read agent response: %w", err)
-	}
-	inW.Close()
-	<-done
+	return br, inW, done, nil
+}
 
-	var resp agentResponse
-	if err := json.Unmarshal([]byte(strings.TrimSpace(respLine)), &resp); err != nil {
-		return nil, fmt.Errorf("parse agent response %q: %w", strings.TrimSpace(respLine), err)
+// agentExecStream sends a streaming exec request and copies the agent's framed
+// stdout/stderr to os.Stdout/os.Stderr LIVE, returning the workload's exit code when
+// the terminal Exit frame arrives (see internal/guestagent).
+func agentExecStream(config *rest.Config, clientset *kubernetes.Clientset, ns, pod, vsockSock string, req []byte) (int, error) {
+	br, inW, done, err := dialAgent(config, clientset, ns, pod, vsockSock)
+	if err != nil {
+		return 1, err
 	}
-	return &resp, nil
+	defer func() { inW.Close(); <-done }()
+
+	if _, err := inW.Write(append(req, '\n')); err != nil {
+		return 1, fmt.Errorf("send request: %w", err)
+	}
+	for {
+		typ, payload, err := guestagent.ReadFrame(br)
+		if err != nil {
+			if err == io.EOF {
+				return 0, nil // stream ended without an explicit Exit frame
+			}
+			return 1, fmt.Errorf("read agent stream: %w", err)
+		}
+		switch typ {
+		case guestagent.FrameStdout:
+			os.Stdout.Write(payload)
+		case guestagent.FrameStderr:
+			os.Stderr.Write(payload)
+		case guestagent.FrameExit:
+			return guestagent.DecodeExitCode(payload), nil
+		}
+	}
 }
 
 func runSandboxLogs(cmd *cobra.Command, args []string) error {

--- a/config/samples/sandbox/README.md
+++ b/config/samples/sandbox/README.md
@@ -45,9 +45,9 @@ Notes:
 - **Interacting** with a running sandbox:
   - `swiftctl sandbox logs <name>` (`-f` to follow) streams the workload console.
   - `swiftctl sandbox exec <name> -- cmd args...` runs a command inside the sandbox's
-    OCI rootfs over a host↔guest vsock channel (an in-guest agent; non-interactive;
-    stdout/stderr returned, exit code propagated). `-e KEY=VALUE` (repeatable) and
-    `-w DIR` set environment variables and the working directory. Interactive `attach`
-    is a follow-up.
+    OCI rootfs over a host↔guest vsock channel (an in-guest agent). stdout/stderr
+    stream back live (no output cap) and the exit code is propagated. `-e KEY=VALUE`
+    (repeatable) and `-w DIR` set environment variables and the working directory.
+    Non-interactive (no stdin/TTY yet) — interactive `attach` is a follow-up.
 - `spec.timeout` force-terminates a runaway sandbox; `spec.ttl` deletes the
   finished record (and frees the node rootfs cache reference) after it elapses.

--- a/config/samples/sandbox/swiftkernel-sandbox.yaml
+++ b/config/samples/sandbox/swiftkernel-sandbox.yaml
@@ -14,6 +14,6 @@ metadata:
   namespace: default
 spec:
   ociRef:
-    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.6
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.7
   kernelCmdline: "console=ttyS0"
   profile: sandbox

--- a/internal/guestagent/frame.go
+++ b/internal/guestagent/frame.go
@@ -1,0 +1,90 @@
+// Package guestagent defines the host<->guest streaming wire protocol shared by
+// the in-guest agent (cmd/kubeswift-guest-agent) and swiftctl for SwiftSandbox
+// `exec` (streaming) and, later, interactive `attach`.
+//
+// A streaming exchange begins with the same newline-JSON request the single-shot
+// ops use (so the CH hybrid-vsock CONNECT/OK handshake is unchanged); once the
+// request sets `stream:true` the connection switches to a sequence of length-
+// prefixed frames in BOTH directions:
+//
+//	[type:1][len:4 big-endian][payload:len]
+//
+// Guest->host: Stdout, Stderr, Exit (payload = 4-byte exit code). Host->guest
+// (attach only): Stdin, Resize. Frames on one connection are serialized by the
+// writer, so a reader always sees whole frames.
+package guestagent
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// Frame types.
+const (
+	FrameStdout byte = 1 // guest->host: workload stdout
+	FrameStderr byte = 2 // guest->host: workload stderr
+	FrameExit   byte = 3 // guest->host: terminal; payload = int32 exit code, big-endian
+	FrameStdin  byte = 4 // host->guest: workload stdin (attach)
+	FrameResize byte = 5 // host->guest: TTY resize (attach); payload = rows:2 + cols:2, big-endian
+)
+
+// MaxFramePayload bounds a single frame's payload so a hostile/broken peer cannot
+// force an unbounded allocation on the reader.
+const MaxFramePayload = 1 << 20 // 1 MiB
+
+// WriteFrame writes one frame ([type][len:4 BE][payload]) to w in a single logical
+// message. Callers that share a writer across goroutines must serialize WriteFrame.
+func WriteFrame(w io.Writer, typ byte, payload []byte) error {
+	if len(payload) > MaxFramePayload {
+		return fmt.Errorf("frame payload too large: %d", len(payload))
+	}
+	var hdr [5]byte
+	hdr[0] = typ
+	binary.BigEndian.PutUint32(hdr[1:], uint32(len(payload)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	if len(payload) > 0 {
+		if _, err := w.Write(payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadFrame reads one frame from r. It returns io.EOF only when the stream ends
+// cleanly on a frame boundary (a truncated frame yields io.ErrUnexpectedEOF).
+func ReadFrame(r io.Reader) (typ byte, payload []byte, err error) {
+	var hdr [5]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return 0, nil, err
+	}
+	n := binary.BigEndian.Uint32(hdr[1:])
+	if n > MaxFramePayload {
+		return 0, nil, fmt.Errorf("frame payload too large: %d", n)
+	}
+	if n == 0 {
+		return hdr[0], nil, nil
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return 0, nil, err
+	}
+	return hdr[0], buf, nil
+}
+
+// ExitCode encodes an exit code as a 4-byte big-endian FrameExit payload.
+func ExitCode(code int) []byte {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], uint32(int32(code)))
+	return b[:]
+}
+
+// DecodeExitCode reads a FrameExit payload back into an int (0 if malformed).
+func DecodeExitCode(payload []byte) int {
+	if len(payload) < 4 {
+		return 0
+	}
+	return int(int32(binary.BigEndian.Uint32(payload)))
+}

--- a/internal/guestagent/frame_test.go
+++ b/internal/guestagent/frame_test.go
@@ -1,0 +1,56 @@
+package guestagent
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestFrameRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	frames := []struct {
+		typ byte
+		pay []byte
+	}{
+		{FrameStdout, []byte("hello\n")},
+		{FrameStderr, []byte("oops")},
+		{FrameStdout, nil}, // zero-length payload is legal
+		{FrameExit, ExitCode(7)},
+	}
+	for _, f := range frames {
+		if err := WriteFrame(&buf, f.typ, f.pay); err != nil {
+			t.Fatalf("write %d: %v", f.typ, err)
+		}
+	}
+	for i, want := range frames {
+		typ, pay, err := ReadFrame(&buf)
+		if err != nil {
+			t.Fatalf("read frame %d: %v", i, err)
+		}
+		if typ != want.typ || !bytes.Equal(pay, want.pay) {
+			t.Fatalf("frame %d = (%d,%q), want (%d,%q)", i, typ, pay, want.typ, want.pay)
+		}
+	}
+	if _, _, err := ReadFrame(&buf); err != io.EOF {
+		t.Fatalf("clean end must be io.EOF, got %v", err)
+	}
+	if got := DecodeExitCode(ExitCode(7)); got != 7 {
+		t.Fatalf("exit code round-trip = %d", got)
+	}
+}
+
+func TestReadFrameTruncated(t *testing.T) {
+	// header claims 10 bytes but only 3 follow -> ErrUnexpectedEOF, not EOF.
+	var buf bytes.Buffer
+	buf.Write([]byte{FrameStdout, 0, 0, 0, 10})
+	buf.WriteString("abc")
+	if _, _, err := ReadFrame(&buf); err != io.ErrUnexpectedEOF {
+		t.Fatalf("truncated frame err = %v, want ErrUnexpectedEOF", err)
+	}
+}
+
+func TestWriteFrameRejectsOversize(t *testing.T) {
+	if err := WriteFrame(io.Discard, FrameStdout, make([]byte, MaxFramePayload+1)); err == nil {
+		t.Fatal("oversize payload must be rejected")
+	}
+}


### PR DESCRIPTION
`swiftctl sandbox exec` now streams the workload's stdout/stderr back **live** as it runs (previously buffered into one response), and the old 1 MiB output cap is gone.

- **`internal/guestagent`** — a small length-prefixed frame protocol `[type][len:4 BE][payload]` shared by the agent and swiftctl. Guest→host: stdout / stderr / exit(int32). Reserves stdin/resize frames for the interactive **attach** that builds on this.
- **agent** — a streaming exec path (`op=exec, stream=true`) dispatched in `serve()`; it pumps the two output pipes into serialized frames then a terminal exit frame. `buildExecCmd` factored out so single-shot and streaming exec share chroot/env/cwd. Single-shot exec op unchanged.
- **swiftctl** — reads frames → `os.Stdout`/`os.Stderr` live, exits with the workload's code.

Cluster-validated on `kernels/sandbox:6.6.7`:
| check | result |
|---|---|
| live streaming | 3 lines arrived exactly 1s apart (host-side timestamps) |
| split streams | stdout→stdout, stderr→stderr |
| uncapped | `seq 1 200000` → 200000 lines, no truncation (>1 MiB) |
| exit code | `exit 7` → swiftctl rc=7 |
| env+cwd | `-e FOO=bar -w /tmp` honored |

Second of the three exec/attach follow-ups (env/cwd → **streaming** → attach).