### PR TITLE
feat(gpu): implement the Tier-2/3 HGX QEMU topology runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to KubeSwift are documented here.
 
 ### Added
 
+- **Tier-2/3 HGX QEMU topology runtime** — the QEMU launch path now renders the
+  full GPU topology the controller has always computed (previously dropped as a
+  documented "when hardware is available" stub, leaving a flat PCI layout that
+  CUDA rejects): each SXM device behind its own `pcie-root-port` (unique
+  chassis/slot per QEMU docs/pcie.txt), `x-no-mmap=true` large-BAR handling,
+  per-NUMA-node shared memory backends + `-numa` bindings, optional 1G/2M
+  hugepage backing, SMP sockets matching the NUMA layout, NVSwitch device
+  passthrough (Tier 3), and post-spawn vCPU→host-CPU pinning via QMP
+  `query-cpus-fast` + `sched_setaffinity`. Grounded in the NVIDIA HGX Shared
+  NVSwitch Passthrough Integration Guide (WP-12736-002). Validated without GPU
+  hardware by `make verify-qemu-topology`, which boots the builder's exact args
+  on the shipping QEMU with emulated PCIe endpoints substituted on the same
+  root ports; VFIO/NVLink/Fabric-Manager runtime behaviour still requires real
+  HGX hardware.
+
 - **GPU sandboxes (Phase 1) — pass a GPU into a SwiftSandbox via DRA.**
   `SwiftSandbox.spec.gpuResourceClaim` allocates one Tier-1 GPU through a Kubernetes
   DRA `ResourceClaim`: the scheduler picks the node/device, the DRA driver injects it

--- a/Makefile
+++ b/Makefile
@@ -403,6 +403,14 @@ verify-dashboards:
 verify-sandbox-config:
 	@./build/kernels/sandbox/verify-config.sh
 
+# Boot-smoke the generated Tier-2/3 HGX QEMU topology (pcie-root-port per
+# device, NUMA memory backends, SMP) against the SHIPPING QEMU in the swiftletd
+# image, with emulated PCIe endpoints substituted on the same root ports — no
+# GPU hardware needed. Lab tool (needs /dev/kvm + docker), not wired into CI.
+# See docs/design/gpu-testing-without-hardware.md.
+verify-qemu-topology:
+	@./test/gpu/verify-qemu-topology.sh
+
 # Sync the canonical dashboards (config/grafana/) into the Helm chart
 # (charts/kubeswift/dashboards/), where templates/monitoring/dashboards.yaml
 # embeds them via .Files.Get. Same pattern as the CRD copy step — the

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1777,7 +1777,9 @@ dependencies = [
 name = "swift-qemu-client"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "log",
+ "serde_json",
 ]
 
 [[package]]

--- a/rust/swift-qemu-client/Cargo.toml
+++ b/rust/swift-qemu-client/Cargo.toml
@@ -9,3 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 log = "0.4"
+# query-cpus-fast response parsing (vCPU thread ids for post-spawn pinning).
+serde_json = "1"
+# sched_setaffinity for vCPU->host-CPU pinning (QEMU has no CLI for affinity).
+libc = "0.2"

--- a/rust/swift-qemu-client/examples/hgx_tier2_args.rs
+++ b/rust/swift-qemu-client/examples/hgx_tier2_args.rs
@@ -1,0 +1,109 @@
+//! Print the QEMU args the builder emits for a canned Tier-2 HGX topology.
+//!
+//! The drift-proof half of test/gpu/verify-qemu-topology.sh: the script feeds
+//! THESE args (the real `QemuConfig::to_args()` output, never a hand-copied
+//! command line) to a real qemu-system-x86_64, so builder changes are always
+//! what gets smoke-booted.
+//!
+//! The canned shape mirrors the NVIDIA HGX H100/H200 layout (integration
+//! guide WP-12736-002): 4 SXM GPUs (real guide BDFs), each behind its own
+//! pcie-root-port, 2 virtual NUMA nodes, optional 1G hugepages. Sizes are
+//! smoke-sized (1 GiB RAM total) — the arg SHAPE is what's under test.
+//!
+//! Flags:
+//!   --dummy           substitute each vfio-pci device with an emulated PCIe
+//!                     endpoint (e1000e) on the SAME root port — boots with no
+//!                     GPU/VFIO on the host, validating that QEMU accepts and
+//!                     realizes the generated hierarchy.
+//!   --run-dir <dir>   place serial/QMP sockets + OVMF_VARS under <dir>
+//!                     (default /tmp/hgx-topology-smoke).
+//!   --hugepages       back RAM with 1G hugepages (needs a host pool);
+//!                     default memfd so the smoke runs anywhere.
+//!
+//! One arg per output line (safe for shell array consumption).
+
+use std::path::PathBuf;
+
+use swift_qemu_client::{QemuConfig, QemuNUMANode, QemuVCPUPin, QemuVFIODevice};
+
+fn main() {
+    let argv: Vec<String> = std::env::args().collect();
+    let dummy = argv.iter().any(|a| a == "--dummy");
+    let hugepages = argv.iter().any(|a| a == "--hugepages");
+    let run_dir = argv
+        .iter()
+        .position(|a| a == "--run-dir")
+        .and_then(|i| argv.get(i + 1))
+        .cloned()
+        .unwrap_or_else(|| "/tmp/hgx-topology-smoke".to_string());
+
+    let rp = |addr: &str| QemuVFIODevice {
+        host_address: addr.to_string(),
+        pcie_root_port: true,
+        no_mmap: true,
+    };
+
+    let config = QemuConfig {
+        guest_id: "smoke/hgx-tier2".to_string(),
+        cpus: 4,
+        memory_mib: 0, // NUMA node sizes are authoritative
+        ovmf_code: PathBuf::from("/usr/share/OVMF/OVMF_CODE.fd"),
+        ovmf_vars: PathBuf::from(format!("{}/OVMF_VARS.fd", run_dir)),
+        disk_path: String::new(),
+        seed_path: String::new(),
+        tap_name: None,
+        mac: String::new(),
+        nics: vec![],
+        serial_socket: PathBuf::from(format!("{}/serial.sock", run_dir)),
+        qmp_socket: PathBuf::from(format!("{}/qmp.sock", run_dir)),
+        data_disk_paths: vec![],
+        // Real HGX H100/H200 GPU BDFs from the NVIDIA integration guide.
+        vfio_devices: vec![
+            rp("0000:0f:00.0"),
+            rp("0000:10:00.0"),
+            rp("0000:41:00.0"),
+            rp("0000:44:00.0"),
+        ],
+        numa_nodes: vec![
+            QemuNUMANode {
+                id: 0,
+                cpus: "0-1".to_string(),
+                memory_mib: 512,
+            },
+            QemuNUMANode {
+                id: 1,
+                cpus: "2-3".to_string(),
+                memory_mib: 512,
+            },
+        ],
+        hugepages: if hugepages {
+            "1G".to_string()
+        } else {
+            String::new()
+        },
+        vcpu_pinning: vec![
+            QemuVCPUPin {
+                vcpu: 0,
+                host_cpu: 0,
+            },
+            QemuVCPUPin {
+                vcpu: 1,
+                host_cpu: 1,
+            },
+        ],
+    };
+
+    for arg in config.to_args() {
+        if dummy && arg.starts_with("vfio-pci,host=") {
+            // Keep the bus=rpN placement (the topology under test); swap the
+            // VFIO endpoint for an emulated PCIe NIC and drop VFIO-only props.
+            let bus = arg
+                .split(',')
+                .find(|p| p.starts_with("bus="))
+                .unwrap_or("bus=pcie.0");
+            println!("e1000e,{}", bus);
+        } else {
+            println!("{}", arg);
+        }
+    }
+}

--- a/rust/swift-qemu-client/src/config.rs
+++ b/rust/swift-qemu-client/src/config.rs
@@ -1,15 +1,52 @@
-//! QEMU command-line configuration for VM boot (Phase 1: no GPU).
+//! QEMU command-line configuration for VM boot.
+//!
+//! Tier-2/3 HGX GPU topology (pcie-root-port per device, x-no-mmap, NUMA
+//! memory backends, hugepages) follows the NVIDIA HGX Shared NVSwitch GPU
+//! Passthrough Virtualization Integration Guide (WP-12736-002) and QEMU's
+//! docs/pcie.txt: SXM-class GPUs must sit behind a PCI Express Root Port —
+//! devices plugged straight into pcie.0 are Root Complex Integrated
+//! Endpoints, which guest drivers/CUDA reject (CUDA init error 3 in the
+//! field) — and each root port needs a unique (chassis, slot) pair.
 
 use std::path::PathBuf;
 
 /// Default QEMU binary. Override with KUBESWIFT_QEMU_BINARY env.
 pub const DEFAULT_QEMU_BINARY: &str = "qemu-system-x86_64";
 
-/// VFIO device for passthrough (GPU or SR-IOV NIC).
+/// VFIO device for passthrough (GPU, NVSwitch, or SR-IOV NIC).
 #[derive(Debug, Clone)]
 pub struct QemuVFIODevice {
     /// Host PCI BDF address (e.g., "0000:3b:0a.0").
     pub host_address: String,
+    /// Place the device behind its own pcie-root-port (Tier-2/3 SXM GPUs:
+    /// CUDA refuses a flat topology). false = attach to pcie.0 directly
+    /// (SR-IOV VFs, Tier-1-style devices).
+    pub pcie_root_port: bool,
+    /// Emit x-no-mmap=true — required for very large BARs (e.g. B200's
+    /// 256 GiB region 2) to avoid multi-minute BAR-mapping boot stalls.
+    pub no_mmap: bool,
+}
+
+/// One virtual guest NUMA node. Rendered as a shared memory backend plus a
+/// `-numa node,...,memdev=` binding; the per-node sizes are authoritative for
+/// total guest RAM (QEMU requires sum(memdev sizes) == -m).
+#[derive(Debug, Clone)]
+pub struct QemuNUMANode {
+    /// Guest NUMA node id (0-based).
+    pub id: u32,
+    /// Guest CPU list in Linux range syntax (e.g., "0-39").
+    pub cpus: String,
+    /// Node memory in MiB.
+    pub memory_mib: u64,
+}
+
+/// One vCPU→host-CPU pin. QEMU has no CLI for thread affinity, so pinning is
+/// applied post-spawn: QMP query-cpus-fast maps vcpu index → host thread id,
+/// then sched_setaffinity pins each thread (see `pinning`).
+#[derive(Debug, Clone, Copy)]
+pub struct QemuVCPUPin {
+    pub vcpu: u32,
+    pub host_cpu: u32,
 }
 
 /// Network interface configuration for multi-NIC mode.
@@ -54,44 +91,141 @@ pub struct QemuConfig {
     /// produces a `-drive file=<p>,format=raw,if=virtio` argument after
     /// the root disk.
     pub data_disk_paths: Vec<String>,
-    /// VFIO devices to pass through (SR-IOV VFs, GPUs).
-    /// Each produces a -device vfio-pci,host=<address> argument.
+    /// VFIO devices to pass through (SR-IOV VFs, GPUs, NVSwitches). A device
+    /// with pcie_root_port=true gets its own pcie-root-port (unique chassis +
+    /// slot per QEMU docs/pcie.txt); flat devices attach to pcie.0.
     pub vfio_devices: Vec<QemuVFIODevice>,
+    /// Virtual guest NUMA topology (Tier-2/3 HGX). Empty = flat (single node,
+    /// the shared memfd backend). Non-empty switches RAM to per-node shared
+    /// backends bound with -numa node,memdev= — the per-node sizes then define
+    /// total guest RAM (QEMU requires the sum to equal -m).
+    pub numa_nodes: Vec<QemuNUMANode>,
+    /// Hugepage size for guest RAM backing: "1G", "2M", or "" (none). Backs
+    /// RAM with memory-backend-file on /dev/hugepages-… + prealloc=on (fail
+    /// fast when the pool is short — a partially-backed GPU guest is a silent
+    /// perf failure).
+    pub hugepages: String,
+    /// vCPU→host-CPU pins, applied post-spawn (not CLI-expressible).
+    pub vcpu_pinning: Vec<QemuVCPUPin>,
 }
 
 impl QemuConfig {
+    /// SMP topology: with a NUMA layout, expose sockets=<node count> so the
+    /// guest sees one socket per NUMA node (matching the -numa cpu ranges the
+    /// controller computed). QEMU requires sockets*cores*threads == vcpus, so
+    /// fall back to a flat -smp when it doesn't divide evenly.
+    fn smp_arg(&self) -> String {
+        let cpus = self.cpus.max(1);
+        let sockets = self.numa_nodes.len() as u32;
+        if sockets > 1 && cpus % sockets == 0 {
+            format!(
+                "{},sockets={},cores={},threads=1",
+                cpus,
+                sockets,
+                cpus / sockets
+            )
+        } else {
+            cpus.to_string()
+        }
+    }
+
+    /// The hugepage mount path for the configured page size. Kubernetes mounts
+    /// hugepage emptyDirs per size; the launcher pod exposes them at the
+    /// standard /dev/hugepages (1G — the GPU default) so keep the sketch's
+    /// canonical path for 1G and the sized path for 2M.
+    fn hugepage_path(&self) -> &'static str {
+        match self.hugepages.as_str() {
+            "2M" => "/dev/hugepages-2Mi",
+            _ => "/dev/hugepages",
+        }
+    }
+
+    /// One memory backend object string (shared, optionally hugepage-backed).
+    fn memory_backend(&self, id: &str, size_mib: u64) -> String {
+        if self.hugepages.is_empty() {
+            // Shared memfd: the QEMU analog of CH's --memory shared=on. VFIO
+            // pins guest RAM on device attach; non-GPU guests keep lazy alloc.
+            format!("memory-backend-memfd,id={},size={}M,share=on", id, size_mib)
+        } else {
+            // Hugepage-backed file backend. prealloc=on: fail at spawn when
+            // the pool is short instead of stalling at first touch.
+            format!(
+                "memory-backend-file,id={},size={}M,mem-path={},share=on,prealloc=on",
+                id,
+                size_mib,
+                self.hugepage_path()
+            )
+        }
+    }
+
     /// Build the full qemu-system-x86_64 argument list.
     pub fn to_args(&self) -> Vec<String> {
+        // With a NUMA layout the per-node sizes are authoritative (QEMU
+        // requires sum(memdev sizes) == -m); flat guests use memory_mib.
+        let total_mib: u64 = if self.numa_nodes.is_empty() {
+            self.memory_mib.max(128) as u64
+        } else {
+            self.numa_nodes.iter().map(|n| n.memory_mib).sum()
+        };
+
         let mut args = vec![
             "-name".to_string(),
             format!("guest={},debug-threads=on", self.guest_id),
             "-enable-kvm".to_string(),
+        ];
+
+        if self.numa_nodes.is_empty() {
             // memory-backend=ram0 routes the machine's main RAM to a shared
-            // memfd backend (defined below) instead of QEMU's default private
+            // backend (defined below) instead of QEMU's default private
             // anonymous mmap. share=on makes guest RAM host-visible/shared --
             // the QEMU analog of Cloud Hypervisor's `--memory shared=on`. It is
             // required for clean VFIO/GPU passthrough (the IOMMU pins guest RAM
             // for device DMA) and is the standard backing for snapshot/live-
-            // migration-capable guests. Tier-1 PCIe GPUs run on Cloud Hypervisor
-            // (already shared via #165); this covers the QEMU path used by
-            // Tier-2/3 HGX GPUs (and non-GPU QEMU via the hypervisor override).
-            "-machine".to_string(),
-            "q35,accel=kvm,memory-backend=ram0".to_string(),
+            // migration-capable guests.
+            args.extend([
+                "-machine".to_string(),
+                "q35,accel=kvm,memory-backend=ram0".to_string(),
+            ]);
+        } else {
+            // NUMA mode: RAM comes from the per-node backends bound via
+            // -numa node,memdev= below — the machine-level memory-backend=
+            // must NOT be set as well (QEMU rejects the combination).
+            args.extend(["-machine".to_string(), "q35,accel=kvm".to_string()]);
+        }
+
+        args.extend([
             "-cpu".to_string(),
             "host".to_string(),
             "-smp".to_string(),
-            self.cpus.max(1).to_string(),
+            self.smp_arg(),
             "-m".to_string(),
-            format!("{}M", self.memory_mib.max(128)),
-            // Shared memfd backend for the main RAM (referenced by -machine
-            // above). size MUST match -m. No prealloc here: VFIO pins on device
-            // attach, and non-GPU guests keep lazy allocation.
-            "-object".to_string(),
-            format!(
-                "memory-backend-memfd,id=ram0,size={}M,share=on",
-                self.memory_mib.max(128)
-            ),
-        ];
+            format!("{}M", total_mib),
+        ]);
+
+        if self.numa_nodes.is_empty() {
+            args.extend([
+                "-object".to_string(),
+                self.memory_backend("ram0", total_mib),
+            ]);
+        } else {
+            // Per-node shared backends + the NUMA bindings. cpus= uses the
+            // Linux range syntax the controller computed from the profile.
+            for node in &self.numa_nodes {
+                args.extend([
+                    "-object".to_string(),
+                    self.memory_backend(&format!("ram{}", node.id), node.memory_mib),
+                ]);
+            }
+            for node in &self.numa_nodes {
+                args.extend([
+                    "-numa".to_string(),
+                    format!(
+                        "node,nodeid={},cpus={},memdev=ram{}",
+                        node.id, node.cpus, node.id
+                    ),
+                ]);
+            }
+        }
 
         // OVMF firmware: code (read-only) + vars (writable, per-VM copy)
         args.extend([
@@ -161,12 +295,36 @@ impl QemuConfig {
             ]);
         }
 
-        // VFIO passthrough devices (SR-IOV VFs, GPUs).
-        for dev in &self.vfio_devices {
-            args.extend([
-                "-device".to_string(),
-                format!("vfio-pci,host={}", dev.host_address),
-            ]);
+        // VFIO passthrough devices (SR-IOV VFs, GPUs, NVSwitches).
+        //
+        // Tier-2/3 SXM devices sit each behind their own pcie-root-port: a
+        // device plugged straight into pcie.0 is a Root Complex Integrated
+        // Endpoint, which the NVIDIA driver/CUDA reject (CUDA init error 3).
+        // Per QEMU docs/pcie.txt the (chassis, slot) pair is mandatory and
+        // must be unique per root port — derive both from the device index.
+        // x-no-mmap=true avoids BAR-mapping boot stalls on very large BARs.
+        for (i, dev) in self.vfio_devices.iter().enumerate() {
+            let no_mmap = if dev.no_mmap { ",x-no-mmap=true" } else { "" };
+            if dev.pcie_root_port {
+                args.extend([
+                    "-device".to_string(),
+                    format!(
+                        "pcie-root-port,id=rp{},bus=pcie.0,chassis={},slot={}",
+                        i,
+                        i + 1,
+                        i + 1
+                    ),
+                ]);
+                args.extend([
+                    "-device".to_string(),
+                    format!("vfio-pci,host={},bus=rp{}{}", dev.host_address, i, no_mmap),
+                ]);
+            } else {
+                args.extend([
+                    "-device".to_string(),
+                    format!("vfio-pci,host={}{}", dev.host_address, no_mmap),
+                ]);
+            }
         }
 
         // Serial console socket — server=on so guest can connect after QEMU starts
@@ -213,6 +371,17 @@ mod tests {
             serial_socket: PathBuf::from("/tmp/run/serial.sock"),
             qmp_socket: PathBuf::from("/tmp/run/qmp.sock"),
             data_disk_paths: vec![],
+            numa_nodes: vec![],
+            hugepages: String::new(),
+            vcpu_pinning: vec![],
+        }
+    }
+
+    fn flat_vfio(addr: &str) -> QemuVFIODevice {
+        QemuVFIODevice {
+            host_address: addr.to_string(),
+            pcie_root_port: false,
+            no_mmap: false,
         }
     }
 
@@ -422,9 +591,7 @@ mod tests {
         let mut cfg = make_config();
         cfg.tap_name = None;
         cfg.nics = vec![];
-        cfg.vfio_devices = vec![QemuVFIODevice {
-            host_address: "0000:3b:0a.0".to_string(),
-        }];
+        cfg.vfio_devices = vec![flat_vfio("0000:3b:0a.0")];
         let args = cfg.to_args();
         let joined = args.join(" ");
         assert!(
@@ -449,9 +616,7 @@ mod tests {
             mac: "52:54:00:01:00:00".to_string(),
             netdev_id: "net0".to_string(),
         }];
-        cfg.vfio_devices = vec![QemuVFIODevice {
-            host_address: "0000:3b:0a.0".to_string(),
-        }];
+        cfg.vfio_devices = vec![flat_vfio("0000:3b:0a.0")];
         let args = cfg.to_args();
         let joined = args.join(" ");
         assert!(
@@ -464,5 +629,273 @@ mod tests {
             "missing vfio-pci for SR-IOV: {}",
             joined
         );
+    }
+}
+
+#[cfg(test)]
+mod hgx_tests {
+    use super::*;
+
+    fn rp_vfio(addr: &str, no_mmap: bool) -> QemuVFIODevice {
+        QemuVFIODevice {
+            host_address: addr.to_string(),
+            pcie_root_port: true,
+            no_mmap,
+        }
+    }
+
+    /// A Tier-2 hgx-shared shape: 4 SXM GPUs (real HGX H100/H200 BDFs from the
+    /// NVIDIA integration guide), 2 virtual NUMA nodes, 1G hugepages.
+    fn tier2_config() -> QemuConfig {
+        QemuConfig {
+            guest_id: "default/hgx-tier2".to_string(),
+            cpus: 80,
+            memory_mib: 0, // NUMA sizes are authoritative
+            ovmf_code: PathBuf::from("/usr/share/OVMF/OVMF_CODE.fd"),
+            ovmf_vars: PathBuf::from("/tmp/run/OVMF_VARS.fd"),
+            disk_path: "/data/image.raw".to_string(),
+            seed_path: String::new(),
+            tap_name: None,
+            mac: String::new(),
+            nics: vec![],
+            serial_socket: PathBuf::from("/tmp/run/serial.sock"),
+            qmp_socket: PathBuf::from("/tmp/run/qmp.sock"),
+            data_disk_paths: vec![],
+            vfio_devices: vec![
+                rp_vfio("0000:0f:00.0", true),
+                rp_vfio("0000:10:00.0", true),
+                rp_vfio("0000:41:00.0", true),
+                rp_vfio("0000:44:00.0", true),
+            ],
+            numa_nodes: vec![
+                QemuNUMANode {
+                    id: 0,
+                    cpus: "0-39".to_string(),
+                    memory_mib: 491_520,
+                },
+                QemuNUMANode {
+                    id: 1,
+                    cpus: "40-79".to_string(),
+                    memory_mib: 491_520,
+                },
+            ],
+            hugepages: "1G".to_string(),
+            vcpu_pinning: vec![
+                QemuVCPUPin {
+                    vcpu: 0,
+                    host_cpu: 8,
+                },
+                QemuVCPUPin {
+                    vcpu: 1,
+                    host_cpu: 9,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn tier2_root_port_per_device() {
+        // Each SXM GPU sits behind its OWN pcie-root-port with a unique
+        // (chassis, slot) pair (QEMU docs/pcie.txt) and binds to it via
+        // bus=rpN. Flat placement is what CUDA rejects (init error 3).
+        let args = tier2_config().to_args();
+        let joined = args.join(" ");
+        for (i, bdf) in [
+            "0000:0f:00.0",
+            "0000:10:00.0",
+            "0000:41:00.0",
+            "0000:44:00.0",
+        ]
+        .iter()
+        .enumerate()
+        {
+            let rp = format!(
+                "pcie-root-port,id=rp{},bus=pcie.0,chassis={},slot={}",
+                i,
+                i + 1,
+                i + 1
+            );
+            assert!(joined.contains(&rp), "missing root port {}: {}", rp, joined);
+            let dev = format!("vfio-pci,host={},bus=rp{},x-no-mmap=true", bdf, i);
+            assert!(joined.contains(&dev), "missing device {}: {}", dev, joined);
+        }
+        // The root port precedes its device (QEMU resolves bus= by prior definition).
+        let rp0 = args
+            .iter()
+            .position(|a| a.contains("pcie-root-port,id=rp0"))
+            .unwrap();
+        let dev0 = args
+            .iter()
+            .position(|a| a.contains("host=0000:0f:00.0"))
+            .unwrap();
+        assert!(rp0 < dev0, "root port must be defined before its device");
+    }
+
+    #[test]
+    fn tier2_numa_memory_layout() {
+        // NUMA mode: no machine-level memory-backend=; one shared hugepage
+        // backend per node; -numa node bindings; -m equals the node sum.
+        let args = tier2_config().to_args();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("-machine q35,accel=kvm ") || args.iter().any(|a| a == "q35,accel=kvm"),
+            "NUMA mode must not set machine memory-backend=: {}",
+            joined
+        );
+        assert!(
+            !joined.contains("memory-backend=ram0"),
+            "machine memory-backend= is invalid with -numa memdev: {}",
+            joined
+        );
+        for n in 0..2 {
+            assert!(
+                joined.contains(&format!(
+                    "memory-backend-file,id=ram{},size=491520M,mem-path=/dev/hugepages,share=on,prealloc=on",
+                    n
+                )),
+                "missing hugepage backend ram{}: {}",
+                n,
+                joined
+            );
+        }
+        assert!(
+            joined.contains("node,nodeid=0,cpus=0-39,memdev=ram0"),
+            "missing numa node 0: {}",
+            joined
+        );
+        assert!(
+            joined.contains("node,nodeid=1,cpus=40-79,memdev=ram1"),
+            "missing numa node 1: {}",
+            joined
+        );
+        assert!(
+            joined.contains("-m 983040M"),
+            "-m must equal node sum: {}",
+            joined
+        );
+    }
+
+    #[test]
+    fn tier2_smp_sockets_match_numa() {
+        let args = tier2_config().to_args();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("-smp 80,sockets=2,cores=40,threads=1"),
+            "smp topology must expose one socket per NUMA node: {}",
+            joined
+        );
+    }
+
+    #[test]
+    fn smp_falls_back_flat_when_indivisible() {
+        let mut cfg = tier2_config();
+        cfg.cpus = 81; // not divisible by 2 sockets
+        let joined = cfg.to_args().join(" ");
+        assert!(
+            joined.contains("-smp 81 "),
+            "indivisible cpus must fall back to flat -smp: {}",
+            joined
+        );
+    }
+
+    #[test]
+    fn flat_hugepages_backend() {
+        // Flat (non-NUMA) + hugepages: the single ram0 backend switches from
+        // memfd to a hugepage file backend; the machine still routes to it.
+        let mut cfg = tier2_config();
+        cfg.numa_nodes = vec![];
+        cfg.memory_mib = 8192;
+        let joined = cfg.to_args().join(" ");
+        assert!(
+            joined.contains("q35,accel=kvm,memory-backend=ram0"),
+            "flat mode keeps machine memory-backend=: {}",
+            joined
+        );
+        assert!(
+            joined.contains(
+                "memory-backend-file,id=ram0,size=8192M,mem-path=/dev/hugepages,share=on,prealloc=on"
+            ),
+            "flat hugepage backend: {}",
+            joined
+        );
+        assert!(joined.contains("-m 8192M"), "{}", joined);
+    }
+
+    #[test]
+    fn mixed_sriov_flat_and_gpu_root_port() {
+        // An SR-IOV VF stays flat on pcie.0 while the GPU gets a root port;
+        // chassis/slot derive from the combined index so they stay unique.
+        let mut cfg = tier2_config();
+        cfg.numa_nodes = vec![];
+        cfg.memory_mib = 4096;
+        cfg.hugepages = String::new();
+        cfg.vfio_devices = vec![
+            QemuVFIODevice {
+                host_address: "0000:3b:0a.0".to_string(),
+                pcie_root_port: false,
+                no_mmap: false,
+            },
+            rp_vfio("0000:0f:00.0", false),
+        ];
+        let joined = cfg.to_args().join(" ");
+        assert!(
+            joined.contains("vfio-pci,host=0000:3b:0a.0 "),
+            "SR-IOV VF must stay flat (no bus=): {}",
+            joined
+        );
+        assert!(
+            joined.contains("pcie-root-port,id=rp1,bus=pcie.0,chassis=2,slot=2"),
+            "GPU root port at combined index: {}",
+            joined
+        );
+        assert!(
+            joined.contains("vfio-pci,host=0000:0f:00.0,bus=rp1"),
+            "GPU binds to its root port: {}",
+            joined
+        );
+        assert!(
+            !joined.contains("host=0000:0f:00.0,bus=rp1,x-no-mmap"),
+            "no x-no-mmap when not requested: {}",
+            joined
+        );
+    }
+
+    #[test]
+    fn non_gpu_args_unchanged_regression() {
+        // The flat/non-GPU arg shape must be byte-stable across the topology
+        // work (the cluster's hypervisor-override QEMU guests ride it).
+        let cfg = QemuConfig {
+            guest_id: "default/plain".to_string(),
+            cpus: 2,
+            memory_mib: 2048,
+            ovmf_code: PathBuf::from("/usr/share/OVMF/OVMF_CODE.fd"),
+            ovmf_vars: PathBuf::from("/tmp/run/OVMF_VARS.fd"),
+            disk_path: "/data/image.raw".to_string(),
+            seed_path: String::new(),
+            tap_name: None,
+            mac: String::new(),
+            nics: vec![],
+            serial_socket: PathBuf::from("/tmp/run/serial.sock"),
+            qmp_socket: PathBuf::from("/tmp/run/qmp.sock"),
+            data_disk_paths: vec![],
+            vfio_devices: vec![],
+            numa_nodes: vec![],
+            hugepages: String::new(),
+            vcpu_pinning: vec![],
+        };
+        let joined = cfg.to_args().join(" ");
+        assert!(
+            joined.contains("q35,accel=kvm,memory-backend=ram0"),
+            "{}",
+            joined
+        );
+        assert!(
+            joined.contains("memory-backend-memfd,id=ram0,size=2048M,share=on"),
+            "{}",
+            joined
+        );
+        assert!(joined.contains("-smp 2 "), "{}", joined);
+        assert!(!joined.contains("pcie-root-port"), "{}", joined);
+        assert!(!joined.contains("-numa"), "{}", joined);
     }
 }

--- a/rust/swift-qemu-client/src/lib.rs
+++ b/rust/swift-qemu-client/src/lib.rs
@@ -1,12 +1,17 @@
 //! QEMU process management for KubeSwift swiftletd.
 //!
-//! Provides QemuProcess (spawn, monitor, shutdown) and QemuConfig (arg builder).
-//! Phase 1: disk boot only, no GPU/NUMA/hugepages.
+//! Provides QemuProcess (spawn, monitor, shutdown) and QemuConfig (arg
+//! builder). Covers disk boot plus the Tier-2/3 HGX GPU topology:
+//! pcie-root-port per SXM device, x-no-mmap large-BAR handling, NUMA memory
+//! backends, hugepages, and post-spawn vCPU pinning.
 
 mod config;
+mod pinning;
 mod qmp;
 
-pub use config::{QemuConfig, QemuNICConfig, QemuVFIODevice, DEFAULT_QEMU_BINARY};
+pub use config::{
+    QemuConfig, QemuNICConfig, QemuNUMANode, QemuVCPUPin, QemuVFIODevice, DEFAULT_QEMU_BINARY,
+};
 
 use std::path::{Path, PathBuf};
 use std::process::{Child, ExitStatus};
@@ -66,6 +71,20 @@ impl QemuProcess {
     /// Returns the OS process ID of the QEMU process.
     pub fn pid(&self) -> u32 {
         self.pid
+    }
+
+    /// Apply vCPU→host-CPU pinning post-spawn (QEMU has no CLI for thread
+    /// affinity — the libvirt-style flow): QMP query-cpus-fast maps each vCPU
+    /// index to its host thread id, then sched_setaffinity pins it. Call once
+    /// the QMP socket is up. Returns the number of vCPUs pinned. Callers
+    /// treat failure as best-effort: a missed pin degrades performance, never
+    /// correctness.
+    pub fn apply_vcpu_pinning(&self, pins: &[QemuVCPUPin]) -> Result<usize, String> {
+        if pins.is_empty() {
+            return Ok(0);
+        }
+        let cpu_threads = self.qmp.query_cpus_fast()?;
+        pinning::apply_pins(pins, &cpu_threads)
     }
 
     /// Returns the path to the serial console Unix socket.

--- a/rust/swift-qemu-client/src/pinning.rs
+++ b/rust/swift-qemu-client/src/pinning.rs
@@ -1,0 +1,103 @@
+//! vCPU→host-CPU pinning via sched_setaffinity.
+//!
+//! QEMU has no command-line option for vCPU thread affinity — libvirt applies
+//! it post-spawn, and so do we: QMP query-cpus-fast maps each vCPU index to
+//! its host thread id, then sched_setaffinity pins that thread to the host CPU
+//! the controller chose (NUMA-local to the passed GPUs). Best-effort by the
+//! caller: a failed pin degrades performance, never correctness.
+
+use crate::config::QemuVCPUPin;
+
+/// Pin each vCPU thread to its host CPU. `cpu_threads` is the
+/// (cpu-index, thread-id) map from query-cpus-fast. Returns the number of
+/// vCPUs pinned; errors on the first pin that cannot be applied (unknown vCPU
+/// index or a rejected sched_setaffinity).
+pub fn apply_pins(pins: &[QemuVCPUPin], cpu_threads: &[(u32, i32)]) -> Result<usize, String> {
+    let mut applied = 0;
+    for pin in pins {
+        let tid = cpu_threads
+            .iter()
+            .find(|(idx, _)| *idx == pin.vcpu)
+            .map(|(_, tid)| *tid)
+            .ok_or_else(|| {
+                format!(
+                    "vcpu {} not in query-cpus-fast map ({} vCPUs reported)",
+                    pin.vcpu,
+                    cpu_threads.len()
+                )
+            })?;
+        set_thread_affinity(tid, pin.host_cpu).map_err(|e| {
+            format!(
+                "pin vcpu {} (tid {}) -> cpu {}: {}",
+                pin.vcpu, tid, pin.host_cpu, e
+            )
+        })?;
+        applied += 1;
+    }
+    Ok(applied)
+}
+
+/// sched_setaffinity(tid, {cpu}) — pin one thread to one host CPU.
+fn set_thread_affinity(tid: i32, cpu: u32) -> Result<(), String> {
+    if cpu as usize >= libc::CPU_SETSIZE as usize {
+        return Err(format!("host cpu {} exceeds CPU_SETSIZE", cpu));
+    }
+    unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        libc::CPU_ZERO(&mut set);
+        libc::CPU_SET(cpu as usize, &mut set);
+        if libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &set) != 0 {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gettid() -> i32 {
+        unsafe { libc::syscall(libc::SYS_gettid) as i32 }
+    }
+
+    #[test]
+    fn set_affinity_on_self_round_trips() {
+        // A real sched_setaffinity on the test's own thread: pin to CPU 0 and
+        // read the mask back. CPU 0 always exists.
+        let tid = gettid();
+        set_thread_affinity(tid, 0).expect("pin self to cpu 0");
+        unsafe {
+            let mut set: libc::cpu_set_t = std::mem::zeroed();
+            assert_eq!(
+                libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut set),
+                0
+            );
+            assert!(libc::CPU_ISSET(0, &set), "cpu 0 must be in the mask");
+            assert_eq!(libc::CPU_COUNT(&set), 1, "mask must be exactly {{0}}");
+        }
+    }
+
+    #[test]
+    fn apply_pins_maps_vcpu_to_thread() {
+        // vcpu 1 maps to OUR tid so the pin lands on the test thread; vcpu 0
+        // maps to a bogus map entry we don't pin.
+        let tid = gettid();
+        let pins = [QemuVCPUPin {
+            vcpu: 1,
+            host_cpu: 0,
+        }];
+        let map = [(0u32, 1i32), (1u32, tid)];
+        assert_eq!(apply_pins(&pins, &map).unwrap(), 1);
+    }
+
+    #[test]
+    fn apply_pins_unknown_vcpu_errors() {
+        let pins = [QemuVCPUPin {
+            vcpu: 7,
+            host_cpu: 0,
+        }];
+        let err = apply_pins(&pins, &[(0, 1234)]).unwrap_err();
+        assert!(err.contains("vcpu 7"), "{}", err);
+    }
+}

--- a/rust/swift-qemu-client/src/qmp.rs
+++ b/rust/swift-qemu-client/src/qmp.rs
@@ -66,6 +66,36 @@ impl QmpClient {
         Ok(())
     }
 
+    /// Like `execute`, but returns the command's response line for parsing.
+    fn execute_query(&self, cmd: &str) -> Result<String, String> {
+        let stream = UnixStream::connect(&self.socket_path)
+            .map_err(|e| format!("QMP connect {:?}: {}", self.socket_path, e))?;
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .map_err(|e| format!("QMP set_read_timeout: {}", e))?;
+        let mut reader = BufReader::new(&stream);
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| format!("QMP read greeting: {}", e))?;
+        (&stream)
+            .write_all(b"{\"execute\":\"qmp_capabilities\"}\n")
+            .map_err(|e| format!("QMP write qmp_capabilities: {}", e))?;
+        line.clear();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| format!("QMP read capabilities response: {}", e))?;
+        let payload = format!("{{\"execute\":\"{}\"}}\n", cmd);
+        (&stream)
+            .write_all(payload.as_bytes())
+            .map_err(|e| format!("QMP write {}: {}", cmd, e))?;
+        line.clear();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| format!("QMP read {} response: {}", cmd, e))?;
+        Ok(line)
+    }
+
     /// Request graceful ACPI power-down. Guest receives ACPI shutdown event and initiates
     /// its own shutdown sequence. The QEMU process exits after guest powers off.
     pub fn powerdown(&self) -> Result<(), String> {
@@ -75,5 +105,54 @@ impl QmpClient {
     /// Force-quit the QEMU process immediately (no guest notification).
     pub fn quit(&self) -> Result<(), String> {
         self.execute("quit")
+    }
+
+    /// Map vCPU index → host thread id via query-cpus-fast. The thread ids are
+    /// what sched_setaffinity pins (QEMU has no CLI for vCPU affinity).
+    pub fn query_cpus_fast(&self) -> Result<Vec<(u32, i32)>, String> {
+        let line = self.execute_query("query-cpus-fast")?;
+        parse_cpus_fast(&line)
+    }
+}
+
+/// Parse a query-cpus-fast response:
+/// `{"return":[{"cpu-index":0,"thread-id":12345,...},...]}`.
+pub(crate) fn parse_cpus_fast(line: &str) -> Result<Vec<(u32, i32)>, String> {
+    let v: serde_json::Value =
+        serde_json::from_str(line).map_err(|e| format!("query-cpus-fast parse: {}", e))?;
+    let cpus = v
+        .get("return")
+        .and_then(|r| r.as_array())
+        .ok_or_else(|| format!("query-cpus-fast: no return array in {}", line.trim()))?;
+    let mut out = Vec::with_capacity(cpus.len());
+    for c in cpus {
+        let idx = c
+            .get("cpu-index")
+            .and_then(|x| x.as_u64())
+            .ok_or_else(|| "query-cpus-fast: entry missing cpu-index".to_string())?;
+        let tid = c
+            .get("thread-id")
+            .and_then(|x| x.as_i64())
+            .ok_or_else(|| "query-cpus-fast: entry missing thread-id".to_string())?;
+        out.push((idx as u32, tid as i32));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_cpus_fast;
+
+    #[test]
+    fn parse_cpus_fast_maps_index_to_thread() {
+        let line = r#"{"return":[{"cpu-index":0,"qom-path":"/machine/unattached/device[0]","thread-id":4100,"target":"x86_64","props":{"core-id":0,"thread-id":0,"socket-id":0}},{"cpu-index":1,"qom-path":"/machine/unattached/device[2]","thread-id":4101,"target":"x86_64","props":{"core-id":1,"thread-id":0,"socket-id":0}}]}"#;
+        let cpus = parse_cpus_fast(line).unwrap();
+        assert_eq!(cpus, vec![(0, 4100), (1, 4101)]);
+    }
+
+    #[test]
+    fn parse_cpus_fast_rejects_garbage() {
+        assert!(parse_cpus_fast("{}").is_err());
+        assert!(parse_cpus_fast("not json").is_err());
     }
 }

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -223,6 +223,50 @@ pub struct GPUIntent {
     /// Fabric Manager partition ID (-1 = none).
     #[serde(default)]
     pub fabric_manager_partition_id: i32,
+    /// Virtual NUMA topology for the guest (Tier-2/3 QEMU only; None = flat).
+    /// The Go controller computes it from SwiftGPUProfile.numaTopology + the
+    /// node inventory; QEMU renders it as per-node memory backends + -numa.
+    #[serde(default)]
+    pub numa: Option<GPUNUMAIntent>,
+    /// vCPU→host-CPU pinning map (Tier-2/3 QEMU only). QEMU has no CLI for
+    /// affinity, so swiftletd applies it post-spawn via QMP query-cpus-fast +
+    /// sched_setaffinity. null-tolerant like `devices`.
+    #[serde(default, deserialize_with = "null_to_default")]
+    pub vcpu_pinning: Vec<VCPUPinIntent>,
+    /// Hugepage size for guest RAM backing: "1G", "2M", or "" (none).
+    /// Already normalized by the controller ("1Gi"→"1G").
+    #[serde(default)]
+    pub hugepages: String,
+    /// NVSwitch VFIO devices (Tier-3 hgx-full only: the whole fabric moves into
+    /// the guest). Same device shape as `devices`; never env-synthesized.
+    #[serde(default, deserialize_with = "null_to_default")]
+    pub nv_switches: Vec<GPUDeviceIntent>,
+}
+
+/// Virtual NUMA topology (mirrors Go runtimeintent.NUMAIntent).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GPUNUMAIntent {
+    #[serde(default, deserialize_with = "null_to_default")]
+    pub nodes: Vec<GPUNUMANodeIntent>,
+}
+
+/// One virtual NUMA node (mirrors Go runtimeintent.NUMANodeIntent).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GPUNUMANodeIntent {
+    pub id: i32,
+    /// Guest CPU list in Linux range syntax (e.g., "0-39").
+    pub cpus: String,
+    pub memory_mi: i64,
+}
+
+/// One vCPU→host-CPU pin (mirrors Go runtimeintent.VCPUPin).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VCPUPinIntent {
+    pub vcpu: u32,
+    pub host_cpu: u32,
 }
 
 impl GPUIntent {
@@ -260,6 +304,7 @@ impl GPUIntent {
                 pcie_root_port: false,
                 gpu_direct_clique: -1,
                 no_mmap: false,
+                numa_node: 0,
             })
             .collect())
     }
@@ -282,6 +327,10 @@ pub struct GPUDeviceIntent {
     /// Add x-no-mmap=true (QEMU, large BARs).
     #[serde(default)]
     pub no_mmap: bool,
+    /// Virtual NUMA node this device belongs to (QEMU Tier 2/3; informational
+    /// for CH).
+    #[serde(default)]
+    pub numa_node: i32,
 }
 
 /// Describes a single virtiofs share (vhost-user-fs). swiftletd runs a
@@ -1214,5 +1263,78 @@ mod tests {
         .unwrap();
         assert!(dra.devices.is_empty());
         assert_eq!(dra.device_source, "env");
+    }
+
+    /// Wire contract for the Tier-2/3 GPU topology fields the Go controller
+    /// emits (runtimeintent.GPUIntent): numa/vcpuPinning/hugepages/nvSwitches
+    /// plus per-device numaNode. Older controllers omit them all — every field
+    /// must default (version-skew tolerance, the C2 dual-field lesson).
+    #[test]
+    fn gpu_intent_tier23_wire_contract() {
+        let json = r#"{
+            "guestId": "default/hgx",
+            "cpu": 80,
+            "memory": 983040,
+            "hypervisor": "qemu",
+            "seedPath": "",
+            "lifecycle": "start",
+            "network": false,
+            "rootDisk": {"format": "raw", "path": "/data/image.raw"},
+            "gpu": {
+                "devices": [
+                    {"hostPath": "/sys/bus/pci/devices/0000:0f:00.0/", "pciAddress": "0000:0f:00.0", "pcieRootPort": true, "gpuDirectClique": 0, "noMmap": true, "numaNode": 0},
+                    {"hostPath": "/sys/bus/pci/devices/0000:86:00.0/", "pciAddress": "0000:86:00.0", "pcieRootPort": true, "gpuDirectClique": 0, "noMmap": true, "numaNode": 1}
+                ],
+                "firmware": "ovmf",
+                "numa": {"nodes": [
+                    {"id": 0, "cpus": "0-39", "memoryMi": 491520},
+                    {"id": 1, "cpus": "40-79", "memoryMi": 491520}
+                ]},
+                "vcpuPinning": [{"vcpu": 0, "hostCpu": 8}, {"vcpu": 1, "hostCpu": 9}],
+                "hugepages": "1G",
+                "nvSwitches": [
+                    {"hostPath": "/sys/bus/pci/devices/0000:03:00.0/", "pciAddress": "0000:03:00.0", "pcieRootPort": true, "gpuDirectClique": 0, "noMmap": false, "numaNode": 0}
+                ],
+                "fabricManagerPartitionId": 1
+            }
+        }"#;
+        let intent: RuntimeIntent = serde_json::from_str(json).expect("tier2/3 intent parses");
+        let gpu = intent.gpu.expect("gpu present");
+        assert_eq!(gpu.devices.len(), 2);
+        assert!(gpu.devices[0].pcie_root_port && gpu.devices[0].no_mmap);
+        assert_eq!(gpu.devices[1].numa_node, 1);
+        let numa = gpu.numa.expect("numa present");
+        assert_eq!(numa.nodes.len(), 2);
+        assert_eq!(numa.nodes[1].cpus, "40-79");
+        assert_eq!(numa.nodes[1].memory_mi, 491520);
+        assert_eq!(gpu.vcpu_pinning.len(), 2);
+        assert_eq!(gpu.vcpu_pinning[1].host_cpu, 9);
+        assert_eq!(gpu.hugepages, "1G");
+        assert_eq!(gpu.nv_switches.len(), 1);
+        assert_eq!(gpu.nv_switches[0].pci_address, "0000:03:00.0");
+        assert_eq!(gpu.fabric_manager_partition_id, 1);
+    }
+
+    /// Version-skew: an OLD controller's GPU intent (no topology fields, and
+    /// explicit nulls where Go emits nil slices) still parses with defaults.
+    #[test]
+    fn gpu_intent_old_controller_defaults() {
+        let json = r#"{
+            "guestId": "default/old",
+            "cpu": 2,
+            "memory": 2048,
+            "hypervisor": "qemu",
+            "seedPath": "",
+            "lifecycle": "start",
+            "network": false,
+            "rootDisk": {"format": "raw", "path": "/d.raw"},
+            "gpu": {"devices": null, "deviceSource": "env", "firmware": "cloudhv", "fabricManagerPartitionId": -1, "vcpuPinning": null, "nvSwitches": null}
+        }"#;
+        let intent: RuntimeIntent = serde_json::from_str(json).expect("old intent parses");
+        let gpu = intent.gpu.expect("gpu present");
+        assert!(gpu.numa.is_none());
+        assert!(gpu.vcpu_pinning.is_empty());
+        assert!(gpu.nv_switches.is_empty());
+        assert!(gpu.hugepages.is_empty());
     }
 }

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -7,7 +7,9 @@ use swift_ch_client::{
     spawn_ch, spawn_ch_receive, spawn_ch_restore, wait_for_socket, FsMount, GenericVhostUser,
     NICConfig, VFIODeviceConfig, VmConfig, VsockConfig,
 };
-use swift_qemu_client::{QemuConfig, QemuNICConfig, QemuProcess, QemuVFIODevice};
+use swift_qemu_client::{
+    QemuConfig, QemuNICConfig, QemuNUMANode, QemuProcess, QemuVCPUPin, QemuVFIODevice,
+};
 use swift_runtime::RuntimeDir;
 
 use crate::intent::{FilesystemIntent, RuntimeIntent};
@@ -514,18 +516,47 @@ where
     let (tap_name, mac, qemu_nics, mut vfio_devices) = build_qemu_nics(intent);
 
     // Add GPU VFIO devices from the GPU intent (resolved_devices: intent list
-    // for native, CDI-injected GPU_PCI_ADDRESSES env for DRA).
+    // for native, CDI-injected GPU_PCI_ADDRESSES env for DRA), then NVSwitches
+    // (Tier-3 hgx-full: the whole fabric moves into the guest). Tier-2/3 SXM
+    // devices carry pcie_root_port=true — QEMU places each behind its own
+    // root port (CUDA rejects a flat topology) — and no_mmap for large BARs.
+    let mut numa_nodes = vec![];
+    let mut hugepages = String::new();
+    let mut vcpu_pinning = vec![];
     if let Some(ref gpu) = intent.gpu {
-        for dev in &gpu.resolved_devices()? {
+        for dev in gpu.resolved_devices()?.iter().chain(gpu.nv_switches.iter()) {
             log::info!(
-                "gpu_device host={} root_port={}",
+                "gpu_device host={} root_port={} no_mmap={}",
                 dev.pci_address,
-                dev.pcie_root_port
+                dev.pcie_root_port,
+                dev.no_mmap
             );
             vfio_devices.push(QemuVFIODevice {
                 host_address: dev.pci_address.clone(),
+                pcie_root_port: dev.pcie_root_port,
+                no_mmap: dev.no_mmap,
             });
         }
+        if let Some(ref numa) = gpu.numa {
+            numa_nodes = numa
+                .nodes
+                .iter()
+                .map(|n| QemuNUMANode {
+                    id: n.id.max(0) as u32,
+                    cpus: n.cpus.clone(),
+                    memory_mib: n.memory_mi.max(0) as u64,
+                })
+                .collect();
+        }
+        hugepages = gpu.hugepages.clone();
+        vcpu_pinning = gpu
+            .vcpu_pinning
+            .iter()
+            .map(|p| QemuVCPUPin {
+                vcpu: p.vcpu,
+                host_cpu: p.host_cpu,
+            })
+            .collect();
     }
 
     let config = QemuConfig {
@@ -543,6 +574,9 @@ where
         serial_socket: serial_socket.clone(),
         qmp_socket: qmp_socket.clone(),
         data_disk_paths: intent.data_disk_paths(),
+        numa_nodes,
+        hugepages,
+        vcpu_pinning: vcpu_pinning.clone(),
     };
 
     let mut process = QemuProcess::spawn(&config)?;
@@ -551,6 +585,16 @@ where
 
     // Wait for QEMU to create the QMP socket (signals QEMU is ready to accept connections)
     wait_for_socket(&qmp_socket, Duration::from_secs(30))?;
+
+    // vCPU pinning is applied post-spawn (QEMU has no CLI for thread
+    // affinity). Best-effort: a missed pin degrades performance, never
+    // correctness — log loudly and keep the guest.
+    if !vcpu_pinning.is_empty() {
+        match process.apply_vcpu_pinning(&vcpu_pinning) {
+            Ok(n) => log::info!("vcpu_pinning_applied pins={}", n),
+            Err(e) => log::warn!("vcpu_pinning_failed err={}", e),
+        }
+    }
 
     if let Some(cb) = on_socket_ready {
         cb(pid, serial_socket_path.clone(), "qemu".to_string());
@@ -676,7 +720,13 @@ fn build_qemu_nics(
                     if let Some(addr) =
                         crate::intent::discover_sriov_vf_address(&dev.resource_name, sriov_idx)
                     {
-                        vfio_devs.push(QemuVFIODevice { host_address: addr });
+                        vfio_devs.push(QemuVFIODevice {
+                            host_address: addr,
+                            // SR-IOV VFs attach flat to pcie.0 (no SXM
+                            // root-port requirement, no large BARs).
+                            pcie_root_port: false,
+                            no_mmap: false,
+                        });
                         sriov_idx += 1;
                     } else {
                         log::error!(

--- a/test/gpu/verify-qemu-topology.sh
+++ b/test/gpu/verify-qemu-topology.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Boot-smoke the generated Tier-2/3 HGX QEMU topology WITHOUT GPU hardware.
+#
+# What it proves: qemu-system-x86_64 ACCEPTS AND REALIZES the exact machine the
+# swift-qemu-client builder emits — per-device pcie-root-port hierarchy (unique
+# chassis/slot), NUMA memory backends + bindings, SMP topology — by booting it
+# with emulated PCIe endpoints (e1000e) substituted on the SAME root ports.
+# What it does NOT prove: VFIO bind, BAR mapping, NVLink, Fabric Manager — those
+# need real HGX hardware (docs/design/gpu-testing-without-hardware.md).
+#
+# Drift-proof: the args come from `cargo run --example hgx_tier2_args`, i.e. the
+# real QemuConfig::to_args() output — never a hand-copied command line.
+#
+# Default runs against the SHIPPING QEMU inside the swiftletd image (docker,
+# needs /dev/kvm). Set QEMU=/path/to/qemu-system-x86_64 to run host-local.
+#
+# Lab tool (needs KVM + docker or a local qemu); not wired into CI.
+set -euo pipefail
+
+REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+IMAGE="${SWIFTLETD_IMAGE:-ghcr.io/kubeswift-io/kubeswift/swiftletd:v0.11.0}"
+WORK="$(mktemp -d /tmp/hgx-topology-smoke.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> generating topology args from the builder (cargo example)"
+(cd "$REPO_ROOT/rust" && cargo run -q -p swift-qemu-client --example hgx_tier2_args -- \
+  --dummy --run-dir /work) > "$WORK/args.txt"
+
+mapfile -t ARGS < "$WORK/args.txt"
+echo "    $(printf '%s ' "${ARGS[@]}" | head -c 400)..."
+
+# Sanity: the load-bearing topology args must be present before we bother booting.
+JOINED="$(printf '%s ' "${ARGS[@]}")"
+for want in \
+  "pcie-root-port,id=rp0,bus=pcie.0,chassis=1,slot=1" \
+  "pcie-root-port,id=rp3,bus=pcie.0,chassis=4,slot=4" \
+  "e1000e,bus=rp0" \
+  "node,nodeid=1,cpus=2-3,memdev=ram1" \
+  "4,sockets=2,cores=2,threads=1"; do
+  if ! grep -qF -- "$want" <<<"$JOINED"; then
+    echo "FAIL: expected arg missing: $want"
+    exit 1
+  fi
+done
+echo "==> topology args sane (4 root ports, NUMA bindings, SMP topology)"
+
+# The QMP driver script that runs NEXT TO qemu (inside the container or host):
+# boot frozen (-S: devices are realized before vCPUs start, so topology errors
+# abort at init), then over QMP: negotiate, query-status (expect prelaunch),
+# query-cpus-fast (SMP came up), quit.
+cat > "$WORK/drive.sh" <<'EOF'
+set -eu
+cd /work
+cp /usr/share/OVMF/OVMF_VARS.fd /work/OVMF_VARS.fd
+mapfile -t ARGS < /work/args.txt
+"${QEMU_BIN:-qemu-system-x86_64}" "${ARGS[@]}" -S &
+QPID=$!
+for i in $(seq 1 50); do [ -S /work/qmp.sock ] && break; sleep 0.2; done
+[ -S /work/qmp.sock ] || { echo "FAIL: QMP socket never appeared"; kill $QPID 2>/dev/null; exit 1; }
+OUT=$(printf '%s\n' \
+  '{"execute":"qmp_capabilities"}' \
+  '{"execute":"query-status"}' \
+  '{"execute":"query-cpus-fast"}' \
+  '{"execute":"quit"}' | socat -t 5 - UNIX-CONNECT:/work/qmp.sock)
+echo "$OUT" > /work/qmp.out
+wait $QPID 2>/dev/null || true
+grep -q '"status": *"prelaunch"' /work/qmp.out || { echo "FAIL: not prelaunch"; cat /work/qmp.out; exit 1; }
+CPUS=$(grep -o '"cpu-index"' /work/qmp.out | wc -l)
+[ "$CPUS" -eq 4 ] || { echo "FAIL: expected 4 vCPUs, saw $CPUS"; cat /work/qmp.out; exit 1; }
+echo "OK: machine realized (prelaunch), 4 vCPUs, topology accepted"
+EOF
+chmod +x "$WORK/drive.sh"
+
+if [ -n "${QEMU:-}" ]; then
+  echo "==> booting on host qemu: $QEMU"
+  ( export QEMU_BIN="$QEMU"; cd "$WORK" && sed "s#/work#$WORK#g" drive.sh > drive.local.sh && bash drive.local.sh )
+else
+  echo "==> booting on the shipping QEMU in $IMAGE"
+  docker run --rm --device /dev/kvm -v "$WORK:/work" --entrypoint bash "$IMAGE" /work/drive.sh
+fi
+
+echo "PASS: the generated Tier-2 HGX topology boots on QEMU (root ports + NUMA + SMP realized)"


### PR DESCRIPTION
## Summary

Part of the GPU roadmap ([#390](https://github.com/kubeswift-io/kubeswift/issues/390)) — the hardware-free half of closing the HGX gap. The Go controller has always computed the full Tier-2/3 GPU topology into the RuntimeIntent (`pcieRootPort`/`noMmap` per device, NUMA, vCPU pinning, hugepages, FM partition) — but the QEMU runtime **dropped all of it**, a documented "Phase 1 (disk boot only)" stub: every VFIO device was emitted flat as `-device vfio-pci,host=<bdf>` on `pcie.0`. A flat topology is exactly what the NVIDIA driver/CUDA reject on SXM parts (root-complex integrated endpoints — CUDA init error 3 in the field), so a Tier-2/3 guest on real HGX would boot and then fail CUDA.

## Grounding

- **NVIDIA HGX Shared NVSwitch GPU Passthrough Virtualization Integration Guide (WP-12736-002, rev 0.5 / 03-2026)** — shared mode passes GPUs only (fabric stays host/Service-VM managed via Fabric Manager; `fmpm -a` before passthrough, `-d` after shutdown); the standalone-QEMU sample uses `pcie-root-port` with explicit `chassis`/`slot`; guest images need `pci=realloc pci=nocrs` (OVMF discards devices whose BARs exceed its aperture).
- **QEMU docs/pcie.txt** — the `(chassis, slot)` pair is mandatory and must be unique per root port; devices plugged straight into `pcie.0` are Root Complex Integrated Endpoints ("guest OSes are suspected to behave strangely").
- **Field reports** (Ubicloud HGX B200): Cloud Hypervisor's flat topology fails CUDA init error 3; the fix is QEMU `pcie-root-port` + `vfio-pci,bus=rpN,x-no-mmap=true` (256 GiB BARs stall otherwise); host FM in Shared NVSwitch mode; exact host-FM ↔ guest-driver version match.

## What

- **swift-qemu-client** — per-device `pcie-root-port,id=rpN,bus=pcie.0,chassis=N+1,slot=N+1` + `vfio-pci,host=…,bus=rpN[,x-no-mmap=true]`; NUMA mode renders per-node shared memory backends (memfd, or hugepage file backends with `prealloc=on`) + `-numa node,cpus=…,memdev=…` (machine-level `memory-backend=` dropped there — invalid with `-numa memdev`; `-m` = node sum); `-smp` exposes `sockets=<node count>`. The flat/non-GPU arg shape is **byte-stable** (regression-tested — the cluster's hypervisor-override QEMU guests ride it).
- **vCPU pinning** — QEMU has no CLI for thread affinity (the libvirt model): `apply_vcpu_pinning` maps vCPU→thread id via QMP `query-cpus-fast` and `sched_setaffinity`s each thread post-spawn; swiftletd applies best-effort once QMP is up. Real setaffinity round-trip in tests.
- **swiftletd intent** — gains the fields Go emits but Rust dropped: `numa`, `vcpuPinning`, `hugepages`, `nvSwitches` (Tier-3), per-device `numaNode` — all serde-defaulted (version-skew tolerant) with wire-contract tests for both the new and old-controller shapes.

## Hardware-free validation

`make verify-qemu-topology` boots the builder's **exact** `to_args()` output (via the `hgx_tier2_args` example — drift-proof, never a hand-copied command) on the **shipping QEMU** in the swiftletd image, with `e1000e` endpoints substituted on the same root ports:

```
OK: machine realized (prelaunch), 4 vCPUs, topology accepted
PASS: the generated Tier-2 HGX topology boots on QEMU (root ports + NUMA + SMP realized)
```

Passed against `swiftletd:v0.11.0`. 26 swift-qemu-client tests + 119 swiftletd tests green; whole Rust workspace green.

## What this does NOT validate (honest scope)

VFIO bind, BAR mapping, NVLink/NVSwitch fabric, Fabric Manager — real-HGX-only. The follow-up PR adds a fake HGX `SwiftGPUNode` fixture + Go allocation/intent tests so the controller half is exercised end-to-end hardware-free too.