### PR TITLE
docs(sandbox): GPU sandbox runbook + sample (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to KubeSwift are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **GPU sandboxes (Phase 1) — pass a GPU into a SwiftSandbox via DRA.**
+  `SwiftSandbox.spec.gpuResourceClaim` allocates one Tier-1 GPU through a Kubernetes
+  DRA `ResourceClaim`: the scheduler picks the node/device, the DRA driver injects it
+  (CDI `GPU_PCI_ADDRESSES`), a `gpu-init` container binds VFIO, and the sandbox boots
+  firmware-less (mode-3) with the GPU passed through — an ephemeral VM boundary around
+  GPU inference / untrusted GPU code. The NVIDIA driver rides the guest OCI image and
+  loads at start; a GPU sandbox boots the new module-capable **`gpu-sandbox`** kernel
+  profile (selected automatically). GPU nodes must also be kernel nodes. DRA-only and
+  cold-boot-only in Phase 1 (`gpuResourceClaim` excludes `poolRef`); the native
+  `SwiftGPUProfile` backend and multi-GPU / multi-node are follow-ups
+  ([#390](https://github.com/kubeswift-io/kubeswift/issues/390)). Cluster-validated on
+  a GTX 1080 (`nvidia-smi` in the guest). Runbook: `docs/sandbox/gpu-sandboxes.md`.
+
 ### Fixed
 
 - **Sandboxes without `spec.workingDir` panicked on kernel 6.6.10** (regression

--- a/config/samples/sandbox/swiftsandbox-gpu.yaml
+++ b/config/samples/sandbox/swiftsandbox-gpu.yaml
@@ -1,0 +1,43 @@
+# A GPU sandbox: an ephemeral microVM with one GPU passed through via DRA. The
+# guest OCI image ships the NVIDIA driver (nvidia.ko built for the gpu-sandbox
+# kernel + nvidia-smi) and loads it at start. See docs/sandbox/gpu-sandboxes.md.
+#
+# Prereqs:
+#   - a DRA GPU driver + a GPU node that is ALSO a kernel node
+#     (kubeswift.io/gpu-node=true AND kubeswift.io/kernel-node=true)
+#   - the gpu-sandbox SwiftKernel: config/samples/sandbox/swiftkernel-gpu-sandbox.yaml
+#   - this ResourceClaimTemplate (one device of your GPU deviceclass)
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: single-vfio-gpu
+  namespace: default
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: kubeswift-vfio-gpu   # your DRA GPU deviceclass
+            allocationMode: ExactCount
+            count: 1
+---
+apiVersion: sandbox.kubeswift.io/v1alpha1
+kind: SwiftSandbox
+metadata:
+  name: gpu-infer
+  namespace: default
+spec:
+  # Replace with a CUDA image that ships nvidia.ko (built for the gpu-sandbox
+  # Linux 6.6.x kernel) + nvidia-smi and insmods it at start.
+  image: <your-registry>/cuda-nvidia-smi@sha256:...
+  cpu: 4
+  memory: 8Gi
+  network:
+    mode: open          # GPU inference typically talks to in-cluster services
+  gpuResourceClaim:
+    resourceClaimTemplateName: single-vfio-gpu
+    tier: pcie
+  # kernelProfileRef defaults to gpu-sandbox when a GPU is requested (the
+  # module-capable kernel); set it explicitly to override.

--- a/docs/sandbox/gpu-sandboxes.md
+++ b/docs/sandbox/gpu-sandboxes.md
@@ -1,0 +1,107 @@
+# GPU sandboxes
+
+Pass a GPU into a [sandbox](overview.md) — an ephemeral microVM with a real VM
+boundary around GPU code (CUDA inference, untrusted or multi-tenant GPU
+workloads). The GPU is allocated through Kubernetes **DRA** (Dynamic Resource
+Allocation): the scheduler picks the node and device, and the sandbox boots
+firmware-less (mode-3) with the GPU passed through via VFIO.
+
+> **Status: Phase 1 — single Tier-1 GPU, cluster-validated on a GTX 1080.**
+> Multi-GPU / NVLink and multi-node distributed inference are scoped but not yet
+> shipped (they need multi-GPU hardware). Allocation is DRA-only in Phase 1; the
+> native `SwiftGPUProfile` backend is a planned follow-up.
+
+## How it works
+
+`spec.gpuResourceClaim` names a DRA `ResourceClaim` (or template). The
+kube-scheduler allocates the device and the KubeSwift DRA driver injects it (CDI
+`GPU_PCI_ADDRESSES`); a `gpu-init` container binds it to `vfio-pci`, and swiftletd
+synthesizes the Cloud Hypervisor `--device` from the injected env. The **NVIDIA
+driver rides the guest OCI image**, not KubeSwift — the sandbox loads it at start.
+
+Because the driver is a loadable module, a GPU sandbox boots the module-capable
+**`gpu-sandbox`** kernel profile (the controller selects it automatically; the base
+sandbox kernel is monolithic and can't `insmod`).
+
+## Prerequisites
+
+1. **A DRA GPU driver** — the KubeSwift reference driver (`gpu.kubeswift.io`,
+   deviceclass `kubeswift-vfio-gpu`) or the NVIDIA `k8s-dra-driver-gpu`. The node
+   publishes a `ResourceSlice` for its GPU(s).
+2. **A GPU node that is also a kernel node.** The node needs both
+   `kubeswift.io/gpu-node=true` (discovery) and **`kubeswift.io/kernel-node=true`**
+   — the kernel artifacts and `/dev/kvm` live on kernel nodes, and a GPU sandbox
+   stays pinned there (unlike a GPU SwiftGuest). `vfio-pci` must be loadable on the
+   node.
+3. **The `gpu-sandbox` SwiftKernel:**
+   ```bash
+   kubectl apply -f config/samples/sandbox/swiftkernel-gpu-sandbox.yaml
+   kubectl get swiftkernel gpu-sandbox -w      # wait for Ready (per-node ORAS pull)
+   ```
+4. **A `ResourceClaimTemplate`** for the GPU (one device of your GPU deviceclass) —
+   see `config/samples/sandbox/` for an example.
+
+## The guest image (BYO)
+
+A GPU sandbox image must ship the NVIDIA driver built for the `gpu-sandbox` kernel
+(Linux 6.6.x) and load it at start:
+
+- **Kernel module** — `nvidia.ko` (+ `nvidia-uvm.ko` for CUDA) built against Linux
+  6.6.x. **Pascal (GTX 10-series) and older need the proprietary driver**; Turing
+  and newer can use `nvidia-open`. Build it against the kernel source tree with the
+  buildroot toolchain (see `build/kernels/sandbox` — the module vermagic must match
+  the shipped `gpu-sandbox` kernel).
+- **Userspace** — `nvidia-smi` + `libnvidia-ml`, plus your framework (vLLM / TGI /
+  PyTorch).
+- **Entrypoint** — `insmod` the modules, create the `/dev/nvidia*` nodes (read the
+  char-major from `/proc/devices`), then run the workload.
+
+Building the driver into the kernel is not an option (the NVIDIA modules are
+out-of-tree); it rides the image. This composes with the "build your own base
+layers" story ([#395](https://github.com/kubeswift-io/kubeswift/issues/395)).
+
+## Quickstart
+
+```yaml
+apiVersion: sandbox.kubeswift.io/v1alpha1
+kind: SwiftSandbox
+metadata:
+  name: gpu-infer
+spec:
+  image: <your-registry>/cuda-vllm@sha256:...   # ships nvidia.ko + nvidia-smi
+  cpu: 4
+  memory: 8Gi
+  gpuResourceClaim:
+    resourceClaimTemplateName: single-vfio-gpu   # your DRA template
+    tier: pcie
+  # kernelProfileRef defaults to gpu-sandbox when a GPU is requested.
+```
+
+```bash
+kubectl apply -f config/samples/sandbox/swiftsandbox-gpu.yaml
+kubectl get sbox gpu-infer -w
+swiftctl sandbox logs gpu-infer         # nvidia-smi output, workload logs
+```
+
+The scheduler places the sandbox on a node with a free GPU device; `kubectl get
+resourceclaim` shows the allocation.
+
+## Limits (Phase 1)
+
+- **DRA only.** `gpuResourceClaim` (not `gpuProfileRef`). Needs a DRA driver on the
+  cluster.
+- **Cold-boot only.** `gpuResourceClaim` and `poolRef` are mutually exclusive — a
+  warm pool can't hold a scarce GPU idle. (Warm GPU pools are a later tier.)
+- **Single Tier-1 GPU.** One PCIe GPU per sandbox, no NVLink. Multi-GPU
+  tensor-parallel and multi-node are scoped
+  ([#390](https://github.com/kubeswift-io/kubeswift/issues/390)) but need hardware.
+- **Security.** A GPU sandbox mounts `/dev/vfio` (a wider host surface than the
+  default restricted sandbox). GPU inference is often trusted first-party code —
+  `network: open` is common — but the VM boundary is the value even so.
+
+## See also
+
+- [Running sandboxes](overview.md)
+- [`config/samples/sandbox/`](../../config/samples/sandbox/) — GPU sandbox +
+  ResourceClaimTemplate samples
+- GPU sandbox scoping / roadmap: [#390](https://github.com/kubeswift-io/kubeswift/issues/390)

--- a/docs/sandbox/overview.md
+++ b/docs/sandbox/overview.md
@@ -192,6 +192,7 @@ you're done inspecting it.
 ## See also
 
 - [Warm pools (fast start)](warm-pool.md) — pre-booted slots for sub-second checkout
+- [GPU sandboxes](gpu-sandboxes.md) — pass a GPU into a sandbox via DRA
 - [`config/samples/sandbox/`](../../config/samples/sandbox/) — sample manifests and notes
 - [swiftctl reference](../swiftctl.md)
 - [SwiftKernel reference](../swiftkernel.md)


### PR DESCRIPTION
## Summary

The docs/samples half of **GPU sandbox Phase 1** ([#390](https://github.com/kubeswift-io/kubeswift/issues/390)), completing the arc after the kernel ([#397](https://github.com/kubeswift-io/kubeswift/pull/397)), API ([#398](https://github.com/kubeswift-io/kubeswift/pull/398)), and controller ([#399](https://github.com/kubeswift-io/kubeswift/pull/399)) PRs.

- **`docs/sandbox/gpu-sandboxes.md`** — operator runbook: how the DRA flow works, node prereqs (a GPU node that is **also** a kernel node; `vfio-pci`), the **BYO CUDA-image contract** (ship `nvidia.ko` built for the `gpu-sandbox` Linux 6.6.x kernel + `insmod` at start; Pascal → proprietary, Turing+ → nvidia-open), a quickstart, and the Phase-1 limits (DRA-only, cold-boot-only, single Tier-1 GPU).
- **`config/samples/sandbox/swiftsandbox-gpu.yaml`** — a `SwiftSandbox` + `ResourceClaimTemplate` sample.
- Overview cross-link + CHANGELOG entry.

## Cluster validation — staged, pending one manual step

The controller image (with the GPU pod wiring from #399) is built + deployed to the dev cluster, the updated CRD is applied, and an NVIDIA test image (nvidia.ko built against the exact `gpu-sandbox` kernel + nvidia-smi) is pushed. The end-to-end validation (a real `SwiftSandbox` with `gpuResourceClaim` → `nvidia-smi` in the guest on the GTX 1080) is blocked only on the new **`kernels/gpu-sandbox` ghcr package being made public** (the SwiftKernel oras pull has no pull-secret path — TFU #26; currently `unauthorized: authentication required`). Once it's public I'll add the `nvidia-smi` proof here and mark this cluster-validated.

The Phase-0 spike (0a + DRA + 0b) already proved every layer of this end-to-end on the same hardware; this is the productized-CR confirmation.