### PR TITLE
docs: align docs + CHANGELOG with v0.12.0 (GPU sandboxes, warm GPU pools, model preload, HGX Tier 2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,37 +4,99 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
-## [Unreleased]
+## [v0.12.0] — 2026-07-17
+
+GPU sandboxes graduate from a DRA-only spike to a complete feature: `SwiftSandbox`/
+`SwiftSandboxPool` gain a **native SwiftGPU allocation backend** (`spec.gpuProfileRef`,
+alongside the existing DRA `gpuResourceClaim`), **warm GPU pools** that hold pre-booted
+GPU slots for sub-second checkout, and **model preload** (`spec.model`) so an inference
+checkout starts with weights already resident. Sandboxes also gain a
+**scratch/persistent block disk** (`spec.scratchDisk`) and a working
+`spec.imagePullSecret`. The QEMU **Tier-2/3 HGX topology runtime** ships — Tier 2
+(`hgx-shared`, host Fabric Manager) is now allocatable and boots on the full generated
+topology; Tier 3 (`hgx-full`, in-guest Fabric Manager) is rejected at allocation, since
+the NVSwitch-into-guest passthrough isn't wired yet. The web console's Explorer now
+lists sandboxes generically, retiring the dedicated gateway `SandboxService`.
 
 ### Added
 
-- **Tier-2/3 HGX QEMU topology runtime** — the QEMU launch path now renders the
-  full GPU topology the controller has always computed (previously dropped as a
-  documented "when hardware is available" stub, leaving a flat PCI layout that
-  CUDA rejects): each SXM device behind its own `pcie-root-port` (unique
-  chassis/slot per QEMU docs/pcie.txt), `x-no-mmap=true` large-BAR handling,
-  per-NUMA-node shared memory backends + `-numa` bindings, optional 1G/2M
-  hugepage backing, SMP sockets matching the NUMA layout, NVSwitch device
-  passthrough (Tier 3), and post-spawn vCPU→host-CPU pinning via QMP
-  `query-cpus-fast` + `sched_setaffinity`. Grounded in the NVIDIA HGX Shared
-  NVSwitch Passthrough Integration Guide (WP-12736-002). Validated without GPU
-  hardware by `make verify-qemu-topology`, which boots the builder's exact args
-  on the shipping QEMU with emulated PCIe endpoints substituted on the same
-  root ports; VFIO/NVLink/Fabric-Manager runtime behaviour still requires real
-  HGX hardware.
+**Tier-2/3 HGX QEMU topology runtime**
+- The QEMU launch path now renders the full GPU topology the controller has always
+  computed (previously dropped as a documented "when hardware is available" stub,
+  leaving a flat PCI layout that CUDA rejects): each SXM device behind its own
+  `pcie-root-port` (unique chassis/slot per QEMU docs/pcie.txt), `x-no-mmap=true`
+  large-BAR handling, per-NUMA-node shared memory backends + `-numa` bindings,
+  optional 1G/2M hugepage backing, SMP sockets matching the NUMA layout, and
+  post-spawn vCPU→host-CPU pinning via QMP `query-cpus-fast` + `sched_setaffinity`
+  — usable today for **Tier 2** (`hgx-shared`). The builder can also emit NVSwitch
+  device-passthrough args for **Tier 3** (`hgx-full`), but Tier 3 allocation is
+  rejected (see Fixed below), so that path isn't reachable through the controller
+  yet. Grounded in the NVIDIA HGX Shared NVSwitch Passthrough Integration Guide
+  (WP-12736-002). Validated without GPU hardware by `make verify-qemu-topology`,
+  which boots the builder's exact args on the shipping QEMU with emulated PCIe
+  endpoints substituted on the same root ports; VFIO/NVLink/Fabric-Manager runtime
+  behaviour still requires real HGX hardware.
 
-- **GPU sandboxes (Phase 1) — pass a GPU into a SwiftSandbox via DRA.**
-  `SwiftSandbox.spec.gpuResourceClaim` allocates one Tier-1 GPU through a Kubernetes
-  DRA `ResourceClaim`: the scheduler picks the node/device, the DRA driver injects it
-  (CDI `GPU_PCI_ADDRESSES`), a `gpu-init` container binds VFIO, and the sandbox boots
-  firmware-less (mode-3) with the GPU passed through — an ephemeral VM boundary around
-  GPU inference / untrusted GPU code. The NVIDIA driver rides the guest OCI image and
-  loads at start; a GPU sandbox boots the new module-capable **`gpu-sandbox`** kernel
-  profile (selected automatically). GPU nodes must also be kernel nodes. DRA-only and
-  cold-boot-only in Phase 1 (`gpuResourceClaim` excludes `poolRef`); the native
-  `SwiftGPUProfile` backend and multi-GPU / multi-node are follow-ups
-  ([#390](https://github.com/kubeswift-io/kubeswift/issues/390)). Cluster-validated on
-  a GTX 1080 (`nvidia-smi` in the guest). Runbook: `docs/sandbox/gpu-sandboxes.md`.
+**GPU sandboxes — two allocation backends, warm GPU pools, model preload**
+- **Pass a GPU into a `SwiftSandbox` via either backend.** `spec.gpuResourceClaim`
+  (DRA — the scheduler + a DRA driver allocate at pod-schedule time) or
+  `spec.gpuProfileRef` (native SwiftGPU — the SwiftGPU controller allocates at
+  controller time), mutually exclusive. Either way a `gpu-init` container binds
+  VFIO and the sandbox boots firmware-less (mode-3) with the GPU passed through —
+  an ephemeral VM boundary around GPU inference / untrusted GPU code. The NVIDIA
+  driver rides the guest OCI image and loads at start; a GPU sandbox boots the
+  module-capable **`gpu-sandbox`** kernel profile (selected automatically). GPU
+  nodes must also be kernel nodes. Single Tier-1 GPU per sandbox; multi-GPU /
+  multi-node remain scoped follow-ups (#390). Cluster-validated on a GTX 1080
+  (`nvidia-smi` in the guest). Runbook: `docs/sandbox/gpu-sandboxes.md`.
+- **Native SwiftGPU allocation backend for sandboxes (`spec.gpuProfileRef`).** The
+  SwiftGPU controller allocates the device(s) at controller time against a
+  `SwiftGPUProfile` + `SwiftGPUNode` (no ResourceClaim), stamps `status.gpu`, pins
+  the sandbox to the allocated node, and `gpu-init` binds the specific BDF(s) — the
+  same allocation core the native SwiftGuest path uses. `tier: pcie` only;
+  `hgx-shared`/`hgx-full` are rejected at allocation (`GPUAllocated=False` reason
+  `UnsupportedTier` — use a SwiftGuest for the QEMU HGX path). (#410)
+- **Warm GPU pools (`SwiftSandboxPool.spec.gpuProfileRef`).** Setting
+  `gpuProfileRef` on a pool makes every warm slot a GPU sandbox holding a native
+  SwiftGPU allocation, pre-booted so a checkout is sub-second instead of a cold GPU
+  boot. Trades an idle GPU per warm slot for latency — size `minWarm` to the free
+  GPU count. GPU pools warm only on nodes that are both `gpu-node` and
+  `kernel-node`; `tier: pcie` only. A checking-out `SwiftSandbox` sets `poolRef`
+  alone — never a GPU field — and inherits the slot's GPU implicitly (the webhook
+  rejects `poolRef` + either GPU field on a user-authored sandbox: a GPU sandbox
+  always boots cold, so the slot's GPU shape, not the claimant's request, is what
+  matters). (#412)
+- **Model preload (`spec.model`, on both `SwiftSandbox` and
+  `SwiftSandboxPool`).** Mounts a read-only, node-shared model artifact — an OCI
+  image whose filesystem holds the weights — into the sandbox over virtio-fs
+  (default `/model`). Materialized once per node (digest-keyed cache,
+  cosign-verifiable via `verifyKeySecretRef`) and shared read-only from the host
+  page cache, so a warm GPU pool with a preloaded model needs neither a cold GPU
+  boot nor a cold model load on checkout. (#414)
+
+**Sandbox scratch disks + private-registry pulls**
+- **Scratch / persistent block disk (`SwiftSandbox.spec.scratchDisk`).** Attaches
+  one secondary block disk to the sandbox guest — for build caches, dataset
+  staging, checkpoints, or a GPU model/weight cache — beyond the ephemeral
+  RAM-backed rootfs overlay. `blank` provisions a new, sandbox-owned, sized Block
+  PVC (GC'd with the sandbox); `pvcRef` attaches an existing Block PVC that
+  persists beyond it. Reuses the v0.4.2 blank-data-disk runtime path (raw
+  `--disk`, no filesystem mount) — the workload runs `mkfs`+`mount` itself. New
+  `ScratchDiskReady` condition gates boot on the PVC being Bound. (#411)
+- **`spec.imagePullSecret` is now wired through the sandbox materialize path**
+  (on both `SwiftSandbox` and `SwiftSandboxPool`, and for `spec.model`'s image).
+  Resolves the named docker-registry Secret and attaches it to the
+  materialize/pool pods so a private-registry rootfs or model image pulls
+  correctly; an invalid or missing secret surfaces as `ImagePullSecretInvalid`
+  rather than a generic pull failure. (#402)
+
+**Gateway Explorer sandbox catalog**
+- **The web console's Explorer replaces the dedicated gateway `SandboxService`.**
+  `SwiftSandbox`/`SwiftSandboxPool` are now surfaced through the generic
+  ResourceService/Explorer resource catalog (phase/image/node/IP and
+  phase/warm/claimed/min columns) instead of a bespoke Connect-RPC service — one
+  fewer service to keep in sync as the sandbox CRD surface grows. (#387) The
+  v0.11.0 `SandboxService` is removed. (#401)
 
 ### Fixed
 
@@ -77,6 +139,26 @@ All notable changes to KubeSwift are documented here.
   the guest), and the `GPUAllocated=NoCapacity` condition names the mismatch
   rather than reporting a bare "no capacity".
 
+- **SwiftGuest GPU allocation now rejects `tier: hgx-full` (Tier 3) instead of
+  silently routing it through the QEMU path.** The native SwiftGPU backend
+  previously treated `hgx-full` the same as `hgx-shared` (Tier 2, host Fabric
+  Manager) and would allocate a Tier 3 guest onto the same QEMU runtime — but
+  the in-guest Fabric Manager / NVSwitch-into-guest passthrough isn't wired, so
+  an `hgx-full` guest would fail at boot/fabric time rather than at allocation
+  (a silent-failure-shaped gap, not a clean rejection). `nativeBackend.Prepare`
+  now returns an `UnsupportedTierError` for `hgx-full`, surfaced as
+  `GPUAllocated=False` reason `UnsupportedTier` — mirroring the SwiftSandbox
+  native GPU path's existing tier gate. `tier: hgx-shared` (Tier 2) is
+  unaffected and allocatable on the topology runtime above. (#416)
+
+- **Sandbox kernel build was silently re-using a stale `.config`, shipping a
+  non-monolithic kernel.** Buildroot applies `configs/sandbox-linux.config` (plus
+  any profile fragment) at its `linux-configure` step and then STAMPS it, so a
+  later edit was ignored on incremental builds — the `sandbox` kernel had shipped
+  `CONFIG_MODULES=y` even though the config had said `=n` for months. `make build`
+  now re-applies the config whenever it changed and prints the built
+  `CONFIG_MODULES`. Republished `kernels/sandbox:6.6.13` (now genuinely monolithic)
+  and `kernels/gpu-sandbox:6.6.2`. (#415)
 
 - **Sandboxes without `spec.workingDir` panicked on kernel 6.6.10** (regression
   from v0.11.0's cold-path workingDir change). The bridge-initramfs runs `set -u`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.11.0 \
+  --version 0.12.0 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -29,7 +29,7 @@ Boot your first VM → [Quickstart](docs/quickstart.md).
 - **Services** — expose guest ports as Kubernetes Services via `spec.network.ports` (ClusterIP/NodePort/LoadBalancer), a load-balanced Service across pool replicas via `SwiftGuestPool.spec.service`, and a VM→cluster egress reachability probe surfaced as `EgressReady`.
 - **Storage** — per-guest root-disk cloning sized from a class; optional data disks (blank/sized, image-backed, or attached PVC); RWX+Block for live-migration-capable volumes.
 - **Snapshots & clones** — disk-only (CSI) and memory+disk (local/S3) snapshots, scheduled snapshots, and `cloneFromSnapshot` for fast VM fan-out.
-- **Sandboxes** — ephemeral OCI-rootfs microVMs ([SwiftSandbox](docs/sandbox/overview.md)) for CI runners, agent/code execution, and untrusted code; restricted-by-default egress, cosign verify-before-boot, and a block or virtio-fs rootfs. Warm pools (`SwiftSandboxPool`) keep pre-booted slots ready for sub-second checkout.
+- **Sandboxes** — ephemeral OCI-rootfs microVMs ([SwiftSandbox](docs/sandbox/overview.md)) for CI runners, agent/code execution, and untrusted code; restricted-by-default egress, cosign verify-before-boot, and a block or virtio-fs rootfs. Warm pools (`SwiftSandboxPool`) keep pre-booted slots ready for sub-second checkout. [GPU sandboxes](docs/sandbox/gpu-sandboxes.md) pass a GPU through via the native SwiftGPU or DRA backend, with warm GPU pools and model preload (`spec.model`) for sub-second inference starts; `spec.scratchDisk` attaches a block disk for build caches or dataset staging.
 - **OCI registry artifacts** — golden VM images (`SwiftImage.spec.source.oci` + `swiftctl image publish`, cosign-signed with verify-on-pull) and VM snapshots / full-state cold migration (`SwiftSnapshot` `backend.type: oci`) stored in any OCI registry, for cross-cluster and edge distribution.
 - **Migration** — offline migration on any storage, and live migration (sub-second downtime) with optional mTLS transport and `kubectl drain` integration.
 - **Fleets** — `SwiftGuestPool` gives ReplicaSet-style scaling with rolling updates, topology spread, and a PVC per replica.

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.11.0
-appVersion: "0.11.0"
+version: 0.12.0
+appVersion: "0.12.0"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/config/samples/sandbox/README.md
+++ b/config/samples/sandbox/README.md
@@ -5,7 +5,31 @@ filesystem (read-only base + tmpfs overlay), boots in a second or two, and clean
 itself up.
 
 - `swiftkernel-sandbox.yaml` — the `sandbox` kernel profile (pulled per node).
+- `swiftkernel-gpu-sandbox.yaml` — the module-capable `gpu-sandbox` kernel profile
+  (required for GPU sandboxes, either backend).
 - `swiftsandbox.yaml` — a restricted shell sandbox and a network-isolated one.
+- `swiftsandbox-verified.yaml` — a cosign-signature-verified sandbox
+  (`verifyKeySecretRef`), plus a warm pool of verified slots.
+- `swiftsandbox-virtiofs.yaml` — rootfs delivered over virtio-fs
+  (`rootfsMode: virtiofs`) instead of the default block disk.
+- `swiftsandbox-scratch-disk.yaml` — a secondary block disk
+  (`spec.scratchDisk`): a sandbox-owned `blank` PVC and an existing-PVC
+  (`pvcRef`) variant. See [`docs/sandbox/scratch-disks.md`](../../../docs/sandbox/scratch-disks.md).
+- `swiftsandbox-gpu.yaml` — a GPU sandbox via the **DRA** backend
+  (`gpuResourceClaim`) + its `ResourceClaimTemplate`.
+- `swiftsandbox-gpu-native.yaml` — a GPU sandbox via the **native SwiftGPU**
+  backend (`gpuProfileRef`) — no DRA driver needed.
+- `swiftsandboxpool.yaml` — a warm pool of plain (non-GPU) slots.
+- `swiftsandbox-pooled.yaml` — a sandbox that checks out from
+  `swiftsandboxpool.yaml`.
+- `swiftsandboxpool-gpu.yaml` — a warm **GPU** pool (every slot holds a GPU) +
+  a sandbox that checks one out.
+- `swiftsandboxpool-gpu-model.yaml` — a warm GPU pool with a preloaded model
+  (`spec.model`) + a checkout that starts inference with no cold model load.
+
+See [`docs/sandbox/gpu-sandboxes.md`](../../../docs/sandbox/gpu-sandboxes.md) and
+[`docs/sandbox/warm-pool.md`](../../../docs/sandbox/warm-pool.md) for the GPU and
+warm-pool samples' operator guides.
 
 Prereqs:
 - A node labeled `kubeswift.io/kernel-node=true`.
@@ -37,8 +61,7 @@ Notes:
   semantics (command overrides the image ENTRYPOINT, args the CMD, env is merged
   over the image env), delivered to the guest on a per-sandbox read-only config
   disk — never the kernel cmdline, so env stays out of `/proc/cmdline` and the
-  host's `ps`/logs. A bare image runs its own entrypoint. (`workingDir` is not
-  honored in v1 — the workload starts in `/`.)
+  host's `ps`/logs. A bare image runs its own entrypoint.
 - **Exit status**: the workload runs as a supervised child, so its real exit code
   is surfaced as `status.exitCode` — a non-zero exit terminates the sandbox `Failed`,
   zero terminates it `Completed`.

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,6 +1,6 @@
 # API Overview
 
-Eight CRDs across five API groups. All `v1alpha1` (no stability guarantee).
+Fifteen CRDs across nine API groups. All `v1alpha1` (no stability guarantee).
 
 ## CRDs
 
@@ -14,6 +14,13 @@ Eight CRDs across five API groups. All `v1alpha1` (no stability guarantee).
 | SwiftKernel | `sk` | Namespaced | Kernel + initramfs OCI artifact; must be Ready before SwiftGuest |
 | SwiftGPUProfile | `sgp` | Namespaced | GPU passthrough request (count, model, tier, topology) |
 | SwiftGPUNode | `sgn` | Cluster | Per-node GPU inventory; auto-populated by Discovery DaemonSet |
+| SwiftSnapshot | `ssnap` | Namespaced | VM snapshot — disk-only (CSI) or memory+disk (local/S3/OCI) |
+| SwiftRestore | `srst` | Namespaced | Restore a VM from a SwiftSnapshot, in-place or as a clone |
+| SwiftSnapshotSchedule | `sss` | Namespaced | Cron-scheduled snapshots + keep-N retention |
+| SwiftMigration | `smig` | Namespaced | Move a SwiftGuest between nodes — offline or live |
+| SwiftSandbox | `sbox` | Namespaced | Ephemeral OCI-rootfs microVM (a third boot mode); PVC-free |
+| SwiftSandboxPool | `sboxpool` | Namespaced | Warm buffer of pre-booted sandbox slots for sub-second checkout |
+| Cluster | `ksc` | Namespaced | Member cluster federated by the kubeswift-gateway hub |
 
 ## API groups
 
@@ -24,6 +31,10 @@ Eight CRDs across five API groups. All `v1alpha1` (no stability guarantee).
 | `seed.kubeswift.io` | SwiftSeedProfile |
 | `kernel.kubeswift.io` | SwiftKernel |
 | `gpu.kubeswift.io` | SwiftGPUProfile, SwiftGPUNode |
+| `snapshot.kubeswift.io` | SwiftSnapshot, SwiftRestore, SwiftSnapshotSchedule |
+| `migration.kubeswift.io` | SwiftMigration |
+| `sandbox.kubeswift.io` | SwiftSandbox, SwiftSandboxPool |
+| `fleet.kubeswift.io` | Cluster |
 
 ## Typical workflows
 
@@ -61,5 +72,12 @@ Eight CRDs across five API groups. All `v1alpha1` (no stability guarantee).
 5. Update `template.spec` to trigger a rolling update.
 
 [SwiftGuest](swiftguest.md) · [SwiftGuestPool](swiftguestpool.md) · [SwiftGuestClass](swiftguestclass.md) · [SwiftImage](swiftimage.md) · [SwiftSeedProfile](swiftseedprofile.md) · [SwiftKernel](swiftkernel.md) · [SwiftGPUProfile](swiftgpuprofile.md) · [SwiftGPUNode](swiftgpunode.md)
+
+The snapshot/migration/sandbox/fleet CRDs (SwiftSnapshot, SwiftRestore,
+SwiftSnapshotSchedule, SwiftMigration, SwiftSandbox, SwiftSandboxPool, Cluster)
+have concise field references in [the CRD reference](../crds.md) and full
+operator guides under [Snapshots](../snapshots/csi-snapshots.md),
+[Migration](../migration/overview.md), [Sandboxes](../sandbox/overview.md), and
+[Gateway](../ui/gateway.md) respectively.
 
 Topics: [Data disks](data-disks.md) — blank / image-backed / attached-PVC secondary disks.

--- a/docs/api/swiftgpunode.md
+++ b/docs/api/swiftgpunode.md
@@ -25,6 +25,8 @@ The entire resource is status-only (no user-editable spec).
 | `gpuCount` | Total number of GPUs on this node |
 | `freeGPUs` | Number of unallocated GPUs |
 | `gpuModel` | GPU model (assumes homogeneous node) |
+| `gpuVendor` | GPU vendor (assumes homogeneous node): `"NVIDIA"`, `"AMD"`, `"Intel"` |
+| `vfioReady` | `true` when the `vfio-pci` driver is loaded on this node (`/sys/bus/pci/drivers/vfio-pci` exists). GPU allocation and the migration GPU target pre-flight refuse a node that isn't `vfioReady`. Loading `vfio-pci` is a host responsibility (e.g. `/etc/modules-load.d`) — the minimal-capability discovery DaemonSet only detects and reports it, it cannot `modprobe`. Printcolumn `VfioReady`. |
 
 ### Host topology
 
@@ -49,6 +51,7 @@ Each entry in `gpus[]`:
 |-------|-------------|
 | `index` | GPU index on this node (0-7) |
 | `pciAddress` | Full PCI BDF (e.g. `"0000:17:00.0"`) |
+| `vendor` | GPU manufacturer: `"NVIDIA"`, `"AMD"`, `"Intel"`, or `"Unknown (<vendor-id>)"` |
 | `model` | Human-readable model (e.g. `"NVIDIA H200 SXM"`) |
 | `deviceId` | PCI vendor:device ID (e.g. `"10de:2336"`) |
 | `numaNode` | Physical NUMA node this GPU is attached to |
@@ -85,8 +88,13 @@ Each entry in `nvSwitches[]`:
 
 | Fields | Written by |
 |--------|-----------|
-| `phase`, `lastDiscovery`, `host`, `gpus[].index` through `gpus[].barSizes`, `nvSwitches`, `fabricManager.installed/version/running/partitions[].id/gpuIndices` | GPU Discovery DaemonSet |
-| `gpus[].allocated`, `gpus[].allocatedTo`, `fabricManager.partitions[].active/allocatedTo`, `gpuCount`, `freeGPUs`, `gpuModel` | SwiftGPU Controller |
+| `phase`, `lastDiscovery`, `host`, `gpuVendor`, `vfioReady`, `gpus[].index` through `gpus[].barSizes` (incl. `gpus[].vendor`), `nvSwitches`, `fabricManager.installed/version/running/partitions[].id/gpuIndices/active` | GPU Discovery DaemonSet |
+| `gpus[].allocated`, `gpus[].allocatedTo`, `fabricManager.partitions[].allocatedTo`, `gpuCount`, `freeGPUs`, `gpuModel` | SwiftGPU Controller |
+
+`fabricManager.partitions[].active` is written by discovery (it reflects the
+host `fmpm` partition state, not a KubeSwift allocation decision) — `gpu-init`
+activates the partition via `fmpm -a` before swiftletd starts, and the next
+discovery cycle picks up the change.
 
 The discovery DaemonSet preserves controller-owned fields during status patches.
 

--- a/docs/api/swiftgpuprofile.md
+++ b/docs/api/swiftgpuprofile.md
@@ -27,9 +27,9 @@ SwiftGPUProfile defines a **GPU passthrough request**. It describes how many GPU
 | `numaTopology.threadsPerCore` | No | `1` | SMT threads per core (usually 1). |
 | `numaTopology.memoryPerSocketMi` | No | — | Memory per NUMA node in MiB. |
 | `hugepages` | No | `""` | Hugepage size: `1Gi`, `2Mi`, or `""` (none). `1Gi` required for most GPU workloads. |
-| `vcpuPinning` | No | `false` | 1:1 vCPU to physical CPU pinning. Critical for HGX performance. |
-| `fabricManager.runInGuest` | No | `false` | `true` for Tier 3 full passthrough (FM inside guest). |
-| `fabricManager.requiredVersion` | No | `""` | Host FM version must match guest nvidia-open driver. |
+| `vcpuPinning` | No | `false` | 1:1 vCPU to physical CPU pinning. Critical for HGX performance. **Best-effort**: swiftletd applies pinning post-spawn via QMP and logs a warning on failure, but does not fail the launch — a pinning failure degrades performance, it does not block boot. |
+| `fabricManager.runInGuest` | No | `false` | `true` for Tier 3 full passthrough (FM inside guest). **Tier 3 is not implemented** — see [Tiers](#tiers) below; setting `tier: hgx-full` is rejected at allocation regardless of this field. |
+| `fabricManager.requiredVersion` | No | `""` | Host FM version must match guest nvidia-open driver. **This is an allocation gate, not advisory**: shared-mode allocation skips any node whose Fabric Manager version doesn't exactly match, and reports the mismatch by name in `GPUAllocated=NoCapacity` if it's the sole blocker. An empty value means no check (any FM version accepted). |
 
 ## Tiers
 
@@ -39,7 +39,7 @@ The `tier` field is the single decision point for hypervisor and topology select
 |------|------------|---------------|----------|----------------|--------------|
 | `pcie` | Cloud Hypervisor | Flat (no root ports) | No | No | A100-PCIe, L40S, RTX 4090 |
 | `hgx-shared` | QEMU | Root port per device | Host-managed | Host (shared partition) | H100-SXM, H200-SXM |
-| `hgx-full` | QEMU | Full PCIe hierarchy | Passed to guest | Guest | 8-GPU HGX full passthrough |
+| `hgx-full` | — | — | — | — | **Not implemented — rejected at allocation.** The design targets full PCIe hierarchy + guest-passed NVSwitches + in-guest FM for 8-GPU HGX full passthrough, but the in-guest Fabric Manager wiring doesn't exist yet. Allocation rejects `tier: hgx-full` with `GPUAllocated=False` reason `UnsupportedTier`. Use `hgx-shared` (Tier 2). |
 
 Firmware is auto-selected: `CLOUDHV.fd` for Cloud Hypervisor, `OVMF` for QEMU.
 
@@ -48,8 +48,8 @@ Firmware is auto-selected: `CLOUDHV.fd` for Cloud Hypervisor, `OVMF` for QEMU.
 | Mode | Description |
 |------|-------------|
 | `isolated` | No NVLink. Single GPU or multiple GPUs without fabric connectivity. |
-| `shared` | GPUs share NVSwitch fabric via host Fabric Manager partition. |
-| `full` | All GPUs + NVSwitches passed to one VM. Fabric Manager runs inside guest. |
+| `shared` | GPUs share NVSwitch fabric via host Fabric Manager partition. **`count` must exactly equal a partition's member-GPU count** (the FM partition, not an arbitrary GPU selection, is the unit of allocation — NVLink only connects GPUs *within* the same activated partition) and Fabric Manager must be running on the node; otherwise allocation permanently reports `NoCapacity` even if enough free GPUs exist. |
+| `full` | All GPUs + NVSwitches passed to one VM. Fabric Manager runs inside guest. **Not implemented — rejected at allocation** (see `hgx-full` in [Tiers](#tiers) above). |
 
 ## Examples
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -315,7 +315,7 @@ Key facts:
 | `sandbox.kubeswift.io/v1alpha1` | SwiftSandbox | Ephemeral OCI-rootfs microVM sandboxes |
 | `fleet.kubeswift.io/v1alpha1` | Cluster | Member cluster federated by the gateway hub |
 
-14 CRDs across 9 API groups, all `v1alpha1`.
+15 CRDs across 9 API groups, all `v1alpha1`.
 
 ## Design principles
 

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -1,6 +1,6 @@
 # CRD Reference
 
-All KubeSwift CRDs are `v1alpha1`. KubeSwift ships **14 CRDs across 9 API groups**. This document gives full field detail for the core workload CRDs (SwiftGuest, SwiftGuestClass, SwiftImage, SwiftSeedProfile, SwiftKernel, SwiftGPUProfile, SwiftGPUNode), and concise reference entries — purpose, key fields, and a link to the authoritative feature doc — for the snapshot, migration, pool, sandbox, and fleet CRDs. For exhaustive field detail on any CRD, use `kubectl explain <crd>` against an installed cluster.
+All KubeSwift CRDs are `v1alpha1`. KubeSwift ships **15 CRDs across 9 API groups**. This document gives full field detail for the core workload CRDs (SwiftGuest, SwiftGuestClass, SwiftImage, SwiftSeedProfile, SwiftKernel, SwiftGPUProfile, SwiftGPUNode), and concise reference entries — purpose, key fields, and a link to the authoritative feature doc — for the snapshot, migration, pool, sandbox, and fleet CRDs. For exhaustive field detail on any CRD, use `kubectl explain <crd>` against an installed cluster.
 
 | CRD | Short | API group | Scope | Reference |
 |-----|-------|-----------|-------|-----------|
@@ -12,11 +12,12 @@ All KubeSwift CRDs are `v1alpha1`. KubeSwift ships **14 CRDs across 9 API groups
 | SwiftKernel | `sk` | `kernel.kubeswift.io` | Namespaced | [below](#swiftkernel) |
 | SwiftGPUProfile | `sgp` | `gpu.kubeswift.io` | Namespaced | [below](#swiftgpuprofile) |
 | SwiftGPUNode | `sgn` | `gpu.kubeswift.io` | Cluster | [below](#swiftgpunode) |
-| SwiftSnapshot | — | `snapshot.kubeswift.io` | Namespaced | [below](#swiftsnapshot) |
-| SwiftRestore | — | `snapshot.kubeswift.io` | Namespaced | [below](#swiftrestore) |
-| SwiftSnapshotSchedule | — | `snapshot.kubeswift.io` | Namespaced | [below](#swiftsnapshotschedule) |
-| SwiftMigration | — | `migration.kubeswift.io` | Namespaced | [below](#swiftmigration) |
+| SwiftSnapshot | `ssnap` | `snapshot.kubeswift.io` | Namespaced | [below](#swiftsnapshot) |
+| SwiftRestore | `srst` | `snapshot.kubeswift.io` | Namespaced | [below](#swiftrestore) |
+| SwiftSnapshotSchedule | `sss` | `snapshot.kubeswift.io` | Namespaced | [below](#swiftsnapshotschedule) |
+| SwiftMigration | `smig` | `migration.kubeswift.io` | Namespaced | [below](#swiftmigration) |
 | SwiftSandbox | `sbox` | `sandbox.kubeswift.io` | Namespaced | [below](#swiftsandbox) |
+| SwiftSandboxPool | `sboxpool` | `sandbox.kubeswift.io` | Namespaced | [below](#swiftsandboxpool) |
 | Cluster | `ksc` | `fleet.kubeswift.io` | Namespaced | [below](#cluster) |
 
 ## Mutual exclusivity rules
@@ -534,16 +535,53 @@ and PVC-free.
 | Key field | Type | Description |
 |-----------|------|--------------|
 | `image` | string | OCI image to run as the root filesystem. Required; immutable after create. |
+| `imagePullSecret` | string | docker-registry Secret (same namespace) for a private `image` (and `model.imageRef`, if set). |
+| `verifyKeySecretRef.name` | string | Secret holding a cosign public key; cosign-verifies `image` before it materializes. |
+| `rootfsMode` | enum | `block` (default, read-only ext4 disk) or `virtiofs` (unpacked tree over virtio-fs). |
 | `cpu` / `memory` | int32 / Quantity | vCPUs (default `1`) and RAM (default `512Mi`). |
-| `command` / `args` / `env` | []string / []string / []EnvVar | Override or extend the image's entrypoint. |
+| `command` / `args` / `env` / `workingDir` | []string / []string / []EnvVar / string | Override or extend the image's entrypoint, environment, and working directory. |
 | `network.mode` | enum | `restricted` (default, deny-ingress + hardened egress), `open` (deny-ingress, allow-all egress), or `none`. |
-| `kernelProfileRef` | LocalObjectReference | SwiftKernel to boot; defaults to the well-known `sandbox` profile. |
+| `kernelProfileRef` | LocalObjectReference | SwiftKernel to boot; defaults to the well-known `sandbox` profile (or `gpu-sandbox` when a GPU is requested). |
+| `nodeSelector` | map[string]string | Extra node constraints, merged with the required `kubeswift.io/kernel-node=true`. |
+| `poolRef` | LocalObjectReference | Check out a pre-booted slot from a `SwiftSandboxPool` instead of the cold path; falls back to cold on a miss. Mutually exclusive with either GPU field. |
+| `gpuResourceClaim` | GPUResourceClaimSpec | Pass a GPU through via Kubernetes DRA (scheduler-time allocation). Mutually exclusive with `gpuProfileRef`. |
+| `gpuProfileRef` | LocalObjectReference | Pass a GPU through via the native SwiftGPU backend (controller-time allocation, `tier: pcie` only). Mutually exclusive with `gpuResourceClaim`. |
+| `scratchDisk` | SandboxScratchDisk | Attaches one secondary raw block disk — `blank` (sandbox-owned, sized) or `pvcRef` (an existing Block PVC). |
+| `model` | SandboxModel | Mounts a read-only, node-shared model artifact over virtio-fs (`imageRef` + `mountPath`, default `/model`). |
 | `timeout` / `ttl` | Duration | Wall-clock run cap and post-terminal retention. |
 
 The whole spec except `ttl` is immutable — recreate the sandbox to change
 image, resources, command, or network.
 
-Full reference: [Sandboxes](sandbox/overview.md).
+Full reference: [Sandboxes](sandbox/overview.md) · [GPU sandboxes](sandbox/gpu-sandboxes.md) · [Scratch disks](sandbox/scratch-disks.md).
+
+---
+
+## SwiftSandboxPool
+
+**Group:** `sandbox.kubeswift.io/v1alpha1`
+**Scope:** Namespaced
+**Short name:** `sboxpool`
+**Subresource:** status, scale
+
+A warm buffer of pre-booted, workload-less `SwiftSandbox` slots for one OCI
+image, kept Ready so a `SwiftSandbox` with `spec.poolRef` checks out in
+sub-second time instead of paying the cold materialize + boot. The `scale`
+subresource (`.spec.minWarm`) is the seam for `kubectl scale` and an HPA.
+
+| Key field | Type | Description |
+|-----------|------|--------------|
+| `image` | string | OCI image every warm slot boots. Required; all slots share one materialized rootfs. |
+| `imagePullSecret` / `verifyKeySecretRef` / `rootfsMode` | string / SecretObjectReference / enum | Same semantics as `SwiftSandbox`, applied to every slot. |
+| `cpu` / `memory` | int32 / Quantity | vCPUs (default `1`) and RAM (default `512Mi`) of each warm slot. |
+| `network.mode` | enum | `restricted` (default), `open`, or `none` — applies to every slot. |
+| `kernelProfileRef` / `nodeSelector` | LocalObjectReference / map[string]string | SwiftKernel to boot (default `sandbox`) and extra node constraints. |
+| `gpuProfileRef` | LocalObjectReference | Makes this a **warm GPU pool**: every slot holds a native SwiftGPU allocation, pre-booted. `tier: pcie` only. |
+| `model` | SandboxModel | Preloads a read-only model artifact into every slot. |
+| `minWarm` | int32 | Desired Ready (unclaimed) warm slots. Default `1`. The scale-subresource target. |
+| `maxWarm` | int32 | Cap on warm slots (back-pressure); `0` means no cap beyond `minWarm`. |
+
+Full reference: [Warm pools](sandbox/warm-pool.md) · [GPU sandboxes › Warm GPU pools](sandbox/gpu-sandboxes.md#warm-gpu-pools-sub-second-inference-start).
 
 ---
 

--- a/docs/gpu-passthrough.md
+++ b/docs/gpu-passthrough.md
@@ -27,12 +27,22 @@ lsmod | grep vfio
 # Expected: vfio_pci, vfio_iommu_type1, vfio listed
 ```
 
-### For HGX SXM nodes (Tier 2/3 only)
+### For HGX SXM nodes (Tier 2 — `hgx-shared`)
 
 - NVIDIA Fabric Manager installed and running
 - Host FM version must exactly match the `nvidia-open` driver version in the guest image
 - 1GiB hugepages configured (`/proc/sys/vm/nr_hugepages`)
 - OVMF firmware available at `/usr/share/OVMF/OVMF_CODE.fd` (included in swiftletd image)
+- **`nvidia-smi` on the node, reachable by the GPU Discovery DaemonSet.** FM
+  expresses partition membership in GPU physical/Module IDs, which do not
+  follow lspci order — discovery needs `nvidia-smi -q` to translate them into
+  the device-Index space the shared-NVSwitch allocator consumes. Without
+  `nvidia-smi`, partition membership silently degrades to an identity mapping
+  (module ID == device index), which is wrong on real HGX baseboards. Discovery
+  logs a prominent warning when it falls back this way.
+
+Tier 3 (`hgx-full`, in-guest Fabric Manager) is **not implemented** — see
+[GPU compatibility tiers](#gpu-compatibility-tiers) below.
 
 ## GPU compatibility tiers
 
@@ -45,13 +55,13 @@ lsmod | grep vfio
 | H100-SXM (2-4 GPU) | `hgx-shared` | QEMU | Yes | Yes (host) | Required | Required |
 | H200-SXM (2-4 GPU) | `hgx-shared` | QEMU | Yes | Yes (host) | Required | Required |
 | B200-SXM (2-4 GPU) | `hgx-shared` | QEMU | Yes + noMmap | Yes (host) | Required | Required |
-| Any HGX (8 GPU full) | `hgx-full` | QEMU | Full hierarchy | Yes (guest) | Required | Required |
+| Any HGX (8 GPU full) | `hgx-full` | — | — | — | — | **not implemented** |
 
 **Tier 1 (`pcie`)**: Cloud Hypervisor is used. Each GPU is passed with `--device path=<sysfs>,x_nv_gpudirect_clique=0`. Flat PCI topology is sufficient — CUDA initializes correctly for PCIe-attached GPUs.
 
 **Tier 2 (`hgx-shared`)**: QEMU is required. CUDA refuses to initialize on a flat PCI topology for HGX SXM GPUs. Each GPU is placed behind its own `pcie-root-port`. The host Fabric Manager manages NVSwitch partitions. OVMF firmware is used for UEFI boot.
 
-**Tier 3 (`hgx-full`)**: QEMU with full PCIe hierarchy including expander buses, root ports, and switches. NVSwitches are passed to the guest. Fabric Manager runs inside the guest. This is Phase 4 — not yet implemented.
+**Tier 3 (`hgx-full`)**: **Not implemented — rejected at allocation.** The design calls for QEMU with a full PCIe hierarchy (expander buses, root ports, switches), NVSwitches passed to the guest, and Fabric Manager running inside the guest (SwiftGPU Phase 4 on the roadmap). The QEMU builder can emit the NVSwitch device-passthrough args, but the in-guest Fabric Manager wiring doesn't exist, so a `SwiftGPUProfile` with `tier: hgx-full` fails at allocation (`GPUAllocated=False` reason `UnsupportedTier`) rather than booting into a broken fabric. Use `tier: hgx-shared` (Tier 2) today.
 
 ## GPU Discovery DaemonSet
 
@@ -301,7 +311,7 @@ Key fields in `status`:
 
 ## Fabric Manager
 
-Fabric Manager (FM) is required for HGX SXM GPUs in shared or full passthrough mode. It manages the NVSwitch fabric that connects GPUs.
+Fabric Manager (FM) is required for HGX SXM GPUs in shared partition mode (Tier 2). It manages the NVSwitch fabric that connects GPUs. Full passthrough mode (Tier 3, FM inside the guest) is not yet implemented — see [GPU compatibility tiers](#gpu-compatibility-tiers).
 
 **Version matching**: The FM version on the host must exactly match the `nvidia-open` driver version in the guest image. Mismatches cause CUDA initialization failures that appear as "no devices found" in `nvidia-smi`.
 
@@ -316,7 +326,7 @@ Fabric Manager (FM) is required for HGX SXM GPUs in shared or full passthrough m
 
 - `isolated` — No Fabric Manager involvement. GPUs have no NVLink connectivity.
 - `shared` — Host FM manages the partition. Guest uses NVLink through the NVSwitch fabric.
-- `full` — All GPUs + NVSwitches passed to a single VM. FM runs inside the guest. (Phase 4)
+- `full` — All GPUs + NVSwitches passed to a single VM. FM runs inside the guest. **Not implemented — rejected at allocation** (see Tier 3 above; SwiftGPU Phase 4 on the roadmap).
 
 ## Network Separation for GPU Workloads
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # KubeSwift Documentation
 
-KubeSwift runs Linux and Windows VMs on Kubernetes. [Cloud Hypervisor](https://www.cloud-hypervisor.org/) is the primary hypervisor — disk boot, kernel boot, Windows guests, PCIe GPU passthrough, snapshots, and migration all run on it. QEMU is a secondary runtime used only for HGX SXM multi-GPU topologies, where CUDA requires a full PCIe hierarchy. Define guests with CRDs; the control plane reconciles them into pods; swiftletd launches the hypervisor. Two boot sources are supported: disk boot (cloud images with firmware) and kernel boot (direct bzImage + initramfs); Windows guests use `osType: windows`, a disk-boot variant.
+KubeSwift runs Linux and Windows VMs on Kubernetes. [Cloud Hypervisor](https://www.cloud-hypervisor.org/) is the primary hypervisor — disk boot, kernel boot, Windows guests, PCIe GPU passthrough, snapshots, and migration all run on it. QEMU is a secondary runtime used only for HGX SXM multi-GPU topologies, where CUDA requires a full PCIe hierarchy. Define guests with CRDs; the control plane reconciles them into pods; swiftletd launches the hypervisor. Three boot modes are supported: disk boot (cloud images with firmware), kernel boot (direct bzImage + initramfs), and ephemeral OCI-rootfs sandboxes (`SwiftSandbox`, direct kernel + read-only OCI rootfs + tmpfs overlay); Windows guests use `osType: windows`, a disk-boot variant.
 
 ## Documentation Index
 
@@ -14,6 +14,7 @@ KubeSwift runs Linux and Windows VMs on Kubernetes. [Cloud Hypervisor](https://w
 ### API Reference
 
 - [API overview](api/overview.md) — API groups, CRDs, versioning
+- [CRD reference](crds.md) — full field detail for every CRD, concise reference for the rest
 - [SwiftGuest](api/swiftguest.md) — VM instance resource
 - [SwiftGuestClass](api/swiftguestclass.md) — Cluster-scoped template (CPU, memory, root disk)
 - [SwiftImage](api/swiftimage.md) — Disk image source (HTTP, PVC)
@@ -34,6 +35,10 @@ KubeSwift runs Linux and Windows VMs on Kubernetes. [Cloud Hypervisor](https://w
 ### Sandboxes
 
 - [Ephemeral OCI-rootfs sandboxes](sandbox/overview.md) — SwiftSandbox: run an OCI image as a microVM (CI runners, agent/code execution, untrusted code)
+- [GPU sandboxes](sandbox/gpu-sandboxes.md) — pass a GPU into a sandbox via the native SwiftGPU or DRA backend, warm GPU pools, model preload
+- [Warm pools](sandbox/warm-pool.md) — pre-booted SwiftSandbox slots for sub-second checkout
+- [Scratch / persistent disks](sandbox/scratch-disks.md) — attach a secondary block disk for build caches or datasets
+- [Build your own](sandbox/build-your-own.md) — custom sandbox kernels + base images (BYO / in-house library)
 
 ### Windows Guests
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,11 +57,11 @@ Verify CRDs are installed:
 
 ```bash
 kubectl get crd | grep kubeswift.io
-# Expected (14 CRDs): swiftguests, swiftguestclasses, swiftguestpools,
+# Expected (15 CRDs): swiftguests, swiftguestclasses, swiftguestpools,
 #   swiftimages, swiftseedprofiles, swiftkernels,
 #   swiftgpuprofiles, swiftgpunodes,
 #   swiftsnapshots, swiftrestores, swiftsnapshotschedules,
-#   swiftmigrations, swiftsandboxes, clusters
+#   swiftmigrations, swiftsandboxes, swiftsandboxpools, clusters
 ```
 
 ## Step 2: Boot a disk-boot VM (Ubuntu Noble)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.11.0 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.12.0 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows

--- a/docs/sandbox/gpu-sandboxes.md
+++ b/docs/sandbox/gpu-sandboxes.md
@@ -2,9 +2,11 @@
 
 Pass a GPU into a [sandbox](overview.md) — an ephemeral microVM with a real VM
 boundary around GPU code (CUDA inference, untrusted or multi-tenant GPU
-workloads). The GPU is allocated through Kubernetes **DRA** (Dynamic Resource
-Allocation): the scheduler picks the node and device, and the sandbox boots
-firmware-less (mode-3) with the GPU passed through via VFIO.
+workloads). Two allocation backends: **native** SwiftGPU (`spec.gpuProfileRef`)
+allocates the device(s) at controller time and pins the sandbox to that node;
+**DRA** (`spec.gpuResourceClaim`) lets the kube-scheduler and a DRA driver
+allocate at pod-schedule time. Either way the sandbox boots firmware-less
+(mode-3) with the GPU passed through via VFIO.
 
 > **Status: Phase 1 — single Tier-1 GPU, cluster-validated on a GTX 1080.**
 > Multi-GPU / NVLink and multi-node distributed inference are scoped but not yet
@@ -34,21 +36,33 @@ sandbox kernel is monolithic and can't `insmod`).
 
 ## Prerequisites
 
-1. **A DRA GPU driver** — the KubeSwift reference driver (`gpu.kubeswift.io`,
-   deviceclass `kubeswift-vfio-gpu`) or the NVIDIA `k8s-dra-driver-gpu`. The node
-   publishes a `ResourceSlice` for its GPU(s).
-2. **A GPU node that is also a kernel node.** The node needs both
+Common to both backends:
+
+1. **A GPU node that is also a kernel node.** The node needs both
    `kubeswift.io/gpu-node=true` (discovery) and **`kubeswift.io/kernel-node=true`**
    — the kernel artifacts and `/dev/kvm` live on kernel nodes, and a GPU sandbox
    stays pinned there (unlike a GPU SwiftGuest). `vfio-pci` must be loadable on the
    node.
-3. **The `gpu-sandbox` SwiftKernel:**
+2. **The `gpu-sandbox` SwiftKernel:**
    ```bash
    kubectl apply -f config/samples/sandbox/swiftkernel-gpu-sandbox.yaml
    kubectl get swiftkernel gpu-sandbox -w      # wait for Ready (per-node ORAS pull)
    ```
+
+**DRA backend only** (`spec.gpuResourceClaim`):
+
+3. **A DRA GPU driver** — the KubeSwift reference driver (`gpu.kubeswift.io`,
+   deviceclass `kubeswift-vfio-gpu`) or the NVIDIA `k8s-dra-driver-gpu`. The node
+   publishes a `ResourceSlice` for its GPU(s).
 4. **A `ResourceClaimTemplate`** for the GPU (one device of your GPU deviceclass) —
    see `config/samples/sandbox/` for an example.
+
+**Native backend only** (`spec.gpuProfileRef`):
+
+3. **`gpu-discovery` running** on the GPU node, populating the `SwiftGPUNode`
+   inventory (no DRA driver, no ResourceSlice, no ResourceClaim).
+4. **A `SwiftGPUProfile`** describing the GPU request (`count`, `tier: pcie`) —
+   see `config/samples/sandbox/swiftsandbox-gpu-native.yaml`.
 
 ## The guest image (BYO)
 
@@ -95,12 +109,17 @@ swiftctl sandbox logs gpu-infer         # nvidia-smi output, workload logs
 The scheduler places the sandbox on a node with a free GPU device; `kubectl get
 resourceclaim` shows the allocation.
 
-## Limits (Phase 1)
+For the native backend instead of DRA — no ResourceClaim, no scheduler
+involvement, the SwiftGPU controller allocates and pins the node — see
+[`config/samples/sandbox/swiftsandbox-gpu-native.yaml`](../../config/samples/sandbox/swiftsandbox-gpu-native.yaml).
 
-- **DRA only.** `gpuResourceClaim` (not `gpuProfileRef`). Needs a DRA driver on the
-  cluster.
-- **Cold-boot only.** `gpuResourceClaim` and `poolRef` are mutually exclusive — a
-  warm pool can't hold a scarce GPU idle. (Warm GPU pools are a later tier.)
+## Limits
+
+- **Cold-boot only for a plain `SwiftSandbox`.** The webhook rejects `poolRef`
+  combined with either `gpuResourceClaim` or `gpuProfileRef` on a user-authored
+  sandbox — a warm pool can't cheaply hold a scarce GPU idle for an arbitrary
+  claimant. (A [warm GPU pool](#warm-gpu-pools-sub-second-inference-start) holds
+  the GPU on the *slot* itself, not the claimant — see below.)
 - **Single Tier-1 GPU.** One PCIe GPU per sandbox, no NVLink. Multi-GPU
   tensor-parallel and multi-node are scoped
   ([#390](https://github.com/kubeswift-io/kubeswift/issues/390)) but need hardware.

--- a/docs/sandbox/overview.md
+++ b/docs/sandbox/overview.md
@@ -74,6 +74,11 @@ Ready-to-edit manifests and notes:
 | `network.mode` | enum | `restricted` | `restricted`, `open`, or `none`. See [Network modes](#network-modes). |
 | `kernelProfileRef.name` | string | `sandbox` | SwiftKernel to boot. |
 | `nodeSelector` | map[string]string | — | Additional node constraints, merged with the required `kubeswift.io/kernel-node=true`. |
+| `poolRef.name` | string | — | Check out a pre-booted slot from this `SwiftSandboxPool` (sub-second) instead of the cold materialize+boot path; falls back to cold on a miss. Same namespace. See [Warm pools](warm-pool.md). |
+| `gpuResourceClaim` | GPUResourceClaimSpec | — | Pass a GPU through via Kubernetes **DRA**: the scheduler + a DRA driver allocate at pod-schedule time. Mutually exclusive with `gpuProfileRef` and with `poolRef`. See [GPU sandboxes](gpu-sandboxes.md). |
+| `gpuProfileRef.name` | string | — | Pass a GPU through via the **native SwiftGPU** backend: the SwiftGPU controller allocates at controller time against this `SwiftGPUProfile` and pins the sandbox to the allocated node. Mutually exclusive with `gpuResourceClaim` and with `poolRef`. `tier: pcie` only. See [GPU sandboxes](gpu-sandboxes.md). |
+| `scratchDisk` | SandboxScratchDisk | — | Attaches one secondary raw block disk (`blank`, sandbox-owned, or `pvcRef`, an existing PVC) for build caches, datasets, or checkpoints. See [Scratch / persistent disks](scratch-disks.md). |
+| `model.imageRef` / `model.mountPath` | string / string (default `/model`) | — | Mounts a read-only, node-shared model artifact (an OCI image whose filesystem holds the weights) over virtio-fs. See [GPU sandboxes › Model preload](gpu-sandboxes.md#model-preload). |
 
 Everything in `spec` except `ttl` is immutable after create — recreate the
 sandbox to change image, resources, command, or network.
@@ -83,15 +88,18 @@ sandbox to change image, resources, command, or network.
 | Field | Type | Description |
 |---|---|---|
 | `phase` | enum | `Pending`, `Materializing`, `Running`, `Completed`, `Failed`. |
-| `conditions[]` | []Condition | `Resolved`, `RootfsReady`, `GuestRunning`. |
+| `conditions[]` | []Condition | `Resolved`, `RootfsReady`, `GuestRunning`, plus `GPUAllocated` (native GPU backend only) and `ScratchDiskReady` (when `spec.scratchDisk` is set). |
 | `nodeName` | string | Node running the sandbox. |
-| `podRef` | string | Launcher pod name. |
+| `podRef` | string | Launcher pod name (the claimed slot's pod name for a pool checkout). |
 | `rootfs.digest` | string | Resolved image digest (`sha256:...`). |
 | `rootfs.sizeBytes` | int64 | Materialized ext4 size. |
 | `rootfs.cachePath` | string | Node-local rootfs artifact path. |
 | `runtime.pid` | int64 | Hypervisor process PID (reported by swiftletd). |
 | `runtime.hypervisor` | string | Always `cloud-hypervisor`. |
 | `network.primaryIP` | string | Guest DHCP IP. Absent for `network.mode: none`. |
+| `gpu.devices[]` / `gpu.nodeName` / `gpu.hypervisor` | []string / string / string | The native backend's allocation (PCI addresses, allocated node, resolved hypervisor). Absent for the DRA backend (the claim's ResourceClaim status carries device identity) and non-GPU sandboxes. |
+| `scratchDisk.pvcName` / `scratchDisk.devicePath` / `scratchDisk.bound` | string / string / bool | The attached scratch disk once its PVC is Bound. Absent when `spec.scratchDisk` is unset. |
+| `model.digest` / `model.mountPath` / `model.cachePath` | string / string / string | The resolved model artifact once materialized. Absent when `spec.model` is unset. |
 | `startedAt` | Time | When the guest began running. |
 | `terminalAt` | Time | When the sandbox first reached `Completed`/`Failed` — the anchor for `spec.ttl`. |
 | `exitCode` | int32 | The workload's real exit code: `0` → `Completed`, non-zero → `Failed`. |
@@ -192,7 +200,8 @@ you're done inspecting it.
 ## See also
 
 - [Warm pools (fast start)](warm-pool.md) — pre-booted slots for sub-second checkout
-- [GPU sandboxes](gpu-sandboxes.md) — pass a GPU into a sandbox via DRA
+- [GPU sandboxes](gpu-sandboxes.md) — pass a GPU into a sandbox via the native SwiftGPU or DRA backend
+- [Scratch / persistent disks](scratch-disks.md) — attach a secondary block disk for build caches or datasets
 - [Build your own](build-your-own.md) — custom sandbox kernels + base images (BYO / in-house library)
 - [`config/samples/sandbox/`](../../config/samples/sandbox/) — sample manifests and notes
 - [swiftctl reference](../swiftctl.md)

--- a/docs/sandbox/scratch-disks.md
+++ b/docs/sandbox/scratch-disks.md
@@ -61,5 +61,14 @@ command: ["/bin/sh", "-c",
 
 - **Auto-mkfs + mount at a path** (a bridge-init addition) — so the workload
   just sees a directory. Follow-up.
-- **Pool-shared read-only cache** across warm `SwiftSandboxPool` slots (the GPU
-  weight-cache case) — tracked with the warm-GPU-pool work.
+
+## Pool-shared read-only cache
+
+A **pool-shared, read-only** cache across warm `SwiftSandboxPool` slots (the GPU
+weight-cache case this doc originally tracked as a follow-up) is now covered by
+`spec.model` — a read-only OCI model artifact mounted over virtio-fs and
+materialized once per node, shared into every slot's host page cache. It composes
+with `scratchDisk` rather than replacing it: `model` is the right tool for
+read-only, registry-distributed weights; `scratchDisk` (especially `pvcRef`) is
+still the tool for a writable or non-OCI shared cache. See
+[GPU sandboxes › Model preload](gpu-sandboxes.md#model-preload).

--- a/docs/sandbox/warm-pool.md
+++ b/docs/sandbox/warm-pool.md
@@ -43,6 +43,13 @@ is involved.
 Same as a plain sandbox — a `kubeswift.io/kernel-node=true` node and a `Ready`
 `sandbox` `SwiftKernel`. See [Running sandboxes › Prerequisites](overview.md#prerequisites).
 
+**A warm GPU pool** (`spec.gpuProfileRef` set) additionally needs a node that is
+**both** `kubeswift.io/gpu-node=true` **and** `kubeswift.io/kernel-node=true`
+(with `vfio-pci` loadable and `gpu-discovery` running), the `gpu-sandbox`
+SwiftKernel instead of the base `sandbox` one, and a `SwiftGPUProfile` with
+**`tier: pcie`** — a warm slot boots mode-3 (Cloud Hypervisor direct-kernel), so
+`hgx-shared`/`hgx-full` are rejected. See [GPU sandboxes › Warm GPU pools](gpu-sandboxes.md#warm-gpu-pools-sub-second-inference-start).
+
 ## Quickstart
 
 ```bash
@@ -66,14 +73,18 @@ Ready-to-edit manifests: [`config/samples/sandbox/`](../../config/samples/sandbo
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `image` | string | — | OCI image every slot boots. Required. All slots share one materialized rootfs. Digest reference preferred. |
-| `imagePullSecret` | string | — | docker-registry Secret (same namespace) for a private `image`. |
+| `imagePullSecret` | string | — | docker-registry Secret (same namespace) for a private `image` (and for `model.imageRef`, if set). |
+| `verifyKeySecretRef.name` | string | — | Secret (same namespace) holding a cosign public key (`cosign.pub`). Every warm slot is cosign-verified before it materializes. |
+| `rootfsMode` | enum | `block` | How each slot's OCI rootfs is delivered: `block` (read-only ext4 disk) or `virtiofs` (unpacked tree over virtio-fs). A claiming `SwiftSandbox` must request the same mode. |
 | `cpu` | int32 | `1` | vCPUs per slot. |
-| `memory` | Quantity | `512Mi` | RAM per slot. |
-| `minWarm` | int32 | `0` | Warm slots to keep ready — the warm buffer the pool maintains. This is the scale-subresource target (`kubectl scale sboxpool`); see [Scaling](#scaling). |
+| `memory` | Quantity | `512Mi` | RAM per slot. Held per warm slot — a pool of N slots holds N × `memory` idle. |
+| `minWarm` | int32 | `1` | Warm slots to keep ready — the warm buffer the pool maintains. This is the scale-subresource target (`kubectl scale sboxpool`); see [Scaling](#scaling). |
 | `maxWarm` | int32 | — | Cap on warm slots. The effective cap is `max(maxWarm, minWarm)` — set below `minWarm` and `minWarm` wins. |
 | `network.mode` | enum | `restricted` | `restricted`, `open`, or `none` — same semantics as [SwiftSandbox](overview.md#network-modes). Applies to every slot. |
 | `kernelProfileRef.name` | string | `sandbox` | SwiftKernel the slots boot. |
 | `nodeSelector` | map[string]string | — | Extra node constraints, merged with the required `kubeswift.io/kernel-node=true`. |
+| `gpuProfileRef.name` | string | — | Makes this a **warm GPU pool**: every slot holds a native SwiftGPU allocation against this `SwiftGPUProfile`, pre-booted. Trades an idle GPU per slot for latency — size `minWarm` ≤ your free GPU count. `tier: pcie` only; `hgx-shared`/`hgx-full` are rejected. See [GPU sandboxes › Warm GPU pools](gpu-sandboxes.md#warm-gpu-pools-sub-second-inference-start). |
+| `model.imageRef` / `model.mountPath` | string / string (default `/model`) | — | Preloads a read-only, node-shared model artifact into every slot over virtio-fs (digest-keyed cache, cosign-verifiable). See [GPU sandboxes › Model preload](gpu-sandboxes.md#model-preload). |
 
 ### Status
 


### PR DESCRIPTION
The docs had drifted from the shipped code across the whole v0.12.0 arc. A staff-architect audit produced a precise, line-referenced gap list; a technical-writer executed it (verifying every field/default/condition against `api/` + the controllers), and I reviewed + added a few adjacent fixes. This is the last piece before cutting **v0.12.0**.

Cuts the **v0.12.0 CHANGELOG** entry and bumps **Chart `0.11.0 → 0.12.0`**. Depends on #415 (merged) and #416 (merged) — the branch is rebased on top of both, so the CHANGELOG credits them and `docs/sandbox/overview.md` carries #415's `kernels/sandbox:6.6.13`.

### What was wrong (highlights)

- **CHANGELOG denied two of its own headline features** — the GPU-sandboxes entry still said "DRA only / native backend is a follow-up" while #410 (native `gpuProfileRef`) and #412 (warm GPU pools) shipped in the same release. Rewritten to the final state; 7 missing entries added (#410/#412/#414/#411/#402/#387/#401) plus the #404 Tier-2/3 runtime, the FM fixes (#405/#406/#407), and the two just-merged fixes (#415/#416).
- **`docs/sandbox/gpu-sandboxes.md` "Limits" contradicted its own page** — "DRA only" and "warm GPU pools are a later tier", both false. Removed; both backends documented; the `poolRef`-XOR-GPU rule written correctly (GPU is the *slot's* shape, not the claimant's request).
- **`warm-pool.md` had `minWarm` default `0`** — the CRD default is `1`, and each warm GPU slot holds a whole GPU idle, so the wrong default mis-sizes a GPU pool on the first try.
- **`config/samples/sandbox/README.md` said `workingDir` is "not honored in v1"** — it is, on both the cold and checkout paths.
- **CRD count `14 → 15`** across `crds.md` / `api/overview.md` / `architecture.md` / `quickstart.md`; the `SwiftSandboxPool` section/row added; 10 missing `SwiftSandbox` fields; four missing short names (`ssnap`/`srst`/`sss`/`smig`); the SwiftSandbox v0.12.0 fields + `GPUAllocated`/`ScratchDiskReady` conditions in `overview.md`.
- **GPU operator traps documented** — the `nvidia-smi` HGX prerequisite (#406), the `partitionMode: shared` exact-count + FM-running requirement, `requiredVersion`-is-a-gate (#407), `vcpuPinning`-is-best-effort; the `swiftgpunode` `fabricManager.partitions[].active` ownership fixed (gpu-discovery, not the controller); every **Tier 3** mention converged on "not implemented / rejected at allocation".

### Verification

The writer verified each claim against `api/sandbox/v1alpha1/`, `api/gpu/v1alpha1/`, `internal/controller/swiftsandbox/`, `internal/controller/swiftgpu/`, and the samples; it also ran a full relative-link + anchor-resolution sweep across every changed file (and caught + fixed a depth-3 link bug in the samples README). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)