### PR TITLE
feat(sandbox): distroless idle keeper — image-independent warm slots

### DIFF
--- a/build/kernels/sandbox/rootfs-overlay/init
+++ b/build/kernels/sandbox/rootfs-overlay/init
@@ -31,12 +31,14 @@ ROOTFS_KIND=block
 ENTRYPOINT=""
 CONFIG_DEV=""
 DNS_SEARCH=""
+IDLE=""
 for arg in $(cat /proc/cmdline); do
 	case "$arg" in
 		kubeswift.rootfs=*)     ROOTFS_KIND="${arg#kubeswift.rootfs=}" ;;
 		kubeswift.entrypoint=*) ENTRYPOINT="${arg#kubeswift.entrypoint=}" ;;
 		kubeswift.config=*)     CONFIG_DEV="${arg#kubeswift.config=}" ;;
 		kubeswift.dns-search=*) DNS_SEARCH="${arg#kubeswift.dns-search=}" ;;
+		kubeswift.idle=*)       IDLE="${arg#kubeswift.idle=}" ;;
 	esac
 done
 
@@ -161,6 +163,17 @@ fi
 # that swiftletd captures as the sandbox log.
 if [ -x /usr/local/bin/kubeswift-guest-agent ]; then
 	/usr/local/bin/kubeswift-guest-agent --exec-root=/newroot >/dev/kmsg 2>&1 &
+fi
+
+# Warm-pool keeper (kubeswift.idle=1): the slot is pre-booted with NO workload yet;
+# a checkout injects one later over vsock (the agent above chroots /newroot for it).
+# Idle in the INITRAMFS busybox — NOT `chroot /newroot sleep` — so warming does not
+# depend on the image carrying a sleep binary; that's what lets a distroless image be
+# pooled. Never emit an exit code or power off: the controller deletes this pod when
+# the slot is consumed, so the keeper just waits.
+if [ "$IDLE" = 1 ]; then
+	echo "sandbox-bridge: warm keeper idle (agent serves checkout; image-independent)"
+	while :; do sleep 86400; done
 fi
 
 echo "sandbox-bridge: OCI rootfs ($ROOTFS_KIND) + tmpfs overlay; run $1 ($# arg(s))"

--- a/config/samples/sandbox/swiftkernel-sandbox.yaml
+++ b/config/samples/sandbox/swiftkernel-sandbox.yaml
@@ -14,6 +14,6 @@ metadata:
   namespace: default
 spec:
   ociRef:
-    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.8
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.9
   kernelCmdline: "console=ttyS0"
   profile: sandbox

--- a/docs/sandbox/overview.md
+++ b/docs/sandbox/overview.md
@@ -34,7 +34,7 @@ For bursts of same-image sandboxes where the ~15s cold boot dominates, a
 
 - A node labeled `kubeswift.io/kernel-node=true`
 - A `Ready` `SwiftKernel` named `sandbox` (OCI artifact
-  `ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.8`, pulled per node)
+  `ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.9`, pulled per node)
 
 The sandbox kernel is not a plain `kernelRef` SwiftGuest kernel — its
 bridge-initramfs needs the OCI rootfs disk that the SwiftSandbox controller

--- a/internal/controller/swiftsandbox/controller.go
+++ b/internal/controller/swiftsandbox/controller.go
@@ -93,7 +93,7 @@ func (r *SwiftSandboxReconciler) createLaunch(ctx context.Context, sb *sandboxv1
 	if err != nil {
 		return r.fail(ctx, sb, "ImageResolveFailed", err.Error())
 	}
-	intent := buildIntent(sb, kernelName, ri.RootfsPath, ri.Exec)
+	intent := buildIntent(sb, kernelName, ri.RootfsPath, ri.Exec, false)
 	intentJSON, err := runtimeintent.Serialize(intent)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/swiftsandbox/controller_test.go
+++ b/internal/controller/swiftsandbox/controller_test.go
@@ -55,7 +55,7 @@ func TestBuildIntent(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "sbx", Namespace: "default"},
 		Spec:       sandboxv1alpha1.SwiftSandboxSpec{CPU: 2, Memory: resource.MustParse("1Gi")},
 	}
-	intent := buildIntent(sb, "sandbox", "/var/lib/kubeswift/sandbox-rootfs/sha256-abc.ext4", execSpec{Argv: []string{"/bin/sh"}})
+	intent := buildIntent(sb, "sandbox", "/var/lib/kubeswift/sandbox-rootfs/sha256-abc.ext4", execSpec{Argv: []string{"/bin/sh"}}, false)
 	if intent.KernelBoot == nil {
 		t.Fatal("kernelBoot nil")
 	}
@@ -90,7 +90,7 @@ func TestBuildIntent(t *testing.T) {
 	}
 	sbNone := sb.DeepCopy()
 	sbNone.Spec.Network.Mode = sandboxv1alpha1.SandboxNetworkNone
-	iNone := buildIntent(sbNone, "sandbox", "/x.ext4", execSpec{Argv: []string{"/bin/sh"}})
+	iNone := buildIntent(sbNone, "sandbox", "/x.ext4", execSpec{Argv: []string{"/bin/sh"}}, false)
 	if iNone.Network {
 		t.Error("mode=none sandbox must be network-isolated")
 	}
@@ -106,9 +106,22 @@ func TestBuildIntent(t *testing.T) {
 		t.Errorf("hypervisor: %s", intent.Hypervisor)
 	}
 	// Trivial exec (bare image, no overrides) -> no config disk, no SandboxExec.
-	i2 := buildIntent(sb, "sandbox", "/x.ext4", execSpec{})
+	i2 := buildIntent(sb, "sandbox", "/x.ext4", execSpec{}, false)
 	if strings.Contains(i2.KernelBoot.Cmdline, "kubeswift.config") || i2.SandboxExec != nil {
 		t.Errorf("trivial exec should omit the config disk: cmdline=%s exec=%+v", i2.KernelBoot.Cmdline, i2.SandboxExec)
+	}
+	// A warm-pool keeper (idle) boots to the bridge idle loop with NO workload: the
+	// cmdline carries kubeswift.idle=1 and NO config disk, even if an exec is passed.
+	keeper := buildIntent(sb, "sandbox", "/x.ext4", execSpec{Argv: []string{"sleep", "infinity"}}, true)
+	if !strings.Contains(keeper.KernelBoot.Cmdline, "kubeswift.idle=1") {
+		t.Errorf("keeper cmdline missing kubeswift.idle=1: %s", keeper.KernelBoot.Cmdline)
+	}
+	if strings.Contains(keeper.KernelBoot.Cmdline, "kubeswift.config") || keeper.SandboxExec != nil {
+		t.Errorf("keeper must carry no workload/config disk: cmdline=%s exec=%+v", keeper.KernelBoot.Cmdline, keeper.SandboxExec)
+	}
+	// A real workload (idle=false) never gets the idle flag.
+	if strings.Contains(intent.KernelBoot.Cmdline, "kubeswift.idle") {
+		t.Errorf("non-keeper cmdline should not carry kubeswift.idle: %s", intent.KernelBoot.Cmdline)
 	}
 }
 

--- a/internal/controller/swiftsandbox/pod.go
+++ b/internal/controller/swiftsandbox/pod.go
@@ -51,10 +51,16 @@ const sandboxConfigDevice = "/dev/vdb"
 
 // buildIntent constructs the mode-3 sandbox RuntimeIntent: kernel boot + the RO
 // OCI rootfs disk + (when the workload has a defined exec) the config disk + the
-// bridge cmdline.
-func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath string, exec execSpec) *runtimeintent.RuntimeIntent {
+// bridge cmdline. idle marks a warm-pool keeper slot: it carries no workload (a
+// checkout injects one later over vsock) and boots straight to the bridge's idle
+// loop via kubeswift.idle=1 — so warming never depends on the image having a sleep
+// binary, and distroless images can be pooled.
+func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath string, exec execSpec, idle bool) *runtimeintent.RuntimeIntent {
 	kernelDir := kernelv1alpha1.KernelLocalPath(sb.Namespace, kernelName)
 	cmdline := "console=ttyS0 kubeswift.rootfs=block"
+	if idle {
+		cmdline += " kubeswift.idle=1"
+	}
 	if networked(sb) {
 		// Kernel IP autoconfig (the sandbox kernel has CONFIG_IP_PNP_DHCP=y). A bare
 		// OCI workload (e.g. /bin/sh) runs no DHCP client and the bridge-init does no
@@ -71,9 +77,10 @@ func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath string
 		cmdline += " kubeswift.dns-search=" + sb.Namespace + ".svc.cluster.local,svc.cluster.local,cluster.local"
 	}
 	var sandboxExec *runtimeintent.SandboxExecSpec
-	if exec.nonTrivial() {
+	if !idle && exec.nonTrivial() {
 		// The workload argv/env/cwd ride the config disk (kubeswift.config points the
 		// bridge at it) — never the cmdline, so env stays out of /proc/cmdline + logs.
+		// A keeper carries no workload (idle), so it gets no config disk.
 		cmdline += " kubeswift.config=" + sandboxConfigDevice
 		sandboxExec = &runtimeintent.SandboxExecSpec{Argv: exec.Argv, Env: exec.Env, Cwd: exec.Cwd}
 	}

--- a/internal/controller/swiftsandbox/pool_controller.go
+++ b/internal/controller/swiftsandbox/pool_controller.go
@@ -35,15 +35,11 @@ const (
 	poolPollInterval = 10 * time.Second
 )
 
-// warmSlotIdleCmd keeps a workload-less slot Running and idle so the in-guest agent
-// stays reachable for a post-boot checkout. It is image-provided (a distroless image
-// without a shell/sleep needs the bridge idle keeper — tracked follow-up).
-var warmSlotIdleCmd = []string{"sleep", "infinity"}
-
 // SwiftSandboxPoolReconciler maintains a warm buffer of pre-booted, workload-less
 // sandbox slots so a SwiftSandbox can check out sub-second. Co-located with the
 // SwiftSandbox controller to reuse its launch builders (buildIntent/buildPod/…) via a
-// synthetic per-slot SwiftSandbox carrying the pool's slot shape + an idle command.
+// synthetic per-slot SwiftSandbox carrying the pool's slot shape; the slot boots as a
+// bridge-side idle keeper (kubeswift.idle=1), image-independent.
 type SwiftSandboxPoolReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
@@ -181,8 +177,10 @@ func warmSlotTopologySpread(poolName string) []corev1.TopologySpreadConstraint {
 }
 
 // slotTemplate builds the synthetic (unpersisted) SwiftSandbox for a warm slot: the
-// pool's slot shape + the idle keeper command. The launch builders read only its
-// fields; the resulting pod/ConfigMap/NetworkPolicy are owned by the POOL.
+// pool's slot shape, with NO workload command — the slot boots as a bridge-side idle
+// keeper (kubeswift.idle=1) and a checkout injects the workload later over vsock. The
+// launch builders read only its fields; the resulting pod/ConfigMap/NetworkPolicy are
+// owned by the POOL.
 func (r *SwiftSandboxPoolReconciler) slotTemplate(pool *sandboxv1alpha1.SwiftSandboxPool, name string) *sandboxv1alpha1.SwiftSandbox {
 	return &sandboxv1alpha1.SwiftSandbox{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pool.Namespace},
@@ -194,7 +192,6 @@ func (r *SwiftSandboxPoolReconciler) slotTemplate(pool *sandboxv1alpha1.SwiftSan
 			Network:          pool.Spec.Network,
 			KernelProfileRef: pool.Spec.KernelProfileRef,
 			NodeSelector:     pool.Spec.NodeSelector,
-			Command:          warmSlotIdleCmd,
 		},
 	}
 }
@@ -204,7 +201,11 @@ func (r *SwiftSandboxPoolReconciler) slotTemplate(pool *sandboxv1alpha1.SwiftSan
 func (r *SwiftSandboxPoolReconciler) createWarmSlot(ctx context.Context, pool *sandboxv1alpha1.SwiftSandboxPool, kernelName string, ri resolvedImage) error {
 	slot := r.slotTemplate(pool, pool.Name+"-slot-"+utilrand.String(5))
 
-	intent := buildIntent(slot, kernelName, ri.RootfsPath, ri.Exec)
+	// idle=true: a warm keeper carries no workload (execSpec{}); it boots to the
+	// bridge idle loop (kubeswift.idle=1) so warming never depends on the image
+	// having a sleep binary, and a distroless image can be pooled. ri.Exec.Env is
+	// still stamped into the pool status for the checkout env-merge (see updateStatus).
+	intent := buildIntent(slot, kernelName, ri.RootfsPath, execSpec{}, true)
 	intentJSON, err := runtimeintent.Serialize(intent)
 	if err != nil {
 		return err


### PR DESCRIPTION
Third of the v0.10.0 "warm-pool maturity" items — ships warm pools feature-complete for the untrusted-code/AI-agent use case.

## The gap

A warm slot stayed idle by running `sleep infinity` **from the image**. Distroless images (`gcr.io/distroless/*`, `scratch` + a static binary, `hello-world`) have no `sleep` and no shell — so exactly the images the secure-sandbox use case wants could not be pooled (the slot crashed `sleep: not found`).

## The fix — idle in the initramfs

- **bridge-init**: a new `kubeswift.idle=1` cmdline flag makes the bridge idle in the **initramfs busybox** (always present) instead of chrooting the image's `sleep`, *after* mounting the overlay + `/newroot` pseudo-fs + starting the vsock agent. It never emits an exit code or powers off — the controller deletes the slot when a checkout consumes it. A checkout still injects the real workload over vsock, chrooted into `/newroot`, exactly as before.
- **controller**: `buildIntent` gains an `idle` bool; a warm slot carries **no workload** (`execSpec{}`, no config disk) and boots with `kubeswift.idle=1`. The pool no longer sets a `sleep infinity` command. `ri.Exec.Env` is still stamped into pool status for the checkout env-merge (#371).
- **kernel**: `kernels/sandbox:6.6.9` (bridge-init only; bzImage unchanged, layer reused).

## Tests

- `buildIntent` unit test: a keeper carries `kubeswift.idle=1` + no config disk even if an exec is passed; a real workload never gets the idle flag.
- `go test ./internal/controller/swiftsandbox/...` green.

## Cluster validation (dev, kernel 6.6.9)

Pooled `hello-world` (a single static `/hello` — **no sleep, no shell**):
- Warm slot reached **Ready** by idling in the initramfs (the old keeper would crash `sleep: not found`).
- A checkout of `command: ["/hello"]` into the shell-less slot → **Completed/0** in ~3s; the pool replenished to warm=1.

Refs #362