### PR TITLE
docs: bump remaining chart-install pins to v0.13.0

### DIFF
--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.11.0 -n kubeswift-system --create-namespace \
+  --version 0.13.0 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.11.0 \
+  --version 0.13.0 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.11.0 \
+  --version 0.13.0 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,7 +66,7 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.11.0 \
+  --version 0.13.0 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.11.0 \
+  --version 0.13.0 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.11.0 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.1.0 \
-    --set swiftletd.image.tag=v0.1.0
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.0 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.0 \
+    --set swiftletd.image.tag=v0.13.0
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.11.0 \
+  --version 0.13.0 \
   -n kubeswift-system \
   --create-namespace
 ```


### PR DESCRIPTION
Follow-up to #425, which was incomplete. The docs install snippets were still pinned to `--version 0.11.0` — they'd never been bumped past v0.11.0. #425 only touched the README/releases/deploy pages and the `helm-oci` *image-tag* lines, so every `helm --version` line stayed stale (the quickstart was still telling operators to install 0.11.0).

Sweeps all remaining current-version-of-record pins to 0.13.0:
- `docs/quickstart.md`, `docs/install/remote-cluster.md`, `docs/gpu/dra-allocation.md` — `--version 0.11.0` → `0.13.0`
- `docs/install/helm-oci.md` — three `--version 0.11.0` → `0.13.0`
- `docs/operator/troubleshooting.md` — the OCI-install example: `--version 0.11.0` → `0.13.0` and `image.tag=v0.1.0` → `v0.13.0` (×2)

Deliberately left untouched (verified via grep):
- `--version 0.0.0-dev.<sha>` — dev-channel placeholder examples (releases.md, troubleshooting.md)
- `--version <version>` — literal templated placeholders (deploy.md, helm-oci.md)
- Historical capability markers — "first ships in v0.9.0/v0.10.0", "Added v0.12.1", "tested on `swiftletd:v0.11.0`"
- `charts/kubeswift/README.md` — uses `latest` → `<appVersion>`, no hardcoded pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)