### PR TITLE
feat(sandbox): merge the pool image env into a checked-out workload

### DIFF
--- a/api/sandbox/v1alpha1/swiftsandboxpool_types.go
+++ b/api/sandbox/v1alpha1/swiftsandboxpool_types.go
@@ -110,6 +110,12 @@ type SwiftSandboxPoolStatus struct {
 	// Rootfs reports the resolved+materialized image shared by every slot.
 	// +optional
 	Rootfs *SandboxRootfsStatus `json:"rootfs,omitempty"`
+	// ImageEnv is the pool image's config env ("KEY=VAL"), resolved once at
+	// materialize. A checkout merges its SwiftSandbox.spec.env over this so the
+	// injected workload sees the image env too — parity with a cold sandbox,
+	// without a per-checkout registry pull.
+	// +optional
+	ImageEnv []string `json:"imageEnv,omitempty"`
 	// +optional
 	// +listType=map
 	// +listMapKey=type

--- a/api/sandbox/v1alpha1/zz_generated.deepcopy.go
+++ b/api/sandbox/v1alpha1/zz_generated.deepcopy.go
@@ -230,6 +230,11 @@ func (in *SwiftSandboxPoolStatus) DeepCopyInto(out *SwiftSandboxPoolStatus) {
 		*out = new(SandboxRootfsStatus)
 		**out = **in
 	}
+	if in.ImageEnv != nil {
+		in, out := &in.ImageEnv, &out.ImageEnv
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]metav1.Condition, len(*in))

--- a/charts/kubeswift/crds/sandbox.kubeswift.io_swiftsandboxpools.yaml
+++ b/charts/kubeswift/crds/sandbox.kubeswift.io_swiftsandboxpools.yaml
@@ -231,6 +231,15 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              imageEnv:
+                description: |-
+                  ImageEnv is the pool image's config env ("KEY=VAL"), resolved once at
+                  materialize. A checkout merges its SwiftSandbox.spec.env over this so the
+                  injected workload sees the image env too — parity with a cold sandbox,
+                  without a per-checkout registry pull.
+                items:
+                  type: string
+                type: array
               message:
                 type: string
               observedGeneration:

--- a/config/crd/bases/sandbox.kubeswift.io_swiftsandboxpools.yaml
+++ b/config/crd/bases/sandbox.kubeswift.io_swiftsandboxpools.yaml
@@ -231,6 +231,15 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              imageEnv:
+                description: |-
+                  ImageEnv is the pool image's config env ("KEY=VAL"), resolved once at
+                  materialize. A checkout merges its SwiftSandbox.spec.env over this so the
+                  injected workload sees the image env too — parity with a cold sandbox,
+                  without a per-checkout registry pull.
+                items:
+                  type: string
+                type: array
               message:
                 type: string
               observedGeneration:

--- a/internal/controller/swiftsandbox/checkout.go
+++ b/internal/controller/swiftsandbox/checkout.go
@@ -61,7 +61,19 @@ func (r *SwiftSandboxReconciler) reconcilePooled(ctx context.Context, sb *sandbo
 	// First reconcile. The workload argv comes from the sandbox spec with NO registry
 	// pull (the sub-second point); a sandbox with no command needs the image entrypoint,
 	// which only the cold materialize path knows — so it cold-falls-back.
-	argv, env, cwd := poolExecArgs(sb)
+	// The pool resolved the image env once (status.imageEnv); merge spec.env over it so
+	// the injected workload sees the image env too — parity with a cold sandbox, no pull.
+	var imageEnv []string
+	var pool sandboxv1alpha1.SwiftSandboxPool
+	if err := r.Get(ctx, types.NamespacedName{Namespace: sb.Namespace, Name: sb.Spec.PoolRef.Name}, &pool); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		// Pool gone — tryClaimWarmSlot finds no slots and cold-falls-back below.
+	} else {
+		imageEnv = pool.Status.ImageEnv
+	}
+	argv, env, cwd := poolExecArgs(sb, imageEnv)
 	if len(argv) == 0 {
 		return r.coldFallback(ctx, sb, kernelName, "no command to inject (needs image entrypoint)")
 	}
@@ -121,17 +133,16 @@ func (r *SwiftSandboxReconciler) coldFallback(ctx context.Context, sb *sandboxv1
 
 // poolExecArgs builds the workload exec (argv/env/cwd) from the sandbox spec WITHOUT a
 // registry pull. argv = command + args (nil when no command — the caller cold-falls-back
-// to resolve the image entrypoint). env is spec.env only (the agent adds a default PATH);
-// the image env is not merged in v1 (a warm slot already booted the image).
-func poolExecArgs(sb *sandboxv1alpha1.SwiftSandbox) (argv, env []string, cwd string) {
+// to resolve the image entrypoint). env is the pool's resolved image env with spec.env
+// overlaid by key (parity with the cold path's mergeEnv), so the injected workload sees
+// the image env too; the pool supplied imageEnv from its one-time resolve.
+func poolExecArgs(sb *sandboxv1alpha1.SwiftSandbox, imageEnv []string) (argv, env []string, cwd string) {
 	if len(sb.Spec.Command) == 0 {
 		return nil, nil, ""
 	}
 	argv = append(argv, sb.Spec.Command...)
 	argv = append(argv, sb.Spec.Args...)
-	for _, e := range sb.Spec.Env {
-		env = append(env, e.Name+"="+e.Value)
-	}
+	env = mergeEnv(imageEnv, sb.Spec.Env)
 	return argv, env, sb.Spec.WorkingDir
 }
 

--- a/internal/controller/swiftsandbox/checkout_test.go
+++ b/internal/controller/swiftsandbox/checkout_test.go
@@ -19,22 +19,24 @@ import (
 )
 
 func TestPoolExecArgs(t *testing.T) {
-	// command + args + env + cwd -> argv/env/cwd (no registry pull).
+	// command + args + cwd + the pool image env merged with spec.env (spec overrides
+	// by key), no registry pull.
 	sb := &sandboxv1alpha1.SwiftSandbox{Spec: sandboxv1alpha1.SwiftSandboxSpec{
 		Command:    []string{"sh", "-c"},
 		Args:       []string{"echo hi"},
 		Env:        []corev1.EnvVar{{Name: "A", Value: "1"}},
 		WorkingDir: "/tmp",
 	}}
-	argv, env, cwd := poolExecArgs(sb)
+	argv, env, cwd := poolExecArgs(sb, []string{"PATH=/usr/bin", "A=image"})
 	if strings.Join(argv, " ") != "sh -c echo hi" {
 		t.Errorf("argv = %v", argv)
 	}
-	if strings.Join(env, ",") != "A=1" || cwd != "/tmp" {
+	// image PATH kept; A overridden by spec.env; image order preserved.
+	if strings.Join(env, ",") != "PATH=/usr/bin,A=1" || cwd != "/tmp" {
 		t.Errorf("env=%v cwd=%q", env, cwd)
 	}
 	// No command -> nil argv (caller cold-falls-back to the image entrypoint).
-	if a, _, _ := poolExecArgs(&sandboxv1alpha1.SwiftSandbox{}); a != nil {
+	if a, _, _ := poolExecArgs(&sandboxv1alpha1.SwiftSandbox{}, nil); a != nil {
 		t.Errorf("no-command argv should be nil, got %v", a)
 	}
 }

--- a/internal/controller/swiftsandbox/pool_controller.go
+++ b/internal/controller/swiftsandbox/pool_controller.go
@@ -257,6 +257,9 @@ func (r *SwiftSandboxPoolReconciler) updateStatus(ctx context.Context, pool *san
 	pool.Status.Selector = PoolLabelKey + "=" + pool.Name
 	if ri != nil {
 		pool.Status.Rootfs = &sandboxv1alpha1.SandboxRootfsStatus{Digest: ri.Digest, CachePath: ri.RootfsPath}
+		// The slot template carries no workload env, so ri.Exec.Env is the image's
+		// own config env — stamp it so a checkout can merge without re-pulling.
+		pool.Status.ImageEnv = ri.Exec.Env
 		apimeta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{
 			Type: sandboxv1alpha1.SwiftSandboxPoolConditionResolved, Status: metav1.ConditionTrue,
 			Reason: "Resolved", Message: "image digest " + ri.Digest, ObservedGeneration: pool.Generation,


### PR DESCRIPTION
Second of the v0.10.0 "warm-pool maturity" items. Parity fix for warm-pool checkouts.

## What

A checkout injected `spec.env` only — the pool image's own config env was dropped, so a checked-out workload saw a different environment than a cold sandbox of the same image (missing the image's `PATH`, `LANG`, and any app vars like `PYTHON_VERSION`).

The pool already resolves the image once at materialize. Stamp its config env in `status.imageEnv` and, at checkout, merge `spec.env` over it with the same `mergeEnv` the cold path uses — so the injected workload gets **image env + spec.env**, with no per-checkout registry pull (the env comes from pool status, not a fresh resolve).

## Tests

- `TestPoolExecArgs` updated: image `PATH` kept, `spec.env` overrides by key, image order preserved.
- `go test ./internal/controller/swiftsandbox/...` green.

## Cluster validation (dev)

Pooled `python:3.12-alpine` (image env sets `LANG`, `GPG_KEY`, `PYTHON_VERSION`, `PYTHON_SHA256`, `PATH`):

- `status.imageEnv` stamped with the full image env.
- A checkout with `spec.env: [SPEC_VAR=from-spec]` produced this exact merged env in the exec-action the controller passed to swiftletd:
  ```
  PATH=/usr/local/bin:... LANG=C.UTF-8 GPG_KEY=... PYTHON_VERSION=3.12.13 PYTHON_SHA256=... SPEC_VAR=from-spec
  ```
  (Before: `SPEC_VAR=from-spec` only.)

Refs #362