### PR TITLE
feat(sandbox): wire spec.imagePullSecret through to the materialize path

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -248,18 +248,20 @@ func main() {
 	}
 
 	if err = (&swiftsandbox.SwiftSandboxReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("swiftsandbox-controller"),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor("swiftsandbox-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftSandbox controller")
 		os.Exit(1)
 	}
 
 	if err = (&swiftsandbox.SwiftSandboxPoolReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("swiftsandboxpool-controller"),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor("swiftsandboxpool-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftSandboxPool controller")
 		os.Exit(1)

--- a/internal/controller/swiftsandbox/controller.go
+++ b/internal/controller/swiftsandbox/controller.go
@@ -38,8 +38,11 @@ const (
 // SwiftSandboxReconciler runs OCI-rootfs microVM sandboxes.
 type SwiftSandboxReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	// APIReader is an uncached reader (mgr.GetAPIReader) used to Get the
+	// imagePullSecret without opening a cluster-wide secrets informer.
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
 }
 
 func isTerminal(p sandboxv1alpha1.SwiftSandboxPhase) bool {
@@ -87,7 +90,11 @@ func (r *SwiftSandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 // createLaunch resolves the image and creates the intent ConfigMap + launcher pod.
 func (r *SwiftSandboxReconciler) createLaunch(ctx context.Context, sb *sandboxv1alpha1.SwiftSandbox, kernelName string) (ctrl.Result, error) {
-	ri, err := resolveImage(sb)
+	auth, err := pullSecretAuth(ctx, r.APIReader, sb.Namespace, sb.Spec.ImagePullSecret, sb.Spec.Image)
+	if err != nil {
+		return r.fail(ctx, sb, "ImagePullSecretInvalid", err.Error())
+	}
+	ri, err := resolveImage(sb, auth)
 	if err != nil {
 		return r.fail(ctx, sb, "ImageResolveFailed", err.Error())
 	}

--- a/internal/controller/swiftsandbox/controller_test.go
+++ b/internal/controller/swiftsandbox/controller_test.go
@@ -458,3 +458,60 @@ func TestResolveKernelProfile(t *testing.T) {
 		t.Errorf("plain sandbox kernel = %q, want sandbox", got)
 	}
 }
+
+func TestBuildPod_ImagePullSecret(t *testing.T) {
+	sb := &sandboxv1alpha1.SwiftSandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "priv", Namespace: "ns"},
+		Spec:       sandboxv1alpha1.SwiftSandboxSpec{Image: "ghcr.io/org/cuda@sha256:x", ImagePullSecret: "ghcr-creds"},
+	}
+	pod := buildPod(sb, "sandbox")
+
+	var mat *corev1.Container
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == materializeInitName {
+			mat = &pod.Spec.InitContainers[i]
+		}
+	}
+	if mat == nil {
+		t.Fatal("sandbox-materialize init container missing")
+	}
+	hasArg := false
+	for _, a := range mat.Args {
+		if a == "--pull-secret=/pull-secret/config.json" {
+			hasArg = true
+		}
+	}
+	if !hasArg {
+		t.Errorf("materialize must get --pull-secret; args=%v", mat.Args)
+	}
+	hasMount := false
+	for _, m := range mat.VolumeMounts {
+		if m.Name == "pull-secret" && m.MountPath == "/pull-secret" {
+			hasMount = true
+		}
+	}
+	if !hasMount {
+		t.Error("materialize must mount the pull-secret volume")
+	}
+	// The volume maps the docker-registry Secret's .dockerconfigjson -> config.json.
+	var vol *corev1.Volume
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Name == "pull-secret" {
+			vol = &pod.Spec.Volumes[i]
+		}
+	}
+	if vol == nil || vol.Secret == nil || vol.Secret.SecretName != "ghcr-creds" {
+		t.Fatalf("pull-secret volume missing/wrong: %+v", vol)
+	}
+	if len(vol.Secret.Items) != 1 || vol.Secret.Items[0].Key != ".dockerconfigjson" || vol.Secret.Items[0].Path != "config.json" {
+		t.Errorf("pull-secret must map .dockerconfigjson->config.json; got %+v", vol.Secret.Items)
+	}
+
+	// No pull secret -> no pull-secret wiring.
+	plain := buildPod(&sandboxv1alpha1.SwiftSandbox{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}, "sandbox")
+	for _, v := range plain.Spec.Volumes {
+		if v.Name == "pull-secret" {
+			t.Error("no imagePullSecret -> no pull-secret volume")
+		}
+	}
+}

--- a/internal/controller/swiftsandbox/image.go
+++ b/internal/controller/swiftsandbox/image.go
@@ -1,10 +1,15 @@
 package swiftsandbox
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/sandbox/materialize"
@@ -53,17 +58,39 @@ func (e execSpec) nonTrivial() bool {
 	return len(e.Argv) > 0 || len(e.Env) > 0 || e.Cwd != ""
 }
 
+// pullSecretAuth builds an in-memory registry authenticator from a
+// docker-registry Secret (spec.imagePullSecret) so the controller can resolve a
+// PRIVATE image upfront — the controller pod has no mounted config.json, and
+// setting the process-global DOCKER_CONFIG env would race concurrent reconciles.
+// The Secret is read with an UNCACHED reader (get-only; no cluster-wide secrets
+// informer). Returns nil (anonymous) when no pull secret is set.
+func pullSecretAuth(ctx context.Context, reader client.Reader, namespace, secretName, imageRef string) (authn.Authenticator, error) {
+	if secretName == "" {
+		return nil, nil
+	}
+	var sec corev1.Secret
+	if err := reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: secretName}, &sec); err != nil {
+		return nil, fmt.Errorf("read imagePullSecret %q: %w", secretName, err)
+	}
+	dcj := sec.Data[corev1.DockerConfigJsonKey] // ".dockerconfigjson"
+	if len(dcj) == 0 {
+		return nil, fmt.Errorf("imagePullSecret %q has no %s (is it a kubernetes.io/dockerconfigjson Secret?)", secretName, corev1.DockerConfigJsonKey)
+	}
+	return materialize.AuthFromDockerConfigJSON(dcj, imageRef)
+}
+
 // resolveImage does a cheap registry resolve (manifest + config, no layers) so
 // the controller learns the digest -> deterministic cache path and the image
 // entrypoint, and can build the launch intent before the materialize init runs.
 // The init container independently resolves the same digest, so they agree.
-func resolveImage(sb *sandboxv1alpha1.SwiftSandbox) (resolvedImage, error) {
+// auth (from pullSecretAuth) authenticates a private image; nil = anonymous.
+func resolveImage(sb *sandboxv1alpha1.SwiftSandbox, auth authn.Authenticator) (resolvedImage, error) {
 	virtiofs := sb.Spec.RootfsMode == sandboxv1alpha1.SandboxRootfsVirtiofs
 	mode := materialize.ModeBlock
 	if virtiofs {
 		mode = materialize.ModeTree
 	}
-	opts := materialize.Options{ImageRef: sb.Spec.Image, CacheDir: rootfsCacheDir, Mode: mode}
+	opts := materialize.Options{ImageRef: sb.Spec.Image, CacheDir: rootfsCacheDir, Mode: mode, Auth: auth}
 	img, digest, err := materialize.RemotePull(opts)
 	if err != nil {
 		return resolvedImage{}, err

--- a/internal/controller/swiftsandbox/pod.go
+++ b/internal/controller/swiftsandbox/pod.go
@@ -219,6 +219,23 @@ func buildPod(sb *sandboxv1alpha1.SwiftSandbox, kernelName string) *corev1.Pod {
 	matMounts := []corev1.VolumeMount{{Name: "rootfs-cache", MountPath: rootfsCacheDir}}
 	var matEnv []corev1.EnvVar
 	var verifyVolumes []corev1.Volume
+
+	if sb.Spec.ImagePullSecret != "" {
+		// Pull a private image: mount the docker-registry Secret's .dockerconfigjson
+		// as config.json and point materialize's --pull-secret at it (the default
+		// keychain reads $DOCKER_CONFIG's config.json). Mirrors the SwiftImage import
+		// path. The controller's upfront resolveImage uses the same Secret via the
+		// apiserver (in-memory auth) — see pullSecretAuth.
+		matArgs = append(matArgs, "--pull-secret=/pull-secret/config.json")
+		matMounts = append(matMounts, corev1.VolumeMount{Name: "pull-secret", MountPath: "/pull-secret", ReadOnly: true})
+		verifyVolumes = append(verifyVolumes, corev1.Volume{
+			Name: "pull-secret",
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+				SecretName: sb.Spec.ImagePullSecret,
+				Items:      []corev1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
+			}},
+		})
+	}
 	if ref := sb.Spec.VerifyKeySecretRef; ref != nil && ref.Name != "" {
 		// cosign-verify image@digest BEFORE materializing. The public key is mounted
 		// read-only at /verify-key/cosign.pub; cosign needs a writable HOME/TMPDIR,

--- a/internal/controller/swiftsandbox/pool_controller.go
+++ b/internal/controller/swiftsandbox/pool_controller.go
@@ -42,8 +42,11 @@ const (
 // bridge-side idle keeper (kubeswift.idle=1), image-independent.
 type SwiftSandboxPoolReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	// APIReader is an uncached reader (mgr.GetAPIReader) used to Get the pool's
+	// imagePullSecret without opening a cluster-wide secrets informer.
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
 }
 
 func (r *SwiftSandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -96,7 +99,11 @@ func (r *SwiftSandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	want := slotsToCreate(int(pool.Spec.MinWarm), int(pool.Spec.MaxWarm), warmLive)
 	var ri *resolvedImage
 	if want > 0 || pool.Status.Rootfs == nil || pool.Status.Rootfs.Digest == "" {
-		resolved, err := resolveImage(r.slotTemplate(&pool, "resolve"))
+		auth, err := pullSecretAuth(ctx, r.APIReader, pool.Namespace, pool.Spec.ImagePullSecret, pool.Spec.Image)
+		if err != nil {
+			return r.degraded(ctx, &pool, ready, claimed, "ImagePullSecretInvalid", err.Error())
+		}
+		resolved, err := resolveImage(r.slotTemplate(&pool, "resolve"), auth)
 		if err != nil {
 			return r.degraded(ctx, &pool, ready, claimed, "ImageResolveFailed", err.Error())
 		}

--- a/internal/sandbox/materialize/auth_test.go
+++ b/internal/sandbox/materialize/auth_test.go
@@ -1,0 +1,54 @@
+package materialize
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func dcj(host, user, pass string) []byte {
+	auth := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+	return []byte(`{"auths":{"` + host + `":{"auth":"` + auth + `"}}}`)
+}
+
+func TestAuthFromDockerConfigJSON(t *testing.T) {
+	// A matching registry yields basic auth with the decoded user/pass.
+	a, err := AuthFromDockerConfigJSON(dcj("ghcr.io", "wrkode", "tok123"), "ghcr.io/org/img:tag")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg, err := a.Authorization()
+	if err != nil {
+		t.Fatalf("authorization: %v", err)
+	}
+	if cfg.Username != "wrkode" || cfg.Password != "tok123" {
+		t.Errorf("got %q/%q, want wrkode/tok123", cfg.Username, cfg.Password)
+	}
+
+	// A registry with no matching entry degrades to anonymous (not an error).
+	a2, err := AuthFromDockerConfigJSON(dcj("ghcr.io", "u", "p"), "docker.io/library/alpine:3.20")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c2, _ := a2.Authorization()
+	if c2.Username != "" || c2.Password != "" {
+		t.Errorf("non-matching registry should be anonymous, got %q/%q", c2.Username, c2.Password)
+	}
+
+	// A scheme-prefixed config key still matches the bare registry host.
+	a3, err := AuthFromDockerConfigJSON(dcj("https://ghcr.io", "x", "y"), "ghcr.io/o/i@sha256:"+repeat("a", 64))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c3, _ := a3.Authorization()
+	if c3.Username != "x" {
+		t.Errorf("scheme-prefixed key should match; got %q", c3.Username)
+	}
+}
+
+func repeat(s string, n int) string {
+	out := ""
+	for i := 0; i < n; i++ {
+		out += s
+	}
+	return out
+}

--- a/internal/sandbox/materialize/materialize.go
+++ b/internal/sandbox/materialize/materialize.go
@@ -11,6 +11,7 @@
 package materialize
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -73,7 +74,84 @@ type Options struct {
 	CacheDir   string // node-local cache root (hostPath)
 	Mode       Mode   // ModeBlock (default) or ModeTree
 	PullSecret string // path to a docker config.json for private registries; "" = anonymous
-	Insecure   bool   // allow a plain-HTTP registry (trusted in-cluster stores only)
+	// Auth is an in-memory registry authenticator. When set it takes precedence
+	// over PullSecret/the default keychain — used by the controller, which reads
+	// the pull Secret from the apiserver (it has no mounted config.json) and can't
+	// set the process-global DOCKER_CONFIG env safely under concurrent reconciles.
+	Auth     authn.Authenticator
+	Insecure bool // allow a plain-HTTP registry (trusted in-cluster stores only)
+}
+
+// authOption resolves the go-containerregistry auth for a pull: an explicit
+// in-memory authenticator (opts.Auth) wins; otherwise the default keychain reads
+// $DOCKER_CONFIG (the mounted pull-secret path, set by RemotePull/Resolve).
+func (opts Options) authOption() remote.Option {
+	if opts.Auth != nil {
+		return remote.WithAuth(opts.Auth)
+	}
+	return remote.WithAuthFromKeychain(authn.DefaultKeychain)
+}
+
+// AuthFromDockerConfigJSON builds a registry authenticator from a
+// kubernetes.io/dockerconfigjson Secret's bytes for the registry that hosts
+// imageRef. Returns authn.Anonymous when the config has no entry for that
+// registry (so a pull secret scoped to a different registry degrades to
+// anonymous rather than erroring). The controller uses this to resolve a private
+// image upfront without mounting a config.json.
+func AuthFromDockerConfigJSON(dockerConfigJSON []byte, imageRef string) (authn.Authenticator, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return nil, fmt.Errorf("parse image ref %q: %w", imageRef, err)
+	}
+	var cfg struct {
+		Auths map[string]struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+			Auth     string `json:"auth"`
+		} `json:"auths"`
+	}
+	if err := json.Unmarshal(dockerConfigJSON, &cfg); err != nil {
+		return nil, fmt.Errorf("parse .dockerconfigjson: %w", err)
+	}
+	reg := ref.Context().RegistryStr()
+	for host, entry := range cfg.Auths {
+		if !registryHostMatches(host, reg) {
+			continue
+		}
+		user, pass := entry.Username, entry.Password
+		if entry.Auth != "" {
+			decoded, derr := base64.StdEncoding.DecodeString(entry.Auth)
+			if derr == nil {
+				if u, p, ok := strings.Cut(string(decoded), ":"); ok {
+					user, pass = u, p
+				}
+			}
+		}
+		if user == "" && pass == "" {
+			return authn.Anonymous, nil
+		}
+		return authn.FromConfig(authn.AuthConfig{Username: user, Password: pass}), nil
+	}
+	return authn.Anonymous, nil
+}
+
+// registryHostMatches compares a docker-config auth key (which may carry a
+// scheme, a path, or the docker.io "https://index.docker.io/v1/" alias) against a
+// go-containerregistry registry host.
+func registryHostMatches(configKey, registry string) bool {
+	k := configKey
+	k = strings.TrimPrefix(k, "https://")
+	k = strings.TrimPrefix(k, "http://")
+	if i := strings.IndexAny(k, "/"); i >= 0 {
+		k = k[:i]
+	}
+	if k == registry {
+		return true
+	}
+	// Docker Hub aliases.
+	dockerAliases := registry == "index.docker.io" || registry == "docker.io" || registry == "registry-1.docker.io"
+	keyIsDockerHub := configKey == "https://index.docker.io/v1/" || k == "index.docker.io" || k == "docker.io" || k == "registry-1.docker.io"
+	return dockerAliases && keyIsDockerHub
 }
 
 // Puller resolves an Options to a pulled image and its digest ("sha256:..."). The
@@ -154,12 +232,12 @@ func RemotePull(opts Options) (v1.Image, string, error) {
 	if err != nil {
 		return nil, "", fmt.Errorf("parse image ref %q: %w", opts.ImageRef, err)
 	}
-	// A pull secret is a mounted docker config.json; DefaultKeychain reads it from
-	// $DOCKER_CONFIG's directory.
+	// A mounted pull secret (config.json) is read via $DOCKER_CONFIG by the default
+	// keychain; an in-memory opts.Auth (controller path) takes precedence.
 	if opts.PullSecret != "" {
 		os.Setenv("DOCKER_CONFIG", filepath.Dir(opts.PullSecret))
 	}
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	img, err := remote.Image(ref, opts.authOption())
 	if err != nil {
 		return nil, "", fmt.Errorf("pull %q: %w", opts.ImageRef, err)
 	}
@@ -186,7 +264,7 @@ func Resolve(opts Options) (repository, digest string, err error) {
 	if opts.PullSecret != "" {
 		os.Setenv("DOCKER_CONFIG", filepath.Dir(opts.PullSecret))
 	}
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	img, err := remote.Image(ref, opts.authOption())
 	if err != nil {
 		return "", "", fmt.Errorf("resolve %q: %w", opts.ImageRef, err)
 	}


### PR DESCRIPTION
## Summary

Part of GPU-sandbox follow-ups (B2). A **private** sandbox/pool image couldn't be pulled — `spec.imagePullSecret` was declared but never wired. It needs auth in **two** places:

1. **The materialize init container** (layer pull) — had a `--pull-secret` flag but the pod builder never mounted the Secret or passed it (a `pod.go` TODO).
2. **The controller's upfront `resolveImage`** (manifest+config, to learn the digest → cache path + entrypoint before the init runs) — pulled anonymously, so a private image failed here *before* the init even ran.

## What

- **materialize** — `Options.Auth` (in-memory `authn.Authenticator`) takes precedence over the file-based `DOCKER_CONFIG` keychain; `AuthFromDockerConfigJSON` parses a `kubernetes.io/dockerconfigjson` Secret's bytes into an authenticator for the image's registry (anonymous fallback when the secret is scoped to a different registry).
- **controller** — `pullSecretAuth` reads the pull Secret via an **uncached `APIReader`** (get-only; no cluster-wide secrets informer — the W7/W8 lesson) and passes the authenticator to `resolveImage`. Both the sandbox controller and the pool controller (`SwiftSandboxPool.spec.imagePullSecret`) use it.
- **pod builder** — mounts the Secret's `.dockerconfigjson` as `config.json` into the materialize init + passes `--pull-secret` (mirrors the SwiftImage import path).

Why in-memory auth for the controller: it has no mounted `config.json`, and setting the process-global `DOCKER_CONFIG` env would race concurrent reconciles. **RBAC unchanged** (the controller already has `secrets get`).

## Validation

Unit tests for the auth parse (matching/non-matching registry, scheme-prefixed key) + the pod pull-secret mount. Cluster validation (a real private image pulled into a SwiftSandbox) to follow on this PR before merge. Surfaced during GPU-sandbox Phase 1 (a private CUDA image couldn't be pulled; I used ttl.sh to sidestep it).