### PR TITLE
docs(sandbox): operator guide + README funnel + v0.9.0 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,60 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.9.0] — 2026-07-12
+
+Adds **SwiftSandbox** — a third boot mode alongside disk boot and kernel
+boot: an ephemeral, strongly-isolated microVM that runs an **OCI image as
+its root filesystem** (the Firecracker/Kata model: direct-kernel boot, a
+read-only ext4 built from the image, a tmpfs overlay, no PVC). Built for CI
+runners, AI-agent/code-interpreter execution, serverless compute, and
+untrusted code. Cluster-validated end to end — an alpine microVM boots, runs
+its workload to a terminal phase, and supports interactive exec/attach over
+vsock on both network modes.
+
+### Added
+
+**SwiftSandbox (`sandbox.kubeswift.io`)**
+- `SwiftSandbox` CRD + controller — resolves an OCI image, materializes it to
+  a node-local ext4 via an init container, and boots it as a direct-kernel
+  microVM with a tmpfs overlay root. New `sandbox` SwiftKernel profile
+  (Linux 6.6.8 + bridge-initramfs; not bootable as a plain `kernelRef`
+  SwiftGuest kernel — it needs the OCI rootfs disk the controller supplies).
+  `status.phase` runs `Pending → Materializing → Running →
+  Completed`/`Failed`; `kubectl get sbox` short name. (#349)
+- **Batch lifecycle** — the workload runs as a supervised child, so its real
+  exit code surfaces as `status.exitCode` (`0` → `Completed`, non-zero →
+  `Failed`); `spec.timeout` force-terminates a runaway run; `spec.ttl`
+  deletes a finished sandbox's record and frees the node's rootfs-cache
+  reference. (#353)
+- **`spec.command`/`args`/`env`/`workingDir`** delivered to the guest over a
+  per-sandbox read-only config disk — never the kernel cmdline, so env stays
+  out of `/proc/cmdline` and the host's `ps`/logs. (`workingDir` is accepted
+  but not honored in v1 — the workload always starts in `/`.) (#352)
+- **Network modes** — `spec.network.mode: restricted` (default: deny-ingress
+  plus hardened egress — DNS and the public internet are reachable, but the
+  cloud metadata endpoint and RFC1918 cluster-internal ranges are blocked via
+  in-pod iptables), `open` (deny-ingress, unrestricted egress), or `none` (no
+  network at all). A networked sandbox resolves cluster service names and
+  external names alike via injected namespace search domains. (#351, #355)
+- **`swiftctl sandbox logs` / `exec` / `attach`** — `logs [-f]` streams the
+  workload console; `exec <name> -- cmd [args...]` runs a command inside the
+  sandbox's OCI rootfs over a host↔guest vsock channel, with stdout/stderr
+  streamed back live, the exit code propagated, `-e KEY=VALUE`/`-w DIR` for
+  env/workdir, and `-i`/`-t` for stdin forwarding and an interactive TTY;
+  `attach` is shorthand for `exec -it -- /bin/sh` with window-resize
+  propagation. (#356, #357, #358, #359, #360)
+
+### Fixed
+
+- **SwiftSandbox status was silently empty.** The sandbox launcher wasn't
+  injecting `POD_NAME`/`POD_NAMESPACE`, so swiftletd skipped all status
+  reporting; `status.runtime` and `status.network` now surface correctly.
+  (#347, #350)
+- Broken Cloud Hypervisor upstream link in `README.md`. (#346)
+
+---
+
 ## [v0.8.0] — 2026-07-08
 
 Makes multi-cluster **federation near-zero-config**. Registering the hub and its

--- a/README.md
+++ b/README.md
@@ -1,15 +1,35 @@
 # KubeSwift
 
-KubeSwift runs virtual machines as Kubernetes workloads. You define a VM with a custom resource; controllers reconcile it into a pod; inside that pod, `swiftletd` launches a hypervisor. [Cloud Hypervisor](https://www.cloudhypervisor.org/) is the hypervisor for nearly every workload — Linux and Windows guests, traditiona disk VMs and kernel boot (microVMs), PCIe GPU passthrough, snapshots, and live migration. QEMU is used for the moment as a secondary runtime only for HGX SXM (multi-GPU NVSwitch) topologies, where CUDA requires a full PCIe hierarchy that Cloud Hypervisor's flat model does not currently provide. We are tracking upstream for this capability.
+KubeSwift runs lightweight virtual machines as native Kubernetes workloads using [Cloud Hypervisor](https://www.cloudhypervisor.org/). Use it for fast Linux and Windows VMs, GPU passthrough, VM fleets, snapshots, and live migration — without adopting a traditional virtualization stack.
+
+## Why KubeSwift
+
+1. **Cloud Hypervisor first** — the hypervisor for nearly every workload: disk-boot VMs, direct kernel-boot microVMs, and ephemeral OCI-image sandboxes ([SwiftSandbox](docs/sandbox/overview.md)). QEMU is a secondary runtime, used only for HGX SXM (multi-GPU NVSwitch) topologies that need a PCIe hierarchy Cloud Hypervisor doesn't yet provide.
+2. **Kubernetes-native operations** — VMs are CRDs, reconciled by controllers like any other workload: `kubectl`, Services, fleets (`SwiftGuestPool`), GitOps, and Prometheus/Grafana observability all apply directly.
+3. **Modern infrastructure workloads** — GPU passthrough (native SwiftGPU or Kubernetes DRA), live migration with sub-second downtime, and OCI-registry-distributed VM artifacts (golden images, snapshots, cold migration).
+
+## Get started
+
+```bash
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
+  --version 0.9.0 \
+  -n kubeswift-system \
+  --create-namespace
+```
+
+Boot your first VM → [Quickstart](docs/quickstart.md).
+
+**Host requirement:** x86_64 Linux nodes with `/dev/kvm` (KVM).
 
 ## Capabilities
 
 - **Boot paths** — disk boot from cloud images (Linux and Windows) and direct kernel boot from OCI artifacts (sub-second microVMs).
 - **GPU passthrough** — whole-GPU VFIO passthrough with two allocation backends: the native SwiftGPU model (discovery DaemonSet + profiles) or Kubernetes [DRA](docs/gpu/dra-allocation.md) ResourceClaims. PCIe GPUs on Cloud Hypervisor; HGX SXM on QEMU.
-- **Networking** — tap + bridge + DHCP with the guest IP surfaced in status; multi-NIC via Multus; SR-IOV NIC passthrough; OVN Backend supported: OVN-Kubernetes and multi-node L2 with IP-preserving cross-node live migration (kube-ovn primary-on-NAD — see [`docs/networking/ovn-l2-install.md`](docs/networking/ovn-l2-install.md)).
+- **Networking** — tap + bridge + DHCP with the guest IP surfaced in status; multi-NIC via Multus; SR-IOV NIC passthrough; OVN backends supported: OVN-Kubernetes and multi-node L2 with IP-preserving cross-node live migration (kube-ovn primary-on-NAD — see [`docs/networking/ovn-l2-install.md`](docs/networking/ovn-l2-install.md)).
 - **Services** — expose guest ports as Kubernetes Services via `spec.network.ports` (ClusterIP/NodePort/LoadBalancer), a load-balanced Service across pool replicas via `SwiftGuestPool.spec.service`, and a VM→cluster egress reachability probe surfaced as `EgressReady`.
 - **Storage** — per-guest root-disk cloning sized from a class; optional data disks (blank/sized, image-backed, or attached PVC); RWX+Block for live-migration-capable volumes.
 - **Snapshots & clones** — disk-only (CSI) and memory+disk (local/S3) snapshots, scheduled snapshots, and `cloneFromSnapshot` for fast VM fan-out.
+- **Sandboxes** — ephemeral OCI-rootfs microVMs ([SwiftSandbox](docs/sandbox/overview.md)) for CI runners, agent/code execution, and untrusted code; restricted-by-default egress.
 - **OCI registry artifacts** — golden VM images (`SwiftImage.spec.source.oci` + `swiftctl image publish`, cosign-signed with verify-on-pull) and VM snapshots / full-state cold migration (`SwiftSnapshot` `backend.type: oci`) stored in any OCI registry, for cross-cluster and edge distribution.
 - **Migration** — offline migration on any storage, and live migration (sub-second downtime) with optional mTLS transport and `kubectl drain` integration.
 - **Fleets** — `SwiftGuestPool` gives ReplicaSet-style scaling with rolling updates, topology spread, and a PVC per replica.
@@ -31,9 +51,10 @@ KubeSwift runs virtual machines as Kubernetes workloads. You define a VM with a 
 | SwiftRestore | srst | `snapshot.kubeswift.io` | Namespaced | Restore from a snapshot |
 | SwiftSnapshotSchedule | — | `snapshot.kubeswift.io` | Namespaced | Cron-scheduled snapshots + keep-N |
 | SwiftMigration | smig | `migration.kubeswift.io` | Namespaced | Move a guest between nodes |
+| SwiftSandbox | `sbox` | `sandbox.kubeswift.io` | Namespaced | Ephemeral OCI-rootfs microVM |
 | Cluster | `ksc` | `fleet.kubeswift.io` | Namespaced | Member cluster federated by the gateway hub |
 
-13 CRDs, all `v1alpha1`.
+14 CRDs, all `v1alpha1`.
 
 ## Documentation
 
@@ -45,8 +66,11 @@ Start at the **[documentation index](docs/index.md)**. Common entry points:
 - [GPU passthrough](docs/gpu-passthrough.md) · [GPU via DRA](docs/gpu/dra-allocation.md)
 - [Networking operations](docs/networking/operations-guide.md)
 - [Snapshots](docs/snapshots/csi-snapshots.md) · [Live migration](docs/migration/overview.md)
+- [Sandboxes](docs/sandbox/overview.md) — ephemeral OCI-rootfs microVMs
 - [swiftctl CLI](docs/swiftctl.md) · [Observability](docs/observability/README.md)
 - [Install (Helm/OCI)](docs/install/helm-oci.md)
+
+Questions or problems: [GitHub Issues](https://github.com/kubeswift-io/kubeswift/issues).
 
 ## Build
 
@@ -60,7 +84,7 @@ cargo test          # Rust tests (from rust/)
 
 ## Status
 
-Pre-1.0; the `v1alpha1` API may change between releases. **Host requirement:** x86_64 Linux nodes with `/dev/kvm` (KVM).
+Pre-1.0; the `v1alpha1` API may change between releases.
 
 ## License
 

--- a/api/sandbox/v1alpha1/swiftsandbox_types.go
+++ b/api/sandbox/v1alpha1/swiftsandbox_types.go
@@ -9,7 +9,7 @@ import (
 // SwiftSandboxSpec defines an ephemeral, strongly-isolated microVM that runs an
 // OCI image as its root filesystem (the mode-3 sandbox boot: a direct-kernel
 // boot + a read-only OCI rootfs + a tmpfs overlay). See
-// docs/design/swiftsandbox-design.md.
+// docs/sandbox/overview.md.
 type SwiftSandboxSpec struct {
 	// Image is the OCI image to run as the sandbox root filesystem. A digest
 	// reference (repo@sha256:...) is strongly preferred for reproducibility and
@@ -95,7 +95,7 @@ const (
 
 // SandboxNetwork is the sandbox networking policy.
 type SandboxNetwork struct {
-	// Mode is "restricted" (default) or "none".
+	// Mode is "restricted" (default), "open", or "none".
 	// +kubebuilder:default=restricted
 	// +optional
 	Mode SandboxNetworkMode `json:"mode,omitempty"`

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.9.0
+appVersion: "0.9.0"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/charts/kubeswift/crds/sandbox.kubeswift.io_swiftsandboxes.yaml
+++ b/charts/kubeswift/crds/sandbox.kubeswift.io_swiftsandboxes.yaml
@@ -59,7 +59,7 @@ spec:
               SwiftSandboxSpec defines an ephemeral, strongly-isolated microVM that runs an
               OCI image as its root filesystem (the mode-3 sandbox boot: a direct-kernel
               boot + a read-only OCI rootfs + a tmpfs overlay). See
-              docs/design/swiftsandbox-design.md.
+              docs/sandbox/overview.md.
             properties:
               args:
                 description: |-
@@ -280,7 +280,7 @@ spec:
                 properties:
                   mode:
                     default: restricted
-                    description: Mode is "restricted" (default) or "none".
+                    description: Mode is "restricted" (default), "open", or "none".
                     enum:
                     - restricted
                     - open

--- a/config/crd/bases/sandbox.kubeswift.io_swiftsandboxes.yaml
+++ b/config/crd/bases/sandbox.kubeswift.io_swiftsandboxes.yaml
@@ -59,7 +59,7 @@ spec:
               SwiftSandboxSpec defines an ephemeral, strongly-isolated microVM that runs an
               OCI image as its root filesystem (the mode-3 sandbox boot: a direct-kernel
               boot + a read-only OCI rootfs + a tmpfs overlay). See
-              docs/design/swiftsandbox-design.md.
+              docs/sandbox/overview.md.
             properties:
               args:
                 description: |-
@@ -280,7 +280,7 @@ spec:
                 properties:
                   mode:
                     default: restricted
-                    description: Mode is "restricted" (default) or "none".
+                    description: Mode is "restricted" (default), "open", or "none".
                     enum:
                     - restricted
                     - open

--- a/config/dra-driver/dra-driver.yaml
+++ b/config/dra-driver/dra-driver.yaml
@@ -83,7 +83,7 @@ spec:
         - name: dra-driver
           # Pinned to the release (no :latest tag is published). Bump on release;
           # or use the Helm chart (dra.enabled=true), which manages this version.
-          image: ghcr.io/kubeswift-io/kubeswift/kubeswift-dra-driver:v0.8.0
+          image: ghcr.io/kubeswift-io/kubeswift/kubeswift-dra-driver:v0.9.0
           args:
             - --v=2
           env:

--- a/config/samples/rocky/swiftguest-rocky.yaml
+++ b/config/samples/rocky/swiftguest-rocky.yaml
@@ -1,3 +1,26 @@
+apiVersion: seed.kubeswift.io/v1alpha1
+kind: SwiftSeedProfile
+metadata:
+  name: default
+  namespace: default
+spec:
+  datasource: NoCloud
+  userData: |
+    #cloud-config
+    hostname: kubeswift-rocky
+    users:
+      - name: kubeswift
+        passwd: $6$kubeswift$/2TeJTNbX7JcApzW0gTbSFzCAN4eFcOdnQsI0lVANFpXhHmjqLy7npyhHxvT65kpUd0YKVMBAbRt3MUfV6eCJ.
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        lock_passwd: false
+        ssh_authorized_keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ53Xu8rRSofCQqb91XUgZqQam+5Q2e7tOwr0egG/W5x
+    runcmd:
+      - systemctl enable --now getty@ttyS0.service
+  metaData: |
+    instance-id: kubeswift-302
+    local-hostname: kubeswift-rocky
+---
 apiVersion: swift.kubeswift.io/v1alpha1
 kind: SwiftGuest
 metadata:
@@ -9,5 +32,5 @@ spec:
   guestClassRef:
     name: default
   seedProfileRef:
-    name: minimal
+    name: default
   runPolicy: Running

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -312,9 +312,10 @@ Key facts:
 | `gpu.kubeswift.io/v1alpha1` | SwiftGPUProfile, SwiftGPUNode | GPU passthrough |
 | `snapshot.kubeswift.io/v1alpha1` | SwiftSnapshot, SwiftRestore, SwiftSnapshotSchedule | Snapshot, restore, scheduled snapshots |
 | `migration.kubeswift.io/v1alpha1` | SwiftMigration | Offline + live migration between nodes |
+| `sandbox.kubeswift.io/v1alpha1` | SwiftSandbox | Ephemeral OCI-rootfs microVM sandboxes |
 | `fleet.kubeswift.io/v1alpha1` | Cluster | Member cluster federated by the gateway hub |
 
-13 CRDs across 8 API groups, all `v1alpha1`.
+14 CRDs across 9 API groups, all `v1alpha1`.
 
 ## Design principles
 

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -1,6 +1,6 @@
 # CRD Reference
 
-All KubeSwift CRDs are `v1alpha1`. KubeSwift ships **13 CRDs across 8 API groups**. This document gives full field detail for the core workload CRDs (SwiftGuest, SwiftGuestClass, SwiftImage, SwiftSeedProfile, SwiftKernel, SwiftGPUProfile, SwiftGPUNode), and concise reference entries — purpose, key fields, and a link to the authoritative feature doc — for the snapshot, migration, pool, and fleet CRDs. For exhaustive field detail on any CRD, use `kubectl explain <crd>` against an installed cluster.
+All KubeSwift CRDs are `v1alpha1`. KubeSwift ships **14 CRDs across 9 API groups**. This document gives full field detail for the core workload CRDs (SwiftGuest, SwiftGuestClass, SwiftImage, SwiftSeedProfile, SwiftKernel, SwiftGPUProfile, SwiftGPUNode), and concise reference entries — purpose, key fields, and a link to the authoritative feature doc — for the snapshot, migration, pool, sandbox, and fleet CRDs. For exhaustive field detail on any CRD, use `kubectl explain <crd>` against an installed cluster.
 
 | CRD | Short | API group | Scope | Reference |
 |-----|-------|-----------|-------|-----------|
@@ -16,6 +16,7 @@ All KubeSwift CRDs are `v1alpha1`. KubeSwift ships **13 CRDs across 8 API groups
 | SwiftRestore | — | `snapshot.kubeswift.io` | Namespaced | [below](#swiftrestore) |
 | SwiftSnapshotSchedule | — | `snapshot.kubeswift.io` | Namespaced | [below](#swiftsnapshotschedule) |
 | SwiftMigration | — | `migration.kubeswift.io` | Namespaced | [below](#swiftmigration) |
+| SwiftSandbox | `sbox` | `sandbox.kubeswift.io` | Namespaced | [below](#swiftsandbox) |
 | Cluster | `ksc` | `fleet.kubeswift.io` | Namespaced | [below](#cluster) |
 
 ## Mutual exclusivity rules
@@ -516,6 +517,33 @@ Moves a SwiftGuest between nodes — offline (any storage) or live (sub-second d
 | `reason` | string | Free-text operator note (e.g. `"node maintenance"`). |
 
 Full reference: [Migration overview](migration/overview.md).
+
+---
+
+## SwiftSandbox
+
+**Group:** `sandbox.kubeswift.io/v1alpha1`
+**Scope:** Namespaced
+**Short name:** `sbox`
+**Subresource:** status
+
+An ephemeral, strongly-isolated microVM that runs an OCI image as its root
+filesystem — a third boot mode alongside disk boot and kernel boot, ephemeral
+and PVC-free.
+
+| Key field | Type | Description |
+|-----------|------|--------------|
+| `image` | string | OCI image to run as the root filesystem. Required; immutable after create. |
+| `cpu` / `memory` | int32 / Quantity | vCPUs (default `1`) and RAM (default `512Mi`). |
+| `command` / `args` / `env` | []string / []string / []EnvVar | Override or extend the image's entrypoint. |
+| `network.mode` | enum | `restricted` (default, deny-ingress + hardened egress), `open` (deny-ingress, allow-all egress), or `none`. |
+| `kernelProfileRef` | LocalObjectReference | SwiftKernel to boot; defaults to the well-known `sandbox` profile. |
+| `timeout` / `ttl` | Duration | Wall-clock run cap and post-terminal retention. |
+
+The whole spec except `ttl` is immutable — recreate the sandbox to change
+image, resources, command, or network.
+
+Full reference: [Sandboxes](sandbox/overview.md).
 
 ---
 

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.6.1 -n kubeswift-system --create-namespace \
+  --version 0.9.0 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,10 @@ KubeSwift runs Linux and Windows VMs on Kubernetes. [Cloud Hypervisor](https://w
 
 - [virtiofs & vhost-user devices](virtiofs.md) — shared filesystems (virtiofs), vhost-user-net/blk/generic (operator backends)
 
+### Sandboxes
+
+- [Ephemeral OCI-rootfs sandboxes](sandbox/overview.md) — SwiftSandbox: run an OCI image as a microVM (CI runners, agent/code execution, untrusted code)
+
 ### Windows Guests
 
 - [Running Windows guests](windows/overview.md) — Overview: `osType: windows`, the end-to-end lifecycle, RDP management, limitations
@@ -144,6 +148,7 @@ The `oci` snapshot backend (`SwiftSnapshot.spec.backend.type: oci`) pushes memor
 | Pass a GPU through to a VM | [GPU Passthrough](gpu-passthrough.md) / [via DRA](gpu/dra-allocation.md) |
 | Snapshot or clone a VM | [Snapshots & fast VMs](snapshots/fast-vms.md) |
 | Migrate a VM between nodes | [Migration overview](migration/overview.md) |
+| Run an ephemeral sandbox | [Sandboxes](sandbox/overview.md) |
 | Publish a golden VM image | [Golden images](registry/golden-images.md) |
 | Migrate from VMware/Proxmox | [Virtualization Comparison](networking/virtualization-comparison.md) |
 | Build locally | [Build](developer/build.md) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.6.1 \
+  --version 0.9.0 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -57,11 +57,11 @@ Verify CRDs are installed:
 
 ```bash
 kubectl get crd | grep kubeswift.io
-# Expected (13 CRDs): swiftguests, swiftguestclasses, swiftguestpools,
+# Expected (14 CRDs): swiftguests, swiftguestclasses, swiftguestpools,
 #   swiftimages, swiftseedprofiles, swiftkernels,
 #   swiftgpuprofiles, swiftgpunodes,
 #   swiftsnapshots, swiftrestores, swiftsnapshotschedules,
-#   swiftmigrations, clusters
+#   swiftmigrations, swiftsandboxes, clusters
 ```
 
 ## Step 2: Boot a disk-boot VM (Ubuntu Noble)
@@ -358,6 +358,7 @@ kubectl get swiftsnapshots          # SwiftSnapshot
 kubectl get swiftrestores           # SwiftRestore
 kubectl get swiftsnapshotschedules  # SwiftSnapshotSchedule
 kubectl get swiftmigrations         # SwiftMigration
+kubectl get sbox                    # SwiftSandbox
 ```
 
 ## Documentation

--- a/docs/sandbox/overview.md
+++ b/docs/sandbox/overview.md
@@ -1,0 +1,163 @@
+# Running sandboxes
+
+KubeSwift runs ephemeral, strongly-isolated microVMs that boot an **OCI image
+as the VM root filesystem** — a `SwiftSandbox`. This page is the operator
+entry point; the sample manifests are linked inline.
+
+> **Status: cluster-validated end-to-end (2026-07-11).** An alpine microVM
+> boots, runs its workload to a terminal `Completed`/`Failed` phase, and
+> supports interactive exec/attach over vsock — validated on both `restricted`
+> and `open` network modes. First ships in **v0.9.0**.
+
+## What it is
+
+SwiftSandbox is a third boot mode alongside SwiftGuest's disk boot and kernel
+boot: a direct-kernel boot + a read-only ext4 built from an OCI image + a
+tmpfs overlay + a bridge-initramfs that execs the image's entrypoint (the
+Firecracker/Kata model — not SwiftGuest's qcow2-disk pipeline). A SwiftSandbox
+is ephemeral: it runs the workload to completion and holds no PVC. Once
+terminal, it stays around for inspection until deleted (or `spec.ttl` cleans
+it up).
+
+## When to use it
+
+- CI runners — a clean, disposable VM per job
+- AI-agent / code-interpreter execution — a real kernel boundary around
+  generated or untrusted code, not just a container
+- Serverless / short-lived compute
+- Untrusted code and security research
+
+## Prerequisites
+
+- A node labeled `kubeswift.io/kernel-node=true`
+- A `Ready` `SwiftKernel` named `sandbox` (OCI artifact
+  `ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.8`, pulled per node)
+
+The sandbox kernel is not a plain `kernelRef` SwiftGuest kernel — its
+bridge-initramfs needs the OCI rootfs disk that the SwiftSandbox controller
+supplies at launch, so it only boots as a SwiftSandbox.
+
+## Quickstart
+
+```bash
+kubectl apply -f config/samples/sandbox/swiftkernel-sandbox.yaml
+kubectl get swiftkernel sandbox -w        # wait for Ready
+
+kubectl apply -f config/samples/sandbox/swiftsandbox.yaml
+kubectl get sbox -w                       # Pending -> Materializing -> Running -> Completed
+```
+
+Ready-to-edit manifests and notes:
+[`config/samples/sandbox/`](../../config/samples/sandbox/).
+
+## CRD field reference
+
+### Spec
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `image` | string | — | OCI image to run as the root filesystem. Required. A digest reference (`repo@sha256:...`) is preferred for reproducibility; a tag is accepted. |
+| `imagePullSecret` | string | — | docker-registry Secret (same namespace) for pulling `image` from a private registry. |
+| `cpu` | int32 | `1` | vCPU count. |
+| `memory` | Quantity | `512Mi` | Guest RAM. |
+| `command` | []string | — | Overrides the image's ENTRYPOINT. Empty uses the image's own Entrypoint+Cmd. |
+| `args` | []string | — | Appended to `command` (or the image's CMD when `command` is empty). |
+| `env` | []EnvVar | — | Merged over the image's config env. |
+| `workingDir` | string | — | Overrides the image's working directory. **Accepted but not honored in v1** — the workload always starts in `/`. |
+| `timeout` | Duration | none | Wall-clock run cap. Past `startedAt + timeout` the controller force-terminates the sandbox to `Failed` (`DeadlineExceeded`). |
+| `ttl` | Duration | none | Once the sandbox has been terminal (`Completed`/`Failed`) for at least `ttl`, the controller deletes it and frees the node's rootfs-cache reference. |
+| `network.mode` | enum | `restricted` | `restricted`, `open`, or `none`. See [Network modes](#network-modes). |
+| `kernelProfileRef.name` | string | `sandbox` | SwiftKernel to boot. |
+| `nodeSelector` | map[string]string | — | Additional node constraints, merged with the required `kubeswift.io/kernel-node=true`. |
+
+Everything in `spec` except `ttl` is immutable after create — recreate the
+sandbox to change image, resources, command, or network.
+
+### Status
+
+| Field | Type | Description |
+|---|---|---|
+| `phase` | enum | `Pending`, `Materializing`, `Running`, `Completed`, `Failed`. |
+| `conditions[]` | []Condition | `Resolved`, `RootfsReady`, `GuestRunning`. |
+| `nodeName` | string | Node running the sandbox. |
+| `podRef` | string | Launcher pod name. |
+| `rootfs.digest` | string | Resolved image digest (`sha256:...`). |
+| `rootfs.sizeBytes` | int64 | Materialized ext4 size. |
+| `rootfs.cachePath` | string | Node-local rootfs artifact path. |
+| `runtime.pid` | int64 | Hypervisor process PID (reported by swiftletd). |
+| `runtime.hypervisor` | string | Always `cloud-hypervisor`. |
+| `network.primaryIP` | string | Guest DHCP IP. Absent for `network.mode: none`. |
+| `startedAt` | Time | When the guest began running. |
+| `terminalAt` | Time | When the sandbox first reached `Completed`/`Failed` — the anchor for `spec.ttl`. |
+| `exitCode` | int32 | The workload's real exit code: `0` → `Completed`, non-zero → `Failed`. |
+| `message` | string | Human-readable status detail. |
+
+`kubectl get sbox` prints Phase, Image, Node, IP, and Age.
+
+## Network modes
+
+| Mode | Ingress | Egress | Use for |
+|---|---|---|---|
+| `restricted` (default) | Denied — nothing reaches the sandbox | DNS and the public internet are allowed; `169.254.0.0/16` (cloud metadata) and RFC1918 cluster/pod/service CIDRs are blocked | Untrusted code |
+| `open` | Denied | Unrestricted — the whole cluster and internet | Trusted workloads that must reach in-cluster services |
+| `none` | No network at all | No network at all | Pure compute / detonation |
+
+Ingress isolation is a NetworkPolicy shared by `restricted` and `open` (deny
+all inbound). The `restricted` vs `open` difference is entirely **in-pod
+iptables** on the VM's forwarded traffic, not a NetworkPolicy — a
+NetworkPolicy that blocked cluster egress would also cut swiftletd's own
+status reporting, since the VM's traffic and swiftletd's apiserver calls
+share the pod IP after MASQUERADE.
+
+A networked sandbox resolves cluster service names and external names alike
+— the controller injects the namespace's search domains and `ndots:5`.
+`restricted` still blocks *connecting* to cluster IPs; name resolution and
+egress reachability are separate concerns.
+
+## Interacting with a sandbox
+
+```bash
+swiftctl sandbox logs <name> [-f]
+swiftctl sandbox exec <name> [-e KEY=VALUE] [-w DIR] [-i] [-t] -- <cmd> [args...]
+swiftctl sandbox attach <name> [-- <cmd>]
+```
+
+- `logs` streams the workload's console (`-f` to follow).
+- `exec` runs a command inside the sandbox's OCI rootfs over a host↔guest
+  vsock channel (an in-guest agent). stdout/stderr stream back live and the
+  command's exit code is propagated. `-e` (repeatable) sets environment
+  variables, `-w` sets the working directory, `-i` forwards stdin, `-t`
+  allocates an interactive TTY.
+- `attach` is shorthand for `exec -it -- /bin/sh` (pass `-- <cmd>` to run
+  something else). Terminal resizes propagate; exit with Ctrl-D or `exit`.
+
+## Lifecycle
+
+`Pending` (resolving the image and kernel profile) → `Materializing` (the
+rootfs init container builds the ext4) → `Running` (guest up) → `Completed`
+(workload exited `0`) or `Failed` (boot/materialize failure, non-zero exit,
+or `spec.timeout` exceeded).
+
+`status.exitCode` carries the workload's real exit code. `spec.timeout`
+bounds a runaway run; `spec.ttl` cleans up a finished sandbox's record once
+you're done inspecting it.
+
+## Troubleshooting
+
+- **Stuck `Materializing`** — check `kubectl describe pod <name>`. Unscheduled
+  usually means no node carries `kubeswift.io/kernel-node=true`, or the
+  `sandbox` SwiftKernel hasn't finished pulling to that node yet
+  (`kubectl get swiftkernel sandbox`). A failing `sandbox-materialize` init
+  container usually means the image pull failed — check `spec.image` and
+  `spec.imagePullSecret` and inspect the init container's logs.
+- **`tty` reports "not a tty" inside an attached session** — a chroot/devpts
+  cosmetic quirk. The session is a real TTY; shells, `vi`, and `top` all
+  behave interactively.
+- **No `status.network.primaryIP`** — expected for `network.mode: none`; by
+  design there is no network to report.
+
+## See also
+
+- [`config/samples/sandbox/`](../../config/samples/sandbox/) — sample manifests and notes
+- [swiftctl reference](../swiftctl.md)
+- [SwiftKernel reference](../swiftkernel.md)


### PR DESCRIPTION
Packages the shipped-but-unreleased **SwiftSandbox** arc and preps the **v0.9.0** release. Staff-architect designed the docs IA + README strategy + version audit; technical-writer wrote the docs; I did the version/CRD mechanics.

## Operator docs
- **New `docs/sandbox/overview.md`** — the SwiftSandbox operator guide (what it is, prerequisites, quickstart, spec+status field reference, network modes, exec/attach/logs, lifecycle, troubleshooting). Grounded in the shipped CRD, `swiftctl sandbox` flags, and the webhook — verified: printcolumns (`Phase/Image/Node/IP/Age`) and "whole spec except `ttl` is immutable" both match code.
- Wired into `docs/index.md`, `docs/crds.md` (reference entry), `docs/architecture.md`.

## README conversion funnel
Restructured per the promotion strategy: one-line what/why → **three differentiators** (Cloud Hypervisor first / Kubernetes-native ops / modern infra workloads) → **Get started** → Capabilities → CRD table → docs+help. Fixed the `traditiona` typo and surfaced SwiftSandbox in the differentiators, capabilities, and CRD table.
> **The README is a structural draft** — I kept it terse/accurate but left the final voice pass to you.

## v0.9.0 prep
- `charts/kubeswift/Chart.yaml` version + appVersion `0.8.0 → 0.9.0`; DRA-driver image pin `→ v0.9.0`.
- **Fixed stale install pins:** `docs/quickstart.md` and `docs/gpu/dra-allocation.md` were pinning the old **0.6.1** (the conversion-funnel bug you flagged) → now `0.9.0`. README install → `0.9.0`.
- CRD count corrected everywhere: **14 CRDs / 9 API groups** (added the `sandbox.kubeswift.io` group), `kubectl get sbox` added to quickstart.
- `CHANGELOG.md`: `[Unreleased]` promoted to **`[v0.9.0] — 2026-07-12`** with the SwiftSandbox arc as headline.
- Two stale SwiftSandbox code docstrings fixed (network.mode enum missing `open`; a pointer to the gitignored design doc → the new operator guide) + CRD regenerated.

## Also included
- The **Rocky SwiftGuest sample** (`b3738f5`) rides along per request.

Closes the docs gap under #341 (epic stays open for warm-pool + follow-ups); #342–#345 already closed. No code behavior change — docs + version strings + CRD field descriptions only.