### PR TITLE
feat(sandbox): GPU-aware pod builder + controller (DRA passthrough)

### DIFF
--- a/internal/controller/swiftsandbox/controller.go
+++ b/internal/controller/swiftsandbox/controller.go
@@ -65,10 +65,7 @@ func (r *SwiftSandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	kernelName := defaultKernelProfile
-	if sb.Spec.KernelProfileRef != nil && sb.Spec.KernelProfileRef.Name != "" {
-		kernelName = sb.Spec.KernelProfileRef.Name
-	}
+	kernelName := resolveKernelProfile(&sb)
 
 	// spec.poolRef: claim a warm slot from a SwiftSandboxPool (sub-second checkout) and
 	// inject the workload over vsock, else cold-fallback. Own path (its pod is a re-parented

--- a/internal/controller/swiftsandbox/controller_test.go
+++ b/internal/controller/swiftsandbox/controller_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/sandbox/materialize"
 )
 
@@ -332,5 +333,128 @@ func TestIsTerminal(t *testing.T) {
 	}
 	if isTerminal(sandboxv1alpha1.SwiftSandboxRunning) || isTerminal(sandboxv1alpha1.SwiftSandboxPending) {
 		t.Error("Running/Pending must not be terminal")
+	}
+}
+
+func TestBuildPod_GPU(t *testing.T) {
+	sb := &sandboxv1alpha1.SwiftSandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "gsb", Namespace: "ns"},
+		Spec: sandboxv1alpha1.SwiftSandboxSpec{
+			Image:            "cuda:12.4",
+			GPUResourceClaim: &swiftv1alpha1.GPUResourceClaimSpec{ResourceClaimTemplateName: "single-vfio-gpu"},
+		},
+	}
+	pod := buildPod(sb, "gpu-sandbox")
+
+	var gpuInit *corev1.Container
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == "gpu-init" {
+			gpuInit = &pod.Spec.InitContainers[i]
+		}
+	}
+	if gpuInit == nil {
+		t.Fatal("gpu-init init container missing on a GPU sandbox")
+	}
+	for _, e := range gpuInit.Env {
+		if e.Name == "GPU_PCI_ADDRESSES" {
+			t.Error("gpu-init must NOT hardcode GPU_PCI_ADDRESSES — the DRA driver's CDI injects it")
+		}
+	}
+	if len(pod.Spec.ResourceClaims) != 1 ||
+		pod.Spec.ResourceClaims[0].ResourceClaimTemplateName == nil ||
+		*pod.Spec.ResourceClaims[0].ResourceClaimTemplateName != "single-vfio-gpu" {
+		t.Errorf("pod.Spec.ResourceClaims = %+v, want one template single-vfio-gpu", pod.Spec.ResourceClaims)
+	}
+	if len(gpuInit.Resources.Claims) != 1 {
+		t.Error("gpu-init must reference the claim (so CDI containerEdits apply)")
+	}
+
+	var launcher *corev1.Container
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == launcherName {
+			launcher = &pod.Spec.Containers[i]
+		}
+	}
+	if launcher == nil {
+		t.Fatal("launcher container missing")
+	}
+	if len(launcher.Resources.Claims) != 1 {
+		t.Error("launcher must reference the claim")
+	}
+	hasVfio := false
+	for _, m := range launcher.VolumeMounts {
+		if m.Name == "dev-vfio" {
+			hasVfio = true
+		}
+	}
+	if !hasVfio {
+		t.Error("launcher must mount dev-vfio")
+	}
+
+	vols := map[string]bool{}
+	for _, v := range pod.Spec.Volumes {
+		vols[v.Name] = true
+	}
+	if !vols["dev-vfio"] || !vols["host-sys"] {
+		t.Errorf("dev-vfio/host-sys volumes missing: %v", vols)
+	}
+	// A GPU sandbox stays pinned to kernel-node (NOT nilled like the SwiftGuest DRA
+	// path) — the kernel artifacts + /dev/kvm live on kernel nodes.
+	if pod.Spec.NodeSelector[kernelNodeLabel] != "true" {
+		t.Error("GPU sandbox nodeSelector must keep kubeswift.io/kernel-node=true")
+	}
+
+	// A non-GPU sandbox has none of the GPU wiring.
+	plain := buildPod(&sandboxv1alpha1.SwiftSandbox{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}, "sandbox")
+	if plain.Spec.ResourceClaims != nil {
+		t.Errorf("non-GPU sandbox must carry no ResourceClaims; got %v", plain.Spec.ResourceClaims)
+	}
+	for _, c := range plain.Spec.InitContainers {
+		if c.Name == "gpu-init" {
+			t.Error("non-GPU sandbox must have no gpu-init container")
+		}
+	}
+}
+
+func TestBuildIntent_GPU(t *testing.T) {
+	sb := &sandboxv1alpha1.SwiftSandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "gsb", Namespace: "ns"},
+		Spec: sandboxv1alpha1.SwiftSandboxSpec{
+			Image:            "cuda:12.4",
+			GPUResourceClaim: &swiftv1alpha1.GPUResourceClaimSpec{ResourceClaimName: "c"},
+		},
+	}
+	bi := buildIntent(sb, "gpu-sandbox", "/x.ext4", execSpec{Argv: []string{"/entrypoint.sh"}}, false)
+	if bi.GPU == nil {
+		t.Fatal("intent.GPU must be set for a GPU sandbox")
+	}
+	if bi.GPU.DeviceSource != "env" {
+		t.Errorf("intent.GPU.DeviceSource = %q, want env (DRA CDI synthesis)", bi.GPU.DeviceSource)
+	}
+
+	plain := buildIntent(&sandboxv1alpha1.SwiftSandbox{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}, "sandbox", "/x.ext4", execSpec{Argv: []string{"/bin/sh"}}, false)
+	if plain.GPU != nil {
+		t.Error("non-GPU sandbox must have no intent.GPU")
+	}
+}
+
+func TestResolveKernelProfile(t *testing.T) {
+	gpu := func() *sandboxv1alpha1.SwiftSandbox {
+		return &sandboxv1alpha1.SwiftSandbox{Spec: sandboxv1alpha1.SwiftSandboxSpec{
+			GPUResourceClaim: &swiftv1alpha1.GPUResourceClaimSpec{ResourceClaimName: "c"}}}
+	}
+	// GPU sandbox with no explicit profile -> the module-capable gpu-sandbox kernel.
+	if got := resolveKernelProfile(gpu()); got != "gpu-sandbox" {
+		t.Errorf("GPU sandbox kernel = %q, want gpu-sandbox", got)
+	}
+	// Explicit profile always wins (operator override).
+	g := gpu()
+	g.Spec.KernelProfileRef = &corev1.LocalObjectReference{Name: "my-gpu-kernel"}
+	if got := resolveKernelProfile(g); got != "my-gpu-kernel" {
+		t.Errorf("explicit kernelProfileRef = %q, want my-gpu-kernel", got)
+	}
+	// Non-GPU sandbox -> the base sandbox kernel.
+	if got := resolveKernelProfile(&sandboxv1alpha1.SwiftSandbox{}); got != "sandbox" {
+		t.Errorf("plain sandbox kernel = %q, want sandbox", got)
 	}
 }

--- a/internal/controller/swiftsandbox/pod.go
+++ b/internal/controller/swiftsandbox/pod.go
@@ -7,6 +7,7 @@ import (
 
 	kernelv1alpha1 "github.com/kubeswift-io/kubeswift/api/kernel/v1alpha1"
 	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/controller/swiftguest"
 	"github.com/kubeswift-io/kubeswift/internal/runtimeintent"
 )
@@ -15,8 +16,17 @@ const (
 	intentConfigMapSuffix = "-runtime-intent"
 	kernelNodeLabel       = "kubeswift.io/kernel-node"
 	defaultKernelProfile  = "sandbox"
-	materializeInitName   = "sandbox-materialize"
-	launcherName          = "launcher"
+	// gpuSandboxKernelProfile is the module-capable kernel a GPU sandbox needs (its
+	// OCI image insmods the NVIDIA driver). The controller selects it when a sandbox
+	// requests a GPU and sets no explicit kernelProfileRef.
+	gpuSandboxKernelProfile = "gpu-sandbox"
+	// sandboxDRAClaimName is the pod-local name under which the sandbox's GPU
+	// ResourceClaim is referenced (pod.spec.resourceClaims[].name + the gpu-init and
+	// launcher containers' resources.claims[].name). Mirrors the SwiftGuest const.
+	sandboxDRAClaimName = "gpu"
+	materializeInitName = "sandbox-materialize"
+	gpuInitName         = "gpu-init"
+	launcherName        = "launcher"
 	// SandboxLabelKey ties the launcher pod (and its intent ConfigMap) to the
 	// owning SwiftSandbox.
 	SandboxLabelKey = "sandbox.kubeswift.io/sandbox"
@@ -24,6 +34,21 @@ const (
 
 func intentConfigMapName(sb *sandboxv1alpha1.SwiftSandbox) string {
 	return sb.Name + intentConfigMapSuffix
+}
+
+// resolveKernelProfile picks the SwiftKernel profile for a sandbox. An explicit
+// spec.kernelProfileRef always wins (operator override); otherwise a GPU sandbox
+// gets the module-capable gpu-sandbox kernel (its OCI image insmods the NVIDIA
+// driver, which the monolithic base sandbox kernel can't load), and everything
+// else gets the base sandbox kernel.
+func resolveKernelProfile(sb *sandboxv1alpha1.SwiftSandbox) string {
+	if sb.Spec.KernelProfileRef != nil && sb.Spec.KernelProfileRef.Name != "" {
+		return sb.Spec.KernelProfileRef.Name
+	}
+	if sb.UsesGPU() {
+		return gpuSandboxKernelProfile
+	}
+	return defaultKernelProfile
 }
 
 func privileged() *corev1.SecurityContext {
@@ -124,7 +149,7 @@ func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath string
 		sandboxRootfs.Path = rootfsPath
 	}
 
-	return &runtimeintent.RuntimeIntent{
+	ri := &runtimeintent.RuntimeIntent{
 		KernelBoot: &runtimeintent.KernelBootSpec{
 			KernelPath:    kernelDir + "/bzImage",
 			InitramfsPath: kernelDir + "/rootfs.cpio.gz",
@@ -148,6 +173,18 @@ func buildIntent(sb *sandboxv1alpha1.SwiftSandbox, kernelName, rootfsPath string
 		// is host<->guest only (not network-reachable), so it costs nothing to have.
 		Vsock: &runtimeintent.VsockIntent{CID: runtimeintent.DeriveVsockCID(sb.Namespace, sb.Name)},
 	}
+	if sb.Spec.GPUResourceClaim != nil {
+		// DRA GPU passthrough. deviceSource=env: swiftletd synthesizes the CH --device
+		// from the CDI-injected GPU_PCI_ADDRESSES (run_ch already applies intent.gpu on
+		// the mode-3 path). Firmware is a no-op for a firmware-less direct-kernel sandbox
+		// (there is no CLOUDHV.fd/OVMF); "cloudhv" is the Tier-1 value. No FM partition.
+		ri.GPU = &runtimeintent.GPUIntent{
+			DeviceSource:             "env",
+			Firmware:                 "cloudhv",
+			FabricManagerPartitionID: -1,
+		}
+	}
+	return ri
 }
 
 // buildIntentConfigMap wraps the serialized intent in the ConfigMap the launcher
@@ -239,7 +276,30 @@ func buildPod(sb *sandboxv1alpha1.SwiftSandbox, kernelName string) *corev1.Pod {
 	}
 	volumes = append(volumes, verifyVolumes...)
 
-	return &corev1.Pod{
+	if sb.Spec.GPUResourceClaim != nil {
+		// gpu-init binds the requested GPU to vfio-pci (two-pass unbind/bind; idempotent
+		// if already bound). It carries NO GPU_PCI_ADDRESSES env — the DRA driver's CDI
+		// containerEdits inject it (applied because gpu-init references the claim, wired
+		// by applySandboxDRAClaim below). Runs among the init containers, before the
+		// launcher. Same VFIO mounts the GPU SwiftGuest launcher uses.
+		hostSysDir := corev1.HostPathDirectory
+		initContainers = append(initContainers, corev1.Container{
+			Name:            gpuInitName,
+			Image:           swiftguest.LauncherImage(),
+			Command:         []string{"/bin/bash", "/usr/local/bin/gpu-init.sh"},
+			SecurityContext: privileged(),
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "dev-vfio", MountPath: "/dev/vfio"},
+				{Name: "host-sys", MountPath: "/host/sys"},
+			},
+		})
+		volumes = append(volumes,
+			corev1.Volume{Name: "dev-vfio", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/dev/vfio", Type: &dirCreate}}},
+			corev1.Volume{Name: "host-sys", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys", Type: &hostSysDir}}},
+		)
+	}
+
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sb.Name,
 			Namespace: sb.Namespace,
@@ -273,5 +333,44 @@ func buildPod(sb *sandboxv1alpha1.SwiftSandbox, kernelName string) *corev1.Pod {
 			}},
 			Volumes: volumes,
 		},
+	}
+	if sb.Spec.GPUResourceClaim != nil {
+		applySandboxDRAClaim(pod, sb.Spec.GPUResourceClaim)
+	}
+	return pod
+}
+
+// applySandboxDRAClaim wires the DRA ResourceClaim onto a GPU sandbox pod: the
+// pod-level resourceClaims entry plus a resources.claims reference on the gpu-init
+// and launcher containers (which is what makes kubelet apply the DRA driver's CDI
+// containerEdits — the GPU_PCI_ADDRESSES env — to them), and the launcher's
+// /dev/vfio mount.
+//
+// Unlike the SwiftGuest DRA path (which nils the node selector so the scheduler
+// picks any GPU node), a sandbox MUST stay pinned to kubeswift.io/kernel-node=true:
+// the kernel artifacts and /dev/kvm live on kernel nodes. GPU sandbox nodes must
+// therefore be BOTH gpu-node and kernel-node; the scheduler then places the pod on
+// a node satisfying the kernel-node label AND the GPU ResourceClaim device.
+func applySandboxDRAClaim(pod *corev1.Pod, rc *swiftv1alpha1.GPUResourceClaimSpec) {
+	claim := corev1.PodResourceClaim{Name: sandboxDRAClaimName}
+	if rc.ResourceClaimTemplateName != "" {
+		claim.ResourceClaimTemplateName = &rc.ResourceClaimTemplateName
+	} else {
+		claim.ResourceClaimName = &rc.ResourceClaimName
+	}
+	pod.Spec.ResourceClaims = []corev1.PodResourceClaim{claim}
+
+	ref := corev1.ResourceClaim{Name: sandboxDRAClaimName, Request: rc.RequestName}
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == gpuInitName {
+			pod.Spec.InitContainers[i].Resources.Claims = append(pod.Spec.InitContainers[i].Resources.Claims, ref)
+		}
+	}
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == launcherName {
+			pod.Spec.Containers[i].Resources.Claims = append(pod.Spec.Containers[i].Resources.Claims, ref)
+			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts,
+				corev1.VolumeMount{Name: "dev-vfio", MountPath: "/dev/vfio"})
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Part of **GPU sandbox Phase 1** ([#390](https://github.com/kubeswift-io/kubeswift/issues/390)). Wires `spec.gpuResourceClaim` (added in #398) through to a booting GPU sandbox — the runtime half. **No swiftletd change**: `run_ch` already applies `intent.gpu` on the mode-3 path, and `deviceSource=env` synthesizes the CH `--device` from the CDI-injected `GPU_PCI_ADDRESSES`.

## What

- **`buildIntent`** — sets `intent.GPU{deviceSource: env}` for a GPU sandbox.
- **`buildPod`** — adds the `gpu-init` init container (VFIO bind; **no** hardcoded `GPU_PCI_ADDRESSES` — the DRA driver's CDI injects it) + `dev-vfio`/`host-sys` volumes, then `applySandboxDRAClaim` wires the pod-level `ResourceClaim` + the `gpu-init`/`launcher` `resources.claims` (what makes kubelet apply the CDI containerEdits) + the launcher's `/dev/vfio` mount. Reuses the launcher image's `gpu-init.sh`.
- **`resolveKernelProfile`** — a GPU sandbox with no explicit `kernelProfileRef` defaults to the module-capable `gpu-sandbox` kernel (#397); an explicit ref still wins.

## Load-bearing difference from the SwiftGuest DRA path

`applySandboxDRAClaim` does **not** clear the node selector. A sandbox must stay pinned to `kubeswift.io/kernel-node=true` (the kernel artifacts + `/dev/kvm` live there), so **GPU sandbox nodes must be both gpu-node and kernel-node**; the scheduler then places the pod on a node satisfying the kernel-node label AND the GPU ResourceClaim device. (SwiftGuest DRA nils the selector because a GPU guest has no kernel-node requirement.)

## Scope / notes

- **DRA-only for Phase 1** — scheduler-native, no allocation controller. The native `SwiftGPUProfile` backend needs the `internal/gpualloc.Backend` seam (today `*SwiftGuest`-typed) to become object-agnostic; a planned follow-up. Adding `gpuProfileRef` later is non-breaking.
- **No new RBAC** — the controller doesn't read ResourceClaims (the scheduler + kubelet drive DRA).

## Validation

Unit tests cover the GPU pod wiring (gpu-init, ResourceClaim, resources.claims, dev-vfio mount, kernel-node selector preserved), the intent GPU block, and the kernel-profile default. The **DRA prong of the Phase-0 spike** already proved this exact pod shape boots the GTX 1080 end-to-end. A real `SwiftSandbox`-driven GPU boot (`nvidia-smi`) is the next PR (PR4: cluster-validate + docs).