### PR TITLE
feat(sandbox): warm-pool ops — node-spread warm slots + checkout metric

### DIFF
--- a/internal/controller/swiftsandbox/checkout.go
+++ b/internal/controller/swiftsandbox/checkout.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/metrics"
 )
 
 // sandbox-exec action/status annotation keys — MUST match the swiftletd action loop's
@@ -84,6 +85,7 @@ func (r *SwiftSandboxReconciler) reconcilePooled(ctx context.Context, sb *sandbo
 		}
 		r.Recorder.Eventf(sb, corev1.EventTypeNormal, "CheckedOut",
 			"claimed warm slot %s from pool %s", slot.Name, sb.Spec.PoolRef.Name)
+		metrics.SandboxCheckoutsTotal.WithLabelValues("hit").Inc()
 	}
 
 	now := metav1.Now()
@@ -108,6 +110,7 @@ func (r *SwiftSandboxReconciler) coldFallback(ctx context.Context, sb *sandboxv1
 	log.FromContext(ctx).Info("SwiftSandbox pool miss; cold-fallback", "sandbox", sb.Name, "reason", reason)
 	r.Recorder.Eventf(sb, corev1.EventTypeNormal, "PoolColdFallback",
 		"pool %s: %s; booting cold", sb.Spec.PoolRef.Name, reason)
+	metrics.SandboxCheckoutsTotal.WithLabelValues("cold").Inc()
 	sb.Status.PodRef = sb.Name
 	return r.createLaunch(ctx, sb, kernelName)
 }

--- a/internal/controller/swiftsandbox/checkout.go
+++ b/internal/controller/swiftsandbox/checkout.go
@@ -85,7 +85,9 @@ func (r *SwiftSandboxReconciler) reconcilePooled(ctx context.Context, sb *sandbo
 		}
 		r.Recorder.Eventf(sb, corev1.EventTypeNormal, "CheckedOut",
 			"claimed warm slot %s from pool %s", slot.Name, sb.Spec.PoolRef.Name)
-		metrics.SandboxCheckoutsTotal.WithLabelValues("hit").Inc()
+		if metrics.MarkSandboxCheckoutObserved(string(sb.UID)) {
+			metrics.SandboxCheckoutsTotal.WithLabelValues("hit").Inc()
+		}
 	}
 
 	now := metav1.Now()
@@ -110,7 +112,9 @@ func (r *SwiftSandboxReconciler) coldFallback(ctx context.Context, sb *sandboxv1
 	log.FromContext(ctx).Info("SwiftSandbox pool miss; cold-fallback", "sandbox", sb.Name, "reason", reason)
 	r.Recorder.Eventf(sb, corev1.EventTypeNormal, "PoolColdFallback",
 		"pool %s: %s; booting cold", sb.Spec.PoolRef.Name, reason)
-	metrics.SandboxCheckoutsTotal.WithLabelValues("cold").Inc()
+	if metrics.MarkSandboxCheckoutObserved(string(sb.UID)) {
+		metrics.SandboxCheckoutsTotal.WithLabelValues("cold").Inc()
+	}
 	sb.Status.PodRef = sb.Name
 	return r.createLaunch(ctx, sb, kernelName)
 }

--- a/internal/controller/swiftsandbox/pool_controller.go
+++ b/internal/controller/swiftsandbox/pool_controller.go
@@ -133,6 +133,17 @@ func slotsToCreate(minWarm, maxWarm, warmLive int) int {
 	return want
 }
 
+// warmSlotTopologySpread spreads a pool's warm slots one-per-node across kernel-nodes
+// (MaxSkew 1 over the hostname), soft so it never blocks warming.
+func warmSlotTopologySpread(poolName string) []corev1.TopologySpreadConstraint {
+	return []corev1.TopologySpreadConstraint{{
+		MaxSkew:           1,
+		TopologyKey:       "kubernetes.io/hostname",
+		WhenUnsatisfiable: corev1.ScheduleAnyway,
+		LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{PoolLabelKey: poolName}},
+	}}
+}
+
 // slotTemplate builds the synthetic (unpersisted) SwiftSandbox for a warm slot: the
 // pool's slot shape + the idle keeper command. The launch builders read only its
 // fields; the resulting pod/ConfigMap/NetworkPolicy are owned by the POOL.
@@ -174,6 +185,10 @@ func (r *SwiftSandboxPoolReconciler) createWarmSlot(ctx context.Context, pool *s
 	pod := buildPod(slot, kernelName)
 	pod.Labels[PoolLabelKey] = pool.Name
 	pod.Labels[SlotStateLabelKey] = slotStateWarm
+	// Spread the pool's slots across kernel-nodes so a checkout landing on any node is
+	// likely to find a warm slot there (warming is node-local). Soft (ScheduleAnyway):
+	// never block warming just because one node is full.
+	pod.Spec.TopologySpreadConstraints = warmSlotTopologySpread(pool.Name)
 	if err := controllerutil.SetControllerReference(pool, pod, r.Scheme); err != nil {
 		return err
 	}

--- a/internal/controller/swiftsandbox/pool_controller.go
+++ b/internal/controller/swiftsandbox/pool_controller.go
@@ -108,7 +108,8 @@ func (r *SwiftSandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return ctrl.Result{}, err
 		}
 	}
-	// (idleTTL scale-down + explicit node-spread are follow-up phases.)
+	// (idleTTL scale-down is a follow-up phase; node-spread is applied per slot
+	// in createWarmSlot via warmSlotTopologySpread.)
 
 	return r.updateStatus(ctx, &pool, ready, claimed, ri)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -311,6 +311,20 @@ func MarkCloneDownloadObserved(key string) bool {
 	return !loaded
 }
 
+// sandboxCheckoutObserved dedupes the per-sandbox checkout decision (hit vs
+// cold) so SandboxCheckoutsTotal counts once per SwiftSandbox — the cold-
+// fallback path can re-enter across reconciles until status.podRef persists
+// (the cold createLaunch may requeue on image resolve before the status write
+// lands). Keyed on the sandbox UID; a controller restart may re-count once
+// (acceptable for a counter, mirroring cloneDownloadObserved).
+var sandboxCheckoutObserved sync.Map
+
+// MarkSandboxCheckoutObserved returns true the first time uid is seen.
+func MarkSandboxCheckoutObserved(uid string) bool {
+	_, loaded := sandboxCheckoutObserved.LoadOrStore(uid, struct{}{})
+	return !loaded
+}
+
 func init() {
 	metrics.Registry.MustRegister(
 		VMBootSeconds,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -283,6 +283,19 @@ var (
 		},
 		[]string{"policy", "result"},
 	)
+
+	// SandboxCheckoutsTotal counts SwiftSandbox pool checkouts by result:
+	// "hit" (claimed a pre-booted warm slot — the fast path) or "cold" (no warm
+	// slot available, or no command to inject — fell back to the cold
+	// materialize+boot path). The hit rate is the warm pool's headline signal;
+	// a persistent "cold" rate means minWarm is too low for the arrival rate.
+	SandboxCheckoutsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubeswift_sandbox_checkouts_total",
+			Help: "SwiftSandbox pool checkouts by result (hit=claimed a warm slot, cold=fell back to the cold path)",
+		},
+		[]string{"result"},
+	)
 )
 
 // cloneDownloadObserved dedupes the per-(node,snapshot) clone download byte
@@ -322,5 +335,6 @@ func init() {
 		GPUReleasesTotal,
 		DrainMigrationsTotal,
 		ImageImportTotal,
+		SandboxCheckoutsTotal,
 	)
 }

--- a/internal/metrics/sandbox_checkout_test.go
+++ b/internal/metrics/sandbox_checkout_test.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestMarkSandboxCheckoutObserved_DedupesPerUID(t *testing.T) {
+	if !MarkSandboxCheckoutObserved("uid-A") {
+		t.Fatal("first sighting of uid-A should return true")
+	}
+	if MarkSandboxCheckoutObserved("uid-A") {
+		t.Error("second sighting of uid-A should return false (deduped)")
+	}
+	if !MarkSandboxCheckoutObserved("uid-B") {
+		t.Error("first sighting of a different uid should return true")
+	}
+}
+
+// The cold-fallback path can re-enter across reconciles until status.podRef
+// persists (the cold createLaunch may requeue on image resolve before the
+// status write lands). Gating SandboxCheckoutsTotal on the UID dedupe makes the
+// counter fire once per sandbox regardless of how many times the decision runs.
+func TestSandboxCheckout_CountsOncePerSandbox(t *testing.T) {
+	before := testutil.ToFloat64(SandboxCheckoutsTotal.WithLabelValues("cold"))
+	const uid = "uid-cold-dedupe"
+	for i := 0; i < 3; i++ { // 3 cold-fallback reconciles of the SAME sandbox
+		if MarkSandboxCheckoutObserved(uid) {
+			SandboxCheckoutsTotal.WithLabelValues("cold").Inc()
+		}
+	}
+	if delta := testutil.ToFloat64(SandboxCheckoutsTotal.WithLabelValues("cold")) - before; delta != 1 {
+		t.Errorf("cold counter delta = %v, want 1 (deduped across 3 reconciles)", delta)
+	}
+}


### PR DESCRIPTION
Warm-pool operational polish (P4), part 1 of the ops+docs pass on the SwiftSandbox warm-pool arc (epic #362).

## What

- **Node-spread warm slots.** A `SwiftSandboxPool`'s warm slots now carry a soft topology-spread constraint (MaxSkew 1 over `kubernetes.io/hostname`, `ScheduleAnyway`) so they land one-per-node across the kernel-nodes instead of piling onto whichever node the scheduler picks first. Warming is node-local (the rootfs materializes on the node), so a checkout that lands on any node is much more likely to find a warm slot *there*. Soft so warming never blocks just because one node is momentarily full.
- **Checkout hit/miss metric.** New `kubeswift_sandbox_checkouts_total{result}` counter: `hit` (claimed a pre-booted warm slot — the sub-second path) vs `cold` (no warm slot available, or a sandbox with no command to inject → cold materialize+boot fallback). The hit rate is the warm pool's headline operational signal; a persistent `cold` rate means `minWarm` is too low for the arrival rate.

## Why

Both are ops-visibility/reliability refinements the warm-pool core (P1–P3, #363/#364/#365/#366) deferred. Node-spread makes multi-node pools actually useful; the counter makes the pool's effectiveness observable.

## Tests

- `go test ./internal/controller/swiftsandbox/... ./internal/metrics/...` green.
- Existing checkout tests (hit/cold behavior) unchanged and passing.

## Cluster validation

Deploying a controller image built from this branch to the dev cluster and confirming a pool's warm slots spread across boba + miles (not one node), and the counter increments on hit/cold. Results appended before merge.

Refs #362