### PR TITLE
fix(sandbox): no-workingDir sandboxes panic PID 1 on kernel 6.6.10 (kernel 6.6.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to KubeSwift are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sandboxes without `spec.workingDir` panicked on kernel 6.6.10** (regression
+  from v0.11.0's cold-path workingDir change). The bridge-initramfs runs `set -u`
+  but only assigned `$WORKDIR` when a workingDir was set, so the no-workingDir case
+  — the common one — hit `WORKDIR: parameter not set`, killing PID 1 ("Attempted to
+  kill init"). Fixed by initialising `WORKDIR=""`; ships as sandbox kernel
+  **6.6.11** (bump the `SwiftKernel sandbox` OCI ref). Operators on 6.6.10 should
+  move to 6.6.11.
+
 ### Removed
 
 - **`SwiftSandboxPool.spec.idleTTL`** — the field was accepted but never honored

--- a/build/kernels/sandbox/README.md
+++ b/build/kernels/sandbox/README.md
@@ -26,7 +26,7 @@ The artifact carries the same two blobs a SwiftKernel expects (`bzImage` +
 
 ```
 cd output/images
-oras push ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.1 \
+oras push ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.11 \
   bzImage:application/vnd.kubeswift.kernel.binary \
   rootfs.cpio.gz:application/vnd.kubeswift.initramfs.binary
 ```

--- a/build/kernels/sandbox/rootfs-overlay/init
+++ b/build/kernels/sandbox/rootfs-overlay/init
@@ -32,6 +32,11 @@ ENTRYPOINT=""
 CONFIG_DEV=""
 DNS_SEARCH=""
 IDLE=""
+# WORKDIR is only assigned from the config-disk CWD line (spec.workingDir). Init it
+# here so the `set -u` reference below is safe when no workingDir is set — the
+# common case (a missing init was a regression that panicked PID 1: "WORKDIR:
+# parameter not set" -> init exits -> "Attempted to kill init").
+WORKDIR=""
 for arg in $(cat /proc/cmdline); do
 	case "$arg" in
 		kubeswift.rootfs=*)     ROOTFS_KIND="${arg#kubeswift.rootfs=}" ;;

--- a/config/samples/sandbox/swiftkernel-sandbox.yaml
+++ b/config/samples/sandbox/swiftkernel-sandbox.yaml
@@ -14,6 +14,6 @@ metadata:
   namespace: default
 spec:
   ociRef:
-    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.10
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.11
   kernelCmdline: "console=ttyS0"
   profile: sandbox

--- a/docs/sandbox/overview.md
+++ b/docs/sandbox/overview.md
@@ -34,7 +34,7 @@ For bursts of same-image sandboxes where the ~15s cold boot dominates, a
 
 - A node labeled `kubeswift.io/kernel-node=true`
 - A `Ready` `SwiftKernel` named `sandbox` (OCI artifact
-  `ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.10`, pulled per node)
+  `ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.11`, pulled per node)
 
 The sandbox kernel is not a plain `kernelRef` SwiftGuest kernel — its
 bridge-initramfs needs the OCI rootfs disk that the SwiftSandbox controller


### PR DESCRIPTION
## Summary

A sandbox **without** `spec.workingDir` — the common case — panics PID 1 on kernel
**6.6.10** (shipped in **v0.11.0**):

```
/init: line 185: WORKDIR: parameter not set
Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000200
```

The bridge-initramfs runs `set -u`, but `$WORKDIR` is only assigned from the
config-disk `CWD` line (`spec.workingDir`). With no workingDir the variable is
unset, so the `set -u` reference at the workload-launch site aborts the shell and
kills init. This is a regression from the D1 cold-path workingDir change (#384) —
D1's validation only exercised the *with*-workingDir path.

## Fix

Initialise `WORKDIR=""` in the bridge var block. One line + a comment; ships as
sandbox kernel **6.6.11**.

- `build/kernels/sandbox/rootfs-overlay/init` — `WORKDIR=""` init
- `config/samples/sandbox/swiftkernel-sandbox.yaml`, `docs/sandbox/overview.md`,
  `build/kernels/sandbox/README.md` — bump the OCI tag `6.6.10` → `6.6.11`
- CHANGELOG `Fixed` entry

## Validation

Surfaced by the GPU-sandbox Phase-0 spike, which booted a **native no-workingDir**
sandbox and hit the panic. Kernel **6.6.11** (with this fix) was rebuilt, pushed,
and deployed to the dev cluster; the same no-workingDir sandbox then booted clean
through to the workload. Operators on 6.6.10 should move to 6.6.11.

Follow-up candidate: a `shellcheck` gate in CI would catch this `set -u`-unset
class at PR time.