### PR TITLE
feat(sandbox): honor spec.workingDir on the cold-boot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to KubeSwift are documented here.
 
 ### Changed
 
+**Sandbox `spec.workingDir` honored on cold boot**
+- The bridge-initramfs ran the workload as `chroot /newroot argv`, which cannot
+  set the working directory, so `spec.workingDir` was accepted-but-ignored on the
+  cold-boot path (it already worked on warm-pool checkout via the vsock agent).
+  The bridge now parses the config-disk CWD and, when set, runs the workload via
+  the guest agent's new one-shot mode (`kubeswift-guest-agent --run` — chroot +
+  chdir + exec in one process, distroless-safe, foreground so the bridge stays
+  PID 1). Ships as sandbox kernel `6.6.10` (initramfs-only; bzImage unchanged).
+
 **Sandbox warm-pool efficiency**
 - `sandbox-materialize` now takes a **node-local per-digest lock** around the
   pull+extract step, so concurrent materializes of the same image on the same

--- a/build/kernels/sandbox/rootfs-overlay/init
+++ b/build/kernels/sandbox/rootfs-overlay/init
@@ -126,6 +126,7 @@ if [ -n "$CONFIG_DEV" ] && [ -r "$CONFIG_DEV" ]; then
 			KUBESWIFT-EXEC-END) break ;;
 			ARGV) set -- "$@" "$(printf '%s' "$val" | base64 -d 2>/dev/null)" ;;
 			ENV)  export "$(printf '%s' "$val" | base64 -d 2>/dev/null)" 2>/dev/null || true ;;
+			CWD)  WORKDIR="$(printf '%s' "$val" | base64 -d 2>/dev/null)" ;;
 		esac
 	done
 	IFS=$oldifs
@@ -154,8 +155,12 @@ fi
 # both work; chroot execs the binary directly, so distroless images work with no
 # shell). When it exits we capture its code, emit it on the console for swiftletd to
 # read, and power the VM off so CH exits and the launcher pod reaches a terminal state.
-# NOTE: spec.workingDir is NOT honored in v1 — chroot starts the workload at / and a
-# chdir wrapper needs a guest shell (deferred). The workload starts in /.
+# spec.workingDir (config-disk CWD): busybox `chroot` cannot set the child's cwd, and a
+# `cd && exec` wrapper would need a guest shell (breaks distroless). When a workingDir is
+# set we instead run the workload via the baked-in guest agent's one-shot mode
+# (`--run --exec-root=/newroot --cwd=<dir>`), which does chroot+chdir+exec in one Go
+# process with in-chroot PATH resolution — foreground, so the bridge stays PID 1 and
+# still reaps the exit code. No workingDir (or no agent) falls back to plain `chroot`.
 # Start the vsock control agent (swiftctl sandbox exec/attach) in the background if it
 # was baked into the initramfs. It runs in the initramfs context (has AF_VSOCK) and
 # chroots into /newroot per exec request. Best-effort — a missing agent just means no
@@ -177,7 +182,12 @@ if [ "$IDLE" = 1 ]; then
 fi
 
 echo "sandbox-bridge: OCI rootfs ($ROOTFS_KIND) + tmpfs overlay; run $1 ($# arg(s))"
-chroot /newroot "$@"
+if [ -n "$WORKDIR" ] && [ "$WORKDIR" != "/" ] && [ -x /usr/local/bin/kubeswift-guest-agent ]; then
+	echo "sandbox-bridge: workingDir=$WORKDIR (via guest-agent --run)"
+	/usr/local/bin/kubeswift-guest-agent --run --exec-root=/newroot --cwd="$WORKDIR" -- "$@"
+else
+	chroot /newroot "$@"
+fi
 code=$?
 printf 'KUBESWIFT-EXIT-CODE=%s\n' "$code" >/dev/console 2>/dev/null
 # Let CH flush the exit line to the host console file before we power off (swiftletd

--- a/cmd/kubeswift-guest-agent/handler_test.go
+++ b/cmd/kubeswift-guest-agent/handler_test.go
@@ -361,3 +361,17 @@ func contains(s []string, v string) bool {
 	}
 	return false
 }
+
+// TestRunOneShot_ErrorPaths covers the one-shot exec failure modes without needing
+// root/chroot: an empty exec-root disables exec, and an empty argv is rejected —
+// both return 127 (the shell "cannot run" convention).
+func TestRunOneShot_ErrorPaths(t *testing.T) {
+	// No exec-root -> buildExecCmd refuses (exec disabled) -> 127.
+	if code := runOneShot("", "/work", []string{"/bin/true"}); code != 127 {
+		t.Errorf("empty exec-root: code = %d, want 127", code)
+	}
+	// Empty argv -> buildExecCmd refuses -> 127.
+	if code := runOneShot("/newroot", "/work", nil); code != 127 {
+		t.Errorf("empty argv: code = %d, want 127", code)
+	}
+}

--- a/cmd/kubeswift-guest-agent/main.go
+++ b/cmd/kubeswift-guest-agent/main.go
@@ -3,9 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
+	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strconv"
 
 	"golang.org/x/sys/unix"
@@ -22,7 +25,17 @@ const (
 func main() {
 	port := flag.Int("port", DefaultPort, "AF_VSOCK port to listen on")
 	execRoot := flag.String("exec-root", "", "chroot dir for the exec op (empty = agent's own root; SwiftSandbox passes /newroot)")
+	runMode := flag.Bool("run", false, "one-shot: exec the argv after -- chrooted into --exec-root at --cwd, inheriting stdio; exit with the child's code. Used by the sandbox bridge to honor spec.workingDir without a guest shell.")
+	runCwd := flag.String("cwd", "", "working directory INSIDE --exec-root for --run (must exist in the rootfs)")
 	flag.Parse()
+
+	// One-shot local exec (the sandbox cold-boot path): chroot + chdir + exec via
+	// the same buildExecCmd the vsock exec op uses (in-chroot PATH resolution, works
+	// for distroless — no guest shell). The bridge runs this as a FOREGROUND child so
+	// it stays PID 1 and still captures the exit code + powers the VM off.
+	if *runMode {
+		os.Exit(runOneShot(*execRoot, *runCwd, flag.Args()))
+	}
 	if env := os.Getenv("KUBESWIFT_GUEST_AGENT_PORT"); env != "" {
 		if p, err := strconv.Atoi(env); err == nil {
 			*port = p
@@ -55,6 +68,32 @@ func main() {
 		}
 		go serve(h, nfd)
 	}
+}
+
+// runOneShot chroots into root, chdirs to cwd, and execs argv as a foreground
+// child inheriting the caller's stdio, returning the child's exit code. Env is the
+// caller's own environment (the bridge exports the config-disk ENV before invoking
+// this), matching what a plain `chroot root argv` would inherit — buildExecCmd's
+// synthetic PATH/HOME defaults are deliberately overridden. Returns 127 when the
+// command cannot be built or started (mirrors the shell "command not found" code).
+func runOneShot(root, cwd string, argv []string) int {
+	h := &handler{sys: realSystem{}, version: version, execRoot: root}
+	cmd, err := h.buildExecCmd(Request{Argv: argv, Cwd: cwd})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "kubeswift-guest-agent --run:", err)
+		return 127
+	}
+	cmd.Env = os.Environ() // inherit the bridge's env, exactly like `chroot root argv` does
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return ee.ExitCode()
+		}
+		fmt.Fprintln(os.Stderr, "kubeswift-guest-agent --run:", err)
+		return 127
+	}
+	return 0
 }
 
 // serve reads one newline-delimited JSON request and dispatches it. Single-shot ops

--- a/config/samples/sandbox/swiftkernel-sandbox.yaml
+++ b/config/samples/sandbox/swiftkernel-sandbox.yaml
@@ -14,6 +14,6 @@ metadata:
   namespace: default
 spec:
   ociRef:
-    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.9
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.10
   kernelCmdline: "console=ttyS0"
   profile: sandbox

--- a/docs/sandbox/overview.md
+++ b/docs/sandbox/overview.md
@@ -34,7 +34,7 @@ For bursts of same-image sandboxes where the ~15s cold boot dominates, a
 
 - A node labeled `kubeswift.io/kernel-node=true`
 - A `Ready` `SwiftKernel` named `sandbox` (OCI artifact
-  `ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.9`, pulled per node)
+  `ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.10`, pulled per node)
 
 The sandbox kernel is not a plain `kernelRef` SwiftGuest kernel — its
 bridge-initramfs needs the OCI rootfs disk that the SwiftSandbox controller
@@ -67,7 +67,7 @@ Ready-to-edit manifests and notes:
 | `command` | []string | — | Overrides the image's ENTRYPOINT. Empty uses the image's own Entrypoint+Cmd. |
 | `args` | []string | — | Appended to `command` (or the image's CMD when `command` is empty). |
 | `env` | []EnvVar | — | Merged over the image's config env. |
-| `workingDir` | string | — | Overrides the image's working directory. **Accepted but not honored in v1** — the workload always starts in `/`. |
+| `workingDir` | string | — | Overrides the image's working directory. Honored on both the cold-boot path (the bridge runs the workload via the guest agent's chroot+chdir+exec) and the warm-pool checkout path. Must exist in the image. |
 | `timeout` | Duration | none | Wall-clock run cap. Past `startedAt + timeout` the controller force-terminates the sandbox to `Failed` (`DeadlineExceeded`). |
 | `ttl` | Duration | none | Once the sandbox has been terminal (`Completed`/`Failed`) for at least `ttl`, the controller deletes it and frees the node's rootfs-cache reference. |
 | `rootfsMode` | enum | `block` | How the OCI rootfs is delivered: `block` (read-only ext4 disk) or `virtiofs` (the unpacked tree over virtio-fs, tag `sandboxroot` — skips `mkfs.ext4` and the ext4 size floor, shares the host page cache). Same RO-base + writable tmpfs-overlay either way. |

--- a/internal/controller/swiftsandbox/image.go
+++ b/internal/controller/swiftsandbox/image.go
@@ -43,7 +43,7 @@ type resolvedImage struct {
 type execSpec struct {
 	Argv []string // full argv (command/args merged over the image entrypoint/cmd)
 	Env  []string // "KEY=VAL", image env overlaid by spec.env
-	Cwd  string   // working dir (v1: best-effort; the bridge defaults to /)
+	Cwd  string   // working dir; honored on the cold path (bridge -> guest-agent chroot+chdir) and checkout path
 }
 
 // nonTrivial reports whether the exec spec carries anything worth a config disk.


### PR DESCRIPTION
## What
`spec.workingDir` was accepted but **not honored** on the cold-boot path — the
bridge-initramfs ran the workload as `chroot /newroot argv`, and busybox `chroot`
can't set the child's cwd (a `cd && exec` wrapper would need a guest shell,
breaking distroless). It already worked on the warm-pool checkout path (the vsock
agent does chroot+chdir+exec).

## How
swiftletd already writes the CWD onto the config disk; the bridge just ignored it.
Now the bridge parses the `CWD` line and, when a workingDir is set, runs the
workload via the guest agent's **new one-shot mode**:
`kubeswift-guest-agent --run --exec-root=/newroot --cwd=<dir> -- argv` — chroot +
chdir + exec in one Go process (reusing `buildExecCmd`'s in-chroot PATH
resolution). It runs foreground so the bridge stays PID 1 and still reaps the exit
code + powers off. No workingDir (or no agent) falls back to plain `chroot`
(behavior-preserving). Env is inherited from the bridge (`os.Environ`), exactly
like the plain chroot.

Ships as sandbox kernel **`6.6.10`** (initramfs-only rebuild; bzImage unchanged).
No controller/swiftletd change (the CWD was already on the wire).

## Cluster validation (kernel `6.6.10`)
- `workingDir: /etc`, `sh -c 'test "$(pwd)" = /etc'` → **Completed, exit 0**.
- Control (`workingDir: /etc`, `test "$(pwd)" = /` — the old default) → **Failed,
  exit 1**, proving the cwd genuinely moved (the exit code discriminates, not a
  vacuous pass).

`go test`, `go vet`, `gofmt` clean; initramfs rebuilt + pushed as `6.6.10`.