### PR TITLE
feat(sandbox): node-local per-digest lock for warm-pool materialize dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to KubeSwift are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+**Sandbox warm-pool efficiency**
+- `sandbox-materialize` now takes a **node-local per-digest lock** around the
+  pull+extract step, so concurrent materializes of the same image on the same
+  node (warm-pool slots when `minWarm` exceeds the node count, or co-located
+  sandboxes) serialize — the first pulls, the rest cache-hit — instead of N
+  redundant parallel pulls of the same layers. The digest cache was already
+  correct (atomic rename); this removes the wasted bandwidth.
+
 ### Added
 
 **Sandbox image signing (verify before boot)**

--- a/internal/sandbox/materialize/materialize.go
+++ b/internal/sandbox/materialize/materialize.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -88,6 +89,27 @@ func CachePathFor(cacheDir, digest string, mode Mode) string {
 		return filepath.Join(cacheDir, name)
 	}
 	return filepath.Join(cacheDir, name+".ext4")
+}
+
+// lockDigest takes a node-local exclusive advisory lock (flock) keyed by digest,
+// serializing concurrent materializes of the same image on the same node. The
+// lock file sits in the shared hostPath cache dir so the flock is visible across
+// init containers. Returns an unlock func; the lock file is intentionally left in
+// place (a 0-byte marker, reused next time — never the materialized artifact).
+func lockDigest(cacheDir, digest string) (func(), error) {
+	name := ".lock-" + strings.ReplaceAll(digest, ":", "-")
+	f, err := os.OpenFile(filepath.Join(cacheDir, name), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open digest lock: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("flock digest lock: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
 }
 
 // ext4SizeBytes sizes the RO ext4: 1.5x the tree + a 64 MiB floor, rounded up to
@@ -205,7 +227,8 @@ func Materialize(opts Options, pull Puller) (*Result, error) {
 		Config:     cfg,
 	}
 
-	// Cache hit: the digest is immutable, so an existing artifact is authoritative.
+	// Fast path — cache hit without locking: the digest is immutable, so an
+	// existing artifact is authoritative and the common case pays no lock cost.
 	if fi, err := os.Stat(rootfsPath); err == nil {
 		res.CacheHit = true
 		res.SizeBytes = artifactSize(rootfsPath, fi)
@@ -214,6 +237,24 @@ func Materialize(opts Options, pull Puller) (*Result, error) {
 
 	if err := os.MkdirAll(opts.CacheDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create cache dir: %w", err)
+	}
+
+	// Slow path — acquire a node-local per-digest lock so concurrent materializes
+	// of the SAME image on the SAME node serialize (warm-pool slots when
+	// replicas > nodes, or co-located sandboxes of one image): the first process
+	// pulls + extracts, the rest wait then hit the cache below — instead of N
+	// redundant parallel pulls of the same layers. The lock file lives in the
+	// shared hostPath cache, so the flock is visible across init containers on the
+	// node. Best-effort: if locking fails we proceed unlocked (the temp-dir +
+	// atomic-rename below still keeps concurrent writers correct, just not deduped).
+	if unlock, err := lockDigest(opts.CacheDir, digest); err == nil {
+		defer unlock()
+		// Re-check under the lock: another process may have finished while we waited.
+		if fi, err := os.Stat(rootfsPath); err == nil {
+			res.CacheHit = true
+			res.SizeBytes = artifactSize(rootfsPath, fi)
+			return res, nil
+		}
 	}
 
 	// Flatten the image (whiteouts applied) into a temp tree next to the target,

--- a/internal/sandbox/materialize/materialize_test.go
+++ b/internal/sandbox/materialize/materialize_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -187,5 +188,67 @@ func TestMaterialize_BlockMissPath(t *testing.T) {
 	}
 	if !res2.CacheHit {
 		t.Error("second materialize of the same digest must be a cache hit")
+	}
+}
+
+// TestLockDigest_Serializes verifies the node-local per-digest lock actually
+// blocks a second holder until the first releases (the warm-pool dedup guard).
+func TestLockDigest_Serializes(t *testing.T) {
+	dir := t.TempDir()
+	const dig = "sha256:deadbeef"
+
+	unlock1, err := lockDigest(dir, dig)
+	if err != nil {
+		t.Fatalf("first lock: %v", err)
+	}
+
+	got := make(chan struct{})
+	go func() {
+		unlock2, err := lockDigest(dir, dig)
+		if err != nil {
+			t.Errorf("second lock: %v", err)
+			return
+		}
+		close(got)
+		unlock2()
+	}()
+
+	// While the first lock is held, the second must block.
+	select {
+	case <-got:
+		t.Fatal("second lock acquired while first still held")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// Release the first; the second must now acquire promptly.
+	unlock1()
+	select {
+	case <-got:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second lock did not acquire after first released")
+	}
+}
+
+// TestLockDigest_DifferentDigests confirms independent digests do not block each
+// other (only same-image same-node materializes serialize).
+func TestLockDigest_DifferentDigests(t *testing.T) {
+	dir := t.TempDir()
+	u1, err := lockDigest(dir, "sha256:aaaa")
+	if err != nil {
+		t.Fatalf("lock a: %v", err)
+	}
+	defer u1()
+	done := make(chan struct{})
+	go func() {
+		u2, err := lockDigest(dir, "sha256:bbbb")
+		if err == nil {
+			u2()
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("distinct digest lock blocked unexpectedly")
 	}
 }


### PR DESCRIPTION
## What
Concurrent `sandbox-materialize` runs of the **same image on the same node**
(warm-pool slots when `minWarm` exceeds the node count, or co-located sandboxes)
each pulled + extracted the same layers independently. The digest cache was
already correct (temp-dir + atomic rename), but the parallel pulls wasted
bandwidth.

## How
`materialize` now takes a **node-local `flock` keyed by digest** (lock file in
the shared hostPath cache, so it's visible across init containers on the node)
around the pull+extract. The first process materializes; the rest wait then
cache-hit. The fast-path cache hit pays no lock cost, and locking is best-effort
(a lock failure falls through to the still-correct atomic-rename path). Unit
tests cover same-digest serialization and independent-digest non-blocking.

## Cluster validation
A `SwiftSandboxPool` with `minWarm: 3` on a 2-node cluster (one node hosts two
slots) of a **fresh, uncached image** (`alpine:3.19`): all 3 slots reached warm,
and the two same-node (miles) slots showed **one `cacheHit=false`** (acquired the
lock, pulled) and **one `cacheHit=true`** (waited on the lock, then cache-hit —
deduped). The boba slot pulled independently on its own node. No corruption.