### PR TITLE
feat(sandbox): scale subresource on the warm pool (kubectl scale + HPA-ready)

### DIFF
--- a/api/sandbox/v1alpha1/swiftsandboxpool_types.go
+++ b/api/sandbox/v1alpha1/swiftsandboxpool_types.go
@@ -117,6 +117,11 @@ type SwiftSandboxPoolStatus struct {
 	// ObservedGeneration is the pool generation last reconciled.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// Selector is the pool's warm-slot label selector serialized as a string.
+	// Required by the scale subresource so `kubectl scale` and an HPA can target
+	// the pool; it selects the warm-slot pods (sandbox.kubeswift.io/pool=<name>).
+	// +optional
+	Selector string `json:"selector,omitempty"`
 	// +optional
 	Message string `json:"message,omitempty"`
 }
@@ -126,6 +131,7 @@ type SwiftSandboxPoolStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=swiftsandboxpools,scope=Namespaced,shortName=sboxpool
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.minWarm,statuspath=.status.warmReplicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.image`
 // +kubebuilder:printcolumn:name="MinWarm",type=integer,JSONPath=`.spec.minWarm`
 // +kubebuilder:printcolumn:name="Warm",type=integer,JSONPath=`.status.warmReplicas`

--- a/charts/kubeswift/crds/sandbox.kubeswift.io_swiftsandboxpools.yaml
+++ b/charts/kubeswift/crds/sandbox.kubeswift.io_swiftsandboxpools.yaml
@@ -260,6 +260,12 @@ spec:
                     format: int64
                     type: integer
                 type: object
+              selector:
+                description: |-
+                  Selector is the pool's warm-slot label selector serialized as a string.
+                  Required by the scale subresource so `kubectl scale` and an HPA can target
+                  the pool; it selects the warm-slot pods (sandbox.kubeswift.io/pool=<name>).
+                type: string
               warmReplicas:
                 description: WarmReplicas is the number of Ready, pre-booted, unclaimed
                   slots.
@@ -270,4 +276,8 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.minWarm
+        statusReplicasPath: .status.warmReplicas
       status: {}

--- a/config/crd/bases/sandbox.kubeswift.io_swiftsandboxpools.yaml
+++ b/config/crd/bases/sandbox.kubeswift.io_swiftsandboxpools.yaml
@@ -260,6 +260,12 @@ spec:
                     format: int64
                     type: integer
                 type: object
+              selector:
+                description: |-
+                  Selector is the pool's warm-slot label selector serialized as a string.
+                  Required by the scale subresource so `kubectl scale` and an HPA can target
+                  the pool; it selects the warm-slot pods (sandbox.kubeswift.io/pool=<name>).
+                type: string
               warmReplicas:
                 description: WarmReplicas is the number of Ready, pre-booted, unclaimed
                   slots.
@@ -270,4 +276,8 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.minWarm
+        statusReplicasPath: .status.warmReplicas
       status: {}

--- a/internal/controller/swiftsandbox/pool_controller.go
+++ b/internal/controller/swiftsandbox/pool_controller.go
@@ -3,6 +3,7 @@ package swiftsandbox
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -76,6 +77,7 @@ func (r *SwiftSandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 	var ready, warmLive, claimed int
+	var warmPods []*corev1.Pod
 	for i := range pods.Items {
 		p := &pods.Items[i]
 		// Terminal/terminating slots don't count — owner-GC or the next pass replaces them.
@@ -84,6 +86,7 @@ func (r *SwiftSandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 		if p.Labels[SlotStateLabelKey] == slotStateWarm {
 			warmLive++
+			warmPods = append(warmPods, p)
 			if launcherReady(p) {
 				ready++
 			}
@@ -105,6 +108,13 @@ func (r *SwiftSandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	for i := 0; i < want; i++ {
 		if err := r.createWarmSlot(ctx, &pool, kernelName, *ri); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	// Drain excess warm slots when the desired count dropped below the live count
+	// (a `kubectl scale`/HPA scale-down). want>0 and this are mutually exclusive.
+	for _, p := range pickWarmToDrain(warmPods, slotsToDelete(int(pool.Spec.MinWarm), warmLive)) {
+		if err := r.Delete(ctx, p); err != nil && !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}
 	}
@@ -132,6 +142,31 @@ func slotsToCreate(minWarm, maxWarm, warmLive int) int {
 		want = 0
 	}
 	return want
+}
+
+// slotsToDelete is the drain-side arithmetic: how many warm slots to remove this
+// pass because the live count exceeds the desired minWarm — e.g. after
+// `kubectl scale sboxpool --replicas=N` or an HPA lowered it. Without this the
+// scale subresource could only ratchet the buffer up. Claimed slots are never
+// counted here (they belong to a SwiftSandbox).
+func slotsToDelete(minWarm, warmLive int) int {
+	if warmLive > minWarm {
+		return warmLive - minWarm
+	}
+	return 0
+}
+
+// pickWarmToDrain selects up to n warm slot pods to delete, preferring
+// not-launcher-ready (still-warming) slots so a ready, checkout-serviceable slot
+// is drained last.
+func pickWarmToDrain(warm []*corev1.Pod, n int) []*corev1.Pod {
+	if n >= len(warm) {
+		return warm
+	}
+	sort.SliceStable(warm, func(i, j int) bool {
+		return !launcherReady(warm[i]) && launcherReady(warm[j])
+	})
+	return warm[:n]
 }
 
 // warmSlotTopologySpread spreads a pool's warm slots one-per-node across kernel-nodes

--- a/internal/controller/swiftsandbox/pool_controller.go
+++ b/internal/controller/swiftsandbox/pool_controller.go
@@ -217,6 +217,9 @@ func (r *SwiftSandboxPoolReconciler) updateStatus(ctx context.Context, pool *san
 	pool.Status.WarmReplicas = int32(ready)
 	pool.Status.ClaimedReplicas = int32(claimed)
 	pool.Status.ObservedGeneration = pool.Generation
+	// The scale subresource selectorpath — the warm-slot label selector, so
+	// `kubectl scale sboxpool` and an HPA can target the pool's warm buffer.
+	pool.Status.Selector = PoolLabelKey + "=" + pool.Name
 	if ri != nil {
 		pool.Status.Rootfs = &sandboxv1alpha1.SandboxRootfsStatus{Digest: ri.Digest, CachePath: ri.RootfsPath}
 		apimeta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{
@@ -247,6 +250,7 @@ func (r *SwiftSandboxPoolReconciler) updateStatus(ctx context.Context, pool *san
 func (r *SwiftSandboxPoolReconciler) degraded(ctx context.Context, pool *sandboxv1alpha1.SwiftSandboxPool, ready, claimed int, reason, msg string) (ctrl.Result, error) {
 	pool.Status.WarmReplicas = int32(ready)
 	pool.Status.ClaimedReplicas = int32(claimed)
+	pool.Status.Selector = PoolLabelKey + "=" + pool.Name
 	pool.Status.Phase = sandboxv1alpha1.SwiftSandboxPoolDegraded
 	pool.Status.Message = msg
 	apimeta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{

--- a/internal/controller/swiftsandbox/pool_controller_test.go
+++ b/internal/controller/swiftsandbox/pool_controller_test.go
@@ -25,3 +25,23 @@ func TestSlotsToCreate(t *testing.T) {
 		}
 	}
 }
+
+func TestSlotsToDelete(t *testing.T) {
+	cases := []struct {
+		name              string
+		minWarm, warmLive int
+		want              int
+	}{
+		{"at target — nothing to drain", 3, 3, 0},
+		{"under target — nothing to drain (create-side handles it)", 3, 1, 0},
+		{"scaled down — drain the excess", 1, 3, 2},
+		{"scaled to zero — drain all", 0, 4, 4},
+		{"empty pool", 0, 0, 0},
+	}
+	for _, c := range cases {
+		if got := slotsToDelete(c.minWarm, c.warmLive); got != c.want {
+			t.Errorf("%s: slotsToDelete(min=%d,live=%d)=%d, want %d",
+				c.name, c.minWarm, c.warmLive, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
First of the v0.10.0 "warm-pool maturity" items. Makes `SwiftSandboxPool` scale like a `SwiftGuestPool`.

## What

- **Scale subresource** on `SwiftSandboxPool` (`specpath=.spec.minWarm`, `statuspath=.status.warmReplicas`, `selectorpath=.status.selector`). So `kubectl scale sboxpool <name> --replicas=N` sets the warm buffer, and an HPA can target the pool. The controller populates `status.selector` with the warm-slot label selector.
- **Scale-down drain.** The controller previously only *created* slots toward `minWarm`; a lowered `minWarm` left the excess warm, so the subresource could only ratchet up. Added `slotsToDelete` + `pickWarmToDrain` (prefer still-warming slots, never touch claimed) and a drain loop — so scale-down actually shrinks the buffer, and **HPA scale-to-zero is real**.

The natural autoscaling signal is the cold-fallback rate shipped in #367 (`kubeswift_sandbox_checkouts_total{result=cold}`): grow the buffer when checkouts miss, drain when quiet. An HPA with `minReplicas: 0` on that metric drains a quiet pool and re-warms on demand — **subsuming `idleTTL` scale-to-zero** with the standard k8s mechanism. (The scale subresource is the cheap, high-value part; wiring an actual autoscaler on cold-rate is a prometheus-adapter recipe on the operator side, to be documented.)

## Tests

- `TestSlotsToDelete` (drain arithmetic) + existing `TestSlotsToCreate`.
- `go test ./internal/controller/swiftsandbox/...` green.

## Cluster validation (dev)

- `kubectl scale sboxpool scale-pool --replicas=3` → `minWarm=3`, pool warmed to 3 (spread miles+boba); the scale endpoint reports `spec.replicas=3` / `status.replicas` / selector.
- `--replicas=1` → drained the 2 excess warm slots → `warm=1`.
- `--replicas=0` → drained all → `warm=0` (scale-to-zero).

Refs #362