### PR TITLE
feat(sandbox): interactive attach + stdin for sandbox exec (PTY over vsock)

### DIFF
--- a/cmd/kubeswift-guest-agent/handler.go
+++ b/cmd/kubeswift-guest-agent/handler.go
@@ -78,6 +78,10 @@ type Request struct {
 	Env    []string `json:"env,omitempty"`
 	Cwd    string   `json:"cwd,omitempty"`
 	Stream bool     `json:"stream,omitempty"` // stream stdout/stderr/exit as frames (see internal/guestagent); dispatched in serve(), not handle()
+	Stdin  bool     `json:"stdin,omitempty"`  // read host FrameStdin frames into the command's stdin
+	TTY    bool     `json:"tty,omitempty"`    // allocate a PTY (interactive attach); implies stdin
+	Rows   uint16   `json:"rows,omitempty"`   // initial TTY rows (tty only)
+	Cols   uint16   `json:"cols,omitempty"`   // initial TTY cols (tty only)
 }
 
 // Response is the guest->host reply.

--- a/cmd/kubeswift-guest-agent/handler_test.go
+++ b/cmd/kubeswift-guest-agent/handler_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/kubeswift-io/kubeswift/internal/guestagent"
@@ -185,6 +187,63 @@ func drainFrames(t *testing.T, r *bytes.Buffer) (string, string, int) {
 		}
 	}
 	return out.String(), errb.String(), code
+}
+
+func TestExecAttachPTY(t *testing.T) {
+	if _, err := os.Stat("/dev/ptmx"); err != nil {
+		t.Skip("no /dev/ptmx in this environment")
+	}
+	h, _ := newHandler()
+	h.execRoot = "/" // enable exec, no chroot in the test
+
+	stdinR, stdinW := io.Pipe() // host->guest; left open so the reader goroutine blocks
+	out := &safeBuffer{}
+	rw := &rwPair{r: stdinR, w: out}
+
+	done := make(chan struct{})
+	go func() {
+		// `test -t 1` is true ONLY on a real TTY — proves a PTY was allocated.
+		h.execAttach(rw, Request{Op: "exec", Stream: true, TTY: true,
+			Argv: []string{"sh", "-c", "test -t 1 && echo HASTTY; exit 4"}})
+		close(done)
+	}()
+	<-done
+	stdinW.Close()
+
+	stdout, _, code := drainFrames(t, out.buffer())
+	if !strings.Contains(stdout, "HASTTY") {
+		t.Errorf("command did not see a TTY (stdout=%q)", stdout)
+	}
+	if code != 4 {
+		t.Errorf("exit code=%d, want 4", code)
+	}
+}
+
+// rwPair is an io.ReadWriter joining a separate reader and writer for the attach test.
+type rwPair struct {
+	r io.Reader
+	w io.Writer
+}
+
+func (p *rwPair) Read(b []byte) (int, error)  { return p.r.Read(b) }
+func (p *rwPair) Write(b []byte) (int, error) { return p.w.Write(b) }
+
+// safeBuffer is a concurrency-safe bytes.Buffer (the frame writer serializes, but the
+// output pump and the terminal Exit write happen on different goroutines).
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *safeBuffer) Write(b []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(b)
+}
+func (s *safeBuffer) buffer() *bytes.Buffer {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return bytes.NewBuffer(s.buf.Bytes())
 }
 
 func TestBadJSON(t *testing.T) {

--- a/cmd/kubeswift-guest-agent/main.go
+++ b/cmd/kubeswift-guest-agent/main.go
@@ -67,22 +67,29 @@ func serve(h *handler, nfd int) {
 	tv := unix.Timeval{Sec: recvTimeoutSecs}
 	_ = unix.SetsockoptTimeval(nfd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &tv)
 
-	buf := readRequestLine(nfd)
+	line, rest := readRequestLine(nfd)
 
 	var req Request
-	if json.Unmarshal(buf, &req) == nil && req.Op == "exec" && req.Stream {
+	if json.Unmarshal(line, &req) == nil && req.Op == "exec" && req.Stream {
 		// clear the read deadline — a streamed command may run far longer than the
-		// request-read timeout, and (for attach) the host keeps sending stdin frames.
+		// request-read timeout, and stdin/attach keeps the host sending frames.
 		_ = unix.SetsockoptTimeval(nfd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{})
-		h.execStream(fdWriter{fd: nfd}, req)
+		rw := &fdReadWriter{fd: nfd, rest: rest}
+		if req.TTY {
+			h.execAttach(rw, req)
+		} else {
+			h.execStream(rw, req)
+		}
 		return
 	}
 
-	writeAll(nfd, h.handle(buf))
+	writeAll(nfd, h.handle(line))
 }
 
-// readRequestLine reads one newline-delimited request (bounded by maxRequestBytes).
-func readRequestLine(nfd int) []byte {
+// readRequestLine reads one newline-delimited request (bounded by maxRequestBytes) and
+// returns the line plus any bytes already read past the newline (the start of the frame
+// stream for a streaming/attach request).
+func readRequestLine(nfd int) (line, rest []byte) {
 	var buf []byte
 	tmp := make([]byte, 4096)
 	for len(buf) < maxRequestBytes {
@@ -90,14 +97,14 @@ func readRequestLine(nfd int) []byte {
 		if n > 0 {
 			buf = append(buf, tmp[:n]...)
 			if i := bytes.IndexByte(buf, '\n'); i >= 0 {
-				return buf[:i]
+				return buf[:i], buf[i+1:]
 			}
 		}
 		if err != nil || n == 0 {
 			break
 		}
 	}
-	return buf
+	return buf, nil
 }
 
 func writeAll(nfd int, resp []byte) {

--- a/cmd/kubeswift-guest-agent/stream.go
+++ b/cmd/kubeswift-guest-agent/stream.go
@@ -6,17 +6,19 @@ import (
 	"os/exec"
 	"sync"
 
+	"github.com/creack/pty"
 	"golang.org/x/sys/unix"
 
 	"github.com/kubeswift-io/kubeswift/internal/guestagent"
 )
 
 // execStream runs argv (chrooted into the sandbox root, with env + cwd) and streams
-// its stdout/stderr to w as frames LIVE, then a terminal Exit frame with the code —
-// unbounded output, no 1 MiB cap. Used by `swiftctl sandbox exec` and the foundation
-// interactive attach builds on. w is the (frame-serialized) connection back to the host.
-func (h *handler) execStream(w io.Writer, req Request) {
-	fc := &frameConn{w: w}
+// its stdout/stderr to the host as frames LIVE, then a terminal Exit frame — unbounded
+// output, no cap. When req.Stdin is set it also reads host FrameStdin frames into the
+// command's stdin (a plain pipe; the PTY path is execAttach). rw is the framed
+// connection back to the host.
+func (h *handler) execStream(rw io.ReadWriter, req Request) {
+	fc := &frameConn{FrameWriter: guestagent.NewFrameWriter(rw)}
 	cmd, err := h.buildExecCmd(req)
 	if err != nil {
 		fc.exitErr(err.Error())
@@ -32,49 +34,110 @@ func (h *handler) execStream(w io.Writer, req Request) {
 		fc.exitErr("stderr pipe: " + err.Error())
 		return
 	}
+	var stdin io.WriteCloser
+	if req.Stdin {
+		if stdin, err = cmd.StdinPipe(); err != nil {
+			fc.exitErr("stdin pipe: " + err.Error())
+			return
+		}
+	}
 	if err := cmd.Start(); err != nil {
 		fc.exitErr("exec: " + err.Error())
 		return
+	}
+	if req.Stdin {
+		go pumpStdin(rw, stdin) // host FrameStdin -> cmd stdin; closes stdin on host EOF/close
 	}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go pumpFrames(fc, guestagent.FrameStdout, stdout, &wg)
 	go pumpFrames(fc, guestagent.FrameStderr, stderr, &wg)
-	wg.Wait() // both pipes drained (EOF) => the process has closed its outputs
+	wg.Wait() // both pipes drained (EOF) => the process closed its outputs
 
-	code := 0
+	fc.exit(waitCode(cmd, fc))
+}
+
+// execAttach runs argv on a PTY (interactive attach): the PTY output streams back as
+// FrameStdout, host FrameStdin frames are written to the PTY, and FrameResize frames
+// resize it. The command's stdin/stdout/stderr are the PTY slave (inherited across the
+// chroot as fds, so /newroot needs no /dev/pts of its own).
+func (h *handler) execAttach(rw io.ReadWriter, req Request) {
+	fc := &frameConn{FrameWriter: guestagent.NewFrameWriter(rw)}
+	cmd, err := h.buildExecCmd(req)
+	if err != nil {
+		fc.exitErr(err.Error())
+		return
+	}
+	sz := &pty.Winsize{Rows: req.Rows, Cols: req.Cols}
+	if sz.Rows == 0 {
+		sz.Rows = 24
+	}
+	if sz.Cols == 0 {
+		sz.Cols = 80
+	}
+	ptmx, err := pty.StartWithSize(cmd, sz)
+	if err != nil {
+		fc.exitErr("pty: " + err.Error())
+		return
+	}
+	defer func() { _ = ptmx.Close() }()
+
+	// host control frames (stdin, resize) -> PTY. Runs until the host closes the
+	// connection (ReadFrame error), which then closes the PTY so the shell sees EOF.
+	go func() {
+		for {
+			typ, payload, err := guestagent.ReadFrame(rw)
+			if err != nil {
+				_ = ptmx.Close()
+				return
+			}
+			switch typ {
+			case guestagent.FrameStdin:
+				_, _ = ptmx.Write(payload)
+			case guestagent.FrameResize:
+				rows, cols := guestagent.DecodeResize(payload)
+				_ = pty.Setsize(ptmx, &pty.Winsize{Rows: rows, Cols: cols})
+			}
+		}
+	}()
+
+	// PTY output -> FrameStdout, until the child exits and the master EOFs.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go pumpFrames(fc, guestagent.FrameStdout, ptmx, &wg)
+	wg.Wait()
+
+	fc.exit(waitCode(cmd, fc))
+}
+
+// waitCode waits for cmd and returns its exit code, surfacing a non-ExitError spawn/run
+// failure as a stderr frame + code 255.
+func waitCode(cmd *exec.Cmd, fc *frameConn) int {
 	if err := cmd.Wait(); err != nil {
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {
-			code = ee.ExitCode()
-		} else {
-			_ = fc.write(guestagent.FrameStderr, []byte("kubeswift-guest-agent: exec: "+err.Error()+"\n"))
-			code = 255
+			return ee.ExitCode()
 		}
+		_ = fc.write(guestagent.FrameStderr, []byte("kubeswift-guest-agent: exec: "+err.Error()+"\n"))
+		return 255
 	}
-	fc.exit(code)
+	return 0
 }
 
-// frameConn serializes frame writes across the two output pumps so a reader always
-// sees whole frames on the shared connection.
+// frameConn adds exit/error helpers over the serialized FrameWriter.
 type frameConn struct {
-	w  io.Writer
-	mu sync.Mutex
+	*guestagent.FrameWriter
 }
 
-func (c *frameConn) write(typ byte, payload []byte) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return guestagent.WriteFrame(c.w, typ, payload)
-}
+func (c *frameConn) write(typ byte, payload []byte) error { return c.Write(typ, payload) }
 
-func (c *frameConn) exit(code int) { _ = c.write(guestagent.FrameExit, guestagent.ExitCode(code)) }
+func (c *frameConn) exit(code int) { _ = c.Write(guestagent.FrameExit, guestagent.ExitCode(code)) }
 
 // exitErr surfaces a pre-run failure (exec disabled, empty argv, spawn error) on the
 // stream: a stderr frame plus a non-zero Exit frame, so the host prints it and exits
 // non-zero — never a silent stall.
 func (c *frameConn) exitErr(msg string) {
-	_ = c.write(guestagent.FrameStderr, []byte("kubeswift-guest-agent: "+msg+"\n"))
+	_ = c.Write(guestagent.FrameStderr, []byte("kubeswift-guest-agent: "+msg+"\n"))
 	c.exit(255)
 }
 
@@ -91,6 +154,27 @@ func pumpFrames(fc *frameConn, typ byte, r io.Reader, wg *sync.WaitGroup) {
 		}
 		if err != nil {
 			return
+		}
+	}
+}
+
+// pumpStdin copies host FrameStdin frames into w (the command's stdin), closing w on a
+// FrameStdinClose (host stdin hit EOF) or when the host closes the connection — so a
+// command like `cat` sees EOF and exits instead of hanging.
+func pumpStdin(r io.Reader, w io.WriteCloser) {
+	defer w.Close()
+	for {
+		typ, payload, err := guestagent.ReadFrame(r)
+		if err != nil {
+			return
+		}
+		switch typ {
+		case guestagent.FrameStdin:
+			if _, werr := w.Write(payload); werr != nil {
+				return
+			}
+		case guestagent.FrameStdinClose:
+			return // defer closes the command's stdin
 		}
 	}
 }
@@ -114,3 +198,22 @@ func (w fdWriter) Write(p []byte) (int, error) {
 	}
 	return total, nil
 }
+
+// fdReadWriter is the full-duplex framed connection over a raw vsock fd. It replays any
+// bytes the request-line read consumed past the newline (rest) before reading the fd,
+// so the first host frame is never lost.
+type fdReadWriter struct {
+	fd   int
+	rest []byte
+}
+
+func (rw *fdReadWriter) Read(p []byte) (int, error) {
+	if len(rw.rest) > 0 {
+		n := copy(p, rw.rest)
+		rw.rest = rw.rest[n:]
+		return n, nil
+	}
+	return unix.Read(rw.fd, p)
+}
+
+func (rw *fdReadWriter) Write(p []byte) (int, error) { return fdWriter{rw.fd}.Write(p) }

--- a/cmd/swiftctl/sandbox.go
+++ b/cmd/swiftctl/sandbox.go
@@ -7,9 +7,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -51,36 +54,68 @@ var sandboxExecCmd = &cobra.Command{
 	Short: "Run a command inside a running sandbox (over vsock)",
 	Long: `Runs a command inside a running SwiftSandbox via the in-guest agent over vsock. The
 command runs in the sandbox's OCI root filesystem. stdout and stderr stream back LIVE
-and the command's exit code is propagated. Non-interactive (no stdin/TTY yet).`,
+and the command's exit code is propagated. Use -i to forward stdin and -t for an
+interactive TTY (e.g. -it -- /bin/sh); "sandbox attach" is shorthand for exec -it.`,
 	Example: `  swiftctl sandbox exec my-job -- ls -la /
-  swiftctl -n ci sandbox exec my-job -- cat /etc/os-release`,
+  swiftctl sandbox exec -i my-job -- sh   < script.sh
+  swiftctl sandbox exec -it my-job -- /bin/sh`,
 	Args:         cobra.MinimumNArgs(2),
 	SilenceUsage: true,
 	RunE:         runSandboxExec,
 }
 
+var sandboxAttachCmd = &cobra.Command{
+	Use:   "attach [sandbox-name] [-- command [args...]]",
+	Short: "Open an interactive shell inside a running sandbox (over vsock)",
+	Long: `Attaches an interactive TTY to a running SwiftSandbox — shorthand for
+"sandbox exec -it". Defaults to /bin/sh; pass -- <command> to run something else.
+Exit the shell (Ctrl-D or 'exit') to detach.`,
+	Example: `  swiftctl sandbox attach my-job
+  swiftctl -n ci sandbox attach my-job -- /bin/bash`,
+	Args:         cobra.MinimumNArgs(1),
+	SilenceUsage: true,
+	RunE:         runSandboxAttach,
+}
+
 var (
 	sandboxExecEnv     []string
 	sandboxExecWorkdir string
+	sandboxExecStdin   bool
+	sandboxExecTTY     bool
 )
 
 func init() {
 	sandboxLogsCmd.Flags().BoolVarP(&sandboxLogsFollow, "follow", "f", false, "Follow the log output")
 	sandboxExecCmd.Flags().StringArrayVarP(&sandboxExecEnv, "env", "e", nil, "Environment variable KEY=VALUE (repeatable)")
 	sandboxExecCmd.Flags().StringVarP(&sandboxExecWorkdir, "workdir", "w", "", "Working directory inside the sandbox")
+	sandboxExecCmd.Flags().BoolVarP(&sandboxExecStdin, "stdin", "i", false, "Forward stdin to the command")
+	sandboxExecCmd.Flags().BoolVarP(&sandboxExecTTY, "tty", "t", false, "Allocate an interactive TTY (implies -i)")
 	sandboxCmd.AddCommand(sandboxLogsCmd)
 	sandboxCmd.AddCommand(sandboxExecCmd)
+	sandboxCmd.AddCommand(sandboxAttachCmd)
 }
 
 func runSandboxExec(cmd *cobra.Command, args []string) error {
 	dash := cmd.ArgsLenAtDash()
 	if dash != 1 || dash >= len(args) {
-		return fmt.Errorf("usage: swiftctl sandbox exec <name> -- command [args...]")
+		return fmt.Errorf("usage: swiftctl sandbox exec [-it] <name> -- command [args...]")
 	}
-	name := args[0]
-	command := args[dash:]
-	ns := getNamespace()
+	return execOrAttach(getNamespace(), args[0], args[dash:],
+		sandboxExecEnv, sandboxExecWorkdir, sandboxExecStdin || sandboxExecTTY, sandboxExecTTY)
+}
 
+func runSandboxAttach(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	command := []string{"/bin/sh"}
+	if dash := cmd.ArgsLenAtDash(); dash >= 1 && dash < len(args) {
+		command = args[dash:]
+	}
+	return execOrAttach(getNamespace(), name, command, nil, "", true, true)
+}
+
+// execOrAttach builds the streaming exec request and dispatches to the TTY-attach or
+// plain-stream client. A non-zero workload exit propagates via os.Exit.
+func execOrAttach(ns, name string, command, env []string, workdir string, stdin, tty bool) error {
 	config, err := kubeConfig.ToRESTConfig()
 	if err != nil {
 		return fmt.Errorf("kubeconfig: %w", err)
@@ -92,15 +127,30 @@ func runSandboxExec(cmd *cobra.Command, args []string) error {
 
 	vsockSock := "/var/lib/kubeswift/run/" + cli.GuestID(ns, name) + "/vsock.sock"
 	reqObj := map[string]interface{}{"v": 1, "op": "exec", "argv": command, "stream": true}
-	if len(sandboxExecEnv) > 0 {
-		reqObj["env"] = sandboxExecEnv
+	if len(env) > 0 {
+		reqObj["env"] = env
 	}
-	if sandboxExecWorkdir != "" {
-		reqObj["cwd"] = sandboxExecWorkdir
+	if workdir != "" {
+		reqObj["cwd"] = workdir
+	}
+	if stdin {
+		reqObj["stdin"] = true
+	}
+	if tty {
+		reqObj["tty"] = true
+		if cols, rows, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+			reqObj["rows"] = rows
+			reqObj["cols"] = cols
+		}
 	}
 	req, _ := json.Marshal(reqObj)
 
-	code, err := agentExecStream(config, clientset, ns, name, vsockSock, req)
+	var code int
+	if tty {
+		code, err = agentAttachTTY(config, clientset, ns, name, vsockSock, req)
+	} else {
+		code, err = agentExecStream(config, clientset, ns, name, vsockSock, req, stdin)
+	}
 	if err != nil {
 		return err
 	}
@@ -156,8 +206,10 @@ func dialAgent(config *rest.Config, clientset *kubernetes.Clientset, ns, pod, vs
 
 // agentExecStream sends a streaming exec request and copies the agent's framed
 // stdout/stderr to os.Stdout/os.Stderr LIVE, returning the workload's exit code when
-// the terminal Exit frame arrives (see internal/guestagent).
-func agentExecStream(config *rest.Config, clientset *kubernetes.Clientset, ns, pod, vsockSock string, req []byte) (int, error) {
+// the terminal Exit frame arrives (see internal/guestagent). When stdin is set it also
+// forwards os.Stdin as FrameStdin frames (line-buffered; the raw-TTY path is
+// agentAttachTTY).
+func agentExecStream(config *rest.Config, clientset *kubernetes.Clientset, ns, pod, vsockSock string, req []byte, stdin bool) (int, error) {
 	br, inW, done, err := dialAgent(config, clientset, ns, pod, vsockSock)
 	if err != nil {
 		return 1, err
@@ -166,6 +218,9 @@ func agentExecStream(config *rest.Config, clientset *kubernetes.Clientset, ns, p
 
 	if _, err := inW.Write(append(req, '\n')); err != nil {
 		return 1, fmt.Errorf("send request: %w", err)
+	}
+	if stdin {
+		go forwardStdin(guestagent.NewFrameWriter(inW))
 	}
 	for {
 		typ, payload, err := guestagent.ReadFrame(br)
@@ -182,6 +237,84 @@ func agentExecStream(config *rest.Config, clientset *kubernetes.Clientset, ns, p
 			os.Stderr.Write(payload)
 		case guestagent.FrameExit:
 			return guestagent.DecodeExitCode(payload), nil
+		}
+	}
+}
+
+// agentAttachTTY runs an interactive exec: it puts the local terminal in raw mode,
+// forwards os.Stdin as FrameStdin and terminal-resize (SIGWINCH) as FrameResize, and
+// copies the guest PTY's output frames to the terminal until the Exit frame.
+func agentAttachTTY(config *rest.Config, clientset *kubernetes.Clientset, ns, pod, vsockSock string, req []byte) (int, error) {
+	br, inW, done, err := dialAgent(config, clientset, ns, pod, vsockSock)
+	if err != nil {
+		return 1, err
+	}
+	defer func() { inW.Close(); <-done }()
+
+	if _, err := inW.Write(append(req, '\n')); err != nil {
+		return 1, fmt.Errorf("send request: %w", err)
+	}
+	fw := guestagent.NewFrameWriter(inW)
+
+	// raw mode so keystrokes (incl. Ctrl-C / Ctrl-D) reach the guest shell verbatim.
+	var restore func()
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		if old, err := term.MakeRaw(int(os.Stdin.Fd())); err == nil {
+			restore = func() { _ = term.Restore(int(os.Stdin.Fd()), old) }
+			defer restore()
+		}
+	}
+
+	go forwardStdin(fw)
+
+	winch := make(chan os.Signal, 1)
+	signal.Notify(winch, syscall.SIGWINCH)
+	defer signal.Stop(winch)
+	go func() {
+		for range winch {
+			if cols, rows, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+				_ = fw.Write(guestagent.FrameResize, guestagent.ResizePayload(uint16(rows), uint16(cols)))
+			}
+		}
+	}()
+
+	for {
+		typ, payload, err := guestagent.ReadFrame(br)
+		if err != nil {
+			if err == io.EOF {
+				return 0, nil
+			}
+			return 1, fmt.Errorf("read agent stream: %w", err)
+		}
+		switch typ {
+		case guestagent.FrameStdout:
+			os.Stdout.Write(payload)
+		case guestagent.FrameStderr:
+			os.Stderr.Write(payload)
+		case guestagent.FrameExit:
+			if restore != nil {
+				restore()
+			}
+			return guestagent.DecodeExitCode(payload), nil
+		}
+	}
+}
+
+// forwardStdin copies os.Stdin into FrameStdin frames until EOF, then sends a
+// FrameStdinClose so the guest closes the command's stdin (a piped `cat`/`sh` sees EOF
+// and exits rather than hanging).
+func forwardStdin(fw *guestagent.FrameWriter) {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := os.Stdin.Read(buf)
+		if n > 0 {
+			if werr := fw.Write(guestagent.FrameStdin, buf[:n]); werr != nil {
+				return
+			}
+		}
+		if err != nil {
+			_ = fw.Write(guestagent.FrameStdinClose, nil)
+			return
 		}
 	}
 }

--- a/config/samples/sandbox/README.md
+++ b/config/samples/sandbox/README.md
@@ -47,7 +47,13 @@ Notes:
   - `swiftctl sandbox exec <name> -- cmd args...` runs a command inside the sandbox's
     OCI rootfs over a host↔guest vsock channel (an in-guest agent). stdout/stderr
     stream back live (no output cap) and the exit code is propagated. `-e KEY=VALUE`
-    (repeatable) and `-w DIR` set environment variables and the working directory.
-    Non-interactive (no stdin/TTY yet) — interactive `attach` is a follow-up.
+    (repeatable) and `-w DIR` set environment variables and the working directory;
+    `-i` forwards stdin (e.g. `exec -i <name> -- sh < script.sh`) and `-t` allocates
+    an interactive TTY.
+  - `swiftctl sandbox attach <name>` opens an interactive shell (shorthand for
+    `exec -it -- /bin/sh`; pass `-- <cmd>` to run something else). Window resizes
+    propagate; exit with Ctrl-D or `exit`. (The guest `tty` command may print
+    "not a tty" — a chroot/devpts cosmetic quirk; the session is a real TTY, so
+    shells, editors, and `top` behave interactively.)
 - `spec.timeout` force-terminates a runaway sandbox; `spec.ttl` deletes the
   finished record (and frees the node rootfs cache reference) after it elapses.

--- a/config/samples/sandbox/swiftkernel-sandbox.yaml
+++ b/config/samples/sandbox/swiftkernel-sandbox.yaml
@@ -14,6 +14,6 @@ metadata:
   namespace: default
 spec:
   ociRef:
-    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.7
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.8
   kernelCmdline: "console=ttyS0"
   profile: sandbox

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	connectrpc.com/connect v1.20.0
 	github.com/coreos/go-oidc/v3 v3.19.0
+	github.com/creack/pty v1.1.24
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-containerregistry v0.21.7
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/coreos/go-oidc/v3 v3.19.0 h1:F/xyOi3x1UnG1U27YVnM1N6bHiL1K2upi6U/0qr8
 github.com/coreos/go-oidc/v3 v3.19.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/internal/guestagent/frame.go
+++ b/internal/guestagent/frame.go
@@ -9,24 +9,26 @@
 //
 //	[type:1][len:4 big-endian][payload:len]
 //
-// Guest->host: Stdout, Stderr, Exit (payload = 4-byte exit code). Host->guest
-// (attach only): Stdin, Resize. Frames on one connection are serialized by the
-// writer, so a reader always sees whole frames.
+// Guest->host: Stdout, Stderr, Exit (payload = 4-byte exit code). Host->guest:
+// Stdin and StdinClose (for -i and attach), Resize (attach). Frames on one
+// connection are serialized by the writer, so a reader always sees whole frames.
 package guestagent
 
 import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"sync"
 )
 
 // Frame types.
 const (
-	FrameStdout byte = 1 // guest->host: workload stdout
-	FrameStderr byte = 2 // guest->host: workload stderr
-	FrameExit   byte = 3 // guest->host: terminal; payload = int32 exit code, big-endian
-	FrameStdin  byte = 4 // host->guest: workload stdin (attach)
-	FrameResize byte = 5 // host->guest: TTY resize (attach); payload = rows:2 + cols:2, big-endian
+	FrameStdout     byte = 1 // guest->host: workload stdout
+	FrameStderr     byte = 2 // guest->host: workload stderr
+	FrameExit       byte = 3 // guest->host: terminal; payload = int32 exit code, big-endian
+	FrameStdin      byte = 4 // host->guest: workload stdin (attach / -i)
+	FrameResize     byte = 5 // host->guest: TTY resize (attach); payload = rows:2 + cols:2, big-endian
+	FrameStdinClose byte = 6 // host->guest: stdin reached EOF; close the command's stdin (keep the connection for output)
 )
 
 // MaxFramePayload bounds a single frame's payload so a hostile/broken peer cannot
@@ -87,4 +89,38 @@ func DecodeExitCode(payload []byte) int {
 		return 0
 	}
 	return int(int32(binary.BigEndian.Uint32(payload)))
+}
+
+// ResizePayload encodes a FrameResize payload (rows:2 + cols:2, big-endian).
+func ResizePayload(rows, cols uint16) []byte {
+	var b [4]byte
+	binary.BigEndian.PutUint16(b[0:2], rows)
+	binary.BigEndian.PutUint16(b[2:4], cols)
+	return b[:]
+}
+
+// DecodeResize reads a FrameResize payload back into (rows, cols); (0,0) if malformed.
+func DecodeResize(payload []byte) (rows, cols uint16) {
+	if len(payload) < 4 {
+		return 0, 0
+	}
+	return binary.BigEndian.Uint16(payload[0:2]), binary.BigEndian.Uint16(payload[2:4])
+}
+
+// FrameWriter serializes WriteFrame across goroutines that share one connection —
+// both the agent (stdout/stderr/exit) and swiftctl (stdin/resize) write frames
+// concurrently, and a frame's header+payload must not interleave with another's.
+type FrameWriter struct {
+	w  io.Writer
+	mu sync.Mutex
+}
+
+// NewFrameWriter wraps w so Write is safe for concurrent use.
+func NewFrameWriter(w io.Writer) *FrameWriter { return &FrameWriter{w: w} }
+
+// Write emits one frame atomically with respect to other Write callers.
+func (f *FrameWriter) Write(typ byte, payload []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return WriteFrame(f.w, typ, payload)
 }

--- a/internal/guestagent/frame_test.go
+++ b/internal/guestagent/frame_test.go
@@ -39,6 +39,16 @@ func TestFrameRoundTrip(t *testing.T) {
 	}
 }
 
+func TestResizeRoundTrip(t *testing.T) {
+	rows, cols := DecodeResize(ResizePayload(50, 132))
+	if rows != 50 || cols != 132 {
+		t.Fatalf("resize round-trip = (%d,%d), want (50,132)", rows, cols)
+	}
+	if r, c := DecodeResize([]byte{0, 1}); r != 0 || c != 0 {
+		t.Fatalf("short resize payload must decode to (0,0), got (%d,%d)", r, c)
+	}
+}
+
 func TestReadFrameTruncated(t *testing.T) {
 	// header claims 10 bytes but only 3 follow -> ErrUnexpectedEOF, not EOF.
 	var buf bytes.Buffer


### PR DESCRIPTION
Completes the exec/attach surface. `swiftctl sandbox exec -i` forwards stdin, `-t` allocates an interactive TTY, and `swiftctl sandbox attach <name>` is shorthand for `exec -it -- /bin/sh`.

- **`internal/guestagent`** — Stdin / Resize / StdinClose frame types, a serialized `FrameWriter` (both ends write frames concurrently), a resize codec.
- **agent** — a PTY exec path (`creack/pty`): the command's stdio is the PTY slave, **inherited across the chroot as fds** (so `/newroot` needs no `/dev/pts`); host FrameStdin feeds the PTY, FrameResize resizes it. A non-TTY `-i` path feeds a plain stdin pipe and honors `FrameStdinClose` so a piped `cat`/`sh` sees EOF instead of hanging. `serve()` dispatches tty-vs-stream over a full-duplex fd wrapper that replays any bytes read past the request newline.
- **swiftctl** — raw-mode terminal, stdin→FrameStdin, SIGWINCH→FrameResize, exit code propagated; shared `execOrAttach`.

Cluster-validated on `kernels/sandbox:6.6.8`:
| check | result |
|---|---|
| `exec -i` pipe | `printf ... \| exec -i -- cat` echoes + exits (no hang); `sh` script exits 9 |
| attach: guest TTY | `test -t 0` → true |
| attach: stdin | keystrokes reach + run in the shell |
| attach: resize | `stty size` 40×100 → **50×132** after SIGWINCH |
| attach: exit | `exit` / Ctrl-D detaches cleanly |

Known cosmetic quirk (documented): the guest `tty` command prints "not a tty" (chroot/devpts `ttyname` can't resolve the slave path) — the session is a real TTY, so isatty-based programs (shells, vi, top) behave interactively.

Third of the three exec/attach follow-ups (env/cwd → streaming → **attach**); the arc is complete.