### PR TITLE
fix(sandbox): re-apply the kernel config on build — stale config shipped a non-monolithic sandbox kernel

### DIFF
--- a/build/kernels/sandbox/Makefile
+++ b/build/kernels/sandbox/Makefile
@@ -46,11 +46,35 @@ agent:
 		go build -ldflags="-s -w" -o $(AGENT_BIN) ./cmd/kubeswift-guest-agent
 	@echo "  guest-agent: $(AGENT_BIN) ($$(du -h $(AGENT_BIN) | cut -f1))"
 
+# The kernel config files the built kernel must match. Buildroot applies these to
+# the kernel's .config ONCE, at its linux-configure step, and then STAMPS it: a
+# later edit to either file is silently ignored, so `make build` happily rebuilds
+# and ships a kernel built from the OLD config. That trap shipped a
+# module-capable "monolithic" sandbox kernel (CONFIG_MODULES=n was honored on a
+# clean build, but the stale tree kept CONFIG_MODULES=y). Re-apply the config
+# whenever it is newer than the stamp, so the built kernel always matches the
+# tracked config -- no silent drift.
+KERNEL_CONFIGS := $(CURDIR)/configs/sandbox-linux.config \
+	$(wildcard $(CURDIR)/configs/$(PROFILE).fragment)
+
 build: setup agent
 	$(MAKE) -C $(BUILDROOT_DIR) \
 		BR2_EXTERNAL=$(EXTERNAL) \
 		O=$(OUTPUT_DIR) \
 		$(PROFILE)_defconfig
+	@stamp=$$(ls -1 $(OUTPUT_DIR)/build/linux-*/.stamp_configured 2>/dev/null | head -1); \
+	if [ -n "$$stamp" ]; then \
+		for cfg in $(KERNEL_CONFIGS); do \
+			if [ "$$cfg" -nt "$$stamp" ]; then \
+				echo "kernel config $$cfg changed since configure -> linux-reconfigure"; \
+				$(MAKE) -C $(BUILDROOT_DIR) \
+					BR2_EXTERNAL=$(EXTERNAL) \
+					O=$(OUTPUT_DIR) \
+					linux-reconfigure; \
+				break; \
+			fi; \
+		done; \
+	fi
 	$(MAKE) -C $(BUILDROOT_DIR) \
 		BR2_EXTERNAL=$(EXTERNAL) \
 		O=$(OUTPUT_DIR) \
@@ -59,6 +83,8 @@ build: setup agent
 	@echo "Build complete ($(PROFILE)):"
 	@echo "  bzImage:           $(OUTPUT_DIR)/images/bzImage"
 	@echo "  rootfs.cpio.gz:    $(OUTPUT_DIR)/images/rootfs.cpio.gz  (bridge-initramfs)"
+	@echo "  CONFIG_MODULES:    $$(grep -E '^CONFIG_MODULES=|^# CONFIG_MODULES is not set' \
+		$(OUTPUT_DIR)/build/linux-*/.config 2>/dev/null | head -1)"
 
 verify:
 	./verify-boot.sh

--- a/build/kernels/sandbox/README.md
+++ b/build/kernels/sandbox/README.md
@@ -37,6 +37,16 @@ make verify                     # boot on cloud-hypervisor with a real OCI rootf
 Each profile builds into its own `OUTPUT_DIR`; override `OUTPUT_DIR=<dir>` to
 reuse an already-built toolchain (a fresh dir rebuilds the toolchain from scratch).
 
+`make build` prints the built kernel's `CONFIG_MODULES` so you can see the config
+actually took. It has to: buildroot applies `configs/sandbox-linux.config` (and a
+profile fragment) to the kernel at its `linux-configure` step and then **stamps**
+it, so a later edit to either file is silently ignored on an incremental build —
+you get a kernel built from the OLD config with no warning. (That trap once
+shipped a `sandbox` kernel carrying `CONFIG_MODULES=y` even though the config had
+said `=n` for months.) The build target now re-applies the config whenever it is
+newer than the stamp. If you ever suspect drift, `make -C buildroot O=<outdir>
+linux-reconfigure` re-applies it unconditionally.
+
 ## Publish (SwiftKernel OCI artifact)
 
 The artifact carries the same two blobs a SwiftKernel expects (`bzImage` +
@@ -45,10 +55,10 @@ The artifact carries the same two blobs a SwiftKernel expects (`bzImage` +
 
 ```
 cd output/images                # or output-gpu-sandbox/images for the gpu profile
-oras push ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.11 \
+oras push ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.13 \
   bzImage:application/vnd.kubeswift.kernel.binary \
   rootfs.cpio.gz:application/vnd.kubeswift.initramfs.binary
-# gpu-sandbox: oras push .../kernels/gpu-sandbox:6.6.1 bzImage:... rootfs.cpio.gz:...
+# gpu-sandbox: oras push .../kernels/gpu-sandbox:6.6.2 bzImage:... rootfs.cpio.gz:...
 ```
 
 Then `kubectl apply -f config/samples/sandbox/swiftkernel-sandbox.yaml` (or

--- a/config/samples/sandbox/swiftkernel-gpu-sandbox.yaml
+++ b/config/samples/sandbox/swiftkernel-gpu-sandbox.yaml
@@ -16,6 +16,6 @@ metadata:
   namespace: default
 spec:
   ociRef:
-    image: ghcr.io/kubeswift-io/kubeswift/kernels/gpu-sandbox:6.6.1
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/gpu-sandbox:6.6.2
   kernelCmdline: "console=ttyS0"
   profile: gpu-sandbox

--- a/config/samples/sandbox/swiftkernel-sandbox.yaml
+++ b/config/samples/sandbox/swiftkernel-sandbox.yaml
@@ -14,6 +14,6 @@ metadata:
   namespace: default
 spec:
   ociRef:
-    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.11
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.13
   kernelCmdline: "console=ttyS0"
   profile: sandbox

--- a/docs/sandbox/overview.md
+++ b/docs/sandbox/overview.md
@@ -34,7 +34,7 @@ For bursts of same-image sandboxes where the ~15s cold boot dominates, a
 
 - A node labeled `kubeswift.io/kernel-node=true`
 - A `Ready` `SwiftKernel` named `sandbox` (OCI artifact
-  `ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.11`, pulled per node)
+  `ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.13`, pulled per node)
 
 The sandbox kernel is not a plain `kernelRef` SwiftGuest kernel — its
 bridge-initramfs needs the OCI rootfs disk that the SwiftSandbox controller


### PR DESCRIPTION
Found while chasing an incidental observation from #414's validation. It turned out to be a real build-hygiene trap, and my first read of it was wrong — worth stating plainly.

### The trap

Buildroot applies `configs/sandbox-linux.config` (plus any profile fragment) to the kernel at its `linux-configure` step and then **stamps** it. A later edit to either file is silently ignored on an incremental build: `make build` rebuilds happily and produces a kernel from the **old** config, with no warning.

### It was live

`sandbox-linux.config` has said `CONFIG_MODULES=n` since the original SwiftSandbox PR, and the sandbox kernel is documented as monolithic — that is the entire reason the `gpu-sandbox` profile exists (its fragment adds `CONFIG_MODULES=y` so a GPU sandbox's image can `insmod` the NVIDIA driver). But the built tree still carried `CONFIG_MODULES=y` from an older configure, so **every `sandbox` kernel published from that tree was module-capable**, including `6.6.12` pushed earlier today.

### Diagnosis, not inference

My first hypothesis was that `CONFIG_MODULES=n` isn't the canonical Kconfig disable form and was being ignored. **That was wrong.** Feeding the config to the kernel's own `olddefconfig` yields `# CONFIG_MODULES is not set`, and `linux-reconfigure` on the existing tree flips the built config to match. So `=n` was always honored — it just never got re-applied. Neither buildroot force-enable path was involved either (`BR2_LINUX_NEEDS_MODULES` is absent; no kernel-module package is selected).

**The config was right and the docs were right. The build was stale.**

### Fix

- `make build` re-applies the kernel config via `linux-reconfigure` whenever a tracked config file is newer than the configure stamp.
- `make build` now prints the built `CONFIG_MODULES`, so drift is visible instead of silent.
- README documents the trap and the manual `linux-reconfigure` escape hatch.

### Republished kernels

| Tag | State |
|---|---|
| `kernels/sandbox:6.6.13` | genuinely monolithic (**5391360** vs 5514240 bytes) + the model-preload bridge |
| `kernels/gpu-sandbox:6.6.2` | `CONFIG_MODULES=y` — correct here; it built from scratch today so its config was never stale |

Sample manifests and `docs/sandbox/overview.md` bumped to match.

### Cluster-validated

A sandbox on `6.6.13` boots (Running + DHCP IP in ~20s); `/proc/modules` is **absent** in-guest (monolithic confirmed, not just asserted from the config); model preload still mounts read-only at `/model`.

Note: `make verify` (local boot smoke) could not run here — it needs `/opt/kata/bin/cloud-hypervisor`, which is not accessible in this environment. The cluster boot above is the validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)