### PR TITLE
feat(net): hand a secondary NAD interface its IP into the guest

### DIFF
--- a/internal/controller/swiftguest/ovnkubernetes.go
+++ b/internal/controller/swiftguest/ovnkubernetes.go
@@ -61,23 +61,24 @@ var ipamClaimGVK = schema.GroupVersionKind{
 // OVN-Kubernetes layer2 NAD. ok=false (no error) means "not an OVN-K layer2
 // primary-on-NAD guest" → the caller skips. A Get error is returned so the caller
 // requeues (fail closed).
-func ovnKubernetesPrimaryNAD(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest) (network, iface string, ok bool, err error) {
-	prim := guest.PrimaryInterface()
-	if prim == nil || prim.NetworkRef == nil {
-		return "", "", false, nil
-	}
-	ns := prim.NetworkRef.Namespace
+// ovnKubernetesNADNetwork resolves a networkRef to the OVN logical-network name (the
+// NAD config "name", used as the IPAMClaim spec.network) when it names an
+// OVN-Kubernetes layer2 NAD. ok=false (no error) means "not an OVN-K layer2 NAD"
+// (kube-ovn / bridge / localnet → the caller skips). A Get error is returned so the
+// caller requeues (fail closed).
+func ovnKubernetesNADNetwork(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest, ref *swiftv1alpha1.NetworkReference) (network string, ok bool, err error) {
+	ns := ref.Namespace
 	if ns == "" {
 		ns = guest.Namespace
 	}
 	nad := &unstructured.Unstructured{}
 	nad.SetGroupVersionKind(networkAttachmentDefinitionGVK)
-	if e := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: prim.NetworkRef.Name}, nad); e != nil {
-		return "", "", false, fmt.Errorf("get NAD %s/%s for ovn-kubernetes identity: %w", ns, prim.NetworkRef.Name, e)
+	if e := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: ref.Name}, nad); e != nil {
+		return "", false, fmt.Errorf("get NAD %s/%s for ovn-kubernetes identity: %w", ns, ref.Name, e)
 	}
 	cfgStr, _, _ := unstructured.NestedString(nad.Object, "spec", "config")
 	if cfgStr == "" {
-		return "", "", false, nil
+		return "", false, nil
 	}
 	var cfg struct {
 		Type     string `json:"type"`
@@ -85,22 +86,34 @@ func ovnKubernetesPrimaryNAD(ctx context.Context, c client.Client, guest *swiftv
 		Name     string `json:"name"`
 	}
 	if json.Unmarshal([]byte(cfgStr), &cfg) != nil {
-		return "", "", false, nil
+		return "", false, nil
 	}
-	// v1: only ovn-k8s-cni-overlay + layer2 + a named OVN network (the IPAMClaim's
-	// spec.network). Any other type/topology is not this backend's (kube-ovn,
-	// bridge, localnet → skip).
+	// v1: only ovn-k8s-cni-overlay + layer2 + a named OVN network. Any other
+	// type/topology is not this backend's (kube-ovn, bridge, localnet → skip).
 	if cfg.Type != OVNKubernetesCNIType || cfg.Topology != OVNKubernetesLayer2Topology || cfg.Name == "" {
+		return "", false, nil
+	}
+	return cfg.Name, true, nil
+}
+
+// ovnKubernetesPrimaryNAD returns the OVN logical-network name + the primary
+// interface's Multus name when the guest's PRIMARY rides an OVN-Kubernetes layer2
+// NAD. ok=false means the primary is not an OVN-K layer2 NAD (a secondary-only guest
+// still takes the general Identity path). Retained for the migration-dst code path.
+func ovnKubernetesPrimaryNAD(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest) (network, iface string, ok bool, err error) {
+	prim := guest.PrimaryInterface()
+	if prim == nil || prim.NetworkRef == nil {
 		return "", "", false, nil
 	}
-	// The primary's Multus interface name (net1, ...) — the IPAMClaim spec.interface
-	// and the entry to augment. primaryIdx is the primary's position among the
-	// NAD-bearing entries; it is >= 0 here because the primary has a NetworkRef.
+	network, ok, err = ovnKubernetesNADNetwork(ctx, c, guest, prim.NetworkRef)
+	if err != nil || !ok {
+		return "", "", ok, err
+	}
 	entries, primaryIdx := buildMultusEntries(guest)
 	if primaryIdx < 0 || primaryIdx >= len(entries) {
 		return "", "", false, nil
 	}
-	return cfg.Name, entries[primaryIdx].Interface, true, nil
+	return network, entries[primaryIdx].Interface, true, nil
 }
 
 // ovnKubernetesClaimName is the deterministic, per-guest-per-interface IPAMClaim
@@ -116,59 +129,90 @@ type ovnKubernetesBackend struct{}
 
 func (ovnKubernetesBackend) Name() string { return "ovn-kubernetes" }
 
-// Detect reports whether the guest's primary interface rides an OVN-Kubernetes
-// layer2 NAD.
+// Detect reports whether ANY of the guest's interfaces (primary or secondary) rides
+// an OVN-Kubernetes layer2 NAD.
 func (ovnKubernetesBackend) Detect(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest) (bool, error) {
-	_, _, ok, err := ovnKubernetesPrimaryNAD(ctx, c, guest)
-	return ok, err
+	for i := range guest.Spec.Interfaces {
+		ref := guest.Spec.Interfaces[i].NetworkRef
+		if ref == nil {
+			continue
+		}
+		_, ok, err := ovnKubernetesNADNetwork(ctx, c, guest, ref)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
-// Identity injects the guest MAC (the LSP identity) + the ipam-claim-reference into
-// the primary NAD's Multus selection element, and returns the per-guest IPAMClaim to
-// ensure. MigrationDstAnnotations is empty: the augmented Multus annotation is carried
-// onto the dst pod by mergeAnnotationsForDst and OVN-K allows the cross-node claim
-// overlap by default (spike P0-c), so the dst keeps the identity + IP with no marker.
+// Identity injects the guest MAC (the LSP identity) + an ipam-claim-reference into
+// EVERY OVN-Kubernetes NAD interface's Multus selection element (primary and/or
+// secondary), and returns the per-interface IPAMClaims to ensure. A secondary NAD
+// interface (e.g. a routable node-datapath NIC) needs the same treatment as the
+// primary, or OVN's per-port ARP responder answers with the pod NIC's MAC and the
+// bridged guest is unreachable on the segment. MigrationDstAnnotations is empty: the
+// augmented Multus annotation is carried onto the dst pod by mergeAnnotationsForDst
+// and OVN-K allows the cross-node claim overlap by default (spike P0-c).
 func (ovnKubernetesBackend) Identity(ctx context.Context, c client.Client, guest *swiftv1alpha1.SwiftGuest, _ string) (ovnIdentity, error) {
-	network, iface, ok, err := ovnKubernetesPrimaryNAD(ctx, c, guest)
-	if err != nil {
-		return ovnIdentity{}, err
-	}
-	if !ok {
+	// The full networks annotation (matching the pod builder's, since both use
+	// buildMultusEntries). Entries are in guest.Spec.Interfaces order among the
+	// NAD-bearing interfaces, so the idx counter below indexes straight into it.
+	entries, _ := buildMultusEntries(guest)
+	if len(entries) == 0 {
 		return ovnIdentity{}, nil
 	}
-	mac := primaryMAC(guest, guest.PrimaryInterface())
-	if mac == "" {
-		return ovnIdentity{}, nil
-	}
-	claimName := ovnKubernetesClaimName(guest, iface)
 
-	// Rebuild the full networks annotation (matching the pod builder's, since both
-	// use buildMultusEntries) with mac + ipam-claim-reference on the primary entry.
-	entries, primaryIdx := buildMultusEntries(guest)
-	if primaryIdx < 0 || primaryIdx >= len(entries) {
+	var claims []*unstructured.Unstructured
+	idx := -1
+	for i := range guest.Spec.Interfaces {
+		iface := &guest.Spec.Interfaces[i]
+		if iface.NetworkRef == nil {
+			continue
+		}
+		idx++
+		if idx >= len(entries) {
+			break
+		}
+		network, ok, err := ovnKubernetesNADNetwork(ctx, c, guest, iface.NetworkRef)
+		if err != nil {
+			return ovnIdentity{}, err
+		}
+		if !ok {
+			continue // kube-ovn / bridge / localnet — not this backend's
+		}
+		mac := primaryMAC(guest, iface)
+		if mac == "" {
+			continue
+		}
+		claimName := ovnKubernetesClaimName(guest, entries[idx].Interface)
+		entries[idx].MAC = mac
+		entries[idx].IPAMClaimReference = claimName
+
+		// spec.network is the OVN logical-network name (the NAD config "name"),
+		// spec.interface this interface's Multus name. Owner-ref + create are applied
+		// by the stamp dispatch (ensureOVNClaim).
+		claim := &unstructured.Unstructured{}
+		claim.SetGroupVersionKind(ipamClaimGVK)
+		claim.SetNamespace(guest.Namespace)
+		claim.SetName(claimName)
+		_ = unstructured.SetNestedField(claim.Object, network, "spec", "network")
+		_ = unstructured.SetNestedField(claim.Object, entries[idx].Interface, "spec", "interface")
+		claims = append(claims, claim)
+	}
+	if len(claims) == 0 {
 		return ovnIdentity{}, nil
 	}
-	entries[primaryIdx].MAC = mac
-	entries[primaryIdx].IPAMClaimReference = claimName
+
 	data, err := json.Marshal(entries)
 	if err != nil {
 		return ovnIdentity{}, fmt.Errorf("marshal ovn-kubernetes networks annotation: %w", err)
 	}
-
-	// The IPAMClaim this guest's pod (and its migration dst) reference. spec.network
-	// is the OVN logical-network name (the NAD config "name"), spec.interface the
-	// primary's Multus interface. Owner-ref + create are applied by the stamp
-	// dispatch (ensureOVNClaim).
-	claim := &unstructured.Unstructured{}
-	claim.SetGroupVersionKind(ipamClaimGVK)
-	claim.SetNamespace(guest.Namespace)
-	claim.SetName(claimName)
-	_ = unstructured.SetNestedField(claim.Object, network, "spec", "network")
-	_ = unstructured.SetNestedField(claim.Object, iface, "spec", "interface")
-
 	return ovnIdentity{
 		PodAnnotations:          map[string]string{MultusAnnotationKey: string(data)},
 		MigrationDstAnnotations: nil,
-		ClaimsToEnsure:          []*unstructured.Unstructured{claim},
+		ClaimsToEnsure:          claims,
 	}, nil
 }

--- a/internal/controller/swiftguest/ovnkubernetes_test.go
+++ b/internal/controller/swiftguest/ovnkubernetes_test.go
@@ -200,6 +200,48 @@ func TestStampOVNIdentity_OVNKubernetes_CreatesClaimAndStamps(t *testing.T) {
 	}
 }
 
+// A guest whose PRIMARY is node-local nat but whose SECONDARY interface rides an
+// OVN-K NAD (e.g. a routable node-datapath NIC) gets the same stamping: the secondary
+// entry carries the guest MAC + ipam-claim-reference and its IPAMClaim is created.
+// Without it OVN's per-port ARP responder answers with the pod NIC's MAC and the
+// bridged guest is unreachable on the segment.
+func TestStampOVNIdentity_OVNKubernetes_SecondaryNAD(t *testing.T) {
+	s := ovnkDispatchScheme()
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ovn-ns", Name: "ovnk-vm"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			Interfaces: []swiftv1alpha1.GuestInterface{
+				{Name: "mgmt", Primary: true}, // node-local nat, no NAD
+				{Name: "node", MAC: "52:54:00:ab:cd:ef", NetworkRef: &swiftv1alpha1.NetworkReference{Name: "ovnk-nad"}},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ovnkNADObj("ovn-ns", "ovnk-nad", "ovnknet", "layer2")).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: s}
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ovn-ns", Name: "p"}}
+	if err := r.stampOVNIdentity(context.Background(), guest, pod); err != nil {
+		t.Fatalf("stampOVNIdentity: %v", err)
+	}
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(ipamClaimGVK)
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "ovn-ns", Name: "ovnk-vm-net1"}, got); err != nil {
+		t.Fatalf("secondary IPAMClaim not created: %v", err)
+	}
+	if net, _, _ := unstructured.NestedString(got.Object, "spec", "network"); net != "ovnknet" {
+		t.Errorf("created claim spec.network = %q, want ovnknet", net)
+	}
+
+	var entries []multusNetworkEntry
+	if err := json.Unmarshal([]byte(pod.Annotations[MultusAnnotationKey]), &entries); err != nil {
+		t.Fatalf("pod networks annotation: %v", err)
+	}
+	if len(entries) != 1 || entries[0].MAC != "52:54:00:ab:cd:ef" || entries[0].IPAMClaimReference != "ovnk-vm-net1" {
+		t.Errorf("secondary NAD entry not augmented: %+v", entries)
+	}
+}
+
 // First-match-wins dispatch over disjoint NAD types: a kube-ovn guest resolves to
 // the kube-ovn backend, an OVN-K guest to the ovn-kubernetes backend.
 func TestResolveOVNBackend_DisjointTypes(t *testing.T) {

--- a/rust/swiftletd/scripts/launcher-entrypoint.sh
+++ b/rust/swiftletd/scripts/launcher-entrypoint.sh
@@ -56,6 +56,26 @@ if network_enabled; then
     # port_security pins MAC+IP). Hand exactly that IP to the guest (matched by MAC) via
     # a fixed dnsmasq lease, and export the MAC so swiftletd uses it for the CH
     # --net mac= (the guest cannot use its own 52:54:.. MAC -- OVN would drop it).
+    # Secondary-on-NAD: network-init persisted a routable secondary NIC's IP. Hand it
+    # to the guest via a SECOND fixed-lease dnsmasq -- no default route (the primary
+    # interface owns that) and no DNS (the primary serves it). This runs regardless of
+    # the primary path (nat / UDN / NAD), backgrounded, BEFORE the primary path's exec;
+    # the reparented dnsmasq survives the exec. A separate leasefile keeps lease.rs's
+    # primary-IP discovery (dnsmasq.leases) untouched.
+    sec_env="$lease_dir/secondary-nad.env"
+    if [ -f "$sec_env" ]; then
+        # shellcheck disable=SC1090
+        . "$sec_env"   # SEC_IP, SEC_PREFIX, SEC_MAC, SEC_BRIDGE, SEC_MTU
+        echo "Secondary-on-NAD dnsmasq: handing $SEC_IP to $SEC_MAC on $SEC_BRIDGE (mtu ${SEC_MTU:-default}, no default route)"
+        dnsmasq --no-daemon --bind-interfaces --interface="$SEC_BRIDGE" \
+            --dhcp-range="$SEC_IP,$SEC_IP,infinite" \
+            ${SEC_MAC:+--dhcp-host="$SEC_MAC,$SEC_IP"} \
+            ${SEC_MAC:+--dhcp-ignore=tag:!known} \
+            ${SEC_MTU:+--dhcp-option=option:mtu,"$SEC_MTU"} \
+            --dhcp-leasefile="$lease_dir/secondary-dnsmasq.leases" \
+            --dhcp-authoritative &
+    fi
+
     udn_env="$lease_dir/primary-udn.env"
     if [ -f "$udn_env" ]; then
         # shellcheck disable=SC1090

--- a/rust/swiftletd/scripts/launcher-entrypoint.sh
+++ b/rust/swiftletd/scripts/launcher-entrypoint.sh
@@ -67,7 +67,10 @@ if network_enabled; then
         # shellcheck disable=SC1090
         . "$sec_env"   # SEC_IP, SEC_PREFIX, SEC_MAC, SEC_BRIDGE, SEC_MTU
         echo "Secondary-on-NAD dnsmasq: handing $SEC_IP to $SEC_MAC on $SEC_BRIDGE (mtu ${SEC_MTU:-default}, no default route)"
-        dnsmasq --no-daemon --bind-interfaces --interface="$SEC_BRIDGE" \
+        # --port=0: DHCP only, no DNS. This dnsmasq coexists with the primary NIC's
+        # dnsmasq in the same pod; without it both bind 127.0.0.1:53 and the primary
+        # one fails ("Address already in use") and exits, so the primary never DHCPs.
+        dnsmasq --no-daemon --port=0 --bind-interfaces --interface="$SEC_BRIDGE" \
             --dhcp-range="$SEC_IP,$SEC_IP,infinite" \
             ${SEC_MAC:+--dhcp-host="$SEC_MAC,$SEC_IP"} \
             ${SEC_MAC:+--dhcp-ignore=tag:!known} \

--- a/rust/swiftletd/scripts/launcher-entrypoint.sh
+++ b/rust/swiftletd/scripts/launcher-entrypoint.sh
@@ -70,8 +70,16 @@ if network_enabled; then
         # --port=0: DHCP only, no DNS. This dnsmasq coexists with the primary NIC's
         # dnsmasq in the same pod; without it both bind 127.0.0.1:53 and the primary
         # one fails ("Address already in use") and exits, so the primary never DHCPs.
+        # --dhcp-option=option:router (empty): send NO default gateway. Without this,
+        # dnsmasq defaults to advertising its own listening address (the br1 helper IP)
+        # as option:router, and the guest installs a default route via the secondary --
+        # a dead end on an isolated L2 (e.g. an OVN-K layer2 UDN) with no off-segment
+        # egress, which blackholes ALL of the guest's traffic. The guest's PRIMARY NIC
+        # owns the default route; the secondary only needs its on-link subnet route
+        # (from the /prefix address) for node-to-node reachability.
         dnsmasq --no-daemon --port=0 --bind-interfaces --interface="$SEC_BRIDGE" \
             --dhcp-range="$SEC_IP,$SEC_IP,infinite" \
+            --dhcp-option=option:router \
             ${SEC_MAC:+--dhcp-host="$SEC_MAC,$SEC_IP"} \
             ${SEC_MAC:+--dhcp-ignore=tag:!known} \
             ${SEC_MTU:+--dhcp-option=option:mtu,"$SEC_MTU"} \
@@ -181,10 +189,23 @@ if network_enabled; then
     # DHCP domain-search option, so the guest resolves bare service names.
     search=$(grep '^search ' /etc/resolv.conf 2>/dev/null | head -1 | cut -d' ' -f2- | tr ' ' ',')
 
+    # MTU: the guest reaches the outside world by MASQUERADE through the pod's
+    # egress interface. On an overlay CNI (OVN-K Geneve, Calico VXLAN, ...) that
+    # interface's MTU is < 1500. If the guest keeps the default 1500 it silently
+    # blackholes every packet larger than the path MTU -- no ICMP frag-needed is
+    # delivered back into the guest, so PMTU discovery cannot recover and TLS
+    # handshakes / package downloads hang. Hand the guest the pod egress MTU so
+    # its NIC matches the path. On a 1500-MTU (non-overlay) cluster this is a
+    # no-op. The UDN / NAD paths above already carry their overlay MTU; only this
+    # plain-nat path lacked it.
+    egress_if=$(ip -4 route show default 2>/dev/null | awk '{print $5; exit}')
+    egress_mtu=$(cat "/sys/class/net/$egress_if/mtu" 2>/dev/null)
+
     dnsmasq --no-daemon --bind-interfaces --interface="$BRIDGE" \
         --dhcp-range="$range" \
         --dhcp-option=option:router,"$gateway" \
         --dhcp-option=option:dns-server,"$dns" \
+        ${egress_mtu:+--dhcp-option=option:mtu,"$egress_mtu"} \
         ${search:+--dhcp-option=option:domain-search,"$search"} \
         --dhcp-leasefile="$lease_dir/dnsmasq.leases" \
         --dhcp-authoritative &

--- a/rust/swiftletd/scripts/network-init.sh
+++ b/rust/swiftletd/scripts/network-init.sh
@@ -186,6 +186,81 @@ setup_secondary_nic() {
     echo "Secondary NIC: $bridge with $tap, bridged to $multus_iface"
 }
 
+# setup_secondary_nad_nic -- a SECONDARY interface that rides a Multus NAD (e.g. an
+# OVN-Kubernetes secondary UDN) and must carry a routable IP INTO the guest. The
+# mirror of setup_primary_nad_nic for a non-primary NIC: without it a secondary NAD
+# interface is only bridged (setup_secondary_nic), so the guest never gets the NAD's
+# IP and the NIC is unusable (e.g. as a routable node-datapath interface).
+#
+# Same read->flush->re-MAC->bridge->serve contract as the primary path, with two
+# differences: the IP is handed via a SECOND dnsmasq (secondary-nad.env, driven by
+# the launcher entrypoint) so the primary NIC's lease is untouched; and NO default
+# route is handed (the primary interface keeps the default route -- the guest gets
+# only the on-link route to the NAD subnet).
+setup_secondary_nad_nic() {
+    bridge="$1"; tap="$2"; multus_iface="$3"; guest_mac="$4"
+
+    attempts=0
+    while [ $attempts -lt 30 ]; do
+        ip link show "$multus_iface" >/dev/null 2>&1 && break
+        sleep 1; attempts=$((attempts + 1))
+    done
+    if ! ip link show "$multus_iface" >/dev/null 2>&1; then
+        echo "ERROR: secondary NAD interface $multus_iface not found after 30s" >&2
+        exit 1
+    fi
+
+    nad_cidr=$(ip -4 addr show "$multus_iface" 2>/dev/null | awk '/inet /{print $2; exit}')
+    if [ -z "$nad_cidr" ]; then
+        echo "ERROR: secondary NAD interface $multus_iface has no IPv4 address (NAD IPAM did not assign one)" >&2
+        exit 1
+    fi
+    nad_ip="${nad_cidr%/*}"
+    nad_prefix="${nad_cidr#*/}"
+    nad_mtu=$(ip -o link show "$multus_iface" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="mtu"){print $(i+1); exit}}')
+
+    rd=$(guest_run_dir); mkdir -p "$rd"
+    {
+        echo "SEC_IP=$nad_ip"
+        echo "SEC_PREFIX=$nad_prefix"
+        echo "SEC_MAC=$guest_mac"
+        echo "SEC_BRIDGE=$bridge"
+        echo "SEC_MTU=$nad_mtu"
+    } > "$rd/secondary-nad.env"
+
+    # The guest claims nad_ip; the host must not also hold it on the L2.
+    ip addr flush dev "$multus_iface" 2>/dev/null || true
+
+    ip link add "$bridge" type bridge stp_state 0 2>/dev/null || true
+    ip link set "$bridge" up
+    ip tuntap add dev "$tap" mode tap 2>/dev/null || true
+    ip link set "$tap" up
+    ip link set "$tap" master "$bridge"
+
+    # Re-MAC the NIC off the guest MAC before enslaving (same reason as the primary
+    # path: when the OVN LSP is stamped with the guest MAC, an enslaved NIC carrying
+    # that same MAC adds a permanent fdb entry that shadows the guest's tap). No-op
+    # when the NIC's IPAM gave it a distinct MAC (plain-bridge / VXLAN-mesh path).
+    nic_mac=$(cat "/sys/class/net/$multus_iface/address" 2>/dev/null)
+    if [ -n "$guest_mac" ] && [ "$nic_mac" = "$guest_mac" ]; then
+        ip link set "$multus_iface" down 2>/dev/null || true
+        ip link set "$multus_iface" address "0a:${guest_mac#*:}" 2>/dev/null || true
+        ip link set "$multus_iface" up 2>/dev/null || true
+        echo "Secondary NAD: re-MAC'd $multus_iface off the guest MAC $guest_mac"
+    fi
+
+    ip link set "$multus_iface" master "$bridge"
+    ip link set "$multus_iface" up
+
+    # Helper IP for the secondary dnsmasq to bind (same .254 heuristic as primary).
+    net_base=$(echo "$nad_ip" | sed 's/\.[0-9]*$//')
+    helper="${net_base}.254"
+    [ "$helper" = "$nad_ip" ] && helper="${net_base}.253"
+    ip addr add "$helper/$nad_prefix" dev "$bridge" 2>/dev/null || true
+
+    echo "Secondary NIC on NAD: $bridge bridges $multus_iface to $tap; guest IP=$nad_ip/$nad_prefix (helper $helper, no default route)"
+}
+
 # setup_primary_nad_nic -- multi-node L2, primary-on-NAD.
 #
 # Datapath is cluster-validated (kube-ovn primary NAD: zero-touch cross-node
@@ -467,6 +542,11 @@ for nic in nics:
         elif [ "$primary" = "1" ]; then
             setup_primary_nic "$bridge" "$tap"
             setup_exposed_ports "$bridge"
+        elif [ -n "$multus" ]; then
+            # Secondary-on-NAD: the NIC rides a Multus NAD and must carry the NAD's
+            # IP into the guest (e.g. a routable node-datapath interface). Hand it
+            # over the same way the primary-on-NAD path does, minus the default route.
+            setup_secondary_nad_nic "$bridge" "$tap" "$multus" "$mac"
         else
             setup_secondary_nic "$bridge" "$tap" "$multus"
         fi


### PR DESCRIPTION
## Summary
Adds a `SwiftGuest` datapath for a **secondary NAD interface** (an OVN-Kubernetes layer2 secondary UDN, or any Multus NAD) that carries its own routable IP into the guest — so a guest can have a node-local nat primary **and** a cross-node-routable secondary NIC at once.

- **hand the secondary its IP** — network-init hands the secondary NAD interface's CNI-assigned IP to the guest via a second fixed-lease dnsmasq (re-MAC + bridge, mirroring the primary-NAD path).
- **OVN-K identity** — stamp the guest MAC + a per-interface IPAMClaim onto every OVN-Kubernetes layer2 NAD interface (primary and/or secondary), so OVN's ARP responder targets the guest and the IP is pinned across pod recreate / migration.
- **DHCP-only secondary dnsmasq** (`--port=0`) so it doesn't fight the primary nat dnsmasq for `127.0.0.1:53`.

## The two egress fixes (final commit)
Bringing a multi-node guest cluster up on an overlay CNI surfaced two datapath bugs that silently blackholed a guest's egress:

1. **Secondary dead-end default route** — the secondary dnsmasq never suppressed `option:router`, so dnsmasq advertised its own listening address (the bridge helper IP) as the gateway. The guest installed a default route via the secondary — a dead end on an isolated layer2 UDN — which won the route table and blackholed all traffic. Fixed with `--dhcp-option=option:router` (empty); the primary owns the default route.
2. **nat MTU blackhole** — the primary nat dnsmasq never handed an MTU. On an overlay CNI (pod MTU < 1500) the guest kept 1500 and silently dropped every packet over the path MTU (no ICMP frag-needed reaches the guest → PMTUD can't recover); TLS/package downloads hung. Fixed by handing the pod egress MTU via `option:mtu`. No-op on a 1500-MTU cluster.

## Validation
On an OVN-Kubernetes cluster: a control-plane guest and a worker guest, each with a nat primary + secondary UDN NIC, egress correctly (apt + registry pulls), and a 2-node workload cluster comes up Ready with cross-node pod networking (both node InternalIPs on the routable UDN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
