### PR TITLE
feat(ch): v53 leverage — safe wins (reserve=on, --seccomp, buffered-serial); L2/L3 validated no-go

### DIFF
--- a/rust/swift-ch-client/src/config.rs
+++ b/rust/swift-ch-client/src/config.rs
@@ -121,6 +121,16 @@ pub struct VmConfig {
     /// controller's configjson patcher rewrites only the socket PATH to the
     /// clone runtime dir).
     pub vsock: Option<VsockConfig>,
+
+    /// Optional `--seccomp <mode>` value. `None` omits the flag entirely, so
+    /// CH uses its built-in default (`true` — a seccomp violation SIGSYS-kills
+    /// the VMM). Set (via `KUBESWIFT_SECCOMP`) only for debugging: `log`
+    /// permits + logs a violation, and `errno` (CH >= v53, cloud-hypervisor
+    /// #8578) returns `EPERM` to the offending syscall instead of killing the
+    /// VMM — either lets an operator see which syscall a hardened profile
+    /// blocked without the process disappearing. Validated to CH's accepted
+    /// set by the launcher before it reaches here.
+    pub seccomp: Option<String>,
 }
 
 /// A vsock device for `--vsock cid=<N>,socket=<path>`.
@@ -186,7 +196,16 @@ impl VmConfig {
             // backing for snapshot/live-migration-capable guests (mirrors QEMU's
             // memory-backend-memfd,share=on) and what the sparse-snapshot /
             // userfaultfd path (#163) wants.
-            format!("size={}M,shared=on", self.memory_mib),
+            //
+            // reserve=on (CH >= v53, cloud-hypervisor#8350): create the guest-RAM
+            // mapping WITHOUT MAP_NORESERVE so the kernel reserves commit up front
+            // and CH fails at VM creation (ENOMEM) if the node cannot back the full
+            // guest RAM -- a fail-fast that turns a mid-run guest OOM into a clean
+            // start-time error. Safe for our model: the launcher pod already
+            // requests the full guest RAM, so a scheduled guest's node has it; this
+            // only trips on real node-level memory pressure, which is exactly when
+            // we want to refuse to start rather than OOM later.
+            format!("size={}M,shared=on,reserve=on", self.memory_mib),
             "--cpus".to_string(),
             {
                 let mut cpus = format!("boot={}", self.cpus.max(1));
@@ -311,15 +330,20 @@ impl VmConfig {
             args.push("--serial".to_string());
             if self.is_sandbox {
                 // Sandbox: write the guest console to a FILE, not an interactive socket.
-                // The workload is a batch job — swiftletd reads this file after CH exits
+                // The workload is a batch job — swiftletd reads this file AFTER CH exits
                 // to recover the workload's exit code (the bridge-init emits a trailing
-                // `KUBESWIFT-EXIT-CODE=<n>`), and it doubles as the sandbox log. CH also
-                // drops serial-socket output emitted before a client connects, which
-                // would lose the exit line. (Interactive exec/attach is a vsock follow-up.)
+                // `KUBESWIFT-EXIT-CODE=<n>`), and it doubles as the sandbox log. A socket
+                // does not survive CH's exit, so `file=` is required for that
+                // read-after-exit regardless of CH version. (v53 #8322 does now buffer
+                // pre-connect socket output — that removes the *other* old reason for
+                // `file=`, but not this one. Interactive exec/attach is over vsock.)
                 args.push(format!("file={}.log", path));
             } else {
                 // Serial socket: bidirectional; connect with socat for interactive console.
-                // Kernel cmdline comes from disk GRUB (patched during SwiftImage import for console=ttyS0).
+                // Kernel cmdline comes from disk GRUB (patched during SwiftImage import for
+                // console=ttyS0). On CH >= v53 (#8322) the socket buffers output emitted
+                // before any client connects, so `swiftctl console` attached AFTER boot now
+                // replays the boot log instead of showing an empty screen (was lost on v52).
                 args.push(format!("socket={}", path));
             }
             // Disable virtio-console; serial is the interactive console.
@@ -398,6 +422,13 @@ impl VmConfig {
             args.push(format!("cid={},socket={}", v.cid, v.socket));
         }
 
+        // Optional --seccomp override (debugging only; None omits the flag so
+        // CH keeps its default `true` = SIGSYS-kill on a violation).
+        if let Some(ref mode) = self.seccomp {
+            args.push("--seccomp".to_string());
+            args.push(mode.clone());
+        }
+
         args
     }
 }
@@ -431,6 +462,7 @@ mod tests {
             vhost_user_blk_sockets: vec![],
             generic_vhost_user: vec![],
             vsock: None,
+            seccomp: None,
         }
     }
 
@@ -630,8 +662,8 @@ mod tests {
         assert!(
             disk.to_args()
                 .join(" ")
-                .contains("--memory size=2048M,shared=on"),
-            "disk-boot --memory must carry shared=on: {}",
+                .contains("--memory size=2048M,shared=on,reserve=on"),
+            "disk-boot --memory must carry shared=on,reserve=on: {}",
             disk.to_args().join(" ")
         );
         let mut kern = make_disk_boot_config();
@@ -640,9 +672,27 @@ mod tests {
         assert!(
             kern.to_args()
                 .join(" ")
-                .contains("--memory size=2048M,shared=on"),
-            "kernel-boot --memory must carry shared=on: {}",
+                .contains("--memory size=2048M,shared=on,reserve=on"),
+            "kernel-boot --memory must carry shared=on,reserve=on: {}",
             kern.to_args().join(" ")
+        );
+    }
+
+    #[test]
+    fn seccomp_none_omits_flag_some_emits_it() {
+        // Default (None) must NOT emit --seccomp so CH keeps its built-in
+        // default; an explicit mode (e.g. the v53 `errno`) is passed through.
+        let mut cfg = make_disk_boot_config();
+        assert!(
+            !cfg.to_args().join(" ").contains("--seccomp"),
+            "default (None) must not emit --seccomp: {}",
+            cfg.to_args().join(" ")
+        );
+        cfg.seccomp = Some("errno".to_string());
+        assert!(
+            cfg.to_args().join(" ").contains("--seccomp errno"),
+            "seccomp=Some(errno) must emit `--seccomp errno`: {}",
+            cfg.to_args().join(" ")
         );
     }
 

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -405,6 +405,25 @@ where
         }
     });
 
+    // Optional --seccomp override for debugging (KUBESWIFT_SECCOMP). CH accepts
+    // true|false|log, plus errno on v53 (#8578: return EPERM instead of
+    // SIGSYS-killing the VMM). Anything else is ignored with a warning so a typo
+    // cannot stop the guest from booting. Unset => omit the flag => CH default.
+    let seccomp = std::env::var("KUBESWIFT_SECCOMP").ok().and_then(|v| {
+        let v = v.trim().to_ascii_lowercase();
+        match v.as_str() {
+            "true" | "false" | "log" | "errno" => Some(v),
+            "" => None,
+            other => {
+                log::warn!(
+                    "ignoring KUBESWIFT_SECCOMP={:?}: not one of true|false|log|errno",
+                    other
+                );
+                None
+            }
+        }
+    });
+
     let config = if intent.has_kernel() {
         let kb = intent.kernel_boot.as_ref().unwrap();
         VmConfig {
@@ -434,6 +453,7 @@ where
             vhost_user_blk_sockets,
             generic_vhost_user,
             vsock: vsock.clone(),
+            seccomp: seccomp.clone(),
         }
     } else {
         VmConfig {
@@ -463,6 +483,7 @@ where
             vhost_user_blk_sockets,
             generic_vhost_user,
             vsock: vsock.clone(),
+            seccomp: seccomp.clone(),
         }
     };
 


### PR DESCRIPTION
## Summary

Follow-up to #422 (CH v53.0). A leverage pass over the v53 changelog: adopt the safe, high-value wins, and **validation-first spike the two big items before committing to their reworks**. Both big items turned out to be validated no-gos — the spikes saved two large reworks that could not have worked and would have shipped regressions.

## Shipped (this PR)

Three low-risk wins, no behaviour change on the common path:

- **L5 (cloud-hypervisor#8350):** emit `reserve=on` on `--memory` so CH reserves guest-RAM commit at VM creation and fails fast with `ENOMEM` instead of a mid-run OOM. Safe for our model (the launcher pod already requests the full guest RAM); restore/receive inherit the memory config from the snapshot/source, so it rides only the fresh-boot path.
- **L8 (cloud-hypervisor#8578):** optional `--seccomp <mode>` via `KUBESWIFT_SECCOMP` (`true|false|log|errno`), validated in the launcher. Unset ⇒ flag omitted ⇒ CH default (kill on violation), so **no change by default**. `errno` returns `EPERM` instead of SIGSYS-killing the VMM — a swiftletd/CH debugging aid.
- **L1 (cloud-hypervisor#8322):** v53 buffers `--serial socket=` output for late clients, so `swiftctl console` attached *after* boot now replays the boot log. Comment fixes only; the sandbox keeps `file=` (a socket does not survive CH's exit).

**Deprecation scan:** the only CH v53 CLI deprecations that touch us are `virtio_id`→`device_type` (shipped in #422) and `--platform serial_number/uuid` (we don't emit those). Nothing left to remove.

## Validated NO-GO (kept the working path) — the two big items

**L2 — retire the stunnel migration sidecar for CH-native mTLS (cloud-hypervisor#8053): NO-GO, keep stunnel.**
Native mTLS verifies the server cert SAN against the host in `destination_url` (no `checkHost` override), so it must connect to the destination by **DNS name**. stunnel connects by destination **pod IP** (no DNS). Proven on the ntx OVN-K cluster: a UDN/OVN-K-primary pod's default network is `role: infrastructure-locked` and **cluster DNS times out** from it (a non-UDN control pod on the same cluster resolves fine). So native mTLS would **regress live migration for exactly the multi-node UDN guests IP-preserving migration exists for**, to save one sidecar. Kept stunnel (already mutual TLS, pod→pod, IP-based). A staff-architect review also caught two day-one bugs (exact-string SAN match; stable-hostname collision on re-migration) had we proceeded.

**L3 — drop `privileged` for GPU launchers via pre-opened VFIO/iommufd FDs (cloud-hypervisor#8287): NO-GO, keep privileged.**
Spiked on the real GTX 1080 (boba). The fd-passing *mechanism* works — CH v53 accepts `--device fd=N` + `--platform iommufd=on,iommufd_fd=M`, inherits the FDs, reads the BARs. **But CH v53's iommufd IOAS DMA-map is broken**: `IommuIoasMap(Error 14)` (EFAULT) mapping guest RAM — config-independent (memfd / `prefault=on` / 2M hugepages / `memlock=unlimited` all fail identically) and **fails with a path-based device too** (so it's iommufd itself, not the fd-passing). Control: legacy VFIO (`--device path=`, the current Tier-1 path) boots fine on v53. Since fd-passing *requires* iommufd, L3 is impossible on CH v53. Kept the privileged legacy-VFIO GPU path (incidentally re-validated: GTX 1080 + CH v53 boots).

## Validation

- Rust: `cargo test` green (swift-ch-client 76, swiftletd 120), `cargo fmt` clean.
- End-to-end on dev: a guest booted on the safe-wins launcher — spawn log shows `--memory size=2048M,shared=on,reserve=on`, guest reached Running, DHCP'd, `launcher_restarts=0` (L5 doesn't regress boot). GPU path re-validated in the L3 spike. Migration/snapshot paths unchanged from #422.

Dev cluster restored to the v0.12.1 launcher afterward.

## Not in scope

CHANGELOG + version bump land with a deliberate release cut. A future **hybrid** (native mTLS for nat-primary guests + stunnel for UDN) could revisit L2 if desired — the `tls_dir` plumbing exists in this branch's history — but it's two code paths, not chosen here. L3 could be revisited if a future CH release fixes the iommufd DMA-map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
