### PR TITLE
fix(gpu): enforce Fabric Manager version match for shared NVSwitch allocation

### DIFF
--- a/internal/controller/swiftgpu/allocate.go
+++ b/internal/controller/swiftgpu/allocate.go
@@ -89,6 +89,7 @@ func (r *SwiftGPUReconciler) findAndAllocate(
 	}
 
 	// Second pass: find a node with capacity and allocate.
+	fmVersionMismatch := false
 	for i := range nodeList.Items {
 		n := &nodeList.Items[i]
 
@@ -99,6 +100,18 @@ func (r *SwiftGPUReconciler) findAndAllocate(
 
 		// Optional model filter: profile.Model must be a substring of the node's GPUModel.
 		if profile.Spec.Model != "" && !strings.Contains(n.Status.GPUModel, profile.Spec.Model) {
+			continue
+		}
+
+		// Fabric Manager version gate (shared NVSwitch mode). Per NVIDIA
+		// WP-12736-002, the host Fabric Manager version MUST exactly match the
+		// guest nvidia-open driver version or partition activation/attach fails
+		// — a broken fabric, not a boot failure, so it must be caught before
+		// allocation (Design Principle #6: no silent failures). Skip the node;
+		// if version mismatch turns out to be the sole blocker the final error
+		// names it (rather than a bare "no capacity").
+		if !fmVersionCompatible(n, profile) {
+			fmVersionMismatch = true
 			continue
 		}
 
@@ -157,7 +170,41 @@ func (r *SwiftGPUReconciler) findAndAllocate(
 		return n, gpus, numa, partID, nil
 	}
 
+	if fmVersionMismatch {
+		return nil, nil, nil, -1, fmt.Errorf("%w: candidate GPU node(s) run a Fabric Manager version that does not match profile.spec.fabricManager.requiredVersion=%q (for shared NVSwitch mode the host Fabric Manager version must exactly match the guest driver version)",
+			errNoCapacity, profile.Spec.FabricManager.RequiredVersion)
+	}
 	return nil, nil, nil, -1, errNoCapacity
+}
+
+// fmVersionCompatible reports whether node's Fabric Manager version satisfies
+// the profile's RequiredVersion.
+//
+// Per NVIDIA WP-12736-002, in shared NVSwitch mode the host Fabric Manager
+// version MUST exactly match the guest nvidia-open driver version
+// (profile.spec.fabricManager.requiredVersion) — the FM partition activate/attach
+// handshake with the guest driver fails otherwise. This applies to SHARED mode
+// only: in full mode (Tier 3) Fabric Manager runs IN the guest, so the host FM
+// version is irrelevant. An empty RequiredVersion means the operator did not pin
+// a version -> no check (any FM version accepted).
+func fmVersionCompatible(node *gpuv1alpha1.SwiftGPUNode, profile *gpuv1alpha1.SwiftGPUProfile) bool {
+	if profile.Spec.PartitionMode != "shared" {
+		return true
+	}
+	if profile.Spec.FabricManager == nil || profile.Spec.FabricManager.RequiredVersion == "" {
+		return true
+	}
+	fm := node.Status.FabricManager
+	return fm != nil && fm.Version == profile.Spec.FabricManager.RequiredVersion
+}
+
+// fmVersionString returns node's Fabric Manager version for error messages, or a
+// placeholder when Fabric Manager is not reported on the node.
+func fmVersionString(node *gpuv1alpha1.SwiftGPUNode) string {
+	if node.Status.FabricManager == nil {
+		return "<no Fabric Manager reported>"
+	}
+	return node.Status.FabricManager.Version
 }
 
 // deallocateGPUs releases the GPU allocation recorded in guest.status.gpu from

--- a/internal/controller/swiftgpu/controller.go
+++ b/internal/controller/swiftgpu/controller.go
@@ -132,8 +132,15 @@ func (r *SwiftGPUReconciler) handlePrepareError(ctx context.Context, guest *swif
 			metrics.GPUAllocationsTotal.WithLabelValues("no_capacity").Inc()
 		}
 		status := guest.Status.DeepCopy()
-		setGPUAllocatedCondition(status, false, "NoCapacity",
-			"no SwiftGPUNode has sufficient free GPUs matching the profile")
+		// Surface the error detail (e.g. a Fabric Manager version mismatch that
+		// was the sole blocker) rather than a bare "no capacity" — no silent
+		// failures (Design Principle #6). findAndAllocate wraps errNoCapacity
+		// with the specific reason when there is one.
+		msg := "no SwiftGPUNode has sufficient free GPUs matching the profile"
+		if detail := err.Error(); detail != errNoCapacity.Error() {
+			msg = detail
+		}
+		setGPUAllocatedCondition(status, false, "NoCapacity", msg)
 		if patchErr := r.patchStatus(ctx, guest, status); patchErr != nil {
 			return ctrl.Result{}, patchErr
 		}

--- a/internal/controller/swiftgpu/fm_version_test.go
+++ b/internal/controller/swiftgpu/fm_version_test.go
@@ -1,0 +1,151 @@
+package swiftgpu
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gpuv1alpha1 "github.com/kubeswift-io/kubeswift/api/gpu/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/scheme"
+)
+
+// sharedProfileWithFMVersion is a hgx-shared profile pinning a required Fabric
+// Manager (== guest driver) version.
+func sharedProfileWithFMVersion(name, ns string, count int, requiredVersion string) *gpuv1alpha1.SwiftGPUProfile {
+	p := testGPUProfile(name, ns, "hgx-shared", "", count, "shared")
+	p.Spec.FabricManager = &gpuv1alpha1.FabricManagerSpec{RequiredVersion: requiredVersion}
+	return p
+}
+
+// The load-bearing NVIDIA WP-12736-002 rule: in shared NVSwitch mode the host
+// Fabric Manager version MUST exactly match the guest driver version. Any
+// mismatch is a broken fabric, not a boot failure, so it must be rejected
+// before allocation — never silently allocated (Design Principle #6).
+func TestFMVersionCompatible(t *testing.T) {
+	node := func(v string) *gpuv1alpha1.SwiftGPUNode {
+		return &gpuv1alpha1.SwiftGPUNode{Status: gpuv1alpha1.SwiftGPUNodeStatus{
+			FabricManager: &gpuv1alpha1.FabricManagerStatus{Version: v, Running: true},
+		}}
+	}
+	noFMNode := &gpuv1alpha1.SwiftGPUNode{}
+	shared := func(req string) *gpuv1alpha1.SwiftGPUProfile {
+		return sharedProfileWithFMVersion("p", "default", 4, req)
+	}
+	full := func(req string) *gpuv1alpha1.SwiftGPUProfile {
+		p := testGPUProfile("p", "default", "hgx-full", "", 8, "full")
+		p.Spec.FabricManager = &gpuv1alpha1.FabricManagerSpec{RequiredVersion: req}
+		return p
+	}
+	pcie := testGPUProfile("p", "default", "pcie", "", 1, "isolated")
+
+	cases := []struct {
+		name    string
+		node    *gpuv1alpha1.SwiftGPUNode
+		profile *gpuv1alpha1.SwiftGPUProfile
+		want    bool
+	}{
+		{"shared match", node("550.163.01"), shared("550.163.01"), true},
+		{"shared mismatch", node("550.163.01"), shared("560.35.03"), false},
+		{"shared no required version (no check)", node("550.163.01"), shared(""), true},
+		{"shared but node has no FM", noFMNode, shared("550.163.01"), false},
+		{"full mode ignores host FM version", node("550.163.01"), full("560.35.03"), true},
+		{"non-shared (pcie) ignored", node("anything"), pcie, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fmVersionCompatible(tc.node, tc.profile); got != tc.want {
+				t.Errorf("fmVersionCompatible = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindAndAllocate_HGXShared_FMVersionMismatch_Rejected(t *testing.T) {
+	node := hgxH100Node("hgx-0") // FM version 550.163.01
+	guest := testSwiftGuest("g1", "default", &corev1.LocalObjectReference{Name: "hgx4"})
+	profile := sharedProfileWithFMVersion("hgx4", "default", 4, "560.35.03") // mismatch
+
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node, guest, profile).
+		WithStatusSubresource(node, guest).
+		Build()
+	r := &SwiftGPUReconciler{Client: c, Scheme: scheme.Scheme}
+
+	_, gpus, _, _, err := r.findAndAllocate(context.Background(), guest, profile)
+	if err == nil {
+		t.Fatalf("expected rejection on FM version mismatch, allocated %d GPU(s)", len(gpus))
+	}
+	if !errors.Is(err, errNoCapacity) {
+		t.Errorf("error should wrap errNoCapacity, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "560.35.03") {
+		t.Errorf("error should name the required version 560.35.03, got: %v", err)
+	}
+	// No GPUs / partition should have been marked allocated on the node.
+	var after gpuv1alpha1.SwiftGPUNode
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "hgx-0"}, &after); err != nil {
+		t.Fatal(err)
+	}
+	if after.Status.FreeGPUs != 8 {
+		t.Errorf("no GPUs should be reserved on a version-mismatched node; FreeGPUs=%d, want 8", after.Status.FreeGPUs)
+	}
+}
+
+func TestFindAndAllocate_HGXShared_FMVersionMatch_Allocates(t *testing.T) {
+	node := hgxH100Node("hgx-0") // FM version 550.163.01
+	guest := testSwiftGuest("g1", "default", &corev1.LocalObjectReference{Name: "hgx4"})
+	profile := sharedProfileWithFMVersion("hgx4", "default", 4, "550.163.01") // match
+
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node, guest, profile).
+		WithStatusSubresource(node, guest).
+		Build()
+	r := &SwiftGPUReconciler{Client: c, Scheme: scheme.Scheme}
+
+	_, gpus, _, partID, err := r.findAndAllocate(context.Background(), guest, profile)
+	if err != nil {
+		t.Fatalf("expected allocation on FM version match, got %v", err)
+	}
+	if partID < 0 || len(gpus) != 4 {
+		t.Fatalf("expected a 4-GPU partition, got partID=%d gpus=%d", partID, len(gpus))
+	}
+}
+
+func TestGPUNodeHasCapacity_HGXShared_FMVersionMismatch(t *testing.T) {
+	node := hgxH100Node("hgx-0")
+	profile := sharedProfileWithFMVersion("hgx4", "default", 4, "560.35.03")
+
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node).WithStatusSubresource(node).Build()
+
+	err := GPUNodeHasCapacity(context.Background(), c, "hgx-0", profile)
+	if err == nil {
+		t.Fatal("expected a capacity rejection on FM version mismatch")
+	}
+	if !strings.Contains(err.Error(), "Fabric Manager version") || !strings.Contains(err.Error(), "560.35.03") {
+		t.Errorf("error should name the FM version mismatch, got: %v", err)
+	}
+}
+
+func TestReserveOnNode_HGXShared_FMVersionMismatch(t *testing.T) {
+	node := hgxH100Node("hgx-0")
+	guest := testSwiftGuest("g1", "default", &corev1.LocalObjectReference{Name: "hgx4"})
+	profile := sharedProfileWithFMVersion("hgx4", "default", 4, "560.35.03")
+
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node, guest, profile).
+		WithStatusSubresource(node, guest).Build()
+
+	_, _, _, err := ReserveOnNode(context.Background(), c, guest, profile, "hgx-0")
+	if err == nil {
+		t.Fatal("expected reserve to fail on FM version mismatch")
+	}
+	if !strings.Contains(err.Error(), "560.35.03") {
+		t.Errorf("error should name the required version, got: %v", err)
+	}
+}

--- a/internal/controller/swiftgpu/preflight.go
+++ b/internal/controller/swiftgpu/preflight.go
@@ -41,6 +41,14 @@ func GPUNodeHasCapacity(ctx context.Context, c client.Client, nodeName string, p
 	if profile.Spec.Model != "" && !strings.Contains(node.Status.GPUModel, profile.Spec.Model) {
 		return fmt.Errorf("GPU node %q model %q does not match profile model %q", nodeName, node.Status.GPUModel, profile.Spec.Model)
 	}
+	// Fabric Manager version gate (shared NVSwitch mode): the host FM version
+	// must exactly match the guest driver version (NVIDIA WP-12736-002), or
+	// partition activate/attach fails. A no-op outside shared mode / when the
+	// profile pins no RequiredVersion.
+	if !fmVersionCompatible(&node, profile) {
+		return fmt.Errorf("GPU node %q Fabric Manager version %q does not match profile requiredVersion %q (host FM version must match the guest driver version for shared NVSwitch mode)",
+			nodeName, fmVersionString(&node), profile.Spec.FabricManager.RequiredVersion)
+	}
 	if profile.Spec.PartitionMode == "shared" {
 		// Match the reserve/allocate selection exactly: a viable partition is
 		// one whose MEMBER GPUs are all free (a free partition whose members

--- a/internal/controller/swiftgpu/primitives.go
+++ b/internal/controller/swiftgpu/primitives.go
@@ -69,6 +69,14 @@ func ReserveOnNode(ctx context.Context, c client.Client, guest *swiftv1alpha1.Sw
 	if profile.Spec.Model != "" && !strings.Contains(node.Status.GPUModel, profile.Spec.Model) {
 		return nil, nil, -1, fmt.Errorf("GPU node %q model %q does not match profile model %q", nodeName, node.Status.GPUModel, profile.Spec.Model)
 	}
+	// Fabric Manager version gate (shared NVSwitch mode) — mirror
+	// findAndAllocate / GPUNodeHasCapacity so a reserve cannot pin a node whose
+	// host FM version does not match the guest driver version (NVIDIA
+	// WP-12736-002). No-op outside shared mode / when RequiredVersion is unset.
+	if !fmVersionCompatible(&node, profile) {
+		return nil, nil, -1, fmt.Errorf("GPU node %q Fabric Manager version %q does not match profile requiredVersion %q",
+			nodeName, fmVersionString(&node), profile.Spec.FabricManager.RequiredVersion)
+	}
 
 	// Shared partition mode: the FM partition is the unit of allocation — the
 	// guest must receive exactly the chosen partition's member GPUs (the


### PR DESCRIPTION
## What

`SwiftGPUProfile.spec.fabricManager.requiredVersion` (the guest nvidia-open driver version) existed on the CRD but had **zero consumers** in the allocation path.

Per the NVIDIA HGX Shared NVSwitch GPU Passthrough guide (WP-12736-002), in **shared** mode the host Fabric Manager version must **exactly** match the guest driver version, or the FM partition activate/attach handshake with the guest driver fails. That produces a **broken fabric, not a boot failure** — nothing downstream catches it, so it was a silent failure (Design Principle #6).

## Fix

Add `fmVersionCompatible` and gate all three node-selection sites for shared-mode guests:
- `findAndAllocate` — primary allocation
- `GPUNodeHasCapacity` — migration/drain GPU target pre-flight
- `ReserveOnNode` — release-and-reallocate reserve

**Scope, per the guide:** shared mode only. In full mode (Tier 3) Fabric Manager runs *in the guest*, so the host FM version is irrelevant. An empty `requiredVersion` means the operator pinned no version → no check.

When a version mismatch is the sole allocation blocker, `findAndAllocate` wraps `errNoCapacity` with the specific reason and the controller surfaces it in the `GPUAllocated=NoCapacity` condition **message** — so `kubectl describe swiftguest` names the FM-version mismatch instead of a bare "no capacity".

## Tests

Against the hardware-faithful HGX H100 fixture (`hgxH100Node`, FM version `550.163.01`):
- mismatch → rejected, **no GPUs reserved** on the node
- match → allocates the partition
- `fmVersionCompatible` table: full-mode / non-shared / empty-version all ignored, nil-FM rejected
- pre-flight (`GPUNodeHasCapacity`) and reserve (`ReserveOnNode`) paths reject too

## Risk

None on the validated PCIe path (non-shared → gate is a no-op). Only shared-NVSwitch allocation is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)