### PR TITLE
docs: reflect v0.13.0 install version + refresh example image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.12.1 \
+  --version 0.13.0 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.1.0 \
+  --set controllerManager.image.tag=v0.13.0 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.1.0
+  --set swiftletd.image.tag=v0.13.0
 ```
 
 ### Release workflow

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -70,9 +70,9 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.1.0 \
+  --set controllerManager.image.tag=v0.13.0 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.1.0
+  --set swiftletd.image.tag=v0.13.0
 ```
 
 ## Migration: previously published charts

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.12.1 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.0 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows


### PR DESCRIPTION
Follow-up to #424 (v0.13.0 — Cloud Hypervisor v53.0). Sweeps the remaining pinned version references in operator-facing docs so a fresh install lands on v0.13.0.

- `README.md`, `docs/releases.md` — chart install `--version 0.12.1` → `0.13.0`
- `docs/deploy.md`, `docs/install/helm-oci.md` — example `image.tag=v0.1.0` → `v0.13.0`

Left intact deliberately: CHANGELOG history, the "validated end-to-end on v52.0" evidence lines, `v52.0+` minimum-version notes, and dated "Added vX.Y.Z" doc markers — those are historical facts, not the current-version-of-record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)