### PR TITLE
feat(sandbox): SwiftSandbox.spec.gpuResourceClaim (DRA GPU passthrough)

### DIFF
--- a/api/sandbox/v1alpha1/swiftsandbox_types.go
+++ b/api/sandbox/v1alpha1/swiftsandbox_types.go
@@ -4,6 +4,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 )
 
 // SwiftSandboxSpec defines an ephemeral, strongly-isolated microVM that runs an
@@ -102,6 +104,27 @@ type SwiftSandboxSpec struct {
 	// the cold path automatically. The pool must be in the same namespace.
 	// +optional
 	PoolRef *corev1.LocalObjectReference `json:"poolRef,omitempty"`
+
+	// GPUResourceClaim, when set, passes one or more GPUs into the sandbox via a
+	// Kubernetes DRA ResourceClaim: the kube-scheduler allocates the device(s) and
+	// the KubeSwift DRA driver injects them (CDI GPU_PCI_ADDRESSES), gpu-init binds
+	// VFIO, and swiftletd synthesizes the Cloud Hypervisor --device from the env.
+	// The guest OCI image ships the NVIDIA driver and loads it, so a GPU sandbox
+	// needs the module-capable "gpu-sandbox" kernel profile — the controller selects
+	// it automatically when kernelProfileRef is unset.
+	//
+	// A GPU sandbox boots COLD: a warm pool cannot cheaply hold a scarce GPU idle,
+	// so gpuResourceClaim and poolRef are mutually exclusive. Mirrors
+	// SwiftGuest.spec.gpuResourceClaim (the DRA allocation backend). The native
+	// SwiftGPUProfile backend (gpuProfileRef) is a planned follow-up for sandboxes.
+	// +optional
+	GPUResourceClaim *swiftv1alpha1.GPUResourceClaimSpec `json:"gpuResourceClaim,omitempty"`
+}
+
+// UsesGPU reports whether the sandbox requests a GPU (currently the DRA backend
+// only).
+func (s *SwiftSandbox) UsesGPU() bool {
+	return s.Spec.GPUResourceClaim != nil
 }
 
 // SecretObjectReference references a Secret by name (in the object's own

--- a/api/sandbox/v1alpha1/zz_generated.deepcopy.go
+++ b/api/sandbox/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -321,6 +322,11 @@ func (in *SwiftSandboxSpec) DeepCopyInto(out *SwiftSandboxSpec) {
 	if in.PoolRef != nil {
 		in, out := &in.PoolRef, &out.PoolRef
 		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
+	if in.GPUResourceClaim != nil {
+		in, out := &in.GPUResourceClaim, &out.GPUResourceClaim
+		*out = new(swiftv1alpha1.GPUResourceClaimSpec)
 		**out = **in
 	}
 }

--- a/charts/kubeswift/crds/sandbox.kubeswift.io_swiftsandboxes.yaml
+++ b/charts/kubeswift/crds/sandbox.kubeswift.io_swiftsandboxes.yaml
@@ -240,6 +240,52 @@ spec:
                   - name
                   type: object
                 type: array
+              gpuResourceClaim:
+                description: |-
+                  GPUResourceClaim, when set, passes one or more GPUs into the sandbox via a
+                  Kubernetes DRA ResourceClaim: the kube-scheduler allocates the device(s) and
+                  the KubeSwift DRA driver injects them (CDI GPU_PCI_ADDRESSES), gpu-init binds
+                  VFIO, and swiftletd synthesizes the Cloud Hypervisor --device from the env.
+                  The guest OCI image ships the NVIDIA driver and loads it, so a GPU sandbox
+                  needs the module-capable "gpu-sandbox" kernel profile — the controller selects
+                  it automatically when kernelProfileRef is unset.
+
+                  A GPU sandbox boots COLD: a warm pool cannot cheaply hold a scarce GPU idle,
+                  so gpuResourceClaim and poolRef are mutually exclusive. Mirrors
+                  SwiftGuest.spec.gpuResourceClaim (the DRA allocation backend). The native
+                  SwiftGPUProfile backend (gpuProfileRef) is a planned follow-up for sandboxes.
+                properties:
+                  hugepages:
+                    description: Hugepages sizes the GPU memory hugepage backing ("1Gi",
+                      "2Mi", or "").
+                    type: string
+                  requestName:
+                    description: |-
+                      RequestName is the device-request name within the claim to read the
+                      allocation result back from. Defaults to "gpu" when empty.
+                    type: string
+                  resourceClaimName:
+                    description: |-
+                      ResourceClaimName references a pre-created, shared ResourceClaim.
+                      Mutually exclusive with ResourceClaimTemplateName.
+                    type: string
+                  resourceClaimTemplateName:
+                    description: |-
+                      ResourceClaimTemplateName references a ResourceClaimTemplate; the
+                      controller stamps it into pod.spec.resourceClaims so the scheduler mints
+                      a per-pod ResourceClaim. Mutually exclusive with ResourceClaimName.
+                    type: string
+                  tier:
+                    default: pcie
+                    description: |-
+                      Tier selects the hypervisor/firmware exactly as SwiftGPUProfile.Tier does:
+                      pcie -> Cloud Hypervisor (default), hgx-shared/hgx-full -> QEMU.
+                    enum:
+                    - pcie
+                    - hgx-shared
+                    - hgx-full
+                    type: string
+                type: object
               image:
                 description: |-
                   Image is the OCI image to run as the sandbox root filesystem. A digest

--- a/config/crd/bases/sandbox.kubeswift.io_swiftsandboxes.yaml
+++ b/config/crd/bases/sandbox.kubeswift.io_swiftsandboxes.yaml
@@ -240,6 +240,52 @@ spec:
                   - name
                   type: object
                 type: array
+              gpuResourceClaim:
+                description: |-
+                  GPUResourceClaim, when set, passes one or more GPUs into the sandbox via a
+                  Kubernetes DRA ResourceClaim: the kube-scheduler allocates the device(s) and
+                  the KubeSwift DRA driver injects them (CDI GPU_PCI_ADDRESSES), gpu-init binds
+                  VFIO, and swiftletd synthesizes the Cloud Hypervisor --device from the env.
+                  The guest OCI image ships the NVIDIA driver and loads it, so a GPU sandbox
+                  needs the module-capable "gpu-sandbox" kernel profile — the controller selects
+                  it automatically when kernelProfileRef is unset.
+
+                  A GPU sandbox boots COLD: a warm pool cannot cheaply hold a scarce GPU idle,
+                  so gpuResourceClaim and poolRef are mutually exclusive. Mirrors
+                  SwiftGuest.spec.gpuResourceClaim (the DRA allocation backend). The native
+                  SwiftGPUProfile backend (gpuProfileRef) is a planned follow-up for sandboxes.
+                properties:
+                  hugepages:
+                    description: Hugepages sizes the GPU memory hugepage backing ("1Gi",
+                      "2Mi", or "").
+                    type: string
+                  requestName:
+                    description: |-
+                      RequestName is the device-request name within the claim to read the
+                      allocation result back from. Defaults to "gpu" when empty.
+                    type: string
+                  resourceClaimName:
+                    description: |-
+                      ResourceClaimName references a pre-created, shared ResourceClaim.
+                      Mutually exclusive with ResourceClaimTemplateName.
+                    type: string
+                  resourceClaimTemplateName:
+                    description: |-
+                      ResourceClaimTemplateName references a ResourceClaimTemplate; the
+                      controller stamps it into pod.spec.resourceClaims so the scheduler mints
+                      a per-pod ResourceClaim. Mutually exclusive with ResourceClaimName.
+                    type: string
+                  tier:
+                    default: pcie
+                    description: |-
+                      Tier selects the hypervisor/firmware exactly as SwiftGPUProfile.Tier does:
+                      pcie -> Cloud Hypervisor (default), hgx-shared/hgx-full -> QEMU.
+                    enum:
+                    - pcie
+                    - hgx-shared
+                    - hgx-full
+                    type: string
+                type: object
               image:
                 description: |-
                   Image is the OCI image to run as the sandbox root filesystem. A digest

--- a/internal/webhook/swiftsandbox/validator.go
+++ b/internal/webhook/swiftsandbox/validator.go
@@ -66,6 +66,18 @@ func validateSpec(s *sandboxv1alpha1.SwiftSandboxSpec) error {
 	if s.VerifyKeySecretRef != nil && s.VerifyKeySecretRef.Name == "" {
 		return fmt.Errorf("spec.verifyKeySecretRef.name is required when verifyKeySecretRef is set")
 	}
+	if rc := s.GPUResourceClaim; rc != nil {
+		// Exactly one claim source (mirror the SwiftGuest DRA rule).
+		hasName := rc.ResourceClaimName != ""
+		hasTemplate := rc.ResourceClaimTemplateName != ""
+		if hasName == hasTemplate {
+			return fmt.Errorf("spec.gpuResourceClaim requires exactly one of resourceClaimName or resourceClaimTemplateName")
+		}
+		// A GPU sandbox boots cold — a warm pool cannot hold a scarce GPU idle.
+		if s.PoolRef != nil {
+			return fmt.Errorf("spec.gpuResourceClaim and spec.poolRef are mutually exclusive: a GPU sandbox boots cold (a warm pool cannot hold a GPU reservation)")
+		}
+	}
 	return nil
 }
 

--- a/internal/webhook/swiftsandbox/validator_test.go
+++ b/internal/webhook/swiftsandbox/validator_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 )
 
 func sb(image string) *sandboxv1alpha1.SwiftSandbox {
@@ -94,5 +96,47 @@ func TestValidateUpdate_VerifyKeySecretRefImmutable(t *testing.T) {
 	chg.Spec.VerifyKeySecretRef = &sandboxv1alpha1.SecretObjectReference{Name: "cosign-pub"}
 	if _, err := v.ValidateUpdate(context.Background(), old, chg); err == nil {
 		t.Error("adding verifyKeySecretRef should be rejected as immutable")
+	}
+}
+
+func TestValidateCreate_GPUResourceClaim(t *testing.T) {
+	v := &Validator{}
+
+	// A single-template claim is valid.
+	tmpl := sb("nvcr.io/nvidia/cuda:12.4.0-runtime-ubuntu22.04")
+	tmpl.Spec.GPUResourceClaim = &swiftv1alpha1.GPUResourceClaimSpec{ResourceClaimTemplateName: "single-vfio-gpu", Tier: "pcie"}
+	if _, err := v.ValidateCreate(context.Background(), tmpl); err != nil {
+		t.Errorf("single-template gpuResourceClaim rejected: %v", err)
+	}
+
+	// A single shared-claim is valid.
+	shared := sb("cuda:12.4")
+	shared.Spec.GPUResourceClaim = &swiftv1alpha1.GPUResourceClaimSpec{ResourceClaimName: "gpu-claim"}
+	if _, err := v.ValidateCreate(context.Background(), shared); err != nil {
+		t.Errorf("single shared-claim gpuResourceClaim rejected: %v", err)
+	}
+
+	// Neither name nor template — rejected.
+	neither := sb("cuda:12.4")
+	neither.Spec.GPUResourceClaim = &swiftv1alpha1.GPUResourceClaimSpec{Tier: "pcie"}
+	if _, err := v.ValidateCreate(context.Background(), neither); err == nil {
+		t.Error("gpuResourceClaim with neither name nor template should be rejected")
+	}
+
+	// Both name and template — rejected.
+	both := sb("cuda:12.4")
+	both.Spec.GPUResourceClaim = &swiftv1alpha1.GPUResourceClaimSpec{ResourceClaimName: "c", ResourceClaimTemplateName: "t"}
+	if _, err := v.ValidateCreate(context.Background(), both); err == nil {
+		t.Error("gpuResourceClaim with both name and template should be rejected")
+	}
+}
+
+func TestValidateCreate_GPUAndPoolMutuallyExclusive(t *testing.T) {
+	v := &Validator{}
+	s := sb("cuda:12.4")
+	s.Spec.GPUResourceClaim = &swiftv1alpha1.GPUResourceClaimSpec{ResourceClaimTemplateName: "single-vfio-gpu"}
+	s.Spec.PoolRef = &corev1.LocalObjectReference{Name: "warm-pool"}
+	if _, err := v.ValidateCreate(context.Background(), s); err == nil {
+		t.Error("gpuResourceClaim + poolRef should be rejected (GPU sandboxes boot cold)")
 	}
 }


### PR DESCRIPTION
## Summary

Part of **GPU sandbox Phase 1** ([#390](https://github.com/kubeswift-io/kubeswift/issues/390)). Adds `spec.gpuResourceClaim` to `SwiftSandbox` — pass GPU(s) into a sandbox via a Kubernetes **DRA** ResourceClaim, mirroring `SwiftGuest.spec.gpuResourceClaim`.

The scheduler allocates, the KubeSwift DRA driver injects the device (CDI `GPU_PCI_ADDRESSES`), and swiftletd synthesizes the CH `--device` from the env (`deviceSource=env`, already in place). This PR is the **API + webhook**; the pod-builder + controller wiring follows in the next PR.

## Why DRA-first

DRA is the Phase-1 backend because it needs **no allocation controller** — the scheduler does the allocation and the pod just carries the claim, which fits the ephemeral/burst sandbox model (and matches the design doc's "DRA-preferred"). The native `SwiftGPUProfile` backend (`gpuProfileRef`) is a planned follow-up: it needs the `internal/gpualloc.Backend` seam — today typed to `*SwiftGuest` — to become object-agnostic. Adding `gpuProfileRef` later is a non-breaking new optional field.

## What

- **API** — `spec.gpuResourceClaim *swiftv1alpha1.GPUResourceClaimSpec` (reuses the SwiftGuest type; no import cycle — swift does not import sandbox). `SwiftSandbox.UsesGPU()` helper. CRD regenerated + chart-synced (the referenced type's schema, incl. the `tier` enum, resolves cross-package).
- **Webhook** (per-operation discipline) — `gpuResourceClaim` requires exactly one of `resourceClaimName`/`resourceClaimTemplateName`; `gpuResourceClaim` + `poolRef` is rejected (a GPU sandbox boots cold — a warm pool cannot hold a scarce GPU idle). The field rides the existing launch-spec immutability check.
- Tests for both rules.

## Validation

The GPU-sandbox Phase-0 spike **DRA prong** already proved a sandbox-shaped pod gets the GTX 1080 via a `ResourceClaim` + CDI end-to-end. Unit tests green; `go build ./api/... ./internal/... ./cmd/...` clean.