### PR TITLE
fix(gpu): reject tier hgx-full (Tier 3) instead of booting a fabric-less guest

### DIFF
--- a/internal/controller/swiftgpu/controller.go
+++ b/internal/controller/swiftgpu/controller.go
@@ -117,10 +117,21 @@ func (r *SwiftGPUReconciler) backend(name string) gpualloc.Backend {
 // requeue / metrics the native path produced before the refactor.
 func (r *SwiftGPUReconciler) handlePrepareError(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, err error) (ctrl.Result, error) {
 	var pnf *ProfileNotFoundError
+	var ute *UnsupportedTierError
 	switch {
 	case errors.As(err, &pnf):
 		status := guest.Status.DeepCopy()
 		setGPUAllocatedCondition(status, false, "ProfileNotFound", pnf.Error())
+		if patchErr := r.patchStatus(ctx, guest, status); patchErr != nil {
+			return ctrl.Result{}, patchErr
+		}
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	case errors.As(err, &ute):
+		// Tier 3 requested but not deliverable — surface it as a condition (no silent
+		// failure) rather than booting a fabric-less guest. No GPUs were allocated
+		// (the tier check precedes findAndAllocate), so nothing to release.
+		status := guest.Status.DeepCopy()
+		setGPUAllocatedCondition(status, false, "UnsupportedTier", ute.Error())
 		if patchErr := r.patchStatus(ctx, guest, status); patchErr != nil {
 			return ctrl.Result{}, patchErr
 		}

--- a/internal/controller/swiftgpu/native_backend.go
+++ b/internal/controller/swiftgpu/native_backend.go
@@ -30,6 +30,28 @@ func (e *ProfileNotFoundError) Error() string {
 	return fmt.Sprintf("SwiftGPUProfile %q not found", e.Name)
 }
 
+// UnsupportedTierError is returned by nativeBackend.Prepare when the guest's
+// SwiftGPUProfile requests tier: hgx-full (Tier 3). The controller maps it to a
+// GPUAllocated=False / UnsupportedTier condition + a 30s requeue.
+//
+// Tier 3 (full baseboard passthrough) needs the host's NVSwitches passed INTO the
+// guest so an in-guest Fabric Manager can drive the fabric. gpu-discovery finds
+// those NVSwitches and records them on SwiftGPUNode.status.nvSwitches, but the
+// controller does not yet thread them into GPUIntent.NVSwitches (buildGPUIntent
+// omits the field), so a Tier-3 guest would boot with GPUs but NO fabric and an
+// in-guest FM with nothing to manage — a silent failure (Design Principle #6).
+// Reject it honestly until the guest-side NVSwitch passthrough is wired and can be
+// validated on real HGX hardware. Tier 2 (hgx-shared, host Fabric Manager, no
+// guest NVSwitches) is unaffected.
+type UnsupportedTierError struct{ Tier string }
+
+func (e *UnsupportedTierError) Error() string {
+	return fmt.Sprintf("tier %q (Tier 3, full baseboard passthrough) is not yet supported: "+
+		"the guest-side NVSwitch passthrough that an in-guest Fabric Manager needs is not wired "+
+		"(NVSwitches are discovered on the SwiftGPUNode but not passed into the guest). "+
+		"Use tier: hgx-shared (Tier 2, host Fabric Manager) or tier: pcie", e.Tier)
+}
+
 // Name implements gpualloc.Backend.
 func (n *nativeBackend) Name() string { return swiftv1alpha1.GPUBackendNative }
 
@@ -47,6 +69,14 @@ func (n *nativeBackend) Prepare(ctx context.Context, guest *swiftv1alpha1.SwiftG
 			return nil, &ProfileNotFoundError{Name: guest.Spec.GPUProfileRef.Name}
 		}
 		return nil, err
+	}
+
+	// Reject Tier 3 BEFORE allocating — it can't be delivered (see
+	// UnsupportedTierError), so allocating GPUs for it would strand them on a guest
+	// that boots without a fabric. Tier 2 (hgx-shared) is allowed: it uses the host
+	// Fabric Manager and does not pass NVSwitches into the guest.
+	if profile.Spec.Tier == "hgx-full" {
+		return nil, &UnsupportedTierError{Tier: profile.Spec.Tier}
 	}
 
 	gpuNode, selectedGPUs, numaNodes, partitionID, err := n.r.findAndAllocate(ctx, guest, &profile)

--- a/internal/controller/swiftgpu/tier3_reject_test.go
+++ b/internal/controller/swiftgpu/tier3_reject_test.go
@@ -1,0 +1,86 @@
+package swiftgpu
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gpuv1alpha1 "github.com/kubeswift-io/kubeswift/api/gpu/v1alpha1"
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+)
+
+// gpuAllocatedReason returns the reason on the GPUAllocated condition (or "").
+func gpuAllocatedReason(guest *swiftv1alpha1.SwiftGuest) string {
+	for _, c := range guest.Status.Conditions {
+		if c.Type == swiftv1alpha1.ConditionGPUAllocated {
+			return c.Reason
+		}
+	}
+	return ""
+}
+
+// A tier: hgx-full (Tier 3) guest must be REJECTED with a GPUAllocated=False /
+// UnsupportedTier condition, NOT booted with GPUs and no NVSwitch fabric. The
+// guest-side NVSwitch passthrough an in-guest Fabric Manager needs is not wired
+// (buildGPUIntent omits GPUIntent.NVSwitches), so allocating for Tier 3 would be a
+// silent failure. LOAD-BEARING: if a future change wires NVSwitches and lifts this
+// rejection, it must be hardware-validated first.
+func TestReconcile_HGXFull_RejectedNotSilentlyBooted(t *testing.T) {
+	node := testGPUNode("boba", eightGPUs(), &gpuv1alpha1.FabricManagerStatus{
+		Installed: true, Running: true, Version: "550.90.07",
+		Partitions: []gpuv1alpha1.FMPartitionStatus{{ID: 0, GPUIndices: []int{0, 1, 2, 3, 4, 5, 6, 7}, Active: true}},
+	})
+	profile := testGPUProfile("hgxfull", "default", "hgx-full", "", 8, "full")
+	guest := testSwiftGuest("t3", "default", &corev1.LocalObjectReference{Name: "hgxfull"})
+	r := newReconciler(node, profile, guest)
+
+	// First reconcile adds the finalizer; reconcile until the condition settles.
+	for i := 0; i < 3; i++ {
+		if _, err := reconcileGuest(r, "t3", "default"); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+	}
+
+	g, err := getGuest(r, "t3", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasGPUAllocatedCondition(g, metav1.ConditionFalse) {
+		t.Fatalf("Tier 3 guest must have GPUAllocated=False, conditions=%+v", g.Status.Conditions)
+	}
+	if reason := gpuAllocatedReason(g); reason != "UnsupportedTier" {
+		t.Errorf("GPUAllocated reason = %q, want UnsupportedTier", reason)
+	}
+	// No GPUs may have been allocated on the node (the tier check precedes allocation).
+	n, _ := getGPUNode(r, "boba")
+	if n.Status.FreeGPUs != 8 {
+		t.Errorf("Tier 3 rejection must not allocate GPUs: node free = %d, want 8", n.Status.FreeGPUs)
+	}
+	// And status.gpu must NOT be stamped (no fabric-less boot).
+	if g.Status.GPU != nil {
+		t.Errorf("Tier 3 guest must not get a GPUStatus, got %+v", g.Status.GPU)
+	}
+}
+
+// Tier 2 (hgx-shared) is NOT rejected by the tier gate — it uses the host Fabric
+// Manager and passes no NVSwitches into the guest, so it stays allocatable.
+func TestReconcile_HGXShared_NotRejectedByTierGate(t *testing.T) {
+	node := testGPUNode("boba", eightGPUs(), &gpuv1alpha1.FabricManagerStatus{
+		Installed: true, Running: true, Version: "550.90.07",
+		Partitions: []gpuv1alpha1.FMPartitionStatus{{ID: 0, GPUIndices: []int{0, 1, 2, 3, 4, 5, 6, 7}, Active: true}},
+	})
+	profile := testGPUProfile("hgx8", "default", "hgx-shared", "", 8, "shared")
+	guest := testSwiftGuest("t2", "default", &corev1.LocalObjectReference{Name: "hgx8"})
+	r := newReconciler(node, profile, guest)
+
+	for i := 0; i < 3; i++ {
+		if _, err := reconcileGuest(r, "t2", "default"); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+	}
+	g, _ := getGuest(r, "t2", "default")
+	if reason := gpuAllocatedReason(g); reason == "UnsupportedTier" {
+		t.Errorf("hgx-shared (Tier 2) must NOT be rejected by the Tier 3 gate, reason=%q", reason)
+	}
+}


### PR DESCRIPTION
Found by the v0.12.0 architectural docs audit. It is a real silent-failure bug, not a docs issue.

### The gap

The Tier-2/3 HGX QEMU runtime shipped in #404, but the Tier-3 chain has **one missing Go link**: `buildGPUIntent` (`internal/controller/swiftguest/gpu.go:153-160`) never populates `GPUIntent.NVSwitches`.

| Link | Status |
|---|---|
| gpu-discovery → `SwiftGPUNode.status.nvSwitches` | ✅ |
| `runtimeintent.GPUIntent.NVSwitches` field | ✅ |
| swiftletd deserializes + chains into VFIO | ✅ |
| swift-qemu-client renders them | ✅ |
| **Go controller populates `GPUIntent.NVSwitches`** | ❌ **zero producers** |

So a `tier: hgx-full` + `partitionMode: full` + `fabricManager.runInGuest: true` guest passed validation, allocated GPUs, selected QEMU, and **booted with GPUs but no NVSwitch fabric** — the in-guest Fabric Manager had nothing to manage, no error surfaced. A Design Principle #6 (no silent failures) violation.

### The fix

Tier 3 full-baseboard passthrough **can't be hardware-validated here** (no HGX in the lab), so wiring NVSwitches speculatively would violate Principle #7 (verified fixes only). Reject it honestly instead:

- `nativeBackend.Prepare` returns a typed `UnsupportedTierError` for `tier: hgx-full` **before** allocating (so no GPUs get stranded on a fabric-less guest).
- The controller maps it to a `GPUAllocated=False` / `UnsupportedTier` condition + 30s requeue.

This mirrors the sandbox path (`internal/controller/swiftsandbox/gpu.go`), which already rejects `hgx-*` honestly. When real HGX hardware exists, wire `GPUIntent.NVSwitches` and lift this gate as a **validated** change.

**Tier 2 (`hgx-shared`) is unaffected** — it uses the host Fabric Manager and passes no NVSwitches into the guest, so its Go-side wiring (#405–#407) is complete. Only Tier 3 is rejected.

### Tests

- Tier-3 guest → `GPUAllocated=False`/`UnsupportedTier`, **no GPUs allocated, no `GPUStatus` stamped** (verified load-bearing: the test FAILs against the reverted gate).
- Tier 2 is not caught by the gate.
- `gofmt -s`, `go build`, full `swiftgpu` suite green.

Part of v0.12.0 release prep: this makes the Tier-3 docs converge on "not implemented" honestly rather than the CHANGELOG/API docs over-claiming it as shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)