### PR TITLE
feat(ch): move swiftletd to Cloud Hypervisor v53.0

### DIFF
--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -566,7 +566,7 @@ const (
 	// VhostUserDeviceTypeBlk is a vhost-user-blk disk (CH --disk vhost_user=on).
 	VhostUserDeviceTypeBlk = "blk"
 	// VhostUserDeviceTypeGeneric is a generic vhost-user device
-	// (CH --generic-vhost-user virtio_id=...).
+	// (CH --generic-vhost-user device_type=...).
 	VhostUserDeviceTypeGeneric = "generic"
 )
 
@@ -583,8 +583,9 @@ type VhostUserDevice struct {
 	// Type selects the device kind:
 	//   blk:     a vhost-user block device (appears as a virtio-blk disk in the
 	//            guest) — Cloud Hypervisor `--disk vhost_user=on,socket=`.
-	//   generic: any vhost-user device by virtio id — Cloud Hypervisor
-	//            `--generic-vhost-user virtio_id=,socket=,queue_sizes=`.
+	//   generic: any vhost-user device by virtio device type — Cloud
+	//            Hypervisor `--generic-vhost-user device_type=,socket=,queue_sizes=`
+	//            (the flag key was `virtio_id=` on CH <= v52).
 	// +kubebuilder:validation:Enum=blk;generic
 	Type string `json:"type"`
 	// Socket is the node-local path of the operator's vhost-user backend

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
@@ -1144,8 +1144,9 @@ spec:
                                 Type selects the device kind:
                                   blk:     a vhost-user block device (appears as a virtio-blk disk in the
                                            guest) — Cloud Hypervisor `--disk vhost_user=on,socket=`.
-                                  generic: any vhost-user device by virtio id — Cloud Hypervisor
-                                           `--generic-vhost-user virtio_id=,socket=,queue_sizes=`.
+                                  generic: any vhost-user device by virtio device type — Cloud
+                                           Hypervisor `--generic-vhost-user device_type=,socket=,queue_sizes=`
+                                           (the flag key was `virtio_id=` on CH <= v52).
                               enum:
                               - blk
                               - generic

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -994,8 +994,9 @@ spec:
                         Type selects the device kind:
                           blk:     a vhost-user block device (appears as a virtio-blk disk in the
                                    guest) — Cloud Hypervisor `--disk vhost_user=on,socket=`.
-                          generic: any vhost-user device by virtio id — Cloud Hypervisor
-                                   `--generic-vhost-user virtio_id=,socket=,queue_sizes=`.
+                          generic: any vhost-user device by virtio device type — Cloud
+                                   Hypervisor `--generic-vhost-user device_type=,socket=,queue_sizes=`
+                                   (the flag key was `virtio_id=` on CH <= v52).
                       enum:
                       - blk
                       - generic

--- a/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
@@ -1144,8 +1144,9 @@ spec:
                                 Type selects the device kind:
                                   blk:     a vhost-user block device (appears as a virtio-blk disk in the
                                            guest) — Cloud Hypervisor `--disk vhost_user=on,socket=`.
-                                  generic: any vhost-user device by virtio id — Cloud Hypervisor
-                                           `--generic-vhost-user virtio_id=,socket=,queue_sizes=`.
+                                  generic: any vhost-user device by virtio device type — Cloud
+                                           Hypervisor `--generic-vhost-user device_type=,socket=,queue_sizes=`
+                                           (the flag key was `virtio_id=` on CH <= v52).
                               enum:
                               - blk
                               - generic

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -994,8 +994,9 @@ spec:
                         Type selects the device kind:
                           blk:     a vhost-user block device (appears as a virtio-blk disk in the
                                    guest) — Cloud Hypervisor `--disk vhost_user=on,socket=`.
-                          generic: any vhost-user device by virtio id — Cloud Hypervisor
-                                   `--generic-vhost-user virtio_id=,socket=,queue_sizes=`.
+                          generic: any vhost-user device by virtio device type — Cloud
+                                   Hypervisor `--generic-vhost-user device_type=,socket=,queue_sizes=`
+                                   (the flag key was `virtio_id=` on CH <= v52).
                       enum:
                       - blk
                       - generic

--- a/images/swiftletd/Containerfile
+++ b/images/swiftletd/Containerfile
@@ -100,11 +100,15 @@ COPY --from=builder /usr/local/bin/virtiofsd /usr/libexec/virtiofsd
 # qemu-system-x86 package provides /usr/bin/qemu-system-x86_64
 # Both paths are the defaults in swift-qemu-client/src/config.rs
 
-# Cloud Hypervisor static binary (v52.0)
-# Bumped v51.1 -> v52.0: v51.1's virtio-blk has a bug that bugchecks Windows'
-# viostor driver (0xD1); v52.0 fixes it and boots Windows cleanly. The CLOUDHV.fd
-# firmware below (ch-13b4963ec4) is the spike-validated pairing with the v52.0 binary.
-ARG CH_VERSION=52.0
+# Cloud Hypervisor static binary (v53.0)
+# Bumped v52.0 -> v53.0: v53 makes vm.send-migration non-blocking (#8021 — the
+# source-side completion-detection rework in swift-ch-client/swiftletd handles it),
+# renames the generic-vhost-user CLI key virtio_id -> device_type (#8564), and brings
+# free fixes (guest clock across snapshot/restore/migration, post-migration GARP,
+# memfd memory-regression revert, guest-triggerable-VMM-panic hardening). The CLOUDHV.fd
+# firmware below (ch-13b4963ec4) is UNCHANGED — the v53 spike confirmed it boots on the
+# v53.0 binary (no re-pair needed).
+ARG CH_VERSION=53.0
 ARG TARGETARCH=amd64
 RUN CH_ARCH=$(echo "${TARGETARCH}" | sed 's/amd64//;s/arm64/-aarch64/') && \
     curl -sSL -o /usr/local/bin/cloud-hypervisor \

--- a/internal/runtimeintent/types.go
+++ b/internal/runtimeintent/types.go
@@ -44,7 +44,7 @@ type RuntimeIntent struct {
 	// VhostUserDevices is the list of operator-backed vhost-user devices
 	// (vhost-user-blk disks and generic vhost-user devices). swiftletd hands
 	// each to Cloud Hypervisor via --disk vhost_user=on,socket= (blk) or
-	// --generic-vhost-user virtio_id=,socket= (generic). CH path only.
+	// --generic-vhost-user device_type=,socket= (generic). CH path only.
 	VhostUserDevices []VhostUserDeviceIntent `json:"vhostUserDevices,omitempty"`
 	// Filesystems is the list of virtiofs shares. For each, swiftletd spawns a
 	// virtiofsd backend (shared-dir = SourcePath, socket = SocketPath) before

--- a/rust/swift-ch-client/src/config.rs
+++ b/rust/swift-ch-client/src/config.rs
@@ -110,7 +110,7 @@ pub struct VmConfig {
     /// appears as a virtio-blk device after the root/data disks.
     pub vhost_user_blk_sockets: Vec<String>,
     /// Generic vhost-user devices. Each produces a
-    /// `--generic-vhost-user virtio_id=<id>,socket=<sock>[,queue_sizes=[...]]`.
+    /// `--generic-vhost-user device_type=<id>,socket=<sock>[,queue_sizes=[...]]`.
     pub generic_vhost_user: Vec<GenericVhostUser>,
     /// Optional vsock device. When set, produces `--vsock cid=<N>,socket=<path>`
     /// — a host<->guest channel for the in-guest identity agent. Set ONLY on a
@@ -139,8 +139,10 @@ pub struct VsockConfig {
 /// A generic vhost-user device for `--generic-vhost-user`.
 #[derive(Debug, Clone)]
 pub struct GenericVhostUser {
-    /// virtio device-type id: a number or symbolic name ("block", "fs", ...).
-    pub virtio_id: String,
+    /// virtio device type: a number or symbolic name ("block", "fs", ...).
+    /// Emitted as `device_type=` (CH >= v53; the `virtio_id=` key of <= v52 was
+    /// renamed to `device_type` by cloud-hypervisor#8564).
+    pub device_type: String,
     /// Operator backend socket path (mounted into the launcher).
     pub socket: String,
     /// Optional per-queue sizes; empty omits the param (CH defaults apply).
@@ -376,7 +378,7 @@ impl VmConfig {
         // Generic vhost-user devices.
         for dev in &self.generic_vhost_user {
             args.push("--generic-vhost-user".to_string());
-            let mut arg = format!("virtio_id={},socket={}", dev.virtio_id, dev.socket);
+            let mut arg = format!("device_type={},socket={}", dev.device_type, dev.socket);
             if !dev.queue_sizes.is_empty() {
                 let list = dev
                     .queue_sizes
@@ -558,12 +560,12 @@ mod tests {
         cfg.vhost_user_blk_sockets = vec!["/run/spdk/vhost.0".to_string()];
         cfg.generic_vhost_user = vec![
             GenericVhostUser {
-                virtio_id: "block".to_string(),
+                device_type: "block".to_string(),
                 socket: "/run/x/gen.sock".to_string(),
                 queue_sizes: vec![1024, 1024],
             },
             GenericVhostUser {
-                virtio_id: "fs".to_string(),
+                device_type: "fs".to_string(),
                 socket: "/run/x/gen2.sock".to_string(),
                 queue_sizes: vec![],
             },
@@ -578,15 +580,15 @@ mod tests {
         // generic with queue_sizes -> bracketed list.
         assert!(
             joined.contains(
-                "--generic-vhost-user virtio_id=block,socket=/run/x/gen.sock,queue_sizes=[1024,1024]"
+                "--generic-vhost-user device_type=block,socket=/run/x/gen.sock,queue_sizes=[1024,1024]"
             ),
             "missing generic w/ queue_sizes: {}",
             joined
         );
         // generic without queue_sizes -> no queue_sizes param.
         assert!(
-            joined.contains("--generic-vhost-user virtio_id=fs,socket=/run/x/gen2.sock")
-                && !joined.contains("virtio_id=fs,socket=/run/x/gen2.sock,queue_sizes"),
+            joined.contains("--generic-vhost-user device_type=fs,socket=/run/x/gen2.sock")
+                && !joined.contains("device_type=fs,socket=/run/x/gen2.sock,queue_sizes"),
             "generic w/o queue_sizes wrong: {}",
             joined
         );

--- a/rust/swift-ch-client/src/lib.rs
+++ b/rust/swift-ch-client/src/lib.rs
@@ -12,5 +12,5 @@ mod spawn;
 
 pub use api::{await_api_client, ApiClient, ApiError, ApiResponse};
 pub use config::{FsMount, GenericVhostUser, NICConfig, VFIODeviceConfig, VmConfig, VsockConfig};
-pub use methods::{VmInfo, VmmVersion};
+pub use methods::{SendMigrationOutcome, VmInfo, VmmVersion};
 pub use spawn::{connect_socket, spawn_ch, spawn_ch_receive, spawn_ch_restore, wait_for_socket};

--- a/rust/swift-ch-client/src/methods.rs
+++ b/rust/swift-ch-client/src/methods.rs
@@ -24,6 +24,8 @@
 //! a generous timeout (the controller derives one from VM RAM size
 //! before issuing the action annotation that drives this method).
 
+use std::time::{Duration, Instant};
+
 use serde::Deserialize;
 
 use crate::api::{ApiClient, ApiError};
@@ -75,6 +77,57 @@ impl VmmVersion {
         let major: u32 = parts.next()?.parse().ok()?;
         let minor: u32 = parts.next()?.parse().ok()?;
         Some((major, minor))
+    }
+}
+
+/// Terminal outcome of a non-blocking (CH >= v53) `send-migration`,
+/// derived by polling `vm.info` on the source after
+/// [`ApiClient::send_migration`] returns 204 ("accepted").
+///
+/// See the CH v53 spike
+/// (`field-testing/ch-v53-spike/results/SPIKE-RESULTS.md`) for the
+/// hardware-confirmed source-side contract this encodes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendMigrationOutcome {
+    /// The source CH process exited — the guest is now running on the
+    /// destination. Success.
+    Completed,
+    /// The deadline elapsed with the guest still `Running` on the source.
+    /// On CH v53 a failed transfer auto-resumes the source guest, so the
+    /// guest never stopped here and **no `vm.resume` is required**. The
+    /// string is a short detail suitable for the status annotation.
+    Failed(String),
+}
+
+/// One `vm.info` sample's verdict while waiting for send-migration to
+/// reach a terminal state. Internal to
+/// [`ApiClient::wait_for_send_migration_terminal`].
+#[derive(Debug, PartialEq, Eq)]
+enum SendMigrationSample {
+    /// Source process is gone (connect refused) — migration completed.
+    SourceGone,
+    /// Source still reachable: `Running`, or a tear-down transient (the
+    /// HTTP 500 "receiving on a closed channel" seen just before the
+    /// process exits). Keep polling; the deadline is the backstop.
+    StillPresent,
+}
+
+/// Classify a single `vm.info` result during a send-migration wait.
+///
+/// The only success edge is the source CH process disappearing: on a
+/// same-host UNIX socket that surfaces as [`ApiError::Connect`] (connect
+/// refused). Every other result — `Ok(Running)`, the transient HTTP 500
+/// "closed channel", a 404, or any other transport error — is treated as
+/// "still present"; whether that ultimately means in-progress or failed
+/// is decided by the deadline in the caller, not here. (This is why a
+/// failed transfer, where CH v53 auto-resumes the source and it stays
+/// `Running` forever, is caught by the deadline rather than a distinct
+/// error edge — the spike confirmed there is no failure-specific signal
+/// on the source API.)
+fn classify_send_migration_sample(sample: &Result<VmInfo, ApiError>) -> SendMigrationSample {
+    match sample {
+        Err(ApiError::Connect { .. }) => SendMigrationSample::SourceGone,
+        _ => SendMigrationSample::StillPresent,
     }
 }
 
@@ -192,6 +245,57 @@ impl ApiClient {
             .map_err(|e| ApiError::Malformed(format!("send_migration body serialize: {}", e)))?;
         self.request_ok("PUT", "/api/v1/vm.send-migration", Some(&body))
             .map(drop)
+    }
+
+    /// Wait for a non-blocking (CH >= v53) `send-migration` to reach a
+    /// terminal state by polling `vm.info` on this (source) CH.
+    ///
+    /// On CH v53 [`send_migration`](Self::send_migration) returns 204 the
+    /// instant CH *accepts* the migration (#8021) — pre-copy and
+    /// stop-and-copy then run on a background thread, so completion must
+    /// be observed out-of-band. This method encodes the hardware-confirmed
+    /// source-side contract (see the v53 spike):
+    ///
+    /// ```text
+    /// poll vm.info:
+    ///   connect refused (source exited)      -> Completed
+    ///   HTTP 500 "closed channel" (teardown) -> keep polling (transient)
+    ///   HTTP 200 Running, now <  deadline    -> keep polling (in progress)
+    ///   HTTP 200 Running, now >= deadline    -> Failed (auto-resumed; no vm.resume)
+    /// ```
+    ///
+    /// `deadline` bounds the total wait — the caller derives it from the
+    /// migration timeout budget (already sized from guest RAM). `poll` is
+    /// the inter-sample sleep.
+    ///
+    /// Safe on CH <= v52 too: there `send_migration` blocked until the
+    /// source had already exited, so the first sample observes the source
+    /// gone and this returns [`SendMigrationOutcome::Completed`] on the
+    /// first iteration. Callers still version-gate (only v53 needs the
+    /// poll) so the historic single-probe v52 path stays byte-identical.
+    ///
+    /// This blocks the calling thread for up to `deadline - now`; the
+    /// caller must not run it on a thread that gates a poll cadence (the
+    /// action loop already dispatches send-migration off its critical
+    /// path).
+    pub fn wait_for_send_migration_terminal(
+        &self,
+        deadline: Instant,
+        poll: Duration,
+    ) -> SendMigrationOutcome {
+        loop {
+            if classify_send_migration_sample(&self.vm_info()) == SendMigrationSample::SourceGone {
+                return SendMigrationOutcome::Completed;
+            }
+            if Instant::now() >= deadline {
+                return SendMigrationOutcome::Failed(
+                    "source guest still Running past the migration deadline \
+                     (v53 auto-resumes the source on a failed transfer)"
+                        .to_string(),
+                );
+            }
+            std::thread::sleep(poll);
+        }
     }
 
     /// Open a migration receive listener on this (empty) CH and wait for
@@ -488,6 +592,88 @@ mod tests {
                 );
             }
             other => panic!("expected Status error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_send_migration_sample_source_gone_on_connect_refused() {
+        // The confirmed success edge: the source CH process exited, so a
+        // connect to its now-dead UNIX socket is refused.
+        let sample = Err(ApiError::Connect {
+            path: PathBuf::from("/run/ch/api.sock"),
+            source: std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused"),
+        });
+        assert_eq!(
+            classify_send_migration_sample(&sample),
+            SendMigrationSample::SourceGone
+        );
+    }
+
+    #[test]
+    fn classify_send_migration_sample_still_present_while_running() {
+        // Guest still resident on the source (in-progress, or failed +
+        // auto-resumed — the deadline, not this classifier, decides which).
+        let sample = Ok(VmInfo {
+            state: "Running".to_string(),
+        });
+        assert_eq!(
+            classify_send_migration_sample(&sample),
+            SendMigrationSample::StillPresent
+        );
+    }
+
+    #[test]
+    fn classify_send_migration_sample_still_present_on_teardown_500() {
+        // The tear-down transient observed just before the process exits:
+        // HTTP 500 "receiving on a closed channel". Must NOT be mistaken
+        // for a terminal state — the next poll gets connect-refused.
+        let sample = Err(ApiError::Status(crate::api::ApiResponse {
+            status: 500,
+            body: b"receiving on a closed channel".to_vec(),
+        }));
+        assert_eq!(
+            classify_send_migration_sample(&sample),
+            SendMigrationSample::StillPresent
+        );
+    }
+
+    #[test]
+    fn wait_for_send_migration_terminal_completed_when_source_gone() {
+        // No server on the path -> connect refused on the first poll ->
+        // Completed immediately (this is also the v52 fast path: after a
+        // blocking send-migration the source has already exited).
+        let tmp = tempfile::tempdir().unwrap();
+        let absent = tmp.path().join("gone.sock");
+        let client = ApiClient::new(absent);
+        let outcome = client.wait_for_send_migration_terminal(
+            Instant::now() + Duration::from_secs(5),
+            Duration::from_millis(1),
+        );
+        assert_eq!(outcome, SendMigrationOutcome::Completed);
+    }
+
+    #[test]
+    fn wait_for_send_migration_terminal_failed_past_deadline() {
+        // Server answers 200 Running and the deadline is already reached:
+        // one sample (StillPresent) then the deadline check -> Failed. The
+        // guest auto-resumed on the source, so the caller must NOT resume.
+        let body = br#"{"state":"Running"}"#;
+        let response = format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", body.len());
+        let mut full = response.into_bytes();
+        full.extend_from_slice(body);
+        let server = MockServer::spawn(full);
+        let client = ApiClient::new(server.path.clone());
+        let outcome =
+            client.wait_for_send_migration_terminal(Instant::now(), Duration::from_millis(1));
+        match outcome {
+            SendMigrationOutcome::Failed(detail) => {
+                assert!(
+                    detail.contains("past the migration deadline"),
+                    "detail: {}",
+                    detail
+                );
+            }
+            other => panic!("expected Failed, got {:?}", other),
         }
     }
 

--- a/rust/swiftletd/src/action.rs
+++ b/rust/swiftletd/src/action.rs
@@ -213,6 +213,16 @@ pub const MIGRATION_PROGRESS_ESTIMATE_KEY: &str = "kubeswift.io/migration-progre
 /// don't ship the field pre-emptively.
 pub const PROGRESS_BASELINE_MBPS: f64 = 108.0;
 
+/// Poll cadence for the CH >= v53 non-blocking `send-migration` completion
+/// wait ([`swift_ch_client::ApiClient::wait_for_send_migration_terminal`]).
+/// CH v53 returns 204 the instant it *accepts* the migration (#8021) and
+/// runs pre-copy/stop-and-copy on a background thread, so completion is
+/// observed by polling `vm.info` this often until the source process exits
+/// (success) or the migration deadline elapses (failure). 200 ms reports
+/// completion promptly while keeping the same-host UNIX-socket query rate
+/// negligible; the v53 spike polled at ~100 ms with no adverse effect.
+const MIGRATION_SEND_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(200);
+
 /// Phase 2 unsafe-plaintext acknowledgement annotation. Required on
 /// the launcher pod for swiftletd to accept any migration action — the
 /// S2 mitigation gate.
@@ -1187,10 +1197,24 @@ async fn dispatch_migration_send(
         std::time::Duration::from_secs(args.timeout_seconds.unwrap_or(DEFAULT_ACTION_TIMEOUT_SECS));
     let client = swift_ch_client::ApiClient::new(api_socket).with_timeout(timeout);
 
-    // Phase 3b PR 1 Commit D — spawn the progress-estimate emitter
-    // BEFORE the blocking send_migration call. Drop guard ensures
-    // the emitter is signaled to exit on any return path (success,
-    // error, async cancellation).
+    // Detect the local CH's blocking semantics up-front — before the VM
+    // starts migrating, so `vmm.ping` is unambiguous. CH >= v53 made
+    // `send-migration` NON-BLOCKING (#8021): the call returns 204 the
+    // instant CH accepts the migration while pre-copy/stop-and-copy run on
+    // a background thread. CH <= v52 blocks the call until the source has
+    // exited. This decides how completion is detected below. On a query
+    // failure we fall back to the historic (blocking) assumption — no
+    // worse than the pre-v53 behaviour.
+    let non_blocking = client
+        .version()
+        .ok()
+        .and_then(|v| v.major_minor())
+        .map(|(major, _)| major >= 53)
+        .unwrap_or(false);
+
+    // Phase 3b PR 1 Commit D — spawn the progress-estimate emitter BEFORE
+    // the send_migration call. Drop guard ensures the emitter is signaled
+    // to exit on any return path (success, error, async cancellation).
     let _progress = spawn_progress_emitter(action.id.clone(), args.guest_ram_mib);
 
     let started = std::time::Instant::now();
@@ -1201,27 +1225,73 @@ async fn dispatch_migration_send(
         ));
     }
 
-    // W1 completion-gate (load-bearing item C, walkthrough W1).
-    // `send_migration` exit=0 is necessary but not sufficient; the
-    // source CH must actually have exited cleanly (Q1c finding).
-    // We probe vm_info: if it returns ConnectionRefused / similar,
-    // CH is gone (the expected post-success state). If it returns
-    // Running, send-migration claimed success but the guest is
-    // still here — abnormal, treat as failure.
-    match client.vm_info() {
-        Err(_) => {
-            // CH is gone — the expected outcome on success.
+    // Completion detection (W1 completion-gate, load-bearing item C).
+    // `send_migration` returning Ok is necessary but not sufficient — the
+    // source CH must actually have exited (Q1c). HOW that is confirmed
+    // depends on the blocking semantics detected above:
+    //
+    //   * CH <= v52 (blocking): the call already returned only after the
+    //     source exited, so a single `vm_info` probe is authoritative —
+    //     ConnectionRefused ⇒ gone (success); Running ⇒ the historic W1
+    //     violation. This branch is byte-identical to the pre-v53 code.
+    //   * CH >= v53 (non-blocking): the call returned while the migration
+    //     is still in flight, so POLL `vm.info` until a terminal edge
+    //     (source gone ⇒ complete; still Running past the deadline ⇒
+    //     failed — v53 auto-resumes the source guest, so no `vm.resume` is
+    //     needed). `receive-migration` stays blocking on v53, so the
+    //     destination handler (`dispatch_migration_receive`) is unchanged.
+    let terminal = if non_blocking {
+        // On v53 `send_migration` has returned 204: CH has ACCEPTED the
+        // migration and now runs it on a background thread. From here a
+        // clean CH exit == migration completed — and at completion the
+        // source CH (and this launcher process) EXITS. main.rs's CH-exit
+        // observer writes the terminal `migration-status: complete` iff the
+        // W22 flag is set (migration_send_completed_clean()), then waits
+        // (W23) for the action loop's own `complete` write before exiting.
+        // So the flag MUST be set BEFORE CH exits. On the blocking v52 path
+        // the send call returned only after the source exited, so setting
+        // the flag in the success match below was in time; on v53 the exit
+        // races the poll loop that would set it there — the cluster
+        // walkthrough hit exactly this: the src pod exited with
+        // migration-status stuck at "sending" and the controller stalled.
+        // Set it NOW, at accept time; the poll below only has to catch the
+        // FAILURE case, where CH does NOT exit and the guest auto-resumes.
+        MIGRATION_SEND_COMPLETED.store(true, Ordering::SeqCst);
+        let deadline = started + timeout;
+        let outcome =
+            client.wait_for_send_migration_terminal(deadline, MIGRATION_SEND_POLL_INTERVAL);
+        if matches!(outcome, swift_ch_client::SendMigrationOutcome::Failed(_)) {
+            // Migration did not complete — the source guest is still Running
+            // (v53 auto-resumed it) and CH did NOT exit, so main.rs's
+            // observer never fires. Undo the optimistic flag so any later
+            // unrelated CH exit is reported as VmStopped rather than
+            // silently suppressed as a migration success.
+            MIGRATION_SEND_COMPLETED.store(false, Ordering::SeqCst);
+        }
+        outcome
+    } else {
+        match client.vm_info() {
+            Err(_) => swift_ch_client::SendMigrationOutcome::Completed,
+            Ok(info) => swift_ch_client::SendMigrationOutcome::Failed(format!(
+                "w1_violation: send_migration returned 0 but CH state={}",
+                info.state
+            )),
+        }
+    };
+
+    match terminal {
+        swift_ch_client::SendMigrationOutcome::Completed => {
             let elapsed_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
             // W22: mark migration-send as cleanly completed so main.rs's
-            // post-launch path suppresses the VmStopped write that
-            // would race the dst-side W16 GuestRunning=True write.
-            // Set BEFORE logging the success message so any future
-            // observer sees a consistent state.
+            // post-launch path suppresses the VmStopped write that would
+            // race the dst-side W16 GuestRunning=True write. Set BEFORE
+            // logging so any future observer sees a consistent state.
             MIGRATION_SEND_COMPLETED.store(true, Ordering::SeqCst);
             log::info!(
-                "dispatch_migration_send_complete id={} elapsed_ms={} w22_send_completed_flag=set",
+                "dispatch_migration_send_complete id={} elapsed_ms={} non_blocking={} w22_send_completed_flag=set",
                 action.id,
-                elapsed_ms
+                elapsed_ms,
+                non_blocking
             );
             Ok(ActionOutcome {
                 detail: Some(format!("sent to {} ({}ms)", args.target_url, elapsed_ms)),
@@ -1231,19 +1301,14 @@ async fn dispatch_migration_send(
                 success_status: Some("complete"),
             })
         }
-        Ok(info) => {
-            // CH is still alive after a "successful" send-migration.
-            // This contradicts Q1c; surface as failure with the W1
-            // category so operators learn the gate fired.
+        swift_ch_client::SendMigrationOutcome::Failed(detail) => {
             log::warn!(
-                "migration_send_w1_violation id={} state={}",
+                "migration_send_failed id={} non_blocking={} detail={}",
                 action.id,
-                info.state
+                non_blocking,
+                detail
             );
-            Err(format!(
-                "w1_violation: send_migration returned 0 but CH state={}",
-                info.state
-            ))
+            Err(detail)
         }
     }
 }
@@ -3024,6 +3089,23 @@ mod tests {
         b"HTTP/1.1 204 No Content\r\n\r\n".to_vec()
     }
 
+    /// A `vmm.ping` 200 response advertising the given build version (e.g.
+    /// "v52.0" or "v53.0"). Drives the send-migration version gate in the
+    /// dispatch tests: the mock is sequence-based, so this is queued as the
+    /// FIRST response because `dispatch_migration_send` pings before it
+    /// sends.
+    fn vmm_ping(build_version: &str) -> Vec<u8> {
+        let body = format!(
+            r#"{{"build_version":"{}","version":"{}","pid":4242}}"#,
+            build_version,
+            build_version.trim_start_matches('v')
+        );
+        let mut full =
+            format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", body.len()).into_bytes();
+        full.extend_from_slice(body.as_bytes());
+        full
+    }
+
     fn capture_action(args: serde_json::Value) -> PendingAction {
         PendingAction {
             kind: ActionKind::SnapshotCapture,
@@ -3592,16 +3674,16 @@ mod tests {
 
     #[tokio::test]
     async fn migration_send_returns_complete_when_ch_exits() {
-        // Phase 2 spike Q1c: source CH auto-exits cleanly on successful
-        // send-migration. The dispatch handler probes vm_info post-send;
-        // ConnectionRefused is the expected outcome (CH gone).
+        // Phase 2 spike Q1c: on CH <= v52 send-migration BLOCKS, and the
+        // source CH auto-exits cleanly on success. The dispatch handler
+        // probes vm_info once post-send; ConnectionRefused is the expected
+        // outcome (CH gone).
         //
-        // We model this with a mock that responds to the send-migration
-        // call with 204 No Content, then the second accept (vm_info)
-        // never connects because the mock has run out of responses.
-        // The vm_info call returns a Connect error → sanitizer maps to
-        // `connection_refused` → W1 gate accepts as "CH gone clean".
-        let server = MultiMockServer::spawn(vec![no_content()]);
+        // Sequence (mock is response-ordered): vmm.ping → v52 (pins the
+        // single-probe blocking path), send-migration → 204, then the
+        // vm_info probe finds the mock exhausted → Connect error → W1 gate
+        // accepts as "CH gone clean".
+        let server = MultiMockServer::spawn(vec![vmm_ping("v52.0"), no_content()]);
         let action = migration_send_action(serde_json::json!({ "target_url": "tcp:1.2.3.4:6789" }));
         let outcome = dispatch(&action, &server.path).await.unwrap();
         let detail = outcome.detail.unwrap();
@@ -3616,6 +3698,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn migration_send_v53_polls_until_source_exits() {
+        // CH v53 (#8021): send-migration is non-blocking, so dispatch must
+        // POLL vm.info rather than probe once. Sequence: vmm.ping → v53,
+        // send-migration → 204 (accepted), then the first vm.info poll
+        // finds the mock exhausted → Connect error → source gone →
+        // Completed. Mirrors the hardware-confirmed v53 spike contract.
+        let server = MultiMockServer::spawn(vec![vmm_ping("v53.0"), no_content()]);
+        let action = migration_send_action(serde_json::json!({ "target_url": "tcp:1.2.3.4:6789" }));
+        let outcome = dispatch(&action, &server.path).await.unwrap();
+        assert!(outcome.detail.unwrap().contains("sent to tcp:1.2.3.4:6789"));
+        // Same source-side success verb as the blocking path.
+        assert_eq!(outcome.success_status, Some("complete"));
+    }
+
+    #[tokio::test]
     async fn migration_send_w1_violates_when_ch_still_running() {
         // W1 gate (load-bearing item C): if send_migration returns 0
         // but vm_info still reports state=Running, that's abnormal —
@@ -3625,7 +3722,9 @@ mod tests {
         let info_response = format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", body.len());
         let mut info_full = info_response.into_bytes();
         info_full.extend_from_slice(body);
-        let server = MultiMockServer::spawn(vec![no_content(), info_full]);
+        // vmm.ping → v52 pins the single-probe path; then send-migration →
+        // 204 and vm_info → 200 Running triggers the historic W1 violation.
+        let server = MultiMockServer::spawn(vec![vmm_ping("v52.0"), no_content(), info_full]);
         let action = migration_send_action(serde_json::json!({ "target_url": "tcp:1.2.3.4:6789" }));
         let err = dispatch(&action, &server.path).await.unwrap_err();
         assert!(err.contains("w1_violation"), "got {}", err);
@@ -3638,7 +3737,10 @@ mod tests {
         // gone or network drops. The sanitizer converts the raw error
         // into a category token; raw bytes never reach the
         // status-detail annotation.
+        // vmm.ping is consumed first (v52); send-migration then returns the
+        // 500, which the sanitizer converts to a category token.
         let server = MultiMockServer::spawn(vec![
+            vmm_ping("v52.0"),
             b"HTTP/1.1 500 Internal\r\nContent-Length: 25\r\n\r\nguest secret memory bytes"
                 .to_vec(),
         ]);

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -368,7 +368,7 @@ where
                     d.socket
                 );
                 generic_vhost_user.push(GenericVhostUser {
-                    virtio_id: d.virtio_id.clone().unwrap_or_default(),
+                    device_type: d.virtio_id.clone().unwrap_or_default(),
                     socket: d.socket.clone(),
                     queue_sizes: d.queue_sizes.clone().unwrap_or_default(),
                 });


### PR DESCRIPTION
## Summary

Move swiftletd to **Cloud Hypervisor v53.0** and adapt to the two v53 behaviour changes the datapath depends on.

### 1. `vm.send-migration` is now non-blocking (cloud-hypervisor#8021)

v53 returns `204` the instant CH *accepts* the migration; pre-copy/stop-and-copy then run on a background thread. The old source-side completion gate relied on the call **blocking** until the source CH exited, then a single `vm.info` probe — on v53 that probe sees the guest still `Running` and misfires the W1 gate.

- New `ApiClient::wait_for_send_migration_terminal` polls `vm.info` until a terminal edge:
  - connect-refused (source process exited) ⇒ **complete**
  - still `Running` past the migration deadline ⇒ **failed** (v53 auto-resumes the source, so no `vm.resume`)
- `dispatch_migration_send` **version-gates on `vmm.ping`**: v53 polls; **v52 keeps the historic single-probe path byte-identical** (no regression, mixed-version-fleet safe — each launcher talks to its own local CH).
- `receive-migration` **remains blocking** on v53 (confirmed in #8021), so the destination handler is unchanged.
- On v53 the source process **exits at completion**, so the W22 flag (which tells `main.rs` "this CH exit is a completed migration, not a stop") is now set at **send-accept time**, not after the poll detects the exit — otherwise the process dies mid-poll with the flag unset and the controller stalls in `StopAndCopy`. Cleared only on detected failure.

### 2. `generic-vhost-user` CLI key renamed `virtio_id` → `device_type` (cloud-hypervisor#8564)

Emit `device_type=` from `swift-ch-client`. The RuntimeIntent / CRD field (`virtioId`) is unchanged (Go↔Rust JSON contract intact); v52 registered only `virtio_id`, so this lands **with** the binary bump, never before.

Firmware `CLOUDHV.fd` (`ch-13b4963ec4`) is **unchanged** — the v53 spike confirmed it boots on the v53.0 binary.

## Validation

A hardware spike (privileged pod, real v53.0 binary + KVM on dev node `miles`) confirmed the non-blocking contract, `vm.info` pollability through the migration, source-exit == success, and v52-snapshot → v53-restore.

**End-to-end live migration on the dev cluster** (k0s, Longhorn RWX+Block, mTLS overlay), disk-boot Ubuntu guest, v53 launchers on both ends:

```
migration.phase=StopAndCopy  src.migration-status=sending
migration.phase=StopAndCopy  src.migration-status=complete
migration.phase=Completed    downtime=1.902575489s  transfer=19.639s   (guest now Running on boba)
```

Source-side log (the v53 completion path):

```
vm_exited_post_send_migration; skipping VmStopped report (W22)
dispatch_migration_send_complete … non_blocking=true w22_send_completed_flag=set
w23_terminal_write_signal_fired … / w23_terminal_write_signal_received; safe to exit
```

The first walkthrough caught the accept-time-flag race (migration hung in `StopAndCopy`, source stuck at `sending`); the fix above resolves it — re-validated with two successful migrations.

## Tests

- Rust: `cargo test` green (swift-ch-client 75, swiftletd 120), `cargo fmt` clean, release build clean.
- Go: touched packages green; CRDs regenerated for the `device_type` description.

## Not in scope (follow-ups)

CHANGELOG + version bump land with the deliberate release cut. v53 leverage items — buffered serial (#8322) → `swiftctl console` post-boot, native migration mTLS (#8053) → drop the stunnel sidecar, VFIO FD-passing (#8287) → GPU live-migration — are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
