### PR TITLE
release: v0.13.1 — gateway sandbox logs + interactive exec/attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.13.1] — 2026-07-23
+
+Adds the sandbox-interactivity backend for kubeswift-ui and folds in the v0.13.0
+doc sweeps. **No runtime, CRD, or migration change** — the launcher and
+controller behave exactly as in v0.13.0; this release is the gateway + docs.
+
+### Added
+
+- **Gateway sandbox logs + interactive exec/attach** — two raw-WebSocket planes
+  for kubeswift-ui: `/sandbox-logs` (read-only, `tail -F` the microVM console
+  log) and `/sandbox-exec` (an interactive shell: pod-exec → the in-guest vsock
+  agent → the `internal/guestagent` frame protocol). Both mirror the existing
+  serial-console plane — a raw WebSocket (browsers can't do bidirectional
+  Connect) with the bearer token on the query string, authorized by the
+  impersonating client. **No proto, RBAC, or chart change**: new routes on the
+  existing gateway listener, reusing `internal/guestagent`.
+
+### Docs
+
+- Install snippets across the docs now pin the current chart version (the
+  `helm --version` lines had lagged at 0.11.0).
+
+The matching **kubeswift-ui v0.8.0** ships the sandbox **Logs** + interactive
+**Shell**, a guided sandbox-create wizard (model preload / scratch disk / GPU
+profile / warm-pool checkout), a snapshot-schedule drawer with suspend/resume,
+Fabric Manager partitions in the GPU node drawer, and a kernel drawer.
+
+---
+
 ## [v0.13.0] — 2026-07-23
 
 Moves the runtime to **Cloud Hypervisor v53.0** and adopts the safe v53 leverage wins.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.0 \
+  --version 0.13.1 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.0
-appVersion: "0.13.0"
+version: 0.13.1
+appVersion: "0.13.1"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.0 \
+  --set controllerManager.image.tag=v0.13.1 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.0
+  --set swiftletd.image.tag=v0.13.1
 ```
 
 ### Release workflow

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.0 -n kubeswift-system --create-namespace \
+  --version 0.13.1 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.0 \
+  --version 0.13.1 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.0 \
+  --version 0.13.1 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.0 \
+  --version 0.13.1 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.0 \
+  --set controllerManager.image.tag=v0.13.1 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.0
+  --set swiftletd.image.tag=v0.13.1
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.0 \
+  --version 0.13.1 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.0 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.0 \
-    --set swiftletd.image.tag=v0.13.0
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.1 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.1 \
+    --set swiftletd.image.tag=v0.13.1
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.0 \
+  --version 0.13.1 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.0 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.1 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows


### PR DESCRIPTION
Patch release cutting the sandbox-interactivity gateway backend (already on main: #427 logs, #428 exec) + the v0.13.0 doc sweeps.

- Chart + appVersion **0.13.0 → 0.13.1**
- CHANGELOG v0.13.1 entry (no runtime/CRD/migration change — gateway + docs only)
- Docs install pins **0.13.0 → 0.13.1**

The matching **kubeswift-ui v0.8.0** (separate repo/tag) ships the sandbox Logs + Shell, guided sandbox-create, snapshot-schedule drawer, GPU FM partitions, and the kernel drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)