### PR TITLE
feat(gateway): surface SwiftSandbox + SwiftSandboxPool in the Explorer catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Boot your first VM → [Quickstart](docs/quickstart.md).
 - **Services** — expose guest ports as Kubernetes Services via `spec.network.ports` (ClusterIP/NodePort/LoadBalancer), a load-balanced Service across pool replicas via `SwiftGuestPool.spec.service`, and a VM→cluster egress reachability probe surfaced as `EgressReady`.
 - **Storage** — per-guest root-disk cloning sized from a class; optional data disks (blank/sized, image-backed, or attached PVC); RWX+Block for live-migration-capable volumes.
 - **Snapshots & clones** — disk-only (CSI) and memory+disk (local/S3) snapshots, scheduled snapshots, and `cloneFromSnapshot` for fast VM fan-out.
-- **Sandboxes** — ephemeral OCI-rootfs microVMs ([SwiftSandbox](docs/sandbox/overview.md)) for CI runners, agent/code execution, and untrusted code; restricted-by-default egress.
+- **Sandboxes** — ephemeral OCI-rootfs microVMs ([SwiftSandbox](docs/sandbox/overview.md)) for CI runners, agent/code execution, and untrusted code; restricted-by-default egress, cosign verify-before-boot, and a block or virtio-fs rootfs. Warm pools (`SwiftSandboxPool`) keep pre-booted slots ready for sub-second checkout.
 - **OCI registry artifacts** — golden VM images (`SwiftImage.spec.source.oci` + `swiftctl image publish`, cosign-signed with verify-on-pull) and VM snapshots / full-state cold migration (`SwiftSnapshot` `backend.type: oci`) stored in any OCI registry, for cross-cluster and edge distribution.
 - **Migration** — offline migration on any storage, and live migration (sub-second downtime) with optional mTLS transport and `kubectl drain` integration.
 - **Fleets** — `SwiftGuestPool` gives ReplicaSet-style scaling with rolling updates, topology spread, and a PVC per replica.
@@ -52,9 +52,10 @@ Boot your first VM → [Quickstart](docs/quickstart.md).
 | SwiftSnapshotSchedule | — | `snapshot.kubeswift.io` | Namespaced | Cron-scheduled snapshots + keep-N |
 | SwiftMigration | smig | `migration.kubeswift.io` | Namespaced | Move a guest between nodes |
 | SwiftSandbox | `sbox` | `sandbox.kubeswift.io` | Namespaced | Ephemeral OCI-rootfs microVM |
+| SwiftSandboxPool | `sboxpool` | `sandbox.kubeswift.io` | Namespaced | Warm pool of pre-booted sandboxes for sub-second checkout |
 | Cluster | `ksc` | `fleet.kubeswift.io` | Namespaced | Member cluster federated by the gateway hub |
 
-14 CRDs, all `v1alpha1`.
+15 CRDs, all `v1alpha1`.
 
 ## Documentation
 

--- a/internal/gateway/resource_catalog.go
+++ b/internal/gateway/resource_catalog.go
@@ -56,6 +56,8 @@ var resourceCatalog = []resourceKind{
 	{key: "swiftkernels", displayName: "Kernels", gvr: gvr("kernel.kubeswift.io", "v1alpha1", "swiftkernels"), namespaced: true, category: "KubeSwift", columns: []string{"phase"}, project: phaseStatusProject},
 	{key: "swiftguestclasses", displayName: "Guest Classes", gvr: gvr("swift.kubeswift.io", "v1alpha1", "swiftguestclasses"), namespaced: true, category: "KubeSwift", columns: nil, project: nilProject},
 	{key: "swiftguestpools", displayName: "Guest Pools", gvr: gvr("swift.kubeswift.io", "v1alpha1", "swiftguestpools"), namespaced: true, category: "KubeSwift", columns: []string{"phase", "replicas"}, project: poolProject},
+	{key: "swiftsandboxes", displayName: "Sandboxes", gvr: gvr("sandbox.kubeswift.io", "v1alpha1", "swiftsandboxes"), namespaced: true, category: "KubeSwift", columns: []string{"phase", "image", "node", "ip"}, project: sandboxProject},
+	{key: "swiftsandboxpools", displayName: "Sandbox Pools", gvr: gvr("sandbox.kubeswift.io", "v1alpha1", "swiftsandboxpools"), namespaced: true, category: "KubeSwift", columns: []string{"phase", "warm", "claimed", "min"}, project: sandboxPoolProject},
 	{key: "swiftseedprofiles", displayName: "Seed Profiles", gvr: gvr("seed.kubeswift.io", "v1alpha1", "swiftseedprofiles"), namespaced: true, category: "KubeSwift", columns: nil, project: nilProject},
 	{key: "swiftsnapshots", displayName: "Snapshots", gvr: gvr("snapshot.kubeswift.io", "v1alpha1", "swiftsnapshots"), namespaced: true, category: "KubeSwift", columns: []string{"guest", "backend", "phase"}, project: snapshotProject},
 	{key: "swiftsnapshotschedules", displayName: "Snapshot Schedules", gvr: gvr("snapshot.kubeswift.io", "v1alpha1", "swiftsnapshotschedules"), namespaced: true, category: "KubeSwift", columns: []string{"schedule", "suspend", "lastRun"}, project: scheduleProject},
@@ -283,6 +285,27 @@ func gpuNodeProject(u *unstructured.Unstructured) map[string]string {
 		"phase": nestedStr(u, "status", "phase"),
 		"gpus":  nestedIntStr(u, "status", "gpuCount"),
 		"free":  nestedIntStr(u, "status", "freeGPUs"),
+	}
+}
+
+// sandboxProject reports a SwiftSandbox's phase, image, node, and guest IP.
+func sandboxProject(u *unstructured.Unstructured) map[string]string {
+	return map[string]string{
+		"phase": nestedStr(u, "status", "phase"),
+		"image": nestedStr(u, "spec", "image"),
+		"node":  nestedStr(u, "status", "nodeName"),
+		"ip":    nestedStr(u, "status", "network", "primaryIP"),
+	}
+}
+
+// sandboxPoolProject reports a SwiftSandboxPool's phase, warm/claimed slot counts,
+// and the configured minimum warm buffer.
+func sandboxPoolProject(u *unstructured.Unstructured) map[string]string {
+	return map[string]string{
+		"phase":   nestedStr(u, "status", "phase"),
+		"warm":    nestedIntStr(u, "status", "warmReplicas"),
+		"claimed": nestedIntStr(u, "status", "claimedReplicas"),
+		"min":     nestedIntStr(u, "spec", "minWarm"),
 	}
 }
 

--- a/internal/gateway/resource_service_test.go
+++ b/internal/gateway/resource_service_test.go
@@ -82,6 +82,14 @@ func TestResourceService_ListResourceKinds(t *testing.T) {
 	if byKey["swiftguests"] != nil || byKey["swiftmigrations"] != nil {
 		t.Errorf("swiftguests/swiftmigrations must not be in the explorer catalog")
 	}
+	// Sandboxes + warm pools are browsed in the Explorer's KubeSwift menu (not a
+	// dedicated top-bar view).
+	if k := byKey["swiftsandboxes"]; k == nil || !k.Namespaced || k.Category != "KubeSwift" {
+		t.Errorf("swiftsandboxes should be a namespaced KubeSwift kind, got %+v", k)
+	}
+	if k := byKey["swiftsandboxpools"]; k == nil || !k.Namespaced || k.Category != "KubeSwift" {
+		t.Errorf("swiftsandboxpools should be a namespaced KubeSwift kind, got %+v", k)
+	}
 }
 
 // TestResourceService_SecretRedaction is the load-bearing E4 test: Secret values


### PR DESCRIPTION
Sandboxes and warm pools belong in the Explorer's **KubeSwift** menu alongside the
other CRDs (browse + row-click drawer), not as a separate top-bar page.

- **Gateway:** add `swiftsandboxes` + `swiftsandboxpools` to the `ResourceService`
  catalog (KubeSwift category) with projected columns — swiftsandboxes →
  phase/image/node/ip; swiftsandboxpools → phase/warm/claimed/min. The Explorer's
  left nav is catalog-driven, so this makes them appear like every other CRD. Unit
  test asserts both are namespaced KubeSwift kinds.
- **README:** add the missing **SwiftSandboxPool** row (`sboxpool`,
  `sandbox.kubeswift.io`), fix the CRD count 14 → 15, and refresh the Sandboxes
  capability (warm pools, cosign verify-before-boot, block/virtio-fs rootfs).

The UI side (row-click drawers + removing the top-bar Sandboxes page) is a
companion kubeswift-ui PR.