### PR TITLE
release: v0.13.0 — Cloud Hypervisor v53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.13.0] — 2026-07-23
+
+Moves the runtime to **Cloud Hypervisor v53.0** and adopts the safe v53 leverage wins.
+The headline is a migration-internals rework forced by v53, done so live migration is
+unchanged for operators: `vm.send-migration` became non-blocking in v53, so the
+source-side completion gate now polls instead of relying on the call blocking. Two v53
+opportunities were investigated and **deliberately not taken** because cluster
+validation proved each would regress or was impossible — see below.
+
+### Changed
+
+- **Cloud Hypervisor v52.0 → v53.0** in the swiftletd image. The paired `CLOUDHV.fd`
+  firmware is unchanged (validated on the v53 binary). Free fixes ride along: the guest
+  clock now advances across snapshot/restore/migration, post-migration GARP speeds L2
+  reconvergence, the memfd private-mapping memory regression is reverted, and
+  guest-triggerable VMM panics are hardened (strengthening the SwiftSandbox boundary).
+- **Source-side live-migration completion detection reworked for v53's non-blocking
+  `vm.send-migration`** (cloud-hypervisor#8021). `send-migration` now returns the instant
+  CH accepts the migration, so swiftletd polls `vm.info` until the source CH exits
+  (success) or the deadline passes (failure, guest auto-resumed). Version-gated: on CH
+  ≤ v52 the historic single-probe path is byte-identical. `receive-migration` remains
+  blocking, so the destination handler is unchanged. Live migration behaviour and
+  downtime are unchanged for operators.
+- **Generic vhost-user CLI key `virtio_id` → `device_type`** (cloud-hypervisor#8564).
+  Emitted to CH only; the `virtioId` CRD/RuntimeIntent field is unchanged.
+
+### Added
+
+- **`reserve=on` on guest memory** (cloud-hypervisor#8350): CH reserves guest-RAM commit
+  at VM creation and fails fast with `ENOMEM` instead of a later out-of-memory kill.
+- **Optional `--seccomp` mode via `KUBESWIFT_SECCOMP`** (`true|false|log|errno`;
+  cloud-hypervisor#8578). Unset keeps CH's default (kill on violation); `errno` returns
+  `EPERM` instead of killing the VMM — a debugging aid, off by default.
+- **`swiftctl console` now replays the boot log** when attached after boot — CH v53
+  buffers pre-connect serial-socket output (cloud-hypervisor#8322).
+
+### Investigated, not adopted (validated regressions)
+
+- **Native CH migration mTLS** (cloud-hypervisor#8053) was evaluated as a replacement for
+  the stunnel sidecar and **rejected**: it connects to the destination by DNS name, and
+  OVN-Kubernetes primary-UDN launchers cannot resolve cluster DNS (proven on-cluster), so
+  it would break live migration for multi-node guests. The stunnel transport (already
+  mutual TLS, pod-to-pod, IP-based) is retained.
+- **Unprivileged GPU launchers via pre-opened VFIO/iommufd FDs** (cloud-hypervisor#8287)
+  was spiked on real hardware and **rejected**: CH v53's iommufd DMA-map fails (`EFAULT`)
+  for the test GPU regardless of memory backing, so the privileged legacy-VFIO GPU path
+  is retained. May be revisited if a future CH release fixes iommufd.
+
+---
+
 ## [v0.12.1] — 2026-07-19
 
 A networking patch release: give a `SwiftGuest` a second, cross-node-routable NIC on

--- a/api/migration/v1alpha1/swiftmigration_types.go
+++ b/api/migration/v1alpha1/swiftmigration_types.go
@@ -578,7 +578,7 @@ type SwiftMigrationStatus struct {
 	// controller actually sent on vm.send-migration (from
 	// spec.downtimeTarget; CH >= v52). It is a BOUND, not a measurement:
 	// CH converges pre-copy so the final vCPU stop-and-copy fits under it,
-	// so the real "guest frozen" window is <= this value — but CH v52 does
+	// so the real "guest frozen" window is <= this value — but CH does
 	// not report the achieved downtime (vm.send-migration returns 204 with
 	// no body, and CH logs no migration telemetry at its default level), so
 	// the achieved window is not directly measurable here. The only ground

--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -10,7 +10,7 @@ import (
 //
 // RunPolicy governs what the controller does when the launcher POD reaches a
 // terminal state (Succeeded/Failed) — i.e. when Cloud Hypervisor itself exits.
-// A guest *reboot* is NOT such an event: on Cloud Hypervisor v52 a guest reboot
+// A guest *reboot* is NOT such an event: on Cloud Hypervisor a guest reboot
 // RESETS THE VM IN PLACE (the CH process and the launcher pod survive, the
 // guest restarts), so reboots never trigger RunPolicy. CH exits only on guest
 // shutdown/poweroff or a crash; those are what Stopped/RestartOnFailure/Always

--- a/api/swift/v1alpha1/swiftguestclass_types.go
+++ b/api/swift/v1alpha1/swiftguestclass_types.go
@@ -21,7 +21,7 @@ type RootDiskSpec struct {
 }
 
 // CoreScheduling selects the Cloud Hypervisor vCPU core-scheduling policy
-// (CH v52 `--cpus core_scheduling=`), a defense against cross-thread SMT
+// (Cloud Hypervisor `--cpus core_scheduling=`), a defense against cross-thread SMT
 // (hyper-threading) side channels without disabling SMT host-wide.
 //
 //	off  (default) no core-scheduling.

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.12.1
-appVersion: "0.12.1"
+version: 0.13.0
+appVersion: "0.13.0"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
+++ b/charts/kubeswift/crds/migration.kubeswift.io_swiftmigrations.yaml
@@ -220,7 +220,7 @@ spec:
                   controller actually sent on vm.send-migration (from
                   spec.downtimeTarget; CH >= v52). It is a BOUND, not a measurement:
                   CH converges pre-copy so the final vCPU stop-and-copy fits under it,
-                  so the real "guest frozen" window is <= this value — but CH v52 does
+                  so the real "guest frozen" window is <= this value — but CH does
                   not report the achieved downtime (vm.send-migration returns 204 with
                   no body, and CH logs no migration telemetry at its default level), so
                   the achieved window is not directly measurable here. The only ground

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
@@ -839,7 +839,7 @@ spec:
                           guest.\n\nRunPolicy governs what the controller does when
                           the launcher POD reaches a\nterminal state (Succeeded/Failed)
                           — i.e. when Cloud Hypervisor itself exits.\nA guest *reboot*
-                          is NOT such an event: on Cloud Hypervisor v52 a guest reboot\nRESETS
+                          is NOT such an event: on Cloud Hypervisor a guest reboot\nRESETS
                           THE VM IN PLACE (the CH process and the launcher pod survive,
                           the\nguest restarts), so reboots never trigger RunPolicy.
                           CH exits only on guest\nshutdown/poweroff or a crash; those

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -690,7 +690,7 @@ spec:
                 description: "RunPolicy defines the desired run state of a guest.\n\nRunPolicy
                   governs what the controller does when the launcher POD reaches a\nterminal
                   state (Succeeded/Failed) — i.e. when Cloud Hypervisor itself exits.\nA
-                  guest *reboot* is NOT such an event: on Cloud Hypervisor v52 a guest
+                  guest *reboot* is NOT such an event: on Cloud Hypervisor a guest
                   reboot\nRESETS THE VM IN PLACE (the CH process and the launcher
                   pod survive, the\nguest restarts), so reboots never trigger RunPolicy.
                   CH exits only on guest\nshutdown/poweroff or a crash; those are

--- a/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
+++ b/config/crd/bases/migration.kubeswift.io_swiftmigrations.yaml
@@ -220,7 +220,7 @@ spec:
                   controller actually sent on vm.send-migration (from
                   spec.downtimeTarget; CH >= v52). It is a BOUND, not a measurement:
                   CH converges pre-copy so the final vCPU stop-and-copy fits under it,
-                  so the real "guest frozen" window is <= this value — but CH v52 does
+                  so the real "guest frozen" window is <= this value — but CH does
                   not report the achieved downtime (vm.send-migration returns 204 with
                   no body, and CH logs no migration telemetry at its default level), so
                   the achieved window is not directly measurable here. The only ground

--- a/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
@@ -839,7 +839,7 @@ spec:
                           guest.\n\nRunPolicy governs what the controller does when
                           the launcher POD reaches a\nterminal state (Succeeded/Failed)
                           — i.e. when Cloud Hypervisor itself exits.\nA guest *reboot*
-                          is NOT such an event: on Cloud Hypervisor v52 a guest reboot\nRESETS
+                          is NOT such an event: on Cloud Hypervisor a guest reboot\nRESETS
                           THE VM IN PLACE (the CH process and the launcher pod survive,
                           the\nguest restarts), so reboots never trigger RunPolicy.
                           CH exits only on guest\nshutdown/poweroff or a crash; those

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -690,7 +690,7 @@ spec:
                 description: "RunPolicy defines the desired run state of a guest.\n\nRunPolicy
                   governs what the controller does when the launcher POD reaches a\nterminal
                   state (Succeeded/Failed) — i.e. when Cloud Hypervisor itself exits.\nA
-                  guest *reboot* is NOT such an event: on Cloud Hypervisor v52 a guest
+                  guest *reboot* is NOT such an event: on Cloud Hypervisor a guest
                   reboot\nRESETS THE VM IN PLACE (the CH process and the launcher
                   pod survive, the\nguest restarts), so reboots never trigger RunPolicy.
                   CH exits only on guest\nshutdown/poweroff or a crash; those are

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@ SwiftGuest Pod (one per SwiftGuest)
   |-- launcher container: swiftletd  (Rust)
         |
         v
-  Cloud Hypervisor v52.0   (primary: Linux + Windows disk boot, kernel boot, Tier 1 PCIe GPU)
+  Cloud Hypervisor v53.0   (primary: Linux + Windows disk boot, kernel boot, Tier 1 PCIe GPU)
   QEMU                     (secondary: HGX SXM Tier 2/3 GPU workloads only)
         |
         v

--- a/docs/architecture/node-runtime.md
+++ b/docs/architecture/node-runtime.md
@@ -74,7 +74,7 @@ The runtime directory is created under `KUBESWIFT_RUN_DIR` (default `/var/lib/ku
 
 ## Cloud Hypervisor requirements
 
-- **Version:** v52.0 (CLI format: `--api-socket path=`, `--disk path=`, etc.)
+- **Version:** v53.0 (CLI format: `--api-socket path=`, `--disk path=`, etc.)
 - **Binary:** Included in the swiftletd container image at `/usr/local/bin/cloud-hypervisor`
 - **Socket:** Unix socket only; no TCP binding
 

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -25,7 +25,7 @@ All KubeSwift CRDs are `v1alpha1`. KubeSwift ships **15 CRDs across 9 API groups
 - `spec.imageRef` and `spec.kernelRef` on SwiftGuest are mutually exclusive.
 - `spec.gpuProfileRef` and `spec.kernelRef` on SwiftGuest are mutually exclusive (GPU boot requires disk boot with UEFI).
 - `spec.gpuProfileRef` can combine with `spec.imageRef`.
-- `spec.osType: windows` requires the disk-boot path (`imageRef`); it is incompatible with `kernelRef`. Windows boots on Cloud Hypervisor v52.0 via the disk path — see [Windows overview](windows/overview.md).
+- `spec.osType: windows` requires the disk-boot path (`imageRef`); it is incompatible with `kernelRef`. Windows boots on Cloud Hypervisor v53.0 via the disk path — see [Windows overview](windows/overview.md).
 
 ---
 
@@ -42,7 +42,7 @@ Represents a running virtual machine instance.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `osType` | enum | No | `linux` | Guest OS family: `linux` or `windows`. `windows` requires `imageRef` (disk boot); it selects the Cloud Hypervisor v52.0 Windows path (`--cpus boot=N,kvm_hyperv=on`, `--disk image_type=raw`) and cloudbase-init provisioning. See [Windows overview](windows/overview.md). |
+| `osType` | enum | No | `linux` | Guest OS family: `linux` or `windows`. `windows` requires `imageRef` (disk boot); it selects the Cloud Hypervisor v53.0 Windows path (`--cpus boot=N,kvm_hyperv=on`, `--disk image_type=raw`) and cloudbase-init provisioning. See [Windows overview](windows/overview.md). |
 | `imageRef.name` | string | No | — | SwiftImage to boot from (disk boot). Mutually exclusive with `kernelRef`. |
 | `kernelRef.name` | string | No | — | SwiftKernel to boot from (kernel boot). Mutually exclusive with `imageRef` and `gpuProfileRef`. Incompatible with `osType: windows`. |
 | `kernelCmdline` | string | No | — | Per-guest kernel command line override (kernel boot only). Overrides SwiftKernel's default cmdline. |

--- a/docs/development.md
+++ b/docs/development.md
@@ -273,7 +273,7 @@ kubectl describe swiftimage <name>
 
 | Component | Version | Notes |
 |-----------|---------|-------|
-| Cloud Hypervisor | v52.0 | Current production version |
+| Cloud Hypervisor | v53.0 | Current production version |
 | CLOUDHV.fd | ch-13b4963ec4 | UEFI firmware via `--kernel`, not `--firmware` |
 | faas-minimal kernel tag | `6.6.1` | Use this. `6.6.0` has broken networking |
 | ORAS | v1.3.1 | Used in SwiftKernel pull jobs |

--- a/docs/operator/operator-checklist-ubuntu-x86_64.md
+++ b/docs/operator/operator-checklist-ubuntu-x86_64.md
@@ -113,7 +113,7 @@ spec:
 | **NoCloud seed as directory** | swiftletd passes NoCloud directory path to CH; CH expects ISO/vfat. May fail on some CH builds; doc suggests adding ISO generation |
 | **Runtime intent disk path** | Intent uses `rootDisk.path` = `/var/lib/kubeswift/disks/root` (mount dir); import writes `image.raw`. CH expects a file path; if CH requires the full path (e.g. `.../disks/root/image.raw`), the intent may need adjustment |
 | **No nodeSelector/tolerations** | Guest pods can schedule on any node; no explicit "KVM-capable" node targeting |
-| **Cloud Hypervisor v52.0** | Containerfile pins CH v52.0; CLI format must match |
+| **Cloud Hypervisor v53.0** | Containerfile pins CH v53.0; CLI format must match |
 | **In-cluster Kubeconfig** | swiftletd assumes in-cluster config (service account) for status patching |
 | **Single launcher container** | No init container; swiftletd does all setup |
 | **Import Job uses curl** | No retries or checksum validation; assumes URL returns valid image |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -328,7 +328,7 @@ Success criteria:
 ## Status
 
 **Working and cluster-validated:** Linux disk boot (CLOUDHV.fd) and kernel boot; Windows guests
-(`osType: windows`, Cloud Hypervisor v52.0 — see [Windows overview](windows/overview.md)); networking
+(`osType: windows`, Cloud Hypervisor v53.0 — see [Windows overview](windows/overview.md)); networking
 (tap+bridge+dnsmasq) and [service exposure](networking/service-exposure.md); SR-IOV NIC passthrough;
 SwiftGuestPool (scaling, rolling updates, topology spread, PVC per replica); per-guest root disk cloning;
 [snapshots and clones](snapshots/csi-snapshots.md) (CSI, local/S3 memory, scheduled, cloneFromSnapshot);

--- a/docs/swiftguest-reconcile.md
+++ b/docs/swiftguest-reconcile.md
@@ -38,7 +38,7 @@ and the pod has failed (or succeeded for Always), the controller:
 
 Both guards key on the launcher **pod's terminal state** (Succeeded/Failed),
 which means Cloud Hypervisor exited. A guest **reboot is not such an event on
-CH v52**: the VM resets in place, so the CH process and the pod survive and the
+Cloud Hypervisor**: the VM resets in place, so the CH process and the pod survive and the
 guest restarts without any controller action (validated 2026-06-09 — the pod
 stayed Running with the same CH PID across an in-guest `reboot`, only the
 guest's `boot_id` changed). CH exits — and these guards fire — only on guest

--- a/docs/swiftletd-mvp.md
+++ b/docs/swiftletd-mvp.md
@@ -37,7 +37,7 @@ The runtime directory is created under `KUBESWIFT_RUN_DIR` (default `/var/lib/ku
 
 ## Cloud Hypervisor requirements
 
-- **Version**: v52.0 (CLI format: `--api-socket path=`, `--disk path=`, etc.)
+- **Version**: v53.0 (CLI format: `--api-socket path=`, `--disk path=`, etc.)
 - **Binary**: Included in the swiftletd container image at `/usr/local/bin/cloud-hypervisor`
 - **Socket**: Unix socket only; no TCP binding
 

--- a/docs/windows/image-prep.md
+++ b/docs/windows/image-prep.md
@@ -148,7 +148,7 @@ over **RDP** (the sample seed enables it); Windows on CH is headless.
 | Setup error "we couldn't find any drives" | viostor not injected — check the `DriverPaths` letters/paths match your `virtio-win.iso` layout (`\viostor\2k22\amd64`). |
 | Boots to a graphical **"Automatic Repair"** that hangs on CH | Missing headless BCD prep — `recoveryenabled no` + `bootstatuspolicy ignoreallfailures` (the answer file applies these). |
 | Windows silently hangs early on CH (no SAC) | Missing `kvm_hyperv` — the KubeSwift runtime adds `--cpus kvm_hyperv=on` for `osType: windows` automatically. |
-| `0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL` in `viostor.sys`, reboot loop | A **CH v51.1** virtio-blk bug. Fixed in **CH v52.0** (KubeSwift ships v52.0). |
+| `0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL` in `viostor.sys`, reboot loop | A **CH v51.1** virtio-blk bug. Fixed in **CH v52.0** (KubeSwift ships v53.0). |
 
 ## 6. Scope
 

--- a/docs/windows/overview.md
+++ b/docs/windows/overview.md
@@ -7,7 +7,7 @@ This page is the operator entry point; the deep dives are linked inline.
 > **Status: v1 cluster-validated (2026-06-13).** The full in-cluster chain runs
 > end-to-end on the dev cluster: a virtio-ready Windows Server image imports
 > (qcow2→raw, osType-gated), clones its root disk, and boots on **Cloud
-> Hypervisor v52.0** (`--kernel CLOUDHV.fd`, `--cpus boot=N,kvm_hyperv=on`);
+> Hypervisor v53.0** (`--kernel CLOUDHV.fd`, `--cpus boot=N,kvm_hyperv=on`);
 > NetKVM brings up the NIC and the guest gets a DHCP IP; and **cloudbase-init
 > reads the NoCloud `cidata` seed and runs the first-boot user-data** (RDP
 > enabled), reaching `Running` with an IP — the last previously-untested piece


### PR DESCRIPTION
Cuts **v0.13.0**, folding the two merged v53 PRs and aligning the docs.

## What's in it
- **Chart 0.12.1 → 0.13.0** (version + appVersion).
- **CHANGELOG v0.13.0** entry covering: the CH **v52.0 → v53.0** move; the non-blocking `vm.send-migration` completion rework (#422); the `virtio_id` → `device_type` rename; the safe leverage wins (`reserve=on`, optional `--seccomp`, buffered-serial post-boot console, #423); and the two items **investigated and not adopted** — native migration mTLS (regresses UDN-guest migration, kept stunnel) and unprivileged-GPU-via-iommufd (CH v53 iommufd DMA-map broken, kept privileged).
- **Docs version-of-record sweep** v52.0 → v53.0 across the operator/architecture/CRD docs. Historical, validation, and min-version references are intentionally left (the v51.1→v52.0 viostor fix, the CH v52 clone-reboot hang, "validated end-to-end on v52.0", "v52.0+"). Three CRD descriptions that named "CH v52" for *stable* behaviour are made version-agnostic so they don't restale next bump; **CRDs regenerated** (sync check passes).

Code for v53.0 already merged in #422 + #423 and is validated on dev; this is the release wrapper. After merge: tag `v0.13.0` (annotated) to trigger `release-stable`, then redeploy the fleet (helm upgrade + `kubectl apply` CRDs + pin the 9 image tags; leave `ui.image.tag`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)