### PR TITLE
docs: v0.10.0 version-pin refresh + warm-pool doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.9.0 \
+  --version 0.10.0 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/config/samples/sandbox/swiftsandboxpool.yaml
+++ b/config/samples/sandbox/swiftsandboxpool.yaml
@@ -15,8 +15,10 @@ spec:
   image: docker.io/library/alpine:3.20
   cpu: 1
   memory: 512Mi
-  minWarm: 2            # keep 2 ready slots (spread across kernel-nodes)
+  minWarm: 2            # keep 2 ready slots (spread across kernel-nodes).
+                        # scale-subresource target: kubectl scale sboxpool <name> --replicas=N
   maxWarm: 6            # never hold more than 6 warm slots
-  idleTTL: 30m          # scale idle slots back toward 0 after 30m quiet
+  # idleTTL is not honored in v1 — for scale-to-zero on a quiet pool, use an HPA
+  # on the scale subresource (see docs/sandbox/warm-pool.md#scaling), not idleTTL.
   network:
     mode: restricted    # restricted | open | none — same as SwiftSandbox

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.9.0 -n kubeswift-system --create-namespace \
+  --version 0.10.0 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.1.0 \
+  --version 0.10.0 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.1.0 \
+  --version 0.10.0 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,7 +66,7 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.1.0 \
+  --version 0.10.0 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.1.0 \
+  --version 0.10.0 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,7 +50,7 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.1.0 -n kubeswift-system \
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.10.0 -n kubeswift-system \
     --set controllerManager.image.tag=v0.1.0 \
     --set swiftletd.image.tag=v0.1.0
   ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.9.0 \
+  --version 0.10.0 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.1.0 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.10.0 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows

--- a/docs/sandbox/warm-pool.md
+++ b/docs/sandbox/warm-pool.md
@@ -9,12 +9,13 @@ materialize + boot (~15s). This page assumes you've read
 > **Status: cluster-validated (2026-07-12).** Checkout claims a warm slot and
 > runs the workload to `Completed`/`Failed`; the consumed slot is destroyed and
 > the pool replenishes a fresh one; a miss falls back to a cold boot. First
-> ships in **v0.9.x**.
+> ships in **v0.10.0**.
 
 ## How checkout works
 
 - The pool boots `minWarm` **idle** slots — each an independent microVM of the
-  pool image with no workload, waiting.
+  pool image with no workload, waiting. The slot idles in the boot bridge (not
+  the image), so **distroless / shell-less images can be pooled**.
 - A `SwiftSandbox` with `spec.poolRef` **claims** one warm slot and injects its
   `command`/`args`/`env` into the already-booted VM over vsock. The VM is
   running, so the workload starts immediately.
@@ -68,9 +69,9 @@ Ready-to-edit manifests: [`config/samples/sandbox/`](../../config/samples/sandbo
 | `imagePullSecret` | string | — | docker-registry Secret (same namespace) for a private `image`. |
 | `cpu` | int32 | `1` | vCPUs per slot. |
 | `memory` | Quantity | `512Mi` | RAM per slot. |
-| `minWarm` | int32 | `0` | Warm slots to keep ready. The warm buffer the pool maintains. |
+| `minWarm` | int32 | `0` | Warm slots to keep ready — the warm buffer the pool maintains. This is the scale-subresource target (`kubectl scale sboxpool`); see [Scaling](#scaling). |
 | `maxWarm` | int32 | — | Cap on warm slots. The effective cap is `max(maxWarm, minWarm)` — set below `minWarm` and `minWarm` wins. |
-| `idleTTL` | Duration | — | **Accepted but not honored in v1** — the pool holds `minWarm` and does not scale idle slots down. Tracked for a follow-up. |
+| `idleTTL` | Duration | — | **Accepted but not honored in v1** — use the scale subresource + an HPA for scale-to-zero (see [Scaling](#scaling)), not this field. |
 | `network.mode` | enum | `restricted` | `restricted`, `open`, or `none` — same semantics as [SwiftSandbox](overview.md#network-modes). Applies to every slot. |
 | `kernelProfileRef.name` | string | `sandbox` | SwiftKernel the slots boot. |
 | `nodeSelector` | map[string]string | — | Extra node constraints, merged with the required `kubeswift.io/kernel-node=true`. |
@@ -109,9 +110,10 @@ spec:
 - The workload **must** have a `command` to check out — with no command the
   image entrypoint has to be resolved, which only the cold path knows, so a
   command-less pooled sandbox cold-falls-back.
-- Unlike the cold path, `env` **and** `workingDir` are honored on a checkout —
-  the workload is injected over the same vsock exec channel `swiftctl sandbox
-  exec` uses, which sets both.
+- `env` **and** `workingDir` are honored on a checkout — the workload is
+  injected over the vsock exec channel. The pool image's own config env is
+  merged in too (resolved once at materialize, no per-checkout pull), so the
+  workload sees **image env + your `spec.env`**, same as a cold sandbox.
 - `status.podRef` points at the claimed slot pod (`<pool>-slot-<x>`), not at a
   pod named after the sandbox. `status.exitCode` carries the workload's real
   exit code just like a cold sandbox.
@@ -127,6 +129,21 @@ materializes on the slot's node), so a checkout that lands on any node is more
 likely to find a warm slot *there*. The constraint is soft — warming never
 blocks just because one node is momentarily full.
 
+## Scaling
+
+The warm buffer is a scale subresource on `spec.minWarm`, so it scales like a
+`SwiftGuestPool`:
+
+```bash
+kubectl scale sboxpool <name> --replicas=10   # sets minWarm
+```
+
+and an HPA can target the pool. The natural signal is the checkout cold-fallback
+rate (`kubeswift_sandbox_checkouts_total{result="cold"}`): grow the buffer when
+checkouts miss, shrink when quiet. An HPA with `minReplicas: 0` drains a quiet
+pool to zero and re-warms on demand — the scale-to-zero the `idleTTL` field was
+reaching for (use scaling, not `idleTTL`, which is unhonored in v1).
+
 ## Observability
 
 `kubeswift_sandbox_checkouts_total{result}` counts checkouts by outcome:
@@ -137,10 +154,9 @@ rate. Pool health is `kubectl get sboxpool` (phase + `warmReplicas`).
 
 ## Limitations (v1)
 
-- **`idleTTL` scale-down is not honored** — the pool holds `minWarm` warm slots;
-  it does not shrink an idle pool. Set `minWarm` to what you want held.
-- **The injected workload's env is `spec.env` only** — the pool image's own env
-  is not merged for the injected command (a warm slot already booted the image).
+- **`idleTTL` is not honored** — the pool holds `minWarm`. For scale-to-zero on a
+  quiet pool, use the scale subresource with an HPA (see [Scaling](#scaling)),
+  not this field.
 - Keep the pooled sandbox's `image` the same as the pool's `image`; the checkout
   runs your command inside the slot's already-booted rootfs, so a different
   `image` on the sandbox is ignored for a hit (and only applies if it


### PR DESCRIPTION
Documentation polish for v0.10.0 (the same version-audit + accuracy pass done for v0.9.0 in #361).

## Version pins
All current-install `helm --version` pins bumped to `0.10.0` (several had drifted — README/quickstart/dra at `0.9.0`, install/troubleshooting/releases at `0.1.0`). The `0.0.0-dev.<sha>` dev-format placeholders are left as-is.

## warm-pool.md accuracy (v0.10.0 features)
The guide (written in #368 during v0.9.x-era work) needed updating for what shipped in v0.10.0:
- **New Scaling section** — `kubectl scale sboxpool` + HPA + scale-to-zero (#370).
- **Corrected the injected-env note** — it said "spec.env only"; #371 merges the **pool image env + spec.env**. Fixed (was a factual error post-#371).
- **Distroless** — noted that shell-less/distroless images can now be pooled (the bridge-side keeper, #372).
- **`idleTTL` reframed** — unhonored → point at the scale subresource for scale-to-zero. Fixed the pool sample's misleading `idleTTL` comment too.

Docs-only.