### PR TITLE
release: v0.11.0 — MicroVM platform expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,26 @@ All notable changes to KubeSwift are documented here.
 
 ## [Unreleased]
 
-### Changed
+---
 
-**Sandbox `spec.workingDir` honored on cold boot**
-- The bridge-initramfs ran the workload as `chroot /newroot argv`, which cannot
-  set the working directory, so `spec.workingDir` was accepted-but-ignored on the
-  cold-boot path (it already worked on warm-pool checkout via the vsock agent).
-  The bridge now parses the config-disk CWD and, when set, runs the workload via
-  the guest agent's new one-shot mode (`kubeswift-guest-agent --run` — chroot +
-  chdir + exec in one process, distroless-safe, foreground so the bridge stays
-  PID 1). Ships as sandbox kernel `6.6.10` (initramfs-only; bzImage unchanged).
+## [v0.11.0] — 2026-07-13
 
-**Sandbox warm-pool efficiency**
-- `sandbox-materialize` now takes a **node-local per-digest lock** around the
-  pull+extract step, so concurrent materializes of the same image on the same
-  node (warm-pool slots when `minWarm` exceeds the node count, or co-located
-  sandboxes) serialize — the first pulls, the rest cache-hit — instead of N
-  redundant parallel pulls of the same layers. The digest cache was already
-  correct (atomic rename); this removes the wasted bandwidth.
+MicroVM platform expansion. Surfaces **SwiftSandbox / SwiftSandboxPool in the
+kubeswift-ui** (a new gateway `SandboxService` read + write plane and live UI
+views), adds **image signing** and a **virtio-fs rootfs** option to sandboxes,
+honors `spec.workingDir` on cold boot, and dedups warm-pool image pulls. Builds
+on the v0.10.0 warm-pool arc; all cluster-validated on the dev fleet.
 
 ### Added
+
+**MicroVM UI surfacing (SwiftSandbox / SwiftSandboxPool in the web UI)**
+- A new gateway **`SandboxService`** (Connect-RPC): a fleet-fan-out read plane
+  (`ListSandboxes` + a `WatchSandboxes` server-stream, `ListSandboxPools`, detail
+  RPCs — per-cluster error surfacing + impersonation) and a write plane
+  (`CreateSandbox`/`DeleteSandbox`, `CreateSandboxPool`/`DeleteSandboxPool` as the
+  signed-in user). The kubeswift-ui gains a live **Sandboxes** view (sandbox +
+  warm-pool tables) and a create drawer. The member RBAC role gains
+  `sandbox.kubeswift.io` get/list/watch/create/delete.
 
 **Sandbox virtio-fs rootfs**
 - **`SwiftSandbox.spec.rootfsMode: block|virtiofs`** (and the same on
@@ -46,6 +46,30 @@ All notable changes to KubeSwift are documented here.
   an unverified rootfs. A pool verifies every warm slot. Mirrors `SwiftImage`'s
   `spec.source.oci.verifyKeySecretRef`, reusing the proven `internal/oci.Verify`.
   Immutable after create; requires a TLS registry (cosign speaks HTTPS only).
+
+### Changed
+
+**Sandbox `spec.workingDir` honored on cold boot**
+- The bridge-initramfs ran the workload as `chroot /newroot argv`, which cannot
+  set the working directory, so `spec.workingDir` was accepted-but-ignored on the
+  cold-boot path (it already worked on warm-pool checkout via the vsock agent).
+  The bridge now parses the config-disk CWD and, when set, runs the workload via
+  the guest agent's new one-shot mode (`kubeswift-guest-agent --run` — chroot +
+  chdir + exec in one process, distroless-safe, foreground so the bridge stays
+  PID 1). Ships as sandbox kernel `6.6.10` (initramfs-only; bzImage unchanged).
+
+**Sandbox warm-pool efficiency**
+- `sandbox-materialize` now takes a **node-local per-digest lock** around the
+  pull+extract step, so concurrent materializes of the same image on the same
+  node (warm-pool slots when `minWarm` exceeds the node count, or co-located
+  sandboxes) serialize — the first pulls, the rest cache-hit — instead of N
+  redundant parallel pulls of the same layers. The digest cache was already
+  correct (atomic rename); this removes the wasted bandwidth.
+
+### Docs
+
+- Clarified the networking operations guide. Community contribution — thanks
+  [@evrardjp](https://github.com/evrardjp) (#377).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.10.0 \
+  --version 0.11.0 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.10.0
-appVersion: "0.10.0"
+version: 0.11.0
+appVersion: "0.11.0"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/config/dra-driver/dra-driver.yaml
+++ b/config/dra-driver/dra-driver.yaml
@@ -83,7 +83,7 @@ spec:
         - name: dra-driver
           # Pinned to the release (no :latest tag is published). Bump on release;
           # or use the Helm chart (dra.enabled=true), which manages this version.
-          image: ghcr.io/kubeswift-io/kubeswift/kubeswift-dra-driver:v0.10.0
+          image: ghcr.io/kubeswift-io/kubeswift/kubeswift-dra-driver:v0.11.0
           args:
             - --v=2
           env:

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.10.0 -n kubeswift-system --create-namespace \
+  --version 0.11.0 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.10.0 \
+  --version 0.11.0 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.10.0 \
+  --version 0.11.0 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,7 +66,7 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.10.0 \
+  --version 0.11.0 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.10.0 \
+  --version 0.11.0 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,7 +50,7 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.10.0 -n kubeswift-system \
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.11.0 -n kubeswift-system \
     --set controllerManager.image.tag=v0.1.0 \
     --set swiftletd.image.tag=v0.1.0
   ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.10.0 \
+  --version 0.11.0 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.10.0 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.11.0 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows


### PR DESCRIPTION
Cuts **v0.11.0**. Chart + appVersion `0.10.0` → `0.11.0`, dra-driver manifest tag
→ `v0.11.0`, docs/install `--version` references → `0.11.0`, CHANGELOG rolled.

## v0.11.0 highlights
- **MicroVM UI surfacing** — a new gateway `SandboxService` (read + write plane,
  fleet fan-out) and live **Sandboxes** views in the kubeswift-ui, so
  SwiftSandbox / SwiftSandboxPool are managed from the web UI. (#378, #379, #380 +
  kubeswift-ui)
- **Sandbox image signing** — `spec.verifyKeySecretRef` cosign-verifies the image
  before boot. (#381)
- **Sandbox virtio-fs rootfs** — `spec.rootfsMode: block|virtiofs`. (#383)
- **`spec.workingDir` on cold boot** — sandbox kernel `6.6.10`. (#384)
- **Warm-pool pull dedup** — node-local per-digest lock. (#382)
- **Docs** — networking operations-guide clarification, community contribution,
  thanks @evrardjp. (#377)

Tag `v0.11.0` after merge triggers `release-stable` (images + OCI chart + GH
Release). `helm lint` clean; `helm template` renders `:v0.11.0` operator images
from appVersion.