### PR TITLE
fix(gpu): translate FM partition Module IDs to device indices in discovery

### DIFF
--- a/cmd/gpu-discovery/discover.go
+++ b/cmd/gpu-discovery/discover.go
@@ -405,7 +405,7 @@ func parseNVSwitchesFromLspci(output string) ([]gpuv1alpha1.NVSwitchDevice, erro
 
 // --- Fabric Manager Discovery ---
 
-func discoverFabricManager() (*gpuv1alpha1.FabricManagerStatus, error) {
+func discoverFabricManager(moduleToIndex map[int]int) (*gpuv1alpha1.FabricManagerStatus, error) {
 	fmpmPath, err := exec.LookPath("fmpm")
 	if err != nil {
 		return nil, fmt.Errorf("fmpm not in PATH")
@@ -432,19 +432,44 @@ func discoverFabricManager() (*gpuv1alpha1.FabricManagerStatus, error) {
 	if err != nil {
 		klog.V(2).InfoS("fmpm -q failed, skipping partition info", "err", err)
 	} else {
-		fm.Partitions = parseFMPartitions(partOutput)
+		fm.Partitions = parseFMPartitions(partOutput, moduleToIndex)
+		if len(fm.Partitions) > 0 && len(moduleToIndex) == 0 {
+			// No silent failure (Design Principle #6): FM partition membership is
+			// keyed on GPU physical/Module IDs, which do NOT follow lspci order.
+			// Without the nvidia-smi Module-ID join the GPUIndices fall back to
+			// identity and are very likely WRONG on real HGX baseboards.
+			klog.ErrorS(nil, "Fabric Manager partitions discovered but GPU Module IDs are unavailable "+
+				"(nvidia-smi missing from the discovery environment); partition GPUIndices fall back to "+
+				"an identity mapping and are very likely INCORRECT on HGX baseboards. Provide nvidia-smi "+
+				"to the gpu-discovery pod (host-mount or NVIDIA container runtime).")
+		}
 	}
 
 	return fm, nil
 }
 
-// parseFMPartitions parses fmpm -q output.
-// Expected format per line: "partition <id>: gpus=<indices> active=<true/false>"
-// Example: "partition 0: gpus=0,1 active=false"
+// parseFMPartitions parses a Fabric Manager partition listing and translates the
+// per-partition GPU membership into the device-Index space the allocator uses
+// (FMPartitionStatus.GPUIndices, consumed by selectPartitionGPUs).
+//
+// SEMANTICS (NVIDIA HGX Shared NVSwitch GPU Passthrough guide, WP-12736-002):
+// Fabric Manager expresses partition membership in GPU *physical IDs* — the
+// baseboard slot / Module ID surfaced by `nvidia-smi -q` as "GPU Module Id".
+// Those IDs do NOT follow lspci/BDF order, so they cannot be used as device
+// indices directly. moduleToIndex (from discoverGPUModuleIDs) carries the
+// (Module ID -> device Index) join; translatePartitionGPUIndices applies it.
+//
+// FORMAT: the line grammar below ("partition N: gpus=... active=...") is a
+// placeholder — the fmpm CLI text format is FM/driver-version dependent and the
+// canonical acquisition is the Fabric Manager shared-library API
+// (fmGetSupportedFabricPartitions). This is the hardware-gated adapter seam; the
+// LOAD-BEARING correctness (physical-ID -> Index translation) lives in
+// translatePartitionGPUIndices and is unit-tested independent of the source
+// format. The parsed `gpus=` values are physical/Module IDs, NOT indices.
 var fmPartitionPattern = regexp.MustCompile(
 	`partition\s+(\d+):\s+gpus=([\d,]+)\s+active=(\w+)`)
 
-func parseFMPartitions(output string) []gpuv1alpha1.FMPartitionStatus {
+func parseFMPartitions(output string, moduleToIndex map[int]int) []gpuv1alpha1.FMPartitionStatus {
 	var partitions []gpuv1alpha1.FMPartitionStatus
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	for scanner.Scan() {
@@ -453,16 +478,143 @@ func parseFMPartitions(output string) []gpuv1alpha1.FMPartitionStatus {
 			continue
 		}
 		id, _ := strconv.Atoi(matches[1])
-		gpuIndices := parseIntList(matches[2])
+		physicalIDs := parseIntList(matches[2])
 		active := matches[3] == "true"
 
 		partitions = append(partitions, gpuv1alpha1.FMPartitionStatus{
 			ID:         id,
-			GPUIndices: gpuIndices,
+			GPUIndices: translatePartitionGPUIndices(physicalIDs, moduleToIndex),
 			Active:     active,
 		})
 	}
 	return partitions
+}
+
+// translatePartitionGPUIndices maps a partition's GPU physical / Module IDs into
+// device-Index space via moduleToIndex (see parseFMPartitions for why this is
+// required).
+//
+//   - Empty map (nvidia-smi unavailable): the raw physical IDs pass through
+//     unchanged (identity) so PCIe-only nodes and unit tests still function; the
+//     caller logs a prominent warning because identity is likely wrong on HGX.
+//   - Non-empty map, physical ID present: translated to its device Index.
+//   - Non-empty map, physical ID absent: DROPPED (the partition ends up
+//     under-count and is therefore not selectable — a safe failure, never a
+//     wrong-NVLink one) with a warning.
+func translatePartitionGPUIndices(physicalIDs []int, moduleToIndex map[int]int) []int {
+	if len(moduleToIndex) == 0 {
+		return physicalIDs
+	}
+	out := make([]int, 0, len(physicalIDs))
+	for _, pid := range physicalIDs {
+		idx, ok := moduleToIndex[pid]
+		if !ok {
+			klog.V(1).InfoS("FM partition references a GPU Module ID with no discovered device; dropping it from the partition",
+				"moduleID", pid)
+			continue
+		}
+		out = append(out, idx)
+	}
+	return out
+}
+
+// --- GPU Module ID Discovery (nvidia-smi) ---
+
+// nvidiaSmiGPUHeaderPattern matches a per-GPU section header in `nvidia-smi -q`,
+// e.g. "GPU 00000000:0F:00.0". nvidia-smi uses an 8-hex-digit domain and
+// upper-case hex; lspci discovery uses a 4-hex-digit lower-case domain —
+// normalizeBDF reconciles the two.
+var nvidiaSmiGPUHeaderPattern = regexp.MustCompile(
+	`^GPU\s+([0-9a-fA-F]{4,8}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F])`)
+
+// moduleIDPattern matches the "GPU Module Id" field in `nvidia-smi -q`. The
+// exact field name is FM/driver-version dependent (seen as "GPU Module Id" and
+// "Module Id"); match case-insensitively on the "module id" tail.
+var moduleIDPattern = regexp.MustCompile(`(?i)module id\s*:\s*(\d+)`)
+
+// discoverGPUModuleIDs runs `nvidia-smi -q` and returns a (GPU Module Id ->
+// device Index) map for the discovered GPUs — the join Fabric Manager partition
+// translation needs. Returns an empty map (never an error) when nvidia-smi is
+// unavailable, so FM partition translation degrades to identity with a
+// caller-side warning.
+//
+// DEPLOYMENT: nvidia-smi must be present in the discovery environment. The
+// shipped gpu-discovery DaemonSet is drop-ALL / read-only-/sys and does NOT ship
+// it — HGX deployments must provide nvidia-smi to the discovery pod (host-mount
+// or NVIDIA container runtime). Correct on PCIe-tier nodes without it (no FM, no
+// partitions to translate).
+func discoverGPUModuleIDs(gpus []gpuv1alpha1.GPUDevice) map[int]int {
+	smiPath, err := exec.LookPath("nvidia-smi")
+	if err != nil {
+		return map[int]int{}
+	}
+	out, err := runCommand(smiPath, "-q")
+	if err != nil {
+		klog.V(2).InfoS("nvidia-smi -q failed; FM partition membership will degrade to identity", "err", err)
+		return map[int]int{}
+	}
+	return buildModuleToIndex(parseModuleIDs(out), gpus)
+}
+
+// parseModuleIDs parses `nvidia-smi -q` output into a (normalized BDF -> GPU
+// Module Id) map. Each "GPU <BDF>" section header starts a new device; the first
+// "Module Id" line within that section records its module id.
+func parseModuleIDs(output string) map[string]int {
+	result := map[string]int{}
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	current := ""
+	for scanner.Scan() {
+		line := scanner.Text()
+		if m := nvidiaSmiGPUHeaderPattern.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			current = normalizeBDF(m[1])
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		if m := moduleIDPattern.FindStringSubmatch(line); m != nil {
+			if _, seen := result[current]; !seen {
+				id, _ := strconv.Atoi(m[1])
+				result[current] = id
+			}
+		}
+	}
+	return result
+}
+
+// buildModuleToIndex joins the (normalized BDF -> Module Id) map from nvidia-smi
+// with the (BDF -> Index) order from lspci discovery to produce the
+// (Module Id -> device Index) map the FM-partition translation consumes.
+func buildModuleToIndex(bdfToModule map[string]int, gpus []gpuv1alpha1.GPUDevice) map[int]int {
+	out := map[int]int{}
+	for _, g := range gpus {
+		if mod, ok := bdfToModule[normalizeBDF(g.PCIAddress)]; ok {
+			out[mod] = g.Index
+		}
+	}
+	return out
+}
+
+// normalizeBDF canonicalizes a PCI address to lower-case with a 4-hex-digit
+// domain, so nvidia-smi's "00000000:0F:00.0" and lspci's "0000:0f:00.0" compare
+// equal. A domain-less "BB:DD.F" is treated as domain 0000.
+func normalizeBDF(bdf string) string {
+	bdf = strings.ToLower(strings.TrimSpace(bdf))
+	if strings.Count(bdf, ":") == 1 {
+		bdf = "0000:" + bdf
+	}
+	parts := strings.SplitN(bdf, ":", 2)
+	if len(parts) != 2 {
+		return bdf
+	}
+	dom := parts[0]
+	switch {
+	case len(dom) > 4:
+		dom = dom[len(dom)-4:]
+	case len(dom) < 4:
+		dom = strings.Repeat("0", 4-len(dom)) + dom
+	}
+	return dom + ":" + parts[1]
 }
 
 // --- Utility functions ---

--- a/cmd/gpu-discovery/discover_test.go
+++ b/cmd/gpu-discovery/discover_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sort"
 	"testing"
 
 	gpuv1alpha1 "github.com/kubeswift-io/kubeswift/api/gpu/v1alpha1"
@@ -493,13 +494,16 @@ func TestNVSwitchDiscoveryNone(t *testing.T) {
 
 // --- TestFabricManagerParsing ---
 
-func TestFabricManagerParsing(t *testing.T) {
+// With an empty module map (nvidia-smi unavailable / PCIe-only), the parsed
+// physical IDs pass through as-is (identity) — preserves pre-translation
+// behavior for nodes without a Fabric.
+func TestParseFMPartitions_IdentityFallback(t *testing.T) {
 	output := `partition 0: gpus=0,1 active=false
 partition 1: gpus=2,3 active=false
 partition 2: gpus=0,1,2,3 active=false
 partition 3: gpus=0,1,2,3,4,5,6,7 active=true
 `
-	partitions := parseFMPartitions(output)
+	partitions := parseFMPartitions(output, map[int]int{})
 	if len(partitions) != 4 {
 		t.Fatalf("expected 4 partitions, got %d", len(partitions))
 	}
@@ -509,6 +513,141 @@ partition 3: gpus=0,1,2,3,4,5,6,7 active=true
 	if !partitions[3].Active || len(partitions[3].GPUIndices) != 8 {
 		t.Errorf("partition[3] Active=%v, GPUs=%d", partitions[3].Active, len(partitions[3].GPUIndices))
 	}
+}
+
+// The load-bearing correctness property (NVIDIA WP-12736-002): Fabric Manager
+// lists partition membership in GPU physical/Module IDs, which do NOT follow
+// lspci order. parseFMPartitions must translate those into device-Index space.
+func TestParseFMPartitions_ModuleIDTranslation(t *testing.T) {
+	// Guide mapping: Module Id -> device Index.
+	moduleToIndex := map[int]int{5: 0, 7: 1, 6: 2, 8: 3, 1: 4, 3: 5, 2: 6, 4: 7}
+	// Partition 1 (the guide's first 4-GPU half) = Module IDs 1,2,3,4.
+	partitions := parseFMPartitions("partition 1: gpus=1,2,3,4 active=false\n", moduleToIndex)
+	if len(partitions) != 1 {
+		t.Fatalf("expected 1 partition, got %d", len(partitions))
+	}
+	got := append([]int(nil), partitions[0].GPUIndices...)
+	sort.Ints(got)
+	// Module {1,2,3,4} -> Index {4,6,5,7}; NOT the raw {1,2,3,4}.
+	want := []int{4, 5, 6, 7}
+	if !equalInts(got, want) {
+		t.Errorf("GPUIndices = %v (raw would be [1 2 3 4]); want translated %v",
+			partitions[0].GPUIndices, want)
+	}
+}
+
+// A physical ID with no discovered device is dropped (safe under-count), not
+// left as a wrong index.
+func TestParseFMPartitions_DropsUnmappedModuleID(t *testing.T) {
+	moduleToIndex := map[int]int{5: 0, 7: 1}
+	partitions := parseFMPartitions("partition 0: gpus=5,99,7 active=false\n", moduleToIndex)
+	got := append([]int(nil), partitions[0].GPUIndices...)
+	sort.Ints(got)
+	if !equalInts(got, []int{0, 1}) {
+		t.Errorf("GPUIndices = %v, want [0 1] (Module Id 99 dropped)", partitions[0].GPUIndices)
+	}
+}
+
+func TestNormalizeBDF(t *testing.T) {
+	cases := map[string]string{
+		"00000000:0F:00.0": "0000:0f:00.0", // nvidia-smi form
+		"0000:0f:00.0":     "0000:0f:00.0", // lspci form
+		"0000:B8:00.0":     "0000:b8:00.0",
+		"0f:00.0":          "0000:0f:00.0", // domain-less
+	}
+	for in, want := range cases {
+		if got := normalizeBDF(in); got != want {
+			t.Errorf("normalizeBDF(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseModuleIDs(t *testing.T) {
+	// Real-shape `nvidia-smi -q` excerpt: 8-hex-digit upper-case domain header,
+	// indented fields.
+	input := `
+==============NVSMI LOG==============
+
+Attached GPUs                             : 2
+GPU 00000000:0F:00.0
+    Product Name                          : NVIDIA H100 80GB HBM3
+    GPU Module Id                         : 5
+    Bus Id                                : 00000000:0F:00.0
+GPU 00000000:10:00.0
+    Product Name                          : NVIDIA H100 80GB HBM3
+    GPU Module Id                         : 7
+`
+	m := parseModuleIDs(input)
+	if m["0000:0f:00.0"] != 5 {
+		t.Errorf("module id for 0f = %d, want 5 (map=%v)", m["0000:0f:00.0"], m)
+	}
+	if m["0000:10:00.0"] != 7 {
+		t.Errorf("module id for 10 = %d, want 7 (map=%v)", m["0000:10:00.0"], m)
+	}
+}
+
+func TestBuildModuleToIndex(t *testing.T) {
+	bdfToModule := map[string]int{"0000:0f:00.0": 5, "0000:10:00.0": 7}
+	gpus := []gpuv1alpha1.GPUDevice{
+		{Index: 0, PCIAddress: "0000:0f:00.0"},
+		{Index: 1, PCIAddress: "0000:10:00.0"},
+	}
+	m := buildModuleToIndex(bdfToModule, gpus)
+	if m[5] != 0 || m[7] != 1 {
+		t.Errorf("moduleToIndex = %v, want {5:0, 7:1}", m)
+	}
+}
+
+// End-to-end round-trip proving discovery produces exactly the Index-space
+// GPUIndices the #405 allocator fixture hard-codes: nvidia-smi Module IDs +
+// lspci BDF order -> the guide's physicalId->Index map -> translated partition.
+func TestFMPartition_GuideRoundTrip(t *testing.T) {
+	smi := `GPU 00000000:0F:00.0
+    GPU Module Id : 5
+GPU 00000000:10:00.0
+    GPU Module Id : 7
+GPU 00000000:41:00.0
+    GPU Module Id : 6
+GPU 00000000:44:00.0
+    GPU Module Id : 8
+GPU 00000000:86:00.0
+    GPU Module Id : 1
+GPU 00000000:87:00.0
+    GPU Module Id : 3
+GPU 00000000:B8:00.0
+    GPU Module Id : 2
+GPU 00000000:BB:00.0
+    GPU Module Id : 4
+`
+	gpus := []gpuv1alpha1.GPUDevice{
+		{Index: 0, PCIAddress: "0000:0f:00.0"}, {Index: 1, PCIAddress: "0000:10:00.0"},
+		{Index: 2, PCIAddress: "0000:41:00.0"}, {Index: 3, PCIAddress: "0000:44:00.0"},
+		{Index: 4, PCIAddress: "0000:86:00.0"}, {Index: 5, PCIAddress: "0000:87:00.0"},
+		{Index: 6, PCIAddress: "0000:b8:00.0"}, {Index: 7, PCIAddress: "0000:bb:00.0"},
+	}
+	moduleToIndex := buildModuleToIndex(parseModuleIDs(smi), gpus)
+
+	// The guide's partition 1 = the 4-GPU half with Module IDs {1,2,3,4}.
+	// The #405 fixture encodes the same partition as device Indices via
+	// phys{1:4,2:6,3:5,4:7} => {4,6,5,7}.
+	partitions := parseFMPartitions("partition 1: gpus=1,2,3,4 active=false\n", moduleToIndex)
+	got := append([]int(nil), partitions[0].GPUIndices...)
+	sort.Ints(got)
+	if !equalInts(got, []int{4, 5, 6, 7}) {
+		t.Errorf("round-trip GPUIndices = %v, want [4 5 6 7] (fixture parity)", partitions[0].GPUIndices)
+	}
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestNoFabricManager(t *testing.T) {

--- a/cmd/gpu-discovery/main.go
+++ b/cmd/gpu-discovery/main.go
@@ -258,7 +258,12 @@ func discoverHardware() (*SwiftGPUNodeStatus, error) {
 			nvSwitches = nil
 		}
 
-		fm, err = discoverFabricManager()
+		// GPU Module IDs (nvidia-smi) are needed to translate Fabric Manager
+		// partition membership (physical/Module IDs) into device-Index space.
+		// Empty when nvidia-smi is unavailable; discoverFabricManager warns.
+		moduleToIndex := discoverGPUModuleIDs(gpus)
+
+		fm, err = discoverFabricManager(moduleToIndex)
 		if err != nil {
 			klog.V(2).InfoS("Fabric Manager discovery skipped", "reason", err)
 			fm = nil


### PR DESCRIPTION
## What

`gpu-discovery` wrote `SwiftGPUNode.status.fabricManager.partitions[].gpuIndices` straight from the parsed Fabric Manager partition listing, treating those values as **device indices**.

Per the NVIDIA HGX Shared NVSwitch GPU Passthrough Virtualization Integration Guide (WP-12736-002), Fabric Manager expresses partition membership in GPU **physical / Module IDs** — the baseboard slot surfaced by `nvidia-smi -q` as `GPU Module Id` — which do **not** follow lspci/BDF order. So `gpuIndices` was wrong on real HGX baseboards.

This is the load-bearing **upstream** half of #405: the shared-NVSwitch allocator (`selectPartitionGPUs`) consumes `gpuIndices` as device-Index space, so the partition-membership coupling operated on mistranslated data the instant discovery ran on hardware.

## Fix

Add the missing join:
1. Parse `GPU Module Id` per device from `nvidia-smi -q` (`parseModuleIDs`).
2. Cross it with the lspci BDF→Index order (`buildModuleToIndex`) → `moduleToIndex`.
3. Translate each partition's physical IDs into device-Index space before writing `gpuIndices` (`translatePartitionGPUIndices`).

Failure behavior (no silent failures, Design Principle #6):
- **Unmapped physical ID** → dropped (partition becomes under-count → not selectable — a *safe* failure, never a wrong-NVLink one).
- **Empty map** (nvidia-smi unavailable) → identity pass-through **plus a prominent warning** that membership is likely wrong on HGX.

## Grounding & tests

- The physical-ID→Index translation is unit-tested independent of the (hardware-gated, FM/driver-version-dependent) partition-list source format.
- `TestFMPartition_GuideRoundTrip` reproduces the **exact** Index-space `gpuIndices` the #405 allocator fixture encodes by hand (`nvidia-smi` Module IDs + lspci order → the guide's `physicalId→Index` map → translated partition), closing the loop end-to-end.

## Risk

**Zero** on the validated PCIe path: no Fabric → empty map → identity pass-through, unchanged. Only the HGX shared/full path is affected, and it was already non-functional (the shipped drop-ALL `/sys`-only discovery DaemonSet has no `nvidia-smi`/`fmpm`). HGX deployments must provide `nvidia-smi` to the discovery pod (documented in the code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)