### PR TITLE
feat(gateway): SandboxService read plane (v0.11.0 A2)

### DIFF
--- a/charts/kubeswift/templates/edge/rbac.yaml
+++ b/charts/kubeswift/templates/edge/rbac.yaml
@@ -108,6 +108,11 @@ rules:
   - apiGroups: ["image.kubeswift.io", "kernel.kubeswift.io", "seed.kubeswift.io", "snapshot.kubeswift.io", "gpu.kubeswift.io"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
+  # MicroVM inventory (UI SandboxService read plane, v0.11.0). Create/delete
+  # verbs are added with the write plane (A3).
+  - apiGroups: ["sandbox.kubeswift.io"]
+    resources: ["swiftsandboxes", "swiftsandboxpools"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "delete"]

--- a/cmd/kubeswift-gateway/main.go
+++ b/cmd/kubeswift-gateway/main.go
@@ -111,6 +111,11 @@ func main() {
 	migSvc := gateway.NewMigrationService(pool, auth)
 	migPath, migHandler := kubeswiftv1connect.NewMigrationServiceHandler(migSvc)
 
+	// Sandboxes (v0.11.0 A2): read plane over SwiftSandbox + SwiftSandboxPool
+	// (the MicroVM inventory). Write actions (create/delete) land in A3.
+	sandboxSvc := gateway.NewSandboxService(pool, auth)
+	sandboxPath, sandboxHandler := kubeswiftv1connect.NewSandboxServiceHandler(sandboxSvc)
+
 	// Telemetry (P1): per-VM range metrics from each member's Prometheus.
 	telSvc := gateway.NewTelemetryService(pool, auth)
 	telPath, telHandler := kubeswiftv1connect.NewTelemetryServiceHandler(telSvc)
@@ -139,6 +144,7 @@ func main() {
 			{Path: clusterPath, Handler: clusterHandler},
 			{Path: guestPath, Handler: guestHandler},
 			{Path: migPath, Handler: migHandler},
+			{Path: sandboxPath, Handler: sandboxHandler},
 			{Path: telPath, Handler: telHandler},
 			{Path: resPath, Handler: resHandler},
 			{Path: accessPath, Handler: accessHandler},

--- a/config/samples/gateway/member-rbac.yaml
+++ b/config/samples/gateway/member-rbac.yaml
@@ -45,6 +45,11 @@ rules:
   - apiGroups: ["swift.kubeswift.io"]
     resources: ["swiftguests", "swiftguestclasses", "swiftguestpools"]
     verbs: ["get", "list", "watch"]
+  # MicroVM inventory (UI SandboxService read plane, v0.11.0). Add the
+  # create/delete verbs alongside the write plane (A3).
+  - apiGroups: ["sandbox.kubeswift.io"]
+    resources: ["swiftsandboxes", "swiftsandboxpools"]
+    verbs: ["get", "list", "watch"]
   # Lifecycle write actions (UI Start/Stop) patch swiftguests.spec.runPolicy.
   # Grant these to the subjects you want to be able to act; drop both rules for
   # a strictly read-only audience.

--- a/internal/gateway/pool.go
+++ b/internal/gateway/pool.go
@@ -42,6 +42,13 @@ var (
 // It is gateway-only (no write action touches nodes), so it stays local.
 var nodeGVR = schema.GroupVersionResource{Version: "v1", Resource: "nodes"}
 
+// swiftSandboxGVR / swiftSandboxPoolGVR are the MicroVM resources the sandbox
+// read plane lists. Gateway-local (no shared write action references them yet).
+var (
+	swiftSandboxGVR     = schema.GroupVersionResource{Group: "sandbox.kubeswift.io", Version: "v1alpha1", Resource: "swiftsandboxes"}
+	swiftSandboxPoolGVR = schema.GroupVersionResource{Group: "sandbox.kubeswift.io", Version: "v1alpha1", Resource: "swiftsandboxpools"}
+)
+
 // guestPodLabel ties a launcher pod to its SwiftGuest. The label (not the pod
 // name) is the stable handle — a live-migrated guest's pod is <guest>-mig-<uid>.
 const guestPodLabel = actions.GuestLabel

--- a/internal/gateway/sandbox_mapper.go
+++ b/internal/gateway/sandbox_mapper.go
@@ -1,0 +1,113 @@
+package gateway
+
+import (
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
+	kubeswiftv1 "github.com/kubeswift-io/kubeswift/gen/kubeswift/v1"
+)
+
+// sandboxNetworkMode returns spec.network.mode, defaulting the empty pre-
+// admission value to "restricted" (the CRD default) so the UI row is accurate.
+func sandboxNetworkMode(mode sandboxv1alpha1.SandboxNetworkMode) string {
+	if mode == "" {
+		return string(sandboxv1alpha1.SandboxNetworkRestricted)
+	}
+	return string(mode)
+}
+
+// sandboxToProto maps a SwiftSandbox to the flat, UI-shaped inventory row,
+// stamped with its member cluster (the D2 dimension). It reads only the sandbox
+// object — no cross-resource lookups — so a List stays one round-trip per
+// cluster; the expanded config is GetSandboxDetail.
+func sandboxToProto(cluster string, s *sandboxv1alpha1.SwiftSandbox) *kubeswiftv1.Sandbox {
+	out := &kubeswiftv1.Sandbox{
+		Ref:         &kubeswiftv1.ObjectRef{Cluster: cluster, Namespace: s.Namespace, Name: s.Name},
+		Phase:       string(s.Status.Phase),
+		Image:       s.Spec.Image,
+		NodeName:    s.Status.NodeName,
+		NetworkMode: sandboxNetworkMode(s.Spec.Network.Mode),
+		Cpu:         s.Spec.CPU,
+		MemoryMib:   s.Spec.Memory.Value() >> 20,
+	}
+	if s.Spec.PoolRef != nil {
+		out.PoolRef = s.Spec.PoolRef.Name
+	}
+	if s.Status.Network != nil {
+		out.PrimaryIp = s.Status.Network.PrimaryIP
+	}
+	if s.Status.ExitCode != nil {
+		out.ExitCode = *s.Status.ExitCode
+	}
+	if !s.CreationTimestamp.IsZero() {
+		out.CreatedAt = timestamppb.New(s.CreationTimestamp.Time)
+	}
+	if s.Status.TerminalAt != nil {
+		out.TerminalAt = timestamppb.New(s.Status.TerminalAt.Time)
+	}
+	for i := range s.Status.Conditions {
+		out.Conditions = append(out.Conditions, conditionToProto(&s.Status.Conditions[i]))
+	}
+	if len(s.Labels) > 0 {
+		out.Labels = make(map[string]string, len(s.Labels))
+		for k, v := range s.Labels {
+			out.Labels[k] = v
+		}
+	}
+	return out
+}
+
+// sandboxSpecToProto surfaces the structured config for the drawer + the Clone
+// pre-fill (mirrors guestSpecToProto).
+func sandboxSpecToProto(s *sandboxv1alpha1.SwiftSandbox) *kubeswiftv1.SandboxSpec {
+	spec := &kubeswiftv1.SandboxSpec{
+		Image:       s.Spec.Image,
+		Command:     s.Spec.Command,
+		Args:        s.Spec.Args,
+		WorkingDir:  s.Spec.WorkingDir,
+		NetworkMode: sandboxNetworkMode(s.Spec.Network.Mode),
+	}
+	if s.Spec.PoolRef != nil {
+		spec.PoolRef = s.Spec.PoolRef.Name
+	}
+	if s.Spec.KernelProfileRef != nil {
+		spec.KernelProfileRef = s.Spec.KernelProfileRef.Name
+	}
+	if s.Spec.Timeout != nil {
+		spec.Timeout = s.Spec.Timeout.Duration.String()
+	}
+	if s.Spec.TTL != nil {
+		spec.Ttl = s.Spec.TTL.Duration.String()
+	}
+	if len(s.Spec.Env) > 0 {
+		spec.Env = make(map[string]string, len(s.Spec.Env))
+		for _, e := range s.Spec.Env {
+			spec.Env[e.Name] = e.Value
+		}
+	}
+	return spec
+}
+
+// sandboxPoolToProto maps a SwiftSandboxPool to the flat, UI-shaped row (the
+// warm buffer + its scale numbers).
+func sandboxPoolToProto(cluster string, p *sandboxv1alpha1.SwiftSandboxPool) *kubeswiftv1.SandboxPool {
+	out := &kubeswiftv1.SandboxPool{
+		Ref:             &kubeswiftv1.ObjectRef{Cluster: cluster, Namespace: p.Namespace, Name: p.Name},
+		Phase:           string(p.Status.Phase),
+		Image:           p.Spec.Image,
+		MinWarm:         p.Spec.MinWarm,
+		MaxWarm:         p.Spec.MaxWarm,
+		WarmReplicas:    p.Status.WarmReplicas,
+		ClaimedReplicas: p.Status.ClaimedReplicas,
+		Cpu:             p.Spec.CPU,
+		MemoryMib:       p.Spec.Memory.Value() >> 20,
+		NetworkMode:     sandboxNetworkMode(p.Spec.Network.Mode),
+	}
+	if !p.CreationTimestamp.IsZero() {
+		out.CreatedAt = timestamppb.New(p.CreationTimestamp.Time)
+	}
+	for i := range p.Status.Conditions {
+		out.Conditions = append(out.Conditions, conditionToProto(&p.Status.Conditions[i]))
+	}
+	return out
+}

--- a/internal/gateway/sandbox_service.go
+++ b/internal/gateway/sandbox_service.go
@@ -1,0 +1,360 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+
+	connect "connectrpc.com/connect"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+
+	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
+	kubeswiftv1 "github.com/kubeswift-io/kubeswift/gen/kubeswift/v1"
+	"github.com/kubeswift-io/kubeswift/gen/kubeswift/v1/kubeswiftv1connect"
+)
+
+// SandboxService is the read plane for the MicroVM inventory (SwiftSandbox +
+// SwiftSandboxPool). List/Watch fan out across the selected members and merge,
+// stamping the cluster dimension (D2) and surfacing a per-cluster error instead
+// of failing the whole-fleet query (no silent failures). Every call impersonates
+// the end user against members (D1). The write RPCs (Create/Delete) stay on the
+// Unimplemented base until A3.
+type SandboxService struct {
+	kubeswiftv1connect.UnimplementedSandboxServiceHandler
+
+	pool clientProvider
+	auth Authenticator
+}
+
+var _ kubeswiftv1connect.SandboxServiceHandler = (*SandboxService)(nil)
+
+// NewSandboxService wires the read plane to the client pool + the authenticator.
+func NewSandboxService(pool clientProvider, auth Authenticator) *SandboxService {
+	return &SandboxService{pool: pool, auth: auth}
+}
+
+// ListSandboxes fans out to the selected clusters concurrently and merges rows.
+func (s *SandboxService) ListSandboxes(ctx context.Context, req *connect.Request[kubeswiftv1.ListSandboxesRequest]) (*connect.Response[kubeswiftv1.ListSandboxesResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	resp := &kubeswiftv1.ListSandboxesResponse{}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, cl := range s.targetClusters(req.Msg.GetClusters()) {
+		wg.Add(1)
+		go func(cl string) {
+			defer wg.Done()
+			rows, lerr := s.listSandboxesOne(ctx, cl, id, req.Msg.GetNamespace(), req.Msg.GetPhase())
+			mu.Lock()
+			defer mu.Unlock()
+			if lerr != nil {
+				resp.Errors = append(resp.Errors, &kubeswiftv1.ClusterError{Cluster: cl, Message: lerr.Error()})
+				return
+			}
+			resp.Sandboxes = append(resp.Sandboxes, rows...)
+		}(cl)
+	}
+	wg.Wait()
+	sort.Slice(resp.Sandboxes, func(i, j int) bool { return refLess(resp.Sandboxes[i].GetRef(), resp.Sandboxes[j].GetRef()) })
+	return connect.NewResponse(resp), nil
+}
+
+func (s *SandboxService) listSandboxesOne(ctx context.Context, cluster string, id Identity, namespace, phase string) ([]*kubeswiftv1.Sandbox, error) {
+	dyn, err := s.pool.DynamicFor(cluster, id)
+	if err != nil {
+		return nil, err
+	}
+	ul, err := sandboxResource(dyn, namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*kubeswiftv1.Sandbox, 0, len(ul.Items))
+	for i := range ul.Items {
+		sb, cerr := toSwiftSandbox(&ul.Items[i])
+		if cerr != nil {
+			continue
+		}
+		if phase != "" && string(sb.Status.Phase) != phase {
+			continue
+		}
+		out = append(out, sandboxToProto(cluster, sb))
+	}
+	return out, nil
+}
+
+// ListSandboxPools fans out over the warm pools.
+func (s *SandboxService) ListSandboxPools(ctx context.Context, req *connect.Request[kubeswiftv1.ListSandboxPoolsRequest]) (*connect.Response[kubeswiftv1.ListSandboxPoolsResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	resp := &kubeswiftv1.ListSandboxPoolsResponse{}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, cl := range s.targetClusters(req.Msg.GetClusters()) {
+		wg.Add(1)
+		go func(cl string) {
+			defer wg.Done()
+			rows, lerr := s.listPoolsOne(ctx, cl, id, req.Msg.GetNamespace())
+			mu.Lock()
+			defer mu.Unlock()
+			if lerr != nil {
+				resp.Errors = append(resp.Errors, &kubeswiftv1.ClusterError{Cluster: cl, Message: lerr.Error()})
+				return
+			}
+			resp.Pools = append(resp.Pools, rows...)
+		}(cl)
+	}
+	wg.Wait()
+	sort.Slice(resp.Pools, func(i, j int) bool { return refLess(resp.Pools[i].GetRef(), resp.Pools[j].GetRef()) })
+	return connect.NewResponse(resp), nil
+}
+
+func (s *SandboxService) listPoolsOne(ctx context.Context, cluster string, id Identity, namespace string) ([]*kubeswiftv1.SandboxPool, error) {
+	dyn, err := s.pool.DynamicFor(cluster, id)
+	if err != nil {
+		return nil, err
+	}
+	ul, err := sandboxPoolResource(dyn, namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*kubeswiftv1.SandboxPool, 0, len(ul.Items))
+	for i := range ul.Items {
+		p, cerr := toSwiftSandboxPool(&ul.Items[i])
+		if cerr != nil {
+			continue
+		}
+		out = append(out, sandboxPoolToProto(cluster, p))
+	}
+	return out, nil
+}
+
+// WatchSandboxes multiplexes a per-cluster watch into one stream. A member whose
+// watch cannot start yields a BOOKMARK event carrying a ClusterError (a
+// per-cluster problem, not a dead stream) — sandboxes are ephemeral and their
+// phase moves fast, so live updates keep the inventory current.
+func (s *SandboxService) WatchSandboxes(ctx context.Context, req *connect.Request[kubeswiftv1.WatchSandboxesRequest], stream *connect.ServerStream[kubeswiftv1.SandboxEvent]) error {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return err
+	}
+	namespace := req.Msg.GetNamespace()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	events := make(chan *kubeswiftv1.SandboxEvent, 256)
+	var wg sync.WaitGroup
+	for _, cl := range s.targetClusters(req.Msg.GetClusters()) {
+		wg.Add(1)
+		go func(cl string) {
+			defer wg.Done()
+			s.watchSandboxesOne(ctx, cl, id, namespace, events)
+		}(cl)
+	}
+	go func() { wg.Wait(); close(events) }()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev, ok := <-events:
+			if !ok {
+				return nil
+			}
+			if err := stream.Send(ev); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (s *SandboxService) watchSandboxesOne(ctx context.Context, cluster string, id Identity, namespace string, out chan<- *kubeswiftv1.SandboxEvent) {
+	sendErr := func(err error) {
+		select {
+		case out <- &kubeswiftv1.SandboxEvent{
+			Type:  kubeswiftv1.EventType_EVENT_TYPE_BOOKMARK,
+			Error: &kubeswiftv1.ClusterError{Cluster: cluster, Message: err.Error()},
+		}:
+		case <-ctx.Done():
+		}
+	}
+	dyn, err := s.pool.DynamicFor(cluster, id)
+	if err != nil {
+		sendErr(err)
+		return
+	}
+	w, err := sandboxResource(dyn, namespace).Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		sendErr(err)
+		return
+	}
+	defer w.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case e, ok := <-w.ResultChan():
+			if !ok {
+				return
+			}
+			if ev := sandboxWatchEventToProto(cluster, e); ev != nil {
+				select {
+				case out <- ev:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}
+}
+
+// GetSandboxDetail returns the flat sandbox + its structured spec (for the
+// drawer + Clone).
+func (s *SandboxService) GetSandboxDetail(ctx context.Context, req *connect.Request[kubeswiftv1.GetSandboxDetailRequest]) (*connect.Response[kubeswiftv1.GetSandboxDetailResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	ref := req.Msg.GetRef()
+	if ref == nil || ref.GetCluster() == "" || ref.GetName() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("ref.cluster and ref.name are required"))
+	}
+	dyn, err := s.pool.DynamicFor(ref.GetCluster(), id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	u, err := dyn.Resource(swiftSandboxGVR).Namespace(ref.GetNamespace()).Get(ctx, ref.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, mapAccessErr(err)
+	}
+	sb, err := toSwiftSandbox(u)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&kubeswiftv1.GetSandboxDetailResponse{
+		Sandbox: sandboxToProto(ref.GetCluster(), sb),
+		Spec:    sandboxSpecToProto(sb),
+	}), nil
+}
+
+// GetSandboxPoolDetail returns one warm pool.
+func (s *SandboxService) GetSandboxPoolDetail(ctx context.Context, req *connect.Request[kubeswiftv1.GetSandboxPoolDetailRequest]) (*connect.Response[kubeswiftv1.GetSandboxPoolDetailResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	ref := req.Msg.GetRef()
+	if ref == nil || ref.GetCluster() == "" || ref.GetName() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("ref.cluster and ref.name are required"))
+	}
+	dyn, err := s.pool.DynamicFor(ref.GetCluster(), id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	u, err := dyn.Resource(swiftSandboxPoolGVR).Namespace(ref.GetNamespace()).Get(ctx, ref.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, mapAccessErr(err)
+	}
+	p, err := toSwiftSandboxPool(u)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&kubeswiftv1.GetSandboxPoolDetailResponse{
+		Pool: sandboxPoolToProto(ref.GetCluster(), p),
+	}), nil
+}
+
+// targetClusters resolves the selector against the registered members (mirrors
+// the guest/migration read planes — per-service by convention).
+func (s *SandboxService) targetClusters(sel *kubeswiftv1.ClusterSelector) []string {
+	all := s.pool.Members()
+	sort.Strings(all)
+	if sel == nil || sel.GetAllClusters() || len(sel.GetClusters()) == 0 {
+		return all
+	}
+	registered := make(map[string]bool, len(all))
+	for _, m := range all {
+		registered[m] = true
+	}
+	var out []string
+	for _, c := range sel.GetClusters() {
+		if registered[c] {
+			out = append(out, c)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sandboxResource(dyn dynamic.Interface, namespace string) dynamic.ResourceInterface {
+	if namespace == "" {
+		return dyn.Resource(swiftSandboxGVR)
+	}
+	return dyn.Resource(swiftSandboxGVR).Namespace(namespace)
+}
+
+func sandboxPoolResource(dyn dynamic.Interface, namespace string) dynamic.ResourceInterface {
+	if namespace == "" {
+		return dyn.Resource(swiftSandboxPoolGVR)
+	}
+	return dyn.Resource(swiftSandboxPoolGVR).Namespace(namespace)
+}
+
+func toSwiftSandbox(u *unstructured.Unstructured) (*sandboxv1alpha1.SwiftSandbox, error) {
+	var sb sandboxv1alpha1.SwiftSandbox
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &sb); err != nil {
+		return nil, err
+	}
+	return &sb, nil
+}
+
+func toSwiftSandboxPool(u *unstructured.Unstructured) (*sandboxv1alpha1.SwiftSandboxPool, error) {
+	var p sandboxv1alpha1.SwiftSandboxPool
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func sandboxWatchEventToProto(cluster string, e watch.Event) *kubeswiftv1.SandboxEvent {
+	var t kubeswiftv1.EventType
+	switch e.Type {
+	case watch.Added:
+		t = kubeswiftv1.EventType_EVENT_TYPE_ADDED
+	case watch.Modified:
+		t = kubeswiftv1.EventType_EVENT_TYPE_MODIFIED
+	case watch.Deleted:
+		t = kubeswiftv1.EventType_EVENT_TYPE_DELETED
+	default: // Bookmark / Error from a member watch: not a sandbox row
+		return nil
+	}
+	u, ok := e.Object.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+	sb, err := toSwiftSandbox(u)
+	if err != nil {
+		return nil
+	}
+	return &kubeswiftv1.SandboxEvent{Type: t, Sandbox: sandboxToProto(cluster, sb)}
+}
+
+// refLess orders rows by (cluster, namespace, name) — the stable inventory sort
+// shared by the sandbox list responses.
+func refLess(a, b *kubeswiftv1.ObjectRef) bool {
+	if a.GetCluster() != b.GetCluster() {
+		return a.GetCluster() < b.GetCluster()
+	}
+	if a.GetNamespace() != b.GetNamespace() {
+		return a.GetNamespace() < b.GetNamespace()
+	}
+	return a.GetName() < b.GetName()
+}

--- a/internal/gateway/sandbox_service_test.go
+++ b/internal/gateway/sandbox_service_test.go
@@ -1,0 +1,146 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	connect "connectrpc.com/connect"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	kubeswiftv1 "github.com/kubeswift-io/kubeswift/gen/kubeswift/v1"
+)
+
+func uSandbox(ns, name, phase, image string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "sandbox.kubeswift.io/v1alpha1",
+		"kind":       "SwiftSandbox",
+		"metadata":   map[string]interface{}{"namespace": ns, "name": name},
+		"spec": map[string]interface{}{
+			"image":   image,
+			"cpu":     int64(1),
+			"memory":  "512Mi",
+			"command": []interface{}{"sh", "-c"},
+			"args":    []interface{}{"echo hi"},
+		},
+		"status": map[string]interface{}{"phase": phase},
+	}}
+}
+
+func uSandboxPool(ns, name, phase string, minWarm, warm int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "sandbox.kubeswift.io/v1alpha1",
+		"kind":       "SwiftSandboxPool",
+		"metadata":   map[string]interface{}{"namespace": ns, "name": name},
+		"spec":       map[string]interface{}{"image": "alpine", "minWarm": minWarm, "memory": "256Mi"},
+		"status":     map[string]interface{}{"phase": phase, "warmReplicas": warm},
+	}}
+}
+
+func fakeSandboxDyn(objs ...*unstructured.Unstructured) dynamic.Interface {
+	// Track each object under its EXPLICIT GVR — the dynamic fake's default
+	// UnsafeGuessKindToResource maps SwiftSandbox to "swiftsandboxs", not the CRD's
+	// actual "swiftsandboxes" plural, so a constructor-seeded object lands under the
+	// wrong resource. Tracker().Create with the real GVR avoids that.
+	c := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			swiftSandboxGVR:     "SwiftSandboxList",
+			swiftSandboxPoolGVR: "SwiftSandboxPoolList",
+		})
+	for _, o := range objs {
+		gvr := swiftSandboxGVR
+		if o.GetKind() == "SwiftSandboxPool" {
+			gvr = swiftSandboxPoolGVR
+		}
+		if err := c.Tracker().Create(gvr, o, o.GetNamespace()); err != nil {
+			panic(err)
+		}
+	}
+	return c
+}
+
+func TestSandboxService_ListSandboxes_FanOutMergeAndPartialError(t *testing.T) {
+	prov := &fakeProvider{
+		clients: map[string]dynamic.Interface{
+			"boba":  fakeSandboxDyn(uSandbox("default", "sb-a", "Running", "alpine"), uSandbox("default", "sb-b", "Completed", "alpine")),
+			"miles": fakeSandboxDyn(uSandbox("default", "sb-c", "Running", "python")),
+		},
+		errs: map[string]error{"down": errors.New("connection refused")},
+	}
+	svc := NewSandboxService(prov, NewInsecureAuthenticator())
+
+	resp, err := svc.ListSandboxes(context.Background(), connect.NewRequest(&kubeswiftv1.ListSandboxesRequest{}))
+	if err != nil {
+		t.Fatalf("ListSandboxes: %v", err)
+	}
+	if len(resp.Msg.Sandboxes) != 3 {
+		t.Fatalf("got %d sandboxes, want 3", len(resp.Msg.Sandboxes))
+	}
+	if len(resp.Msg.Errors) != 1 || resp.Msg.Errors[0].Cluster != "down" {
+		t.Errorf("want one partial-fleet error for 'down', got %+v", resp.Msg.Errors)
+	}
+	// cluster dimension stamped + merged sort by (cluster, ns, name).
+	if resp.Msg.Sandboxes[0].GetRef().GetCluster() != "boba" || resp.Msg.Sandboxes[2].GetRef().GetCluster() != "miles" {
+		t.Errorf("not sorted by cluster: %v / %v", resp.Msg.Sandboxes[0].GetRef(), resp.Msg.Sandboxes[2].GetRef())
+	}
+	// flat-row fields mapped (image, default network mode).
+	if resp.Msg.Sandboxes[0].GetImage() != "alpine" || resp.Msg.Sandboxes[0].GetNetworkMode() != "restricted" {
+		t.Errorf("row map wrong: %+v", resp.Msg.Sandboxes[0])
+	}
+}
+
+func TestSandboxService_ListSandboxes_PhaseFilter(t *testing.T) {
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{
+		"boba": fakeSandboxDyn(uSandbox("default", "sb-a", "Running", "alpine"), uSandbox("default", "sb-b", "Completed", "alpine")),
+	}}
+	svc := NewSandboxService(prov, NewInsecureAuthenticator())
+	resp, err := svc.ListSandboxes(context.Background(), connect.NewRequest(&kubeswiftv1.ListSandboxesRequest{Phase: "Completed"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Msg.Sandboxes) != 1 || resp.Msg.Sandboxes[0].GetRef().GetName() != "sb-b" {
+		t.Errorf("phase filter wrong: %+v", resp.Msg.Sandboxes)
+	}
+}
+
+func TestSandboxService_ListSandboxPools(t *testing.T) {
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{
+		"boba": fakeSandboxDyn(uSandboxPool("default", "pool-a", "Ready", 2, 2)),
+	}}
+	svc := NewSandboxService(prov, NewInsecureAuthenticator())
+	resp, err := svc.ListSandboxPools(context.Background(), connect.NewRequest(&kubeswiftv1.ListSandboxPoolsRequest{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Msg.Pools) != 1 {
+		t.Fatalf("got %d pools, want 1", len(resp.Msg.Pools))
+	}
+	p := resp.Msg.Pools[0]
+	if p.GetPhase() != "Ready" || p.GetMinWarm() != 2 || p.GetWarmReplicas() != 2 || p.GetRef().GetCluster() != "boba" {
+		t.Errorf("pool map wrong: %+v", p)
+	}
+}
+
+func TestSandboxService_GetSandboxDetail(t *testing.T) {
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{
+		"boba": fakeSandboxDyn(uSandbox("default", "sb-a", "Running", "alpine")),
+	}}
+	svc := NewSandboxService(prov, NewInsecureAuthenticator())
+	resp, err := svc.GetSandboxDetail(context.Background(), connect.NewRequest(&kubeswiftv1.GetSandboxDetailRequest{
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "sb-a"},
+	}))
+	if err != nil {
+		t.Fatalf("GetSandboxDetail: %v", err)
+	}
+	if resp.Msg.GetSandbox().GetImage() != "alpine" {
+		t.Errorf("sandbox image: %q", resp.Msg.GetSandbox().GetImage())
+	}
+	spec := resp.Msg.GetSpec()
+	if spec.GetImage() != "alpine" || len(spec.GetCommand()) != 2 || spec.GetArgs()[0] != "echo hi" {
+		t.Errorf("spec map wrong: %+v", spec)
+	}
+}


### PR DESCRIPTION
Second step of the v0.11.0 MicroVM UI surfacing (epic #376, workstream A), on top of #378's proto contract. Implements the gateway **read plane** for `SandboxService`.

## What
- **`ListSandboxes` / `ListSandboxPools`** — fleet fan-out across the selected members, merged with the cluster dimension stamped and a per-cluster `ClusterError` surface (no silent partial-fleet failures), impersonating the end user (D1). Mirrors the guest read plane.
- **`WatchSandboxes`** — multiplexes per-cluster watches into one stream; a member that can't watch yields a BOOKMARK+ClusterError (sandboxes are ephemeral, so live updates keep the inventory current).
- **`GetSandboxDetail` / `GetSandboxPoolDetail`** — the drawer view (+ `SandboxSpec` for Clone).
- `sandbox_mapper.go`: SwiftSandbox/Pool → flat UI rows.
- **vm-reader role** (edge chart + sample): `sandbox.kubeswift.io` get/list/watch, so an impersonated UI reader can list the inventory (create/delete verbs land with A3).
- Write RPCs stay on the `Unimplemented` base until A3.

## Tests
`go test ./internal/gateway/...` green — fan-out+partial-error, phase filter, pool mapping, detail-spec. (Test-only note: the dynamic fake's `UnsafeGuessKindToResource` maps `SwiftSandbox`→`swiftsandboxs`, not the CRD's `swiftsandboxes`, so the fake tracks objects under the explicit GVR. Prod uses the real apiserver + CRD plural.)

Next: A3 (write plane — Create/Delete), then A4 (kubeswift-ui views).

Refs #376