### PR TITLE
fix(gpu): couple shared-NVSwitch GPU selection to FM partition membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,22 @@ All notable changes to KubeSwift are documented here.
 
 ### Fixed
 
+- **Shared-NVSwitch GPU allocation now couples GPU selection to the Fabric
+  Manager partition membership.** Previously the allocator picked GPUs by NUMA
+  locality and an FM partition by count *independently* — but the NVSwitch
+  fabric only allows NVLink among the GPUs **within** the activated partition
+  (NVIDIA WP-12736-002), and FM physical IDs do not follow lspci order, so a
+  Tier-2 `hgx-shared` guest could receive one partition's GPUs while a
+  *different* partition was activated: no NVLink for that tenant and a fabric
+  cross-wired against the next one. The partition is now the unit of
+  allocation (`findAndAllocate`, the migration `ReserveOnNode` primitive, and
+  the `GPUNodeHasCapacity` pre-flight all select a free partition whose member
+  GPUs are all free and hand the guest exactly those members). Proven with a
+  hardware-faithful HGX H100 fixture built from the NVIDIA guide's real BDFs,
+  Module-ID mapping, and partition table — the mismatch reproduced verbatim on
+  the old code.
+
+
 - **Sandboxes without `spec.workingDir` panicked on kernel 6.6.10** (regression
   from v0.11.0's cold-path workingDir change). The bridge-initramfs runs `set -u`
   but only assigned `$WORKDIR` when a workingDir was set, so the no-workingDir case

--- a/internal/controller/swiftgpu/allocate.go
+++ b/internal/controller/swiftgpu/allocate.go
@@ -102,18 +102,28 @@ func (r *SwiftGPUReconciler) findAndAllocate(
 			continue
 		}
 
-		// Select GPUs, preferring same NUMA node for locality.
-		gpus, numa := selectGPUs(n.Status.GPUs, profile.Spec.Count, profile.Spec.Model)
-		if gpus == nil {
-			continue
-		}
-
-		// For shared partition mode, find an available Fabric Manager partition.
+		// Select GPUs. In shared partition mode the Fabric Manager partition is
+		// the unit of allocation: the NVSwitch fabric is programmed to allow
+		// NVLink among ONLY the GPUs within the activated partition (NVIDIA HGX
+		// Shared NVSwitch integration guide, WP-12736-002), so the guest MUST
+		// receive exactly that partition's member GPUs. Selecting GPUs by NUMA
+		// locality and a partition by count independently hands the guest GPUs
+		// the activated partition doesn't cover — no NVLink for this tenant,
+		// and a fabric cross-wired against another tenant's devices.
+		var gpus []gpuv1alpha1.GPUDevice
+		var numa []int
 		partID := -1
 		if profile.Spec.PartitionMode == "shared" {
-			partID, err = findFMPartition(n.Status.FabricManager, profile.Spec.Count)
-			if err != nil {
-				// Try the next node.
+			gpus, numa, partID = selectPartitionGPUs(n, profile.Spec.Count, profile.Spec.Model)
+			if gpus == nil {
+				// No free partition whose member GPUs are all free — try the
+				// next node.
+				continue
+			}
+		} else {
+			// No fabric constraint: prefer same-NUMA GPUs for locality.
+			gpus, numa = selectGPUs(n.Status.GPUs, profile.Spec.Count, profile.Spec.Model)
+			if gpus == nil {
 				continue
 			}
 		}
@@ -234,18 +244,59 @@ func selectGPUs(gpus []gpuv1alpha1.GPUDevice, count int, model string) (selected
 	return picked, numaSetToSlice(numaSet)
 }
 
-// findFMPartition returns the ID of an unallocated Fabric Manager partition
-// whose GPU count matches gpuCount.
-func findFMPartition(fm *gpuv1alpha1.FabricManagerStatus, gpuCount int) (int, error) {
+// selectPartitionGPUs picks a free Fabric Manager partition with exactly count
+// member GPUs whose members are ALL free (and match the optional model filter),
+// and returns those member devices — the partition is the unit of allocation
+// in shared NVSwitch mode. Partition GPUIndices reference GPUDevice.Index
+// (gpu-discovery owns mapping the FM physical/module IDs — which do NOT follow
+// lspci order, per nvidia-smi -q "Module ID" — onto the device inventory).
+// When several partitions qualify, one whose members share a single NUMA node
+// is preferred (locality, matching selectGPUs' preference). Returns nil when
+// no viable partition exists.
+func selectPartitionGPUs(
+	n *gpuv1alpha1.SwiftGPUNode,
+	count int,
+	model string,
+) (selected []gpuv1alpha1.GPUDevice, numaNodes []int, partitionID int) {
+	fm := n.Status.FabricManager
 	if fm == nil || !fm.Running {
-		return -1, fmt.Errorf("Fabric Manager is not running")
+		return nil, nil, -1
 	}
+	byIndex := map[int]gpuv1alpha1.GPUDevice{}
+	for _, g := range n.Status.GPUs {
+		byIndex[g.Index] = g
+	}
+
+	var fbGPUs []gpuv1alpha1.GPUDevice
+	var fbNUMA []int
+	fbPart := -1
 	for _, p := range fm.Partitions {
-		if len(p.GPUIndices) == gpuCount && p.AllocatedTo == "" {
-			return p.ID, nil
+		if len(p.GPUIndices) != count || p.AllocatedTo != "" {
+			continue
+		}
+		members := make([]gpuv1alpha1.GPUDevice, 0, count)
+		numaSet := map[int]bool{}
+		viable := true
+		for _, idx := range p.GPUIndices {
+			g, ok := byIndex[idx]
+			if !ok || g.Allocated || (model != "" && !strings.Contains(g.Model, model)) {
+				viable = false
+				break
+			}
+			members = append(members, g)
+			numaSet[g.NUMANode] = true
+		}
+		if !viable {
+			continue
+		}
+		if len(numaSet) == 1 {
+			return members, numaSetToSlice(numaSet), p.ID
+		}
+		if fbPart < 0 {
+			fbGPUs, fbNUMA, fbPart = members, numaSetToSlice(numaSet), p.ID
 		}
 	}
-	return -1, fmt.Errorf("no unallocated Fabric Manager partition for %d GPUs", gpuCount)
+	return fbGPUs, fbNUMA, fbPart
 }
 
 // countFreeGPUs recomputes the free GPU count from the allocation state.

--- a/internal/controller/swiftgpu/allocate_test.go
+++ b/internal/controller/swiftgpu/allocate_test.go
@@ -140,7 +140,18 @@ func TestSelectGPUs_ModelFilter_Match(t *testing.T) {
 	}
 }
 
-func TestFindFMPartition_Match(t *testing.T) {
+// partitionNode wraps an FM status in a minimal node whose GPU inventory
+// (indices 0-3, all free, one NUMA node) backs the partition membership.
+func partitionNode(fm *gpuv1alpha1.FabricManagerStatus) *gpuv1alpha1.SwiftGPUNode {
+	gpus := make([]gpuv1alpha1.GPUDevice, 4)
+	for i := range gpus {
+		gpus[i] = makeGPU(i, "0000:0"+string(rune('a'+i))+":00.0", "H200", 0, false, "")
+	}
+	n := testGPUNode("part-node", gpus, fm)
+	return n
+}
+
+func TestSelectPartitionGPUs_Match(t *testing.T) {
 	fm := &gpuv1alpha1.FabricManagerStatus{
 		Installed: true,
 		Version:   "580.95.05",
@@ -151,17 +162,16 @@ func TestFindFMPartition_Match(t *testing.T) {
 			{ID: 2, GPUIndices: []int{0, 1, 2, 3}, AllocatedTo: ""},
 		},
 	}
-
-	id, err := findFMPartition(fm, 4)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	gpus, _, id := selectPartitionGPUs(partitionNode(fm), 4, "")
 	if id != 2 {
 		t.Errorf("partition ID = %d, want 2", id)
 	}
+	if len(gpus) != 4 {
+		t.Errorf("got %d GPUs, want the partition's 4 members", len(gpus))
+	}
 }
 
-func TestFindFMPartition_NoMatch(t *testing.T) {
+func TestSelectPartitionGPUs_NoCountMatch(t *testing.T) {
 	fm := &gpuv1alpha1.FabricManagerStatus{
 		Installed: true,
 		Version:   "580.95.05",
@@ -171,14 +181,12 @@ func TestFindFMPartition_NoMatch(t *testing.T) {
 			{ID: 1, GPUIndices: []int{2, 3}, AllocatedTo: ""},
 		},
 	}
-
-	_, err := findFMPartition(fm, 8)
-	if err == nil {
-		t.Error("expected error when no partition matches GPU count")
+	if gpus, _, _ := selectPartitionGPUs(partitionNode(fm), 8, ""); gpus != nil {
+		t.Error("expected nil when no partition matches GPU count")
 	}
 }
 
-func TestFindFMPartition_AlreadyAllocated(t *testing.T) {
+func TestSelectPartitionGPUs_AlreadyAllocated(t *testing.T) {
 	fm := &gpuv1alpha1.FabricManagerStatus{
 		Installed: true,
 		Version:   "580.95.05",
@@ -187,14 +195,12 @@ func TestFindFMPartition_AlreadyAllocated(t *testing.T) {
 			{ID: 0, GPUIndices: []int{0, 1, 2, 3}, AllocatedTo: "default/other-guest"},
 		},
 	}
-
-	_, err := findFMPartition(fm, 4)
-	if err == nil {
-		t.Error("expected error when matching partition is already allocated")
+	if gpus, _, _ := selectPartitionGPUs(partitionNode(fm), 4, ""); gpus != nil {
+		t.Error("expected nil when matching partition is already allocated")
 	}
 }
 
-func TestFindFMPartition_FMNotRunning(t *testing.T) {
+func TestSelectPartitionGPUs_FMNotRunning(t *testing.T) {
 	fm := &gpuv1alpha1.FabricManagerStatus{
 		Installed: true,
 		Version:   "580.95.05",
@@ -203,10 +209,32 @@ func TestFindFMPartition_FMNotRunning(t *testing.T) {
 			{ID: 0, GPUIndices: []int{0, 1, 2, 3}, AllocatedTo: ""},
 		},
 	}
+	if gpus, _, _ := selectPartitionGPUs(partitionNode(fm), 4, ""); gpus != nil {
+		t.Error("expected nil when Fabric Manager is not running")
+	}
+}
 
-	_, err := findFMPartition(fm, 4)
-	if err == nil {
-		t.Error("expected error when Fabric Manager is not running")
+func TestSelectPartitionGPUs_MemberHeld(t *testing.T) {
+	// A count-matching FREE partition whose MEMBER is held must be skipped —
+	// the count-only check this replaces got that wrong.
+	fm := &gpuv1alpha1.FabricManagerStatus{
+		Installed: true,
+		Version:   "580.95.05",
+		Running:   true,
+		Partitions: []gpuv1alpha1.FMPartitionStatus{
+			{ID: 0, GPUIndices: []int{0, 1}, AllocatedTo: ""},
+			{ID: 1, GPUIndices: []int{2, 3}, AllocatedTo: ""},
+		},
+	}
+	n := partitionNode(fm)
+	n.Status.GPUs[0].Allocated = true
+	n.Status.GPUs[0].AllocatedTo = "default/other"
+	gpus, _, id := selectPartitionGPUs(n, 2, "")
+	if id != 1 {
+		t.Errorf("must skip partition 0 (member held) and pick 1, got %d", id)
+	}
+	if len(gpus) != 2 || gpus[0].Index != 2 {
+		t.Errorf("must return partition 1's members, got %+v", gpus)
 	}
 }
 

--- a/internal/controller/swiftgpu/hgx_fixture_test.go
+++ b/internal/controller/swiftgpu/hgx_fixture_test.go
@@ -1,0 +1,345 @@
+package swiftgpu
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gpuv1alpha1 "github.com/kubeswift-io/kubeswift/api/gpu/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/scheme"
+)
+
+// hgxH100Node is a hardware-faithful 8-GPU HGX H100/H200 SwiftGPUNode fixture,
+// taken verbatim from the NVIDIA HGX Shared NVSwitch GPU Passthrough
+// Virtualization Integration Guide (WP-12736-002):
+//
+//   - GPU BDFs (lspci): 0f, 10, 41, 44, 86, 87, b8, bb :00.0 — device 10de:2330.
+//     Device Index follows lspci order (what gpu-discovery produces).
+//   - NVSwitch BDFs: 03, 04, 05, 06 :00.0 — device 10de:22a3.
+//   - The Fabric Manager partition table is the guide's real fmpm -l output:
+//     partition 0 = all 8 GPUs, 1–2 = 4-GPU halves, 3–6 = pairs, 7–14 = singles.
+//   - CRITICALLY, FM partitions reference GPU *physical IDs* (nvidia-smi -q
+//     "Module ID"), which do NOT follow lspci order. The guide's mapping:
+//     0f→5, 10→7, 41→6, 44→8, 86→1, 87→3, b8→2, bb→4. GPUIndices below carry
+//     that mapping translated into device-Index space — which is exactly what
+//     makes an uncoupled "pick GPUs by NUMA, pick a partition by count"
+//     allocation hand a guest GPUs the activated partition doesn't cover.
+//
+// NUMA: the first four GPUs by lspci order (0f,10,41,44) sit on socket 0, the
+// rest on socket 1 (the standard dual-socket HGX split).
+func hgxH100Node(name string) *gpuv1alpha1.SwiftGPUNode {
+	gpu := func(idx int, bdf string, numa int) gpuv1alpha1.GPUDevice {
+		return gpuv1alpha1.GPUDevice{
+			Index:      idx,
+			PCIAddress: bdf,
+			Model:      "H100-SXM",
+			DeviceID:   "10de:2330",
+			NUMANode:   numa,
+			IOMMUGroup: 10 + idx,
+			Driver:     "vfio-pci",
+			BARSizes:   []gpuv1alpha1.BARSize{{Region: 1, SizeMi: 131072}},
+		}
+	}
+	// physicalId (Module ID) → device Index, per the guide's nvidia-smi -q map.
+	phys := map[int]int{1: 4, 2: 6, 3: 5, 4: 7, 5: 0, 6: 2, 7: 1, 8: 3}
+	part := func(id int, physIDs ...int) gpuv1alpha1.FMPartitionStatus {
+		idx := make([]int, 0, len(physIDs))
+		for _, p := range physIDs {
+			idx = append(idx, phys[p])
+		}
+		return gpuv1alpha1.FMPartitionStatus{ID: id, GPUIndices: idx}
+	}
+	return &gpuv1alpha1.SwiftGPUNode{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: gpuv1alpha1.SwiftGPUNodeStatus{
+			Phase:     "Ready",
+			GPUCount:  8,
+			FreeGPUs:  8,
+			GPUModel:  "H100-SXM",
+			VfioReady: true,
+			Host: gpuv1alpha1.HostTopology{
+				CPUTopology: gpuv1alpha1.CPUTopologyInfo{
+					Sockets: 2, CoresPerSocket: 56, ThreadsPerCore: 2, TotalCPUs: 224,
+				},
+				NUMANodes: []gpuv1alpha1.NUMANodeInfo{
+					{ID: 0, CPUs: "0-55,112-167", MemoryMi: 1048576},
+					{ID: 1, CPUs: "56-111,168-223", MemoryMi: 1048576},
+				},
+				IOMMUEnabled: true,
+				Hugepages1Gi: gpuv1alpha1.HugepageInfo{Total: 1800, Free: 1800},
+			},
+			GPUs: []gpuv1alpha1.GPUDevice{
+				gpu(0, "0000:0f:00.0", 0),
+				gpu(1, "0000:10:00.0", 0),
+				gpu(2, "0000:41:00.0", 0),
+				gpu(3, "0000:44:00.0", 0),
+				gpu(4, "0000:86:00.0", 1),
+				gpu(5, "0000:87:00.0", 1),
+				gpu(6, "0000:b8:00.0", 1),
+				gpu(7, "0000:bb:00.0", 1),
+			},
+			NVSwitches: []gpuv1alpha1.NVSwitchDevice{
+				{PCIAddress: "0000:03:00.0", DeviceID: "10de:22a3", NUMANode: 0},
+				{PCIAddress: "0000:04:00.0", DeviceID: "10de:22a3", NUMANode: 0},
+				{PCIAddress: "0000:05:00.0", DeviceID: "10de:22a3", NUMANode: 0},
+				{PCIAddress: "0000:06:00.0", DeviceID: "10de:22a3", NUMANode: 0},
+			},
+			FabricManager: &gpuv1alpha1.FabricManagerStatus{
+				Installed: true,
+				Version:   "550.163.01",
+				Running:   true,
+				Partitions: []gpuv1alpha1.FMPartitionStatus{
+					part(0, 1, 2, 3, 4, 5, 6, 7, 8),
+					part(1, 1, 2, 3, 4),
+					part(2, 5, 6, 7, 8),
+					part(3, 1, 3),
+					part(4, 2, 4),
+					part(5, 5, 7),
+					part(6, 6, 8),
+					part(7, 1), part(8, 2), part(9, 3), part(10, 4),
+					part(11, 5), part(12, 6), part(13, 7), part(14, 8),
+				},
+			},
+		},
+	}
+}
+
+// partitionMembers returns the PCI addresses of a partition's member devices.
+func partitionMembers(n *gpuv1alpha1.SwiftGPUNode, partID int) map[string]bool {
+	byIndex := map[int]string{}
+	for _, g := range n.Status.GPUs {
+		byIndex[g.Index] = g.PCIAddress
+	}
+	out := map[string]bool{}
+	for _, p := range n.Status.FabricManager.Partitions {
+		if p.ID == partID {
+			for _, idx := range p.GPUIndices {
+				out[byIndex[idx]] = true
+			}
+		}
+	}
+	return out
+}
+
+// The load-bearing shared-NVSwitch invariant (NVIDIA WP-12736-002: the fabric
+// allows NVLink among ONLY the GPUs within the activated partition, and the
+// admin passes through the GPUs WITHIN that partition): the devices an
+// allocation returns must be exactly the returned partition's members. With
+// the guide's real Module-ID mapping, an uncoupled NUMA-first GPU pick +
+// count-first partition pick hands the guest partition 2's GPUs while
+// activating partition 1 — no NVLink for this tenant, and a fabric
+// cross-wired against the next one.
+func TestFindAndAllocate_HGXShared_PartitionMembershipCoupled(t *testing.T) {
+	node := hgxH100Node("hgx-0")
+	guest := testSwiftGuest("g1", "default", &corev1.LocalObjectReference{Name: "hgx4"})
+	profile := testGPUProfile("hgx4", "default", "hgx-shared", "", 4, "shared")
+
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node, guest, profile).
+		WithStatusSubresource(node, guest).
+		Build()
+	r := &SwiftGPUReconciler{Client: c, Scheme: scheme.Scheme}
+
+	_, gpus, numa, partID, err := r.findAndAllocate(context.Background(), guest, profile)
+	if err != nil {
+		t.Fatalf("findAndAllocate: %v", err)
+	}
+	if partID < 0 {
+		t.Fatalf("shared mode must select an FM partition, got %d", partID)
+	}
+	members := partitionMembers(node, partID)
+	if len(gpus) != 4 {
+		t.Fatalf("got %d GPUs, want 4", len(gpus))
+	}
+	for _, g := range gpus {
+		if !members[g.PCIAddress] {
+			t.Errorf("allocated GPU %s is NOT a member of activated partition %d %v — the guest would have no NVLink to it",
+				g.PCIAddress, partID, members)
+		}
+	}
+	// The guide's 4-GPU partitions are single-NUMA halves; the derived NUMA
+	// set must reflect the members, not an independent NUMA-first pick.
+	if len(numa) != 1 {
+		t.Errorf("partition members are one NUMA node, got numa=%v", numa)
+	}
+}
+
+// Two 4-GPU guests must land on the two disjoint 4-GPU partitions, each
+// receiving exactly its partition's members; a third finds no capacity.
+func TestFindAndAllocate_HGXShared_TwoTenantsDisjoint(t *testing.T) {
+	node := hgxH100Node("hgx-0")
+	g1 := testSwiftGuest("g1", "default", &corev1.LocalObjectReference{Name: "hgx4"})
+	g2 := testSwiftGuest("g2", "default", &corev1.LocalObjectReference{Name: "hgx4"})
+	g3 := testSwiftGuest("g3", "default", &corev1.LocalObjectReference{Name: "hgx4"})
+	profile := testGPUProfile("hgx4", "default", "hgx-shared", "", 4, "shared")
+
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node, g1, g2, g3, profile).
+		WithStatusSubresource(node, g1, g2, g3).
+		Build()
+	r := &SwiftGPUReconciler{Client: c, Scheme: scheme.Scheme}
+	ctx := context.Background()
+
+	_, gpus1, _, part1, err := r.findAndAllocate(ctx, g1, profile)
+	if err != nil {
+		t.Fatalf("g1: %v", err)
+	}
+	_, gpus2, _, part2, err := r.findAndAllocate(ctx, g2, profile)
+	if err != nil {
+		t.Fatalf("g2: %v", err)
+	}
+	if part1 == part2 {
+		t.Fatalf("both guests got partition %d", part1)
+	}
+	seen := map[string]bool{}
+	for _, g := range gpus1 {
+		seen[g.PCIAddress] = true
+	}
+	for _, g := range gpus2 {
+		if seen[g.PCIAddress] {
+			t.Errorf("GPU %s allocated to both guests", g.PCIAddress)
+		}
+	}
+	// Each set must equal its own partition's membership.
+	var updated gpuv1alpha1.SwiftGPUNode
+	if err := c.Get(ctx, client.ObjectKey{Name: "hgx-0"}, &updated); err != nil {
+		t.Fatal(err)
+	}
+	for _, pair := range []struct {
+		gpus []gpuv1alpha1.GPUDevice
+		part int
+	}{{gpus1, part1}, {gpus2, part2}} {
+		members := partitionMembers(&updated, pair.part)
+		for _, g := range pair.gpus {
+			if !members[g.PCIAddress] {
+				t.Errorf("GPU %s outside its partition %d", g.PCIAddress, pair.part)
+			}
+		}
+	}
+	if updated.Status.FreeGPUs != 0 {
+		t.Errorf("freeGPUs = %d, want 0", updated.Status.FreeGPUs)
+	}
+
+	if _, _, _, _, err := r.findAndAllocate(ctx, g3, profile); err == nil {
+		t.Error("third 4-GPU tenant must fail: no free partition with free members")
+	}
+}
+
+// A COUNT-matching free partition whose members are (partially) held must be
+// skipped in favor of one whose members are all free — the case a count-only
+// partition pick gets wrong (it would activate a partition overlapping another
+// tenant's devices).
+func TestFindAndAllocate_HGXShared_SkipsPartitionWithHeldMembers(t *testing.T) {
+	node := hgxH100Node("hgx-0")
+	// Hold ONE member of partition 1 (physicalId 1 → index 4 → 0000:86:00.0)
+	// for another guest, without touching partition records.
+	for j := range node.Status.GPUs {
+		if node.Status.GPUs[j].Index == 4 {
+			node.Status.GPUs[j].Allocated = true
+			node.Status.GPUs[j].AllocatedTo = "default/other"
+		}
+	}
+	node.Status.FreeGPUs = 7
+
+	guest := testSwiftGuest("g1", "default", &corev1.LocalObjectReference{Name: "hgx4"})
+	profile := testGPUProfile("hgx4", "default", "hgx-shared", "", 4, "shared")
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node, guest, profile).
+		WithStatusSubresource(node, guest).
+		Build()
+	r := &SwiftGPUReconciler{Client: c, Scheme: scheme.Scheme}
+
+	_, gpus, _, partID, err := r.findAndAllocate(context.Background(), guest, profile)
+	if err != nil {
+		t.Fatalf("findAndAllocate: %v", err)
+	}
+	if partID != 2 {
+		t.Fatalf("must skip partition 1 (member held) and select partition 2, got %d", partID)
+	}
+	members := partitionMembers(node, 2)
+	for _, g := range gpus {
+		if !members[g.PCIAddress] {
+			t.Errorf("GPU %s not in partition 2 %v", g.PCIAddress, members)
+		}
+	}
+}
+
+// The whole-baseboard (Tier-3-shaped) 8-GPU partition allocates all devices.
+func TestFindAndAllocate_HGXShared_FullBaseboard(t *testing.T) {
+	node := hgxH100Node("hgx-0")
+	guest := testSwiftGuest("g1", "default", &corev1.LocalObjectReference{Name: "hgx8"})
+	profile := testGPUProfile("hgx8", "default", "hgx-shared", "", 8, "shared")
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node, guest, profile).
+		WithStatusSubresource(node, guest).
+		Build()
+	r := &SwiftGPUReconciler{Client: c, Scheme: scheme.Scheme}
+
+	_, gpus, numa, partID, err := r.findAndAllocate(context.Background(), guest, profile)
+	if err != nil {
+		t.Fatalf("findAndAllocate: %v", err)
+	}
+	if partID != 0 || len(gpus) != 8 {
+		t.Fatalf("want partition 0 with 8 GPUs, got partition %d with %d", partID, len(gpus))
+	}
+	if len(numa) != 2 {
+		t.Errorf("8 GPUs span both NUMA nodes, got %v", numa)
+	}
+}
+
+// ReserveOnNode (the migration reserve-before-stop primitive) must apply the
+// same partition-membership coupling as findAndAllocate.
+func TestReserveOnNode_HGXShared_PartitionMembershipCoupled(t *testing.T) {
+	node := hgxH100Node("hgx-target")
+	guest := testSwiftGuest("g1", "default", &corev1.LocalObjectReference{Name: "hgx4"})
+	profile := testGPUProfile("hgx4", "default", "hgx-shared", "", 4, "shared")
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node, guest, profile).
+		WithStatusSubresource(node, guest).
+		Build()
+
+	gpus, _, partID, err := ReserveOnNode(context.Background(), c, guest, profile, "hgx-target")
+	if err != nil {
+		t.Fatalf("ReserveOnNode: %v", err)
+	}
+	members := partitionMembers(node, partID)
+	for _, g := range gpus {
+		if !members[g.PCIAddress] {
+			t.Errorf("reserved GPU %s outside activated partition %d", g.PCIAddress, partID)
+		}
+	}
+}
+
+// GPUNodeHasCapacity must agree with the selection: enough FREE GPUs by count
+// is NOT capacity when every count-matching partition has a held member.
+func TestGPUNodeHasCapacity_HGXShared_HeldMembersFail(t *testing.T) {
+	node := hgxH100Node("hgx-0")
+	// Hold one member of EACH 4-GPU partition (indices 4 and 0) for others:
+	// 6 GPUs remain free (>= 4), but no viable 4-GPU partition exists.
+	for j := range node.Status.GPUs {
+		if node.Status.GPUs[j].Index == 4 || node.Status.GPUs[j].Index == 0 {
+			node.Status.GPUs[j].Allocated = true
+			node.Status.GPUs[j].AllocatedTo = "default/other"
+		}
+	}
+	node.Status.FreeGPUs = 6
+
+	profile := testGPUProfile("hgx4", "default", "hgx-shared", "", 4, "shared")
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node).
+		WithStatusSubresource(node).
+		Build()
+
+	if err := GPUNodeHasCapacity(context.Background(), c, "hgx-0", profile); err == nil {
+		t.Error("capacity check must fail: 6 free GPUs but no 4-GPU partition with all members free")
+	}
+	// A pair is still viable: partition 4 ({2,4}→indices 6,7) has free members.
+	pair := testGPUProfile("hgx2", "default", "hgx-shared", "", 2, "shared")
+	if err := GPUNodeHasCapacity(context.Background(), c, "hgx-0", pair); err != nil {
+		t.Errorf("2-GPU capacity should pass (partition with free members exists): %v", err)
+	}
+}

--- a/internal/controller/swiftgpu/preflight.go
+++ b/internal/controller/swiftgpu/preflight.go
@@ -42,8 +42,12 @@ func GPUNodeHasCapacity(ctx context.Context, c client.Client, nodeName string, p
 		return fmt.Errorf("GPU node %q model %q does not match profile model %q", nodeName, node.Status.GPUModel, profile.Spec.Model)
 	}
 	if profile.Spec.PartitionMode == "shared" {
-		if _, err := findFMPartition(node.Status.FabricManager, profile.Spec.Count); err != nil {
-			return fmt.Errorf("GPU node %q has no free Fabric Manager partition for %d GPU(s): %w", nodeName, profile.Spec.Count, err)
+		// Match the reserve/allocate selection exactly: a viable partition is
+		// one whose MEMBER GPUs are all free (a free partition whose members
+		// are held by another allocation would pass a count-only check here
+		// and then fail at reserve).
+		if gpus, _, _ := selectPartitionGPUs(&node, profile.Spec.Count, profile.Spec.Model); gpus == nil {
+			return fmt.Errorf("GPU node %q has no free Fabric Manager partition with %d free matching GPU(s)", nodeName, profile.Spec.Count)
 		}
 	}
 	return nil

--- a/internal/controller/swiftgpu/primitives.go
+++ b/internal/controller/swiftgpu/primitives.go
@@ -70,16 +70,22 @@ func ReserveOnNode(ctx context.Context, c client.Client, guest *swiftv1alpha1.Sw
 		return nil, nil, -1, fmt.Errorf("GPU node %q model %q does not match profile model %q", nodeName, node.Status.GPUModel, profile.Spec.Model)
 	}
 
-	gpus, numa := selectGPUs(node.Status.GPUs, profile.Spec.Count, profile.Spec.Model)
-	if gpus == nil {
-		return nil, nil, -1, fmt.Errorf("GPU node %q could not select %d matching GPU(s)", nodeName, profile.Spec.Count)
-	}
-
+	// Shared partition mode: the FM partition is the unit of allocation — the
+	// guest must receive exactly the chosen partition's member GPUs (the
+	// NVSwitch fabric only allows NVLink within the activated partition). Same
+	// coupling as findAndAllocate's selection.
+	var gpus []gpuv1alpha1.GPUDevice
+	var numa []int
 	partID := -1
 	if profile.Spec.PartitionMode == "shared" {
-		partID, err = findFMPartition(node.Status.FabricManager, profile.Spec.Count)
-		if err != nil {
-			return nil, nil, -1, fmt.Errorf("GPU node %q: no free FM partition for %d GPU(s): %w", nodeName, profile.Spec.Count, err)
+		gpus, numa, partID = selectPartitionGPUs(&node, profile.Spec.Count, profile.Spec.Model)
+		if gpus == nil {
+			return nil, nil, -1, fmt.Errorf("GPU node %q: no free FM partition with %d free matching GPU(s)", nodeName, profile.Spec.Count)
+		}
+	} else {
+		gpus, numa = selectGPUs(node.Status.GPUs, profile.Spec.Count, profile.Spec.Model)
+		if gpus == nil {
+			return nil, nil, -1, fmt.Errorf("GPU node %q could not select %d matching GPU(s)", nodeName, profile.Spec.Count)
 		}
 	}
 

--- a/internal/controller/swiftguest/gpu_test.go
+++ b/internal/controller/swiftguest/gpu_test.go
@@ -15,6 +15,7 @@ import (
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/resolved"
 	"github.com/kubeswift-io/kubeswift/internal/runtimeintent"
+	kscheme "github.com/kubeswift-io/kubeswift/internal/scheme"
 )
 
 func gpuGuest(nodeName string, devices []string, partitionID int) *swiftv1alpha1.SwiftGuest {
@@ -687,5 +688,129 @@ func TestBuildPodDispatcher_GPUOnlyNoMigrationNodeName(t *testing.T) {
 	}
 	if pod.Spec.NodeSelector["kubernetes.io/hostname"] != "miles" {
 		t.Errorf("GPU pod NodeSelector hostname = %q, want miles", pod.Spec.NodeSelector["kubernetes.io/hostname"])
+	}
+}
+
+// TestBuildGPUIntent_HGXSharedTier2 exercises the FULL Tier-2 intent assembly
+// against a hardware-faithful HGX H100 node (real BDFs + the dual-socket NUMA
+// split from the NVIDIA WP-12736-002 integration guide): every SXM device
+// behind a pcie-root-port with x-no-mmap, per-device NUMA affinity looked up
+// from the node inventory, OVMF firmware, 1G hugepages, the FM partition id,
+// and the virtual-NUMA + vCPU-pinning layout. This is the allocation→intent
+// boundary a real HGX box would otherwise be the first to test.
+func TestBuildGPUIntent_HGXSharedTier2(t *testing.T) {
+	profile := &gpuv1alpha1.SwiftGPUProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "hgx4", Namespace: "default"},
+		Spec: gpuv1alpha1.SwiftGPUProfileSpec{
+			Count:         4,
+			Tier:          "hgx-shared",
+			PartitionMode: "shared",
+			PCIeTopology: &gpuv1alpha1.PCIeTopologySpec{
+				RootPortPerDevice: true,
+				NoMmap:            true,
+			},
+			NUMATopology: &gpuv1alpha1.NUMATopologySpec{
+				Sockets:           2,
+				CoresPerSocket:    20,
+				ThreadsPerCore:    1,
+				MemoryPerSocketMi: 491520,
+			},
+			Hugepages:   "1Gi",
+			VCPUPinning: true,
+			FabricManager: &gpuv1alpha1.FabricManagerSpec{
+				RequiredVersion: "550.163.01",
+			},
+		},
+	}
+	// The allocation the SwiftGPU controller produced: partition 1's members
+	// (physicalIds 1-4 → BDFs 86/87/b8/bb, ALL on NUMA 1 — the guide's real
+	// Module-ID mapping).
+	node := &gpuv1alpha1.SwiftGPUNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "hgx-0"},
+		Status: gpuv1alpha1.SwiftGPUNodeStatus{
+			GPUModel: "H100-SXM",
+			Host: gpuv1alpha1.HostTopology{
+				NUMANodes: []gpuv1alpha1.NUMANodeInfo{
+					{ID: 0, CPUs: "0-55,112-167", MemoryMi: 1048576},
+					{ID: 1, CPUs: "56-111,168-223", MemoryMi: 1048576},
+				},
+			},
+			GPUs: []gpuv1alpha1.GPUDevice{
+				{Index: 0, PCIAddress: "0000:0f:00.0", Model: "H100-SXM", NUMANode: 0},
+				{Index: 1, PCIAddress: "0000:10:00.0", Model: "H100-SXM", NUMANode: 0},
+				{Index: 2, PCIAddress: "0000:41:00.0", Model: "H100-SXM", NUMANode: 0},
+				{Index: 3, PCIAddress: "0000:44:00.0", Model: "H100-SXM", NUMANode: 0},
+				{Index: 4, PCIAddress: "0000:86:00.0", Model: "H100-SXM", NUMANode: 1},
+				{Index: 5, PCIAddress: "0000:87:00.0", Model: "H100-SXM", NUMANode: 1},
+				{Index: 6, PCIAddress: "0000:b8:00.0", Model: "H100-SXM", NUMANode: 1},
+				{Index: 7, PCIAddress: "0000:bb:00.0", Model: "H100-SXM", NUMANode: 1},
+			},
+			FabricManager: &gpuv1alpha1.FabricManagerStatus{
+				Installed: true, Version: "550.163.01", Running: true,
+				Partitions: []gpuv1alpha1.FMPartitionStatus{
+					{ID: 1, GPUIndices: []int{4, 6, 5, 7}, AllocatedTo: "default/hgx-guest"},
+				},
+			},
+		},
+	}
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "hgx-guest", Namespace: "default"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			GPUProfileRef: &corev1.LocalObjectReference{Name: "hgx4"},
+		},
+		Status: swiftv1alpha1.SwiftGuestStatus{
+			GPU: &swiftv1alpha1.GPUStatus{
+				Devices:     []string{"0000:86:00.0", "0000:87:00.0", "0000:b8:00.0", "0000:bb:00.0"},
+				PartitionID: 1,
+				NUMANodes:   []int{1},
+				Hypervisor:  "qemu",
+				NodeName:    "hgx-0",
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(kscheme.Scheme).
+		WithObjects(profile, node, guest).
+		Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: kscheme.Scheme}
+
+	gi, err := r.buildGPUIntent(context.Background(), guest)
+	if err != nil {
+		t.Fatalf("buildGPUIntent: %v", err)
+	}
+	if gi.Firmware != "ovmf" {
+		t.Errorf("firmware = %q, want ovmf (QEMU Tier-2)", gi.Firmware)
+	}
+	if gi.Hugepages != "1G" {
+		t.Errorf("hugepages = %q, want 1G (normalized from 1Gi)", gi.Hugepages)
+	}
+	if gi.FabricManagerPartitionID != 1 {
+		t.Errorf("fmPartition = %d, want 1", gi.FabricManagerPartitionID)
+	}
+	if len(gi.Devices) != 4 {
+		t.Fatalf("devices = %d, want 4", len(gi.Devices))
+	}
+	for _, d := range gi.Devices {
+		if !d.PCIeRootPort {
+			t.Errorf("device %s must be behind a pcie-root-port (SXM: CUDA rejects flat)", d.PCIAddress)
+		}
+		if !d.NoMmap {
+			t.Errorf("device %s must carry noMmap (large BARs)", d.PCIAddress)
+		}
+		if d.NUMANode != 1 {
+			t.Errorf("device %s numaNode = %d, want 1 (from the node inventory)", d.PCIAddress, d.NUMANode)
+		}
+		if d.HostPath != "/sys/bus/pci/devices/"+d.PCIAddress+"/" {
+			t.Errorf("device hostPath = %q", d.HostPath)
+		}
+	}
+	if gi.NUMA == nil || len(gi.NUMA.Nodes) != 2 {
+		t.Fatalf("virtual NUMA layout missing: %+v", gi.NUMA)
+	}
+	if gi.NUMA.Nodes[0].MemoryMi != 491520 {
+		t.Errorf("numa node 0 memoryMi = %d", gi.NUMA.Nodes[0].MemoryMi)
+	}
+	if len(gi.VCPUPinning) == 0 {
+		t.Error("vcpuPinning must be computed (profile.vcpuPinning=true)")
 	}
 }


### PR DESCRIPTION
## Summary

The second half of the hardware-free HGX validation program ([#390](https://github.com/kubeswift-io/kubeswift/issues/390); runtime half in #404) — and it caught a **real Tier-2 allocation bug**.

In `shared` partition mode the allocator picked GPUs by NUMA locality (`selectGPUs`) and a Fabric Manager partition by count (`findFMPartition`) **independently**. Per the NVIDIA HGX Shared NVSwitch integration guide (WP-12736-002), the NVSwitch fabric allows NVLink among **only the GPUs within the activated partition**, and the admin passes through *the GPUs within that partition* — and FM physical IDs (`nvidia-smi -q` "Module ID") do **not** follow lspci order. With the guide's real Module-ID mapping, the very first 4-GPU allocation hands the guest partition 2's GPUs (`0f/10/41/44`) while activating partition **1** (`86/87/b8/bb`):

```
--- FAIL: TestFindAndAllocate_HGXShared_PartitionMembershipCoupled
    allocated GPU 0000:0f:00.0 is NOT a member of activated partition 1
    map[0000:86:00.0 0000:87:00.0 0000:b8:00.0 0000:bb:00.0] — the guest would have no NVLink to it
```

No NVLink for that tenant, and a fabric cross-wired against the next one — a silent real-HGX failure, caught hardware-free.

## Fix

The **partition is the unit of allocation**: `selectPartitionGPUs` picks a free partition with exactly `count` members whose member GPUs are **all free** (+ model filter) and hands the guest exactly those members (NUMA derived from them; single-NUMA partitions preferred). Wired into all three selection sites so they agree:

- `findAndAllocate` (the SwiftGPU controller),
- `ReserveOnNode` (the migration reserve-before-stop primitive — same bug),
- `GPUNodeHasCapacity` (the pre-flight — a count-only check passed nodes whose count-matching partitions had held members; reserve would then fail).

`findFMPartition` is superseded and removed; its tests retarget `selectPartitionGPUs` (incl. a new held-member case).

## The fixture (reusable for all future Tier-2/3 work)

`hgxH100Node()` — a hardware-faithful 8-GPU HGX H100 `SwiftGPUNode` built **verbatim from the NVIDIA guide**: real GPU BDFs (`0f/10/41/44/86/87/b8/bb`, `10de:2330`), NVSwitches (`03–06`, `10de:22a3`), the guide's real `fmpm -l` partition table (1×8, 2×4, 4×2, 8×1) and its Module-ID→BDF mapping (the non-obvious bit that makes the bug fire).

Tests: membership coupling (verified **load-bearing** — fails on the pre-fix code via stash/restore), two-tenant disjointness + third-tenant rejection, held-member partition skipping, whole-baseboard 8-GPU, `ReserveOnNode` coupling, capacity-check agreement, and `TestBuildGPUIntent_HGXSharedTier2` locking the full allocation→intent boundary (root ports, `noMmap`, per-device NUMA from inventory, `ovmf`, hugepages `1Gi`→`1G`, FM id, virtual NUMA + pinning) that previously had no coverage above isolated unit helpers.

## Note for real hardware

gpu-discovery must populate `FMPartitionStatus.GPUIndices` with the Module-ID→BDF mapping (`nvidia-smi -q`, guide §5.3) — the controller contract is device-Index space; noted in the `selectPartitionGPUs` docstring.