### PR TITLE
feat(observability): SwiftSandbox + warm-pool metrics + Grafana dashboard

### DIFF
--- a/charts/kubeswift/dashboards/kubeswift-sandboxes.json
+++ b/charts/kubeswift/dashboards/kubeswift-sandboxes.json
@@ -1,0 +1,253 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "kubeswift",
+    "sandbox"
+  ],
+  "title": "KubeSwift \u2014 Sandboxes & Warm Pools",
+  "uid": "kubeswift-sandboxes",
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "query": "prometheus",
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Sandbox runs by result (range)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (increase(kubeswift_sandbox_total[$__range]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Checkout hit ratio (range)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(kubeswift_sandbox_checkouts_total{result=\"hit\"}[$__range])) / clamp_min(sum(increase(kubeswift_sandbox_checkouts_total[$__range])), 1)",
+          "legendFormat": "hit ratio"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Warm pools by phase",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (phase) (kubeswift_sandbox_pools)",
+          "legendFormat": "{{phase}}"
+        }
+      ]
+    },
+    {
+      "title": "Sandbox run rate by result",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(kubeswift_sandbox_total[$__rate_interval]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Checkout rate \u2014 hit vs cold",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(kubeswift_sandbox_checkouts_total[$__rate_interval]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Sandboxes by phase",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (phase) (kubeswift_sandboxes)",
+          "legendFormat": "{{phase}}"
+        }
+      ]
+    },
+    {
+      "title": "Warm pool \u2014 warm vs claimed slots",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kubeswift_sandbox_pool_warm_replicas)",
+          "legendFormat": "warm"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kubeswift_sandbox_pool_claimed_replicas)",
+          "legendFormat": "claimed"
+        }
+      ]
+    }
+  ]
+}

--- a/config/grafana/kubeswift-sandboxes.json
+++ b/config/grafana/kubeswift-sandboxes.json
@@ -1,0 +1,253 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "kubeswift",
+    "sandbox"
+  ],
+  "title": "KubeSwift \u2014 Sandboxes & Warm Pools",
+  "uid": "kubeswift-sandboxes",
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "query": "prometheus",
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Sandbox runs by result (range)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (increase(kubeswift_sandbox_total[$__range]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Checkout hit ratio (range)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(kubeswift_sandbox_checkouts_total{result=\"hit\"}[$__range])) / clamp_min(sum(increase(kubeswift_sandbox_checkouts_total[$__range])), 1)",
+          "legendFormat": "hit ratio"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Warm pools by phase",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (phase) (kubeswift_sandbox_pools)",
+          "legendFormat": "{{phase}}"
+        }
+      ]
+    },
+    {
+      "title": "Sandbox run rate by result",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(kubeswift_sandbox_total[$__rate_interval]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Checkout rate \u2014 hit vs cold",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(kubeswift_sandbox_checkouts_total[$__rate_interval]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "title": "Sandboxes by phase",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (phase) (kubeswift_sandboxes)",
+          "legendFormat": "{{phase}}"
+        }
+      ]
+    },
+    {
+      "title": "Warm pool \u2014 warm vs claimed slots",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kubeswift_sandbox_pool_warm_replicas)",
+          "legendFormat": "warm"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kubeswift_sandbox_pool_claimed_replicas)",
+          "legendFormat": "claimed"
+        }
+      ]
+    }
+  ]
+}

--- a/internal/controller/swiftsandbox/controller.go
+++ b/internal/controller/swiftsandbox/controller.go
@@ -22,6 +22,7 @@ import (
 
 	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/controller/swiftguest"
+	"github.com/kubeswift-io/kubeswift/internal/metrics"
 	"github.com/kubeswift-io/kubeswift/internal/runtimeintent"
 	"github.com/kubeswift-io/kubeswift/internal/sandbox/materialize"
 )
@@ -204,6 +205,12 @@ func (r *SwiftSandboxReconciler) terminal(ctx context.Context, sb *sandboxv1alph
 	if sb.Status.TerminalAt == nil {
 		now := metav1.Now()
 		sb.Status.TerminalAt = &now
+		// Once per sandbox, on the non-terminal -> terminal transition.
+		result := "failed"
+		if phase == sandboxv1alpha1.SwiftSandboxCompleted {
+			result = "completed"
+		}
+		metrics.SandboxTotal.WithLabelValues(result).Inc()
 	}
 	sb.Status.Phase = phase
 	sb.Status.Message = msg

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -284,6 +284,19 @@ var (
 		[]string{"policy", "result"},
 	)
 
+	// SandboxTotal counts SwiftSandboxes that reached a terminal phase, by result
+	// (completed | failed). Recorded once per sandbox on the non-terminal ->
+	// terminal transition. Robust to the ephemeral+TTL nature of sandboxes (the
+	// kubeswift_sandboxes phase gauge is transient); this is the run-throughput /
+	// failure-rate signal over time.
+	SandboxTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubeswift_sandbox_total",
+			Help: "SwiftSandboxes that reached a terminal phase, by result (completed | failed)",
+		},
+		[]string{"result"},
+	)
+
 	// SandboxCheckoutsTotal counts SwiftSandbox pool checkouts by result:
 	// "hit" (claimed a pre-booted warm slot — the fast path) or "cold" (no warm
 	// slot available, or no command to inject — fell back to the cold
@@ -349,6 +362,7 @@ func init() {
 		GPUReleasesTotal,
 		DrainMigrationsTotal,
 		ImageImportTotal,
+		SandboxTotal,
 		SandboxCheckoutsTotal,
 	)
 }

--- a/internal/metrics/state_collector.go
+++ b/internal/metrics/state_collector.go
@@ -12,6 +12,7 @@ import (
 	imagev1alpha1 "github.com/kubeswift-io/kubeswift/api/image/v1alpha1"
 	kernelv1alpha1 "github.com/kubeswift-io/kubeswift/api/kernel/v1alpha1"
 	migrationv1alpha1 "github.com/kubeswift-io/kubeswift/api/migration/v1alpha1"
+	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
 	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 )
@@ -109,6 +110,23 @@ var (
 		"kubeswift_snapshot_schedule_last_success_timestamp_seconds",
 		"Unix time a SwiftSnapshotSchedule's snapshot last reached Ready",
 		[]string{"namespace", "schedule"}, nil)
+
+	sandboxesDesc = prometheus.NewDesc(
+		"kubeswift_sandboxes",
+		"SwiftSandboxes by namespace and phase",
+		[]string{"namespace", "phase"}, nil)
+	sandboxPoolsDesc = prometheus.NewDesc(
+		"kubeswift_sandbox_pools",
+		"SwiftSandboxPools by namespace and phase",
+		[]string{"namespace", "phase"}, nil)
+	sandboxPoolWarmDesc = prometheus.NewDesc(
+		"kubeswift_sandbox_pool_warm_replicas",
+		"Ready, unclaimed warm slots per SwiftSandboxPool",
+		[]string{"namespace", "pool"}, nil)
+	sandboxPoolClaimedDesc = prometheus.NewDesc(
+		"kubeswift_sandbox_pool_claimed_replicas",
+		"Slots currently checked out per SwiftSandboxPool",
+		[]string{"namespace", "pool"}, nil)
 )
 
 var (
@@ -141,6 +159,19 @@ var (
 		snapshotv1alpha1.SwiftSnapshotPhaseReady,
 		snapshotv1alpha1.SwiftSnapshotPhaseFailed,
 	}
+	sandboxPhases = []sandboxv1alpha1.SwiftSandboxPhase{
+		sandboxv1alpha1.SwiftSandboxPending,
+		sandboxv1alpha1.SwiftSandboxMaterializing,
+		sandboxv1alpha1.SwiftSandboxRunning,
+		sandboxv1alpha1.SwiftSandboxCompleted,
+		sandboxv1alpha1.SwiftSandboxFailed,
+	}
+	sandboxPoolPhases = []sandboxv1alpha1.SwiftSandboxPoolPhase{
+		sandboxv1alpha1.SwiftSandboxPoolPending,
+		sandboxv1alpha1.SwiftSandboxPoolWarming,
+		sandboxv1alpha1.SwiftSandboxPoolReady,
+		sandboxv1alpha1.SwiftSandboxPoolDegraded,
+	}
 )
 
 // Describe implements prometheus.Collector.
@@ -158,6 +189,10 @@ func (c *StateCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- gpuNodeInfoDesc
 	ch <- gpuNodeLastDiscoveryDesc
 	ch <- scheduleLastSuccessDesc
+	ch <- sandboxesDesc
+	ch <- sandboxPoolsDesc
+	ch <- sandboxPoolWarmDesc
+	ch <- sandboxPoolClaimedDesc
 }
 
 // Collect implements prometheus.Collector. Each type is collected
@@ -175,6 +210,45 @@ func (c *StateCollector) Collect(ch chan<- prometheus.Metric) {
 	c.collectMigrations(ctx, ch)
 	c.collectGPUNodes(ctx, ch)
 	c.collectSchedules(ctx, ch)
+	c.collectSandboxes(ctx, ch)
+}
+
+func (c *StateCollector) collectSandboxes(ctx context.Context, ch chan<- prometheus.Metric) {
+	var list sandboxv1alpha1.SwiftSandboxList
+	if err := c.reader.List(ctx, &list); err == nil {
+		byNSPhase := map[string]map[sandboxv1alpha1.SwiftSandboxPhase]int{}
+		for i := range list.Items {
+			s := &list.Items[i]
+			if byNSPhase[s.Namespace] == nil {
+				byNSPhase[s.Namespace] = map[sandboxv1alpha1.SwiftSandboxPhase]int{}
+			}
+			byNSPhase[s.Namespace][s.Status.Phase]++
+		}
+		for ns, phases := range byNSPhase {
+			for _, p := range sandboxPhases {
+				gauge(ch, sandboxesDesc, float64(phases[p]), ns, string(p))
+			}
+		}
+	}
+
+	var pools sandboxv1alpha1.SwiftSandboxPoolList
+	if err := c.reader.List(ctx, &pools); err == nil {
+		byNSPhase := map[string]map[sandboxv1alpha1.SwiftSandboxPoolPhase]int{}
+		for i := range pools.Items {
+			p := &pools.Items[i]
+			if byNSPhase[p.Namespace] == nil {
+				byNSPhase[p.Namespace] = map[sandboxv1alpha1.SwiftSandboxPoolPhase]int{}
+			}
+			byNSPhase[p.Namespace][p.Status.Phase]++
+			gauge(ch, sandboxPoolWarmDesc, float64(p.Status.WarmReplicas), p.Namespace, p.Name)
+			gauge(ch, sandboxPoolClaimedDesc, float64(p.Status.ClaimedReplicas), p.Namespace, p.Name)
+		}
+		for ns, phases := range byNSPhase {
+			for _, ph := range sandboxPoolPhases {
+				gauge(ch, sandboxPoolsDesc, float64(phases[ph]), ns, string(ph))
+			}
+		}
+	}
 }
 
 func gauge(ch chan<- prometheus.Metric, desc *prometheus.Desc, v float64, labels ...string) {


### PR DESCRIPTION
Fourth v0.10.0 item — extends the observability program (O1–O4) to the sandbox arc so `sbox`/`sboxpool` are first-class in the metrics + dashboards.

## Metrics

- **State gauges** (`internal/metrics/state_collector.go`): `kubeswift_sandboxes{namespace,phase}`, `kubeswift_sandbox_pools{namespace,phase}`, and per-pool `kubeswift_sandbox_pool_warm_replicas` / `_claimed_replicas`.
- **`kubeswift_sandbox_total{result=completed|failed}`** — recorded once per sandbox on the non-terminal→terminal transition (in `terminal()`'s `TerminalAt==nil` guard). Robust to the ephemeral+TTL nature of sandboxes — the phase gauge is transient; this is the run-throughput / failure-rate signal over time. Complements the checkout hit/cold counter from #367.

## Dashboard

`config/grafana/kubeswift-sandboxes.json` — **KubeSwift — Sandboxes & Warm Pools**: run outcomes, checkout hit ratio, run/checkout rates, sandboxes by phase, warm-vs-claimed slots. Provisioning-native (no `__inputs`/`${DS_*}`), chart-globbed via `.Files.Glob`, passes `make verify-dashboards`.

## Tests

- `go test ./internal/metrics/... ./internal/controller/swiftsandbox/...` green.
- `make verify-dashboards` green (all 7 dashboards provisioning-native + chart-synced).

Cluster metrics scrape will be validated on the merged-main image during the v0.10.0 fleet redeploy (the gauges mirror the proven O1–O4 collector pattern).

Refs #362