### PR TITLE
feat(gateway): SandboxService write plane (v0.11.0 A3)

### DIFF
--- a/charts/kubeswift/templates/edge/rbac.yaml
+++ b/charts/kubeswift/templates/edge/rbac.yaml
@@ -108,11 +108,11 @@ rules:
   - apiGroups: ["image.kubeswift.io", "kernel.kubeswift.io", "seed.kubeswift.io", "snapshot.kubeswift.io", "gpu.kubeswift.io"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
-  # MicroVM inventory (UI SandboxService read plane, v0.11.0). Create/delete
-  # verbs are added with the write plane (A3).
+  # MicroVM inventory (UI SandboxService, v0.11.0): read plane (list/watch) +
+  # create/delete for the UI create/delete actions.
   - apiGroups: ["sandbox.kubeswift.io"]
     resources: ["swiftsandboxes", "swiftsandboxpools"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "delete"]

--- a/config/samples/gateway/member-rbac.yaml
+++ b/config/samples/gateway/member-rbac.yaml
@@ -45,11 +45,11 @@ rules:
   - apiGroups: ["swift.kubeswift.io"]
     resources: ["swiftguests", "swiftguestclasses", "swiftguestpools"]
     verbs: ["get", "list", "watch"]
-  # MicroVM inventory (UI SandboxService read plane, v0.11.0). Add the
-  # create/delete verbs alongside the write plane (A3).
+  # MicroVM inventory (UI SandboxService, v0.11.0): read (list/watch) + the
+  # create/delete verbs for the UI create/delete actions.
   - apiGroups: ["sandbox.kubeswift.io"]
     resources: ["swiftsandboxes", "swiftsandboxpools"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "create", "delete"]
   # Lifecycle write actions (UI Start/Stop) patch swiftguests.spec.runPolicy.
   # Grant these to the subjects you want to be able to act; drop both rules for
   # a strictly read-only audience.

--- a/internal/gateway/sandbox_service_test.go
+++ b/internal/gateway/sandbox_service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	connect "connectrpc.com/connect"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -142,5 +143,82 @@ func TestSandboxService_GetSandboxDetail(t *testing.T) {
 	spec := resp.Msg.GetSpec()
 	if spec.GetImage() != "alpine" || len(spec.GetCommand()) != 2 || spec.GetArgs()[0] != "echo hi" {
 		t.Errorf("spec map wrong: %+v", spec)
+	}
+}
+
+func TestSandboxService_CreateSandbox(t *testing.T) {
+	boba := fakeSandboxDyn()
+	svc := NewSandboxService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+
+	resp, err := svc.CreateSandbox(context.Background(), connect.NewRequest(&kubeswiftv1.CreateSandboxRequest{
+		Cluster: "boba", Namespace: "default", Name: "sb-1",
+		Image: "alpine:3.20", Command: []string{"sh", "-c"}, Args: []string{"echo hi"},
+		Env: map[string]string{"A": "1"}, NetworkMode: "open", Cpu: 2, MemoryMib: 512, PoolRef: "p1",
+	}))
+	if err != nil {
+		t.Fatalf("CreateSandbox: %v", err)
+	}
+	if resp.Msg.GetRef().GetName() != "sb-1" || resp.Msg.GetRef().GetCluster() != "boba" {
+		t.Errorf("ref: %+v", resp.Msg.GetRef())
+	}
+	got, err := boba.Resource(swiftSandboxGVR).Namespace("default").Get(context.Background(), "sb-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("created sandbox not found: %v", err)
+	}
+	image, _, _ := unstructured.NestedString(got.Object, "spec", "image")
+	mem, _, _ := unstructured.NestedString(got.Object, "spec", "memory")
+	poolRef, _, _ := unstructured.NestedString(got.Object, "spec", "poolRef", "name")
+	netMode, _, _ := unstructured.NestedString(got.Object, "spec", "network", "mode")
+	if image != "alpine:3.20" || mem != "512Mi" || poolRef != "p1" || netMode != "open" {
+		t.Errorf("spec wrong: image=%q mem=%q pool=%q net=%q", image, mem, poolRef, netMode)
+	}
+
+	// Missing image -> InvalidArgument (a clear gateway error ahead of the webhook).
+	_, err = svc.CreateSandbox(context.Background(), connect.NewRequest(&kubeswiftv1.CreateSandboxRequest{Cluster: "boba", Namespace: "default", Name: "x"}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("missing image: want InvalidArgument, got %v", err)
+	}
+	// A name clash fails loudly.
+	_, err = svc.CreateSandbox(context.Background(), connect.NewRequest(&kubeswiftv1.CreateSandboxRequest{Cluster: "boba", Namespace: "default", Name: "sb-1", Image: "x"}))
+	if connect.CodeOf(err) != connect.CodeAlreadyExists {
+		t.Errorf("duplicate name should be AlreadyExists, got %v", err)
+	}
+}
+
+func TestSandboxService_DeleteSandbox(t *testing.T) {
+	boba := fakeSandboxDyn(uSandbox("default", "sb-a", "Running", "alpine"))
+	svc := NewSandboxService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+
+	if _, err := svc.DeleteSandbox(context.Background(), connect.NewRequest(&kubeswiftv1.DeleteSandboxRequest{})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("missing ref: want InvalidArgument, got %v", err)
+	}
+	if _, err := svc.DeleteSandbox(context.Background(), connect.NewRequest(&kubeswiftv1.DeleteSandboxRequest{
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "sb-a"},
+	})); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	list, _ := boba.Resource(swiftSandboxGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
+	if len(list.Items) != 0 {
+		t.Errorf("sandbox should be deleted, got %d", len(list.Items))
+	}
+}
+
+func TestSandboxService_CreateSandboxPool(t *testing.T) {
+	boba := fakeSandboxDyn()
+	svc := NewSandboxService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+
+	if _, err := svc.CreateSandboxPool(context.Background(), connect.NewRequest(&kubeswiftv1.CreateSandboxPoolRequest{
+		Cluster: "boba", Namespace: "default", Name: "pool-1", Image: "alpine", MinWarm: 3, MaxWarm: 6, MemoryMib: 256,
+	})); err != nil {
+		t.Fatalf("CreateSandboxPool: %v", err)
+	}
+	got, err := boba.Resource(swiftSandboxPoolGVR).Namespace("default").Get(context.Background(), "pool-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("pool not found: %v", err)
+	}
+	minWarm, _, _ := unstructured.NestedInt64(got.Object, "spec", "minWarm")
+	mem, _, _ := unstructured.NestedString(got.Object, "spec", "memory")
+	if minWarm != 3 || mem != "256Mi" {
+		t.Errorf("pool spec wrong: minWarm=%d mem=%q", minWarm, mem)
 	}
 }

--- a/internal/gateway/sandbox_write.go
+++ b/internal/gateway/sandbox_write.go
@@ -1,0 +1,232 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	connect "connectrpc.com/connect"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+
+	kubeswiftv1 "github.com/kubeswift-io/kubeswift/gen/kubeswift/v1"
+)
+
+// CreateSandbox builds a SwiftSandbox from the form input and creates it as the
+// impersonated user (D1). The admission webhook is the authority on spec
+// validity; a denial (or a name clash, or an RBAC refusal) surfaces with its
+// reason — never a silent create.
+func (s *SandboxService) CreateSandbox(ctx context.Context, req *connect.Request[kubeswiftv1.CreateSandboxRequest]) (*connect.Response[kubeswiftv1.CreateSandboxResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	m := req.Msg
+	if m.GetCluster() == "" || m.GetNamespace() == "" || m.GetName() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cluster, namespace, and name are required"))
+	}
+	if m.GetImage() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("image is required"))
+	}
+	dyn, err := s.pool.DynamicFor(m.GetCluster(), id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	if _, err := sandboxResource(dyn, m.GetNamespace()).Create(ctx, buildSwiftSandbox(m), metav1.CreateOptions{}); err != nil {
+		return nil, mapCreateErr(err)
+	}
+	return connect.NewResponse(&kubeswiftv1.CreateSandboxResponse{
+		Ref: &kubeswiftv1.ObjectRef{Cluster: m.GetCluster(), Namespace: m.GetNamespace(), Name: m.GetName()},
+	}), nil
+}
+
+// DeleteSandbox deletes one SwiftSandbox as the impersonated user.
+func (s *SandboxService) DeleteSandbox(ctx context.Context, req *connect.Request[kubeswiftv1.DeleteSandboxRequest]) (*connect.Response[kubeswiftv1.DeleteSandboxResponse], error) {
+	dyn, ref, err := s.authRefDyn(ctx, req.Header(), req.Msg.GetRef())
+	if err != nil {
+		return nil, err
+	}
+	if err := sandboxResource(dyn, ref.GetNamespace()).Delete(ctx, ref.GetName(), metav1.DeleteOptions{}); err != nil {
+		return nil, mapDeleteErr(err)
+	}
+	return connect.NewResponse(&kubeswiftv1.DeleteSandboxResponse{}), nil
+}
+
+// CreateSandboxPool builds a SwiftSandboxPool from the form input and creates it
+// as the impersonated user. Same authority model as CreateSandbox.
+func (s *SandboxService) CreateSandboxPool(ctx context.Context, req *connect.Request[kubeswiftv1.CreateSandboxPoolRequest]) (*connect.Response[kubeswiftv1.CreateSandboxPoolResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	m := req.Msg
+	if m.GetCluster() == "" || m.GetNamespace() == "" || m.GetName() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cluster, namespace, and name are required"))
+	}
+	if m.GetImage() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("image is required"))
+	}
+	dyn, err := s.pool.DynamicFor(m.GetCluster(), id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	if _, err := sandboxPoolResource(dyn, m.GetNamespace()).Create(ctx, buildSwiftSandboxPool(m), metav1.CreateOptions{}); err != nil {
+		return nil, mapCreateErr(err)
+	}
+	return connect.NewResponse(&kubeswiftv1.CreateSandboxPoolResponse{
+		Ref: &kubeswiftv1.ObjectRef{Cluster: m.GetCluster(), Namespace: m.GetNamespace(), Name: m.GetName()},
+	}), nil
+}
+
+// DeleteSandboxPool deletes one SwiftSandboxPool as the impersonated user.
+func (s *SandboxService) DeleteSandboxPool(ctx context.Context, req *connect.Request[kubeswiftv1.DeleteSandboxPoolRequest]) (*connect.Response[kubeswiftv1.DeleteSandboxPoolResponse], error) {
+	dyn, ref, err := s.authRefDyn(ctx, req.Header(), req.Msg.GetRef())
+	if err != nil {
+		return nil, err
+	}
+	if err := sandboxPoolResource(dyn, ref.GetNamespace()).Delete(ctx, ref.GetName(), metav1.DeleteOptions{}); err != nil {
+		return nil, mapDeleteErr(err)
+	}
+	return connect.NewResponse(&kubeswiftv1.DeleteSandboxPoolResponse{}), nil
+}
+
+// authRefDyn is the shared prelude for the ref-addressed write RPCs: authenticate,
+// validate the ref, resolve the impersonating dynamic client.
+func (s *SandboxService) authRefDyn(ctx context.Context, hdr http.Header, ref *kubeswiftv1.ObjectRef) (dynamic.Interface, *kubeswiftv1.ObjectRef, error) {
+	id, err := s.auth.Authenticate(ctx, hdr)
+	if err != nil {
+		return nil, nil, err
+	}
+	if ref == nil || ref.GetCluster() == "" || ref.GetName() == "" {
+		return nil, nil, connect.NewError(connect.CodeInvalidArgument, errors.New("ref.cluster and ref.name are required"))
+	}
+	dyn, err := s.pool.DynamicFor(ref.GetCluster(), id)
+	if err != nil {
+		return nil, nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	return dyn, ref, nil
+}
+
+// mapCreateErr maps a create failure to a connect code — a name clash, a webhook
+// denial, or an RBAC refusal surfaces with its reason (no silent create).
+func mapCreateErr(err error) *connect.Error {
+	switch {
+	case apierrors.IsAlreadyExists(err):
+		return connect.NewError(connect.CodeAlreadyExists, err)
+	case apierrors.IsForbidden(err) || apierrors.IsInvalid(err) || apierrors.IsBadRequest(err):
+		return connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	return connect.NewError(connect.CodeInternal, err)
+}
+
+// mapDeleteErr maps a delete failure to a connect code (NotFound / RBAC).
+func mapDeleteErr(err error) *connect.Error {
+	switch {
+	case apierrors.IsNotFound(err):
+		return connect.NewError(connect.CodeNotFound, err)
+	case apierrors.IsForbidden(err) || apierrors.IsInvalid(err):
+		return connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	return connect.NewError(connect.CodeInternal, err)
+}
+
+// buildSwiftSandbox constructs the SwiftSandbox unstructured from the form
+// request — only set fields are written; CRD defaults + the webhook do the rest.
+func buildSwiftSandbox(m *kubeswiftv1.CreateSandboxRequest) *unstructured.Unstructured {
+	spec := map[string]interface{}{"image": m.GetImage()}
+	if v := m.GetCommand(); len(v) > 0 {
+		spec["command"] = toIfaceSlice(v)
+	}
+	if v := m.GetArgs(); len(v) > 0 {
+		spec["args"] = toIfaceSlice(v)
+	}
+	if v := m.GetEnv(); len(v) > 0 {
+		spec["env"] = envToIface(v)
+	}
+	if v := m.GetWorkingDir(); v != "" {
+		spec["workingDir"] = v
+	}
+	if v := m.GetNetworkMode(); v != "" {
+		spec["network"] = map[string]interface{}{"mode": v}
+	}
+	if v := m.GetCpu(); v > 0 {
+		spec["cpu"] = int64(v)
+	}
+	if v := m.GetMemoryMib(); v > 0 {
+		spec["memory"] = fmt.Sprintf("%dMi", v)
+	}
+	if v := m.GetPoolRef(); v != "" {
+		spec["poolRef"] = map[string]interface{}{"name": v}
+	}
+	if v := m.GetKernelProfileRef(); v != "" {
+		spec["kernelProfileRef"] = map[string]interface{}{"name": v}
+	}
+	if v := m.GetTimeout(); v != "" {
+		spec["timeout"] = v
+	}
+	if v := m.GetTtl(); v != "" {
+		spec["ttl"] = v
+	}
+	if v := m.GetImagePullSecret(); v != "" {
+		spec["imagePullSecret"] = v
+	}
+	return sandboxUnstructured("SwiftSandbox", m.GetName(), m.GetNamespace(), spec)
+}
+
+// buildSwiftSandboxPool constructs the SwiftSandboxPool unstructured from the
+// form request.
+func buildSwiftSandboxPool(m *kubeswiftv1.CreateSandboxPoolRequest) *unstructured.Unstructured {
+	spec := map[string]interface{}{"image": m.GetImage()}
+	if v := m.GetMinWarm(); v > 0 {
+		spec["minWarm"] = int64(v)
+	}
+	if v := m.GetMaxWarm(); v > 0 {
+		spec["maxWarm"] = int64(v)
+	}
+	if v := m.GetCpu(); v > 0 {
+		spec["cpu"] = int64(v)
+	}
+	if v := m.GetMemoryMib(); v > 0 {
+		spec["memory"] = fmt.Sprintf("%dMi", v)
+	}
+	if v := m.GetNetworkMode(); v != "" {
+		spec["network"] = map[string]interface{}{"mode": v}
+	}
+	if v := m.GetKernelProfileRef(); v != "" {
+		spec["kernelProfileRef"] = map[string]interface{}{"name": v}
+	}
+	if v := m.GetImagePullSecret(); v != "" {
+		spec["imagePullSecret"] = v
+	}
+	return sandboxUnstructured("SwiftSandboxPool", m.GetName(), m.GetNamespace(), spec)
+}
+
+func sandboxUnstructured(kind, name, namespace string, spec map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "sandbox.kubeswift.io/v1alpha1",
+		"kind":       kind,
+		"metadata":   map[string]interface{}{"name": name, "namespace": namespace},
+		"spec":       spec,
+	}}
+}
+
+func toIfaceSlice(ss []string) []interface{} {
+	out := make([]interface{}, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}
+
+// envToIface renders the form's env map as the SwiftSandbox spec.env list of
+// {name, value} (the CRD's corev1.EnvVar shape).
+func envToIface(env map[string]string) []interface{} {
+	out := make([]interface{}, 0, len(env))
+	for k, v := range env {
+		out = append(out, map[string]interface{}{"name": k, "value": v})
+	}
+	return out
+}


### PR DESCRIPTION
Third step of the v0.11.0 MicroVM UI surfacing (epic #376, workstream A). Completes the gateway with the create/delete write RPCs.

## What
- **`CreateSandbox` / `CreateSandboxPool`** — build the unstructured from the form input (only set fields; CRD defaults + the webhook fill the rest) and create it as the impersonated user. A name clash → `AlreadyExists`, a webhook/RBAC denial → `FailedPrecondition`, a missing image → `InvalidArgument` — surfaced with the reason, never a silent create. Mirrors `CreateGuest`.
- **`DeleteSandbox` / `DeleteSandboxPool`** — delete by ref as the impersonated user.
- `vm-reader` role (edge chart + sample): + `create`/`delete` on `swiftsandboxes`/`swiftsandboxpools`.

## Tests
`go test ./internal/gateway/...` green — create maps image/mem/pool/net + `AlreadyExists` + missing-image `InvalidArgument`; delete removes the object + missing-ref `InvalidArgument`; pool create maps minWarm/memory.

## Cluster validation
Deploying the A3 gateway image to dev and confirming the write RPCs are registered (401 auth-gated, not 404). The build logic is unit-tested; the OIDC token flow isn't scriptable here.

**Workstream A gateway side is complete after this (A1 proto + A2 read + A3 write).** Next: A4 — the kubeswift-ui views.

Refs #376