### PR TITLE
test(gpu): fake-HGX injectable SwiftGPUNode for hardware-free validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,30 @@ All notable changes to KubeSwift are documented here.
   Module-ID mapping, and partition table — the mismatch reproduced verbatim on
   the old code.
 
+- **GPU discovery now translates Fabric Manager partition membership from GPU
+  Module IDs to device indices.** `gpu-discovery` wrote
+  `SwiftGPUNode.status.fabricManager.partitions[].gpuIndices` straight from the
+  parsed FM partition listing, treating the values as device indices — but FM
+  expresses membership in GPU physical/Module IDs (`nvidia-smi -q` "GPU Module
+  Id"), which do not follow lspci order (NVIDIA WP-12736-002). The membership
+  the shared-NVSwitch allocator consumes was therefore wrong on real HGX
+  baseboards. Discovery now joins the Module IDs from `nvidia-smi -q` with the
+  lspci BDF→index order and translates each partition into device-Index space;
+  an unmapped ID is dropped (safe under-count, never a wrong-NVLink one) and an
+  empty map (no `nvidia-smi`) degrades to identity with a prominent warning.
+  HGX deployments must provide `nvidia-smi` to the discovery pod. No effect on
+  the PCIe path (no Fabric, identity pass-through).
+
+- **Shared-NVSwitch allocation now enforces the Fabric Manager version match.**
+  `SwiftGPUProfile.spec.fabricManager.requiredVersion` (the guest driver
+  version) had no consumers; per NVIDIA WP-12736-002 the host Fabric Manager
+  version must exactly match the guest driver version in shared mode or the
+  partition attach fails — a broken fabric, not a boot failure. The allocator,
+  the migration `ReserveOnNode` reserve, and the `GPUNodeHasCapacity` pre-flight
+  now reject a version-mismatched node (shared mode only; full mode runs FM in
+  the guest), and the `GPUAllocated=NoCapacity` condition names the mismatch
+  rather than reporting a bare "no capacity".
+
 
 - **Sandboxes without `spec.workingDir` panicked on kernel 6.6.10** (regression
   from v0.11.0's cold-path workingDir change). The bridge-initramfs runs `set -u`

--- a/Makefile
+++ b/Makefile
@@ -411,6 +411,15 @@ verify-sandbox-config:
 verify-qemu-topology:
 	@./test/gpu/verify-qemu-topology.sh
 
+# Inject / remove a hardware-faithful fake 8-GPU HGX H100 SwiftGPUNode so the
+# shared-NVSwitch allocation + FM-version-gate path can be exercised on a
+# cluster with NO HGX hardware. Honors $KUBECONFIG.
+# See docs/gpu/hgx-hardware-free-validation.md.
+inject-fake-hgx:
+	@./test/gpu/inject-fake-hgx-node.sh
+remove-fake-hgx:
+	@./test/gpu/inject-fake-hgx-node.sh remove
+
 # Sync the canonical dashboards (config/grafana/) into the Helm chart
 # (charts/kubeswift/dashboards/), where templates/monitoring/dashboards.yaml
 # embeds them via .Files.Get. Same pattern as the CRD copy step — the

--- a/docs/gpu/hgx-hardware-free-validation.md
+++ b/docs/gpu/hgx-hardware-free-validation.md
@@ -1,0 +1,96 @@
+# Validating HGX shared-NVSwitch allocation without HGX hardware
+
+KubeSwift's Tier-2 HGX path (`tier: hgx-shared`) needs 8-GPU SXM baseboards with
+NVSwitch and Fabric Manager. Most clusters, including our dev cluster, have none.
+This fixture lets you exercise the allocation and pod/intent-build logic against
+a realistic HGX inventory anyway, and draws an honest line at what still needs
+real hardware.
+
+## What each layer needs
+
+| Layer | Hardware-free? |
+|---|---|
+| FM partition membership -> device allocation coupling (`selectPartitionGPUs`, #405) | yes -- this fixture |
+| Fabric Manager version gate (#407) | yes -- this fixture |
+| GPU launcher pod + QEMU RuntimeIntent (root-port-per-GPU, NUMA, hugepages, pinning, #404) | yes -- `make verify-qemu-topology` + unit tests |
+| gpu-discovery Module-ID -> Index translation (#406) | yes -- unit tests (`cmd/gpu-discovery`) |
+| VFIO bind, BAR mapping, NVLink/NVSwitch, `fmpm -a` activation, NCCL | **no -- real HGX only** |
+
+Everything above the line is covered without hardware. The last row is the
+irreducible gate: it involves real PCI devices, the NVSwitch fabric, and the
+Fabric Manager partition handshake with the guest driver.
+
+## The fake node
+
+`test/gpu/fake-hgx-h100-status.json` is an 8-GPU HGX H100 `SwiftGPUNode` status
+taken verbatim from the NVIDIA HGX Shared NVSwitch GPU Passthrough guide
+(WP-12736-002): GPU BDFs `0f/10/41/44/86/87/b8/bb`, 4 NVSwitches, and the real
+Fabric Manager partition table (one 8-GPU, two 4-GPU halves, four pairs, eight
+singles).
+
+The partition `gpuIndices` are in **device-Index space** -- what gpu-discovery
+emits *after* translating the FM physical/Module IDs (which do not follow lspci
+order) via `nvidia-smi -q` (#406). The guide's Module-ID -> Index map is
+`{1:4, 2:6, 3:5, 4:7, 5:0, 6:2, 7:1, 8:3}`; e.g. the 4-GPU partition 1 holds
+Module IDs `1,2,3,4`, which is device indices `4,6,5,7` (the NUMA-1 half).
+
+## Walkthrough
+
+```bash
+export KUBECONFIG=... # a cluster with KubeSwift installed
+
+# 1. Inject the fake node.
+./test/gpu/inject-fake-hgx-node.sh
+#   -> NAME=fake-hgx-0 PHASE=Ready GPUS=8 FREE=8 MODEL=H100-SXM VFIO=true
+#   -> prints the partition id -> device-index table
+
+# 2. Create the tenants (two 4-GPU guests + a third + a bad-version one).
+kubectl apply -f test/gpu/fake-hgx-workload.yaml
+
+# 3. Read the allocation result. The SwiftGPU controller allocates as soon as
+#    the profile + node resolve -- independent of image readiness -- so this
+#    populates even though the launcher pod stays Pending (fake-hgx-0 is not a
+#    real kubelet) and imageRef need not exist.
+kubectl get swiftguest hgx-tenant-a -o jsonpath='{.status.gpu}{"\n"}'
+kubectl get swiftguest hgx-tenant-b -o jsonpath='{.status.gpu}{"\n"}'
+```
+
+Expected:
+
+- **`hgx-tenant-a`** gets four devices that are exactly one FM partition's
+  members -- e.g. `["0000:86:00.0","0000:b8:00.0","0000:87:00.0","0000:bb:00.0"]`
+  (partition 1, NUMA 1), `partitionId: 1`, `numaNodes: [1]`, `hypervisor: qemu`.
+- **`hgx-tenant-b`** gets the **disjoint** other half (partition 2, NUMA 0).
+  Two tenants, two partitions, no overlap -- the shared-NVSwitch invariant.
+- **`hgx-tenant-c`** stays `GPUAllocated=False, reason=NoCapacity` (only 8 GPUs;
+  both 4-GPU partitions are taken).
+- **`hgx-badver`** stays `GPUAllocated=False, reason=NoCapacity` with a message
+  naming the Fabric Manager version mismatch (`requiredVersion=999.99.99` vs the
+  node's `550.163.01`) -- the #407 gate, not a silent allocation.
+
+```bash
+kubectl get swiftguest -o custom-columns=\
+NAME:.metadata.name,GPUALLOC:'.status.conditions[?(@.type=="GPUAllocated")].status',REASON:'.status.conditions[?(@.type=="GPUAllocated")].reason',DEVICES:.status.gpu.devices
+kubectl get swiftgpunode fake-hgx-0 -o jsonpath='{.status.freeGPUs}{"\n"}'  # -> 0
+
+# 4. Clean up.
+kubectl delete -f test/gpu/fake-hgx-workload.yaml
+./test/gpu/inject-fake-hgx-node.sh remove
+```
+
+## What this does NOT prove
+
+The launcher pod pins to `fake-hgx-0` and stays `Pending` -- there is no real
+kubelet, no VFIO devices, no NVSwitch, no Fabric Manager. Boot, VFIO bind, BAR
+mapping, `fmpm -a` partition activation, NVLink, and NCCL are only exercised on a
+real HGX node. This fixture proves the Kubernetes-side allocation and intent are
+correct so that, when hardware lands, the remaining gap is exactly the hardware.
+
+## Deployment note for real HGX
+
+gpu-discovery translates FM partition membership using `nvidia-smi -q` (#406).
+The shipped gpu-discovery DaemonSet is drop-ALL with a read-only `/sys` and does
+**not** ship `nvidia-smi`/`fmpm`. On a real HGX node you must provide them to the
+discovery pod (host-mount or the NVIDIA container runtime); without `nvidia-smi`
+the partition indices fall back to identity and discovery logs a prominent
+warning.

--- a/docs/gpu/hgx-hardware-free-validation.md
+++ b/docs/gpu/hgx-hardware-free-validation.md
@@ -55,26 +55,61 @@ kubectl get swiftguest hgx-tenant-a -o jsonpath='{.status.gpu}{"\n"}'
 kubectl get swiftguest hgx-tenant-b -o jsonpath='{.status.gpu}{"\n"}'
 ```
 
-Expected:
+Expected (verified on-cluster, controller `sha-13291e4`):
 
 - **`hgx-tenant-a`** gets four devices that are exactly one FM partition's
-  members -- e.g. `["0000:86:00.0","0000:b8:00.0","0000:87:00.0","0000:bb:00.0"]`
+  members -- `["0000:86:00.0","0000:b8:00.0","0000:87:00.0","0000:bb:00.0"]`
   (partition 1, NUMA 1), `partitionId: 1`, `numaNodes: [1]`, `hypervisor: qemu`.
-- **`hgx-tenant-b`** gets the **disjoint** other half (partition 2, NUMA 0).
-  Two tenants, two partitions, no overlap -- the shared-NVSwitch invariant.
+- **`hgx-tenant-b`** gets the **disjoint** other half:
+  `["0000:0f:00.0","0000:41:00.0","0000:10:00.0","0000:44:00.0"]` (partition 2,
+  NUMA 0). Two tenants, two partitions, no overlap -- the shared-NVSwitch
+  invariant. The node's `fabricManager.partitions[1].allocatedTo` and `[2]` now
+  name the two guests.
 - **`hgx-tenant-c`** stays `GPUAllocated=False, reason=NoCapacity` (only 8 GPUs;
   both 4-GPU partitions are taken).
-- **`hgx-badver`** stays `GPUAllocated=False, reason=NoCapacity` with a message
-  naming the Fabric Manager version mismatch (`requiredVersion=999.99.99` vs the
-  node's `550.163.01`) -- the #407 gate, not a silent allocation.
 
 ```bash
 kubectl get swiftguest -o custom-columns=\
 NAME:.metadata.name,GPUALLOC:'.status.conditions[?(@.type=="GPUAllocated")].status',REASON:'.status.conditions[?(@.type=="GPUAllocated")].reason',DEVICES:.status.gpu.devices
-kubectl get swiftgpunode fake-hgx-0 -o jsonpath='{.status.freeGPUs}{"\n"}'  # -> 0
+```
 
-# 4. Clean up.
+### The Fabric Manager version gate (#407) -- a separate step
+
+No-capacity wins over a version mismatch when the node has no free GPUs (correct
+precedence), so the version-mismatch surface only appears on a node **with**
+capacity. Reset to a fresh 8-free node and apply one guest on the bad-version
+profile:
+
+```bash
 kubectl delete -f test/gpu/fake-hgx-workload.yaml
+./test/gpu/inject-fake-hgx-node.sh   # freeGPUs back to 8
+kubectl apply -f - <<'EOF'
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata: { name: hgx-badver }
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: default }
+  gpuProfileRef: { name: hgx-shared-4-badver }   # requiredVersion 999.99.99
+EOF
+kubectl get swiftguest hgx-badver \
+  -o jsonpath='{.status.conditions[?(@.type=="GPUAllocated")].message}{"\n"}'
+```
+
+`hgx-badver` stays `GPUAllocated=False, reason=NoCapacity` with a message that
+**names** the mismatch, not a silent allocation:
+
+```
+no GPU node has sufficient capacity: candidate GPU node(s) run a Fabric Manager
+version that does not match profile.spec.fabricManager.requiredVersion="999.99.99"
+(for shared NVSwitch mode the host Fabric Manager version must exactly match the
+guest driver version)
+```
+
+```bash
+# Clean up.
+kubectl delete swiftguest hgx-badver --ignore-not-found
+kubectl delete -f test/gpu/fake-hgx-workload.yaml --ignore-not-found
 ./test/gpu/inject-fake-hgx-node.sh remove
 ```
 

--- a/test/gpu/fake-hgx-h100-status.json
+++ b/test/gpu/fake-hgx-h100-status.json
@@ -1,0 +1,57 @@
+{
+  "status": {
+    "phase": "Ready",
+    "gpuCount": 8,
+    "freeGPUs": 8,
+    "gpuModel": "H100-SXM",
+    "gpuVendor": "NVIDIA",
+    "vfioReady": true,
+    "host": {
+      "cpuTopology": { "sockets": 2, "coresPerSocket": 56, "threadsPerCore": 2, "totalCPUs": 224 },
+      "numaNodes": [
+        { "id": 0, "cpus": "0-55,112-167", "memoryMi": 1048576 },
+        { "id": 1, "cpus": "56-111,168-223", "memoryMi": 1048576 }
+      ],
+      "iommuEnabled": true,
+      "hugepages1Gi": { "total": 1800, "free": 1800 }
+    },
+    "gpus": [
+      { "index": 0, "pciAddress": "0000:0f:00.0", "vendor": "NVIDIA", "model": "H100-SXM", "deviceId": "10de:2330", "numaNode": 0, "iommuGroup": 10, "driver": "vfio-pci", "barSizes": [{ "region": 1, "sizeMi": 131072 }], "allocated": false },
+      { "index": 1, "pciAddress": "0000:10:00.0", "vendor": "NVIDIA", "model": "H100-SXM", "deviceId": "10de:2330", "numaNode": 0, "iommuGroup": 11, "driver": "vfio-pci", "barSizes": [{ "region": 1, "sizeMi": 131072 }], "allocated": false },
+      { "index": 2, "pciAddress": "0000:41:00.0", "vendor": "NVIDIA", "model": "H100-SXM", "deviceId": "10de:2330", "numaNode": 0, "iommuGroup": 12, "driver": "vfio-pci", "barSizes": [{ "region": 1, "sizeMi": 131072 }], "allocated": false },
+      { "index": 3, "pciAddress": "0000:44:00.0", "vendor": "NVIDIA", "model": "H100-SXM", "deviceId": "10de:2330", "numaNode": 0, "iommuGroup": 13, "driver": "vfio-pci", "barSizes": [{ "region": 1, "sizeMi": 131072 }], "allocated": false },
+      { "index": 4, "pciAddress": "0000:86:00.0", "vendor": "NVIDIA", "model": "H100-SXM", "deviceId": "10de:2330", "numaNode": 1, "iommuGroup": 14, "driver": "vfio-pci", "barSizes": [{ "region": 1, "sizeMi": 131072 }], "allocated": false },
+      { "index": 5, "pciAddress": "0000:87:00.0", "vendor": "NVIDIA", "model": "H100-SXM", "deviceId": "10de:2330", "numaNode": 1, "iommuGroup": 15, "driver": "vfio-pci", "barSizes": [{ "region": 1, "sizeMi": 131072 }], "allocated": false },
+      { "index": 6, "pciAddress": "0000:b8:00.0", "vendor": "NVIDIA", "model": "H100-SXM", "deviceId": "10de:2330", "numaNode": 1, "iommuGroup": 16, "driver": "vfio-pci", "barSizes": [{ "region": 1, "sizeMi": 131072 }], "allocated": false },
+      { "index": 7, "pciAddress": "0000:bb:00.0", "vendor": "NVIDIA", "model": "H100-SXM", "deviceId": "10de:2330", "numaNode": 1, "iommuGroup": 17, "driver": "vfio-pci", "barSizes": [{ "region": 1, "sizeMi": 131072 }], "allocated": false }
+    ],
+    "nvSwitches": [
+      { "pciAddress": "0000:03:00.0", "deviceId": "10de:22a3", "numaNode": 0 },
+      { "pciAddress": "0000:04:00.0", "deviceId": "10de:22a3", "numaNode": 0 },
+      { "pciAddress": "0000:05:00.0", "deviceId": "10de:22a3", "numaNode": 1 },
+      { "pciAddress": "0000:06:00.0", "deviceId": "10de:22a3", "numaNode": 1 }
+    ],
+    "fabricManager": {
+      "installed": true,
+      "version": "550.163.01",
+      "running": true,
+      "partitions": [
+        { "id": 0,  "gpuIndices": [4, 6, 5, 7, 0, 2, 1, 3], "active": false },
+        { "id": 1,  "gpuIndices": [4, 6, 5, 7], "active": false },
+        { "id": 2,  "gpuIndices": [0, 2, 1, 3], "active": false },
+        { "id": 3,  "gpuIndices": [4, 5], "active": false },
+        { "id": 4,  "gpuIndices": [6, 7], "active": false },
+        { "id": 5,  "gpuIndices": [0, 1], "active": false },
+        { "id": 6,  "gpuIndices": [2, 3], "active": false },
+        { "id": 7,  "gpuIndices": [4], "active": false },
+        { "id": 8,  "gpuIndices": [6], "active": false },
+        { "id": 9,  "gpuIndices": [5], "active": false },
+        { "id": 10, "gpuIndices": [7], "active": false },
+        { "id": 11, "gpuIndices": [0], "active": false },
+        { "id": 12, "gpuIndices": [2], "active": false },
+        { "id": 13, "gpuIndices": [1], "active": false },
+        { "id": 14, "gpuIndices": [3], "active": false }
+      ]
+    }
+  }
+}

--- a/test/gpu/fake-hgx-workload.yaml
+++ b/test/gpu/fake-hgx-workload.yaml
@@ -1,0 +1,88 @@
+# Fake-HGX walkthrough workload -- exercises the shared-NVSwitch allocation path
+# against the injected fake-hgx-0 SwiftGPUNode (test/gpu/inject-fake-hgx-node.sh).
+#
+# What this validates hardware-free:
+#   - selectPartitionGPUs couples the guest's devices to a Fabric Manager
+#     partition's MEMBER GPUs (the #405 shared-NVSwitch invariant).
+#   - Two 4-GPU tenants land on the two DISJOINT 4-GPU partitions (the NUMA
+#     halves); a third gets GPUAllocated=NoCapacity.
+#   - The Fabric Manager version gate (#407): a guest whose profile pins a
+#     requiredVersion the node does not run is rejected, not silently allocated.
+#
+# The SwiftGPU controller allocates as soon as the profile + node resolve,
+# INDEPENDENT of image readiness -- so status.gpu populates even though the
+# launcher pod stays Pending (fake-hgx-0 is not a real kubelet) and imageRef
+# need not exist. Read the result with:
+#   kubectl get swiftguest <name> -o jsonpath='{.status.gpu}{"\n"}'
+#   kubectl get swiftgpunode fake-hgx-0 -o jsonpath='{.status.freeGPUs}{"\n"}'
+---
+apiVersion: gpu.kubeswift.io/v1alpha1
+kind: SwiftGPUProfile
+metadata:
+  name: hgx-shared-4
+spec:
+  count: 4
+  model: H100-SXM
+  tier: hgx-shared
+  partitionMode: shared
+  pcieTopology:
+    rootPortPerDevice: true
+    noMmap: true
+  numaTopology:
+    sockets: 1
+    coresPerSocket: 16
+    threadsPerCore: 1
+    memoryPerSocketMi: 131072
+  hugepages: "1Gi"
+  vcpuPinning: true
+---
+# Same as hgx-shared-4 but pins a Fabric Manager / guest-driver version the fake
+# node does NOT run (it reports 550.163.01) -- drives the #407 version gate.
+apiVersion: gpu.kubeswift.io/v1alpha1
+kind: SwiftGPUProfile
+metadata:
+  name: hgx-shared-4-badver
+spec:
+  count: 4
+  model: H100-SXM
+  tier: hgx-shared
+  partitionMode: shared
+  hugepages: "1Gi"
+  fabricManager:
+    requiredVersion: "999.99.99"
+---
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: hgx-tenant-a
+spec:
+  imageRef: { name: ubuntu-noble }   # need not exist: allocation precedes image resolution
+  guestClassRef: { name: default }
+  gpuProfileRef: { name: hgx-shared-4 }
+---
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: hgx-tenant-b
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: default }
+  gpuProfileRef: { name: hgx-shared-4 }
+---
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: hgx-tenant-c   # third 4-GPU guest -> GPUAllocated=NoCapacity (only 8 GPUs)
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: default }
+  gpuProfileRef: { name: hgx-shared-4 }
+---
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuest
+metadata:
+  name: hgx-badver   # -> GPUAllocated=NoCapacity naming the FM version mismatch
+spec:
+  imageRef: { name: ubuntu-noble }
+  guestClassRef: { name: default }
+  gpuProfileRef: { name: hgx-shared-4-badver }

--- a/test/gpu/fake-hgx-workload.yaml
+++ b/test/gpu/fake-hgx-workload.yaml
@@ -77,12 +77,8 @@ spec:
   imageRef: { name: ubuntu-noble }
   guestClassRef: { name: default }
   gpuProfileRef: { name: hgx-shared-4 }
----
-apiVersion: swift.kubeswift.io/v1alpha1
-kind: SwiftGuest
-metadata:
-  name: hgx-badver   # -> GPUAllocated=NoCapacity naming the FM version mismatch
-spec:
-  imageRef: { name: ubuntu-noble }
-  guestClassRef: { name: default }
-  gpuProfileRef: { name: hgx-shared-4-badver }
+# The FM-version gate (#407) is a SEPARATE step: no-capacity wins over a version
+# mismatch when the node has no free GPUs (correct precedence), so the
+# version-mismatch surface only appears on a node WITH capacity. Apply a guest
+# on the hgx-shared-4-badver profile above against a freshly-injected (8-free)
+# node -- see docs/gpu/hgx-hardware-free-validation.md.

--- a/test/gpu/inject-fake-hgx-node.sh
+++ b/test/gpu/inject-fake-hgx-node.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# inject-fake-hgx-node.sh -- inject (or remove) a hardware-faithful, fake 8-GPU
+# HGX H100 SwiftGPUNode so the SwiftGPU allocation + GPU-pod/intent-build path
+# can be exercised on a cluster that has NO HGX hardware.
+#
+# The node's status is taken verbatim from the NVIDIA HGX Shared NVSwitch GPU
+# Passthrough Virtualization Integration Guide (WP-12736-002): 8 H100 SXM GPUs
+# (BDFs 0f/10/41/44/86/87/b8/bb), 4 NVSwitches, and the real Fabric Manager
+# partition table. CRITICALLY, the partition gpuIndices are in device-Index
+# space -- exactly what gpu-discovery produces AFTER translating the FM
+# physical/Module IDs (which do NOT follow lspci order) via `nvidia-smi -q`.
+# See docs/gpu/hgx-hardware-free-validation.md.
+#
+# This is a TEST FIXTURE. It does not represent real hardware; a launcher pod
+# pinned to this node stays Pending (the node name is not a real kubelet). The
+# validation boundary is everything up to VFIO bind / NVLink / Fabric Manager,
+# which is irreducibly hardware-gated.
+#
+# Usage:
+#   ./inject-fake-hgx-node.sh          # create/refresh the fake node
+#   ./inject-fake-hgx-node.sh remove   # delete it
+#
+# Honors $KUBECONFIG and $NODE_NAME (default: fake-hgx-0).
+
+NODE_NAME="${NODE_NAME:-fake-hgx-0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUS_JSON="${SCRIPT_DIR}/fake-hgx-h100-status.json"
+
+if [ "${1:-inject}" = "remove" ]; then
+  echo "Removing fake HGX SwiftGPUNode ${NODE_NAME}"
+  kubectl delete swiftgpunode "${NODE_NAME}" --ignore-not-found
+  exit 0
+fi
+
+echo "Injecting fake HGX SwiftGPUNode ${NODE_NAME}"
+
+# 1. Create the object (metadata only -- status is a subresource, ignored by apply).
+kubectl apply -f - <<EOF
+apiVersion: gpu.kubeswift.io/v1alpha1
+kind: SwiftGPUNode
+metadata:
+  name: ${NODE_NAME}
+  labels:
+    kubeswift.io/gpu-node: "true"
+    kubeswift.io/fake-hgx: "true"
+EOF
+
+# 2. Patch the status subresource with the fake HGX inventory.
+kubectl patch swiftgpunode "${NODE_NAME}" \
+  --subresource=status --type=merge --patch-file "${STATUS_JSON}"
+
+echo
+echo "Injected. Current state:"
+kubectl get swiftgpunode "${NODE_NAME}" \
+  -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,GPUS:.status.gpuCount,FREE:.status.freeGPUs,MODEL:.status.gpuModel,VFIO:.status.vfioReady
+echo
+echo "Fabric Manager partitions (id -> device indices):"
+kubectl get swiftgpunode "${NODE_NAME}" -o jsonpath='{range .status.fabricManager.partitions[*]}{"  partition "}{.id}{" -> "}{.gpuIndices}{"\n"}{end}'


### PR DESCRIPTION
## What

A hardware-faithful, cluster-injectable **8-GPU HGX H100 `SwiftGPUNode`** fixture so the shared-NVSwitch allocation path — the #405 partition-membership coupling and the #407 Fabric Manager version gate — can be exercised end-to-end through the real SwiftGPU controller on a cluster with **no HGX hardware**.

## Files

- `test/gpu/fake-hgx-h100-status.json` — the injected node status, taken verbatim from NVIDIA WP-12736-002 (BDFs `0f/10/41/44/86/87/b8/bb`, 4 NVSwitches, the real FM partition table). Partition `gpuIndices` are in **device-Index space** — exactly what gpu-discovery emits after the #406 Module-ID translation — so the same data closes the loop with the #405 allocator test fixture.
- `test/gpu/inject-fake-hgx-node.sh` — create/refresh/remove (patches the status subresource).
- `test/gpu/fake-hgx-workload.yaml` — `hgx-shared` profiles + tenant guests, including a version-mismatch profile that drives the #407 gate.
- `docs/gpu/hgx-hardware-free-validation.md` — walkthrough + the honest hardware boundary.
- `make inject-fake-hgx` / `make remove-fake-hgx`.

## Validates (hardware-free)

- Two 4-GPU tenants land on the two **disjoint** 4-GPU partitions (the NUMA halves).
- A third 4-GPU guest → `GPUAllocated=NoCapacity`.
- A version-mismatched guest → rejected **naming the FM version**, not silently allocated (#407).

## Honest boundary

The launcher pod pins to the fake node and stays `Pending`. VFIO bind, BAR mapping, NVLink/NVSwitch, `fmpm -a` activation, and NCCL are **only** exercised on a real HGX node. This fixture proves the Kubernetes-side allocation + intent are correct so that, when hardware lands, the remaining gap is exactly the hardware.

Depends conceptually on #406 (discovery translation) and #407 (version gate); the fixture works against any controller that has the #405 coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)