### PR TITLE
docs: gateway sandbox WS planes + UI Logs/Shell cross-ref

### DIFF
--- a/docs/sandbox/overview.md
+++ b/docs/sandbox/overview.md
@@ -157,6 +157,11 @@ is verified, so a pool never warms an unverified image. This mirrors
 
 ## Interacting with a sandbox
 
+> Also available in **kubeswift-ui** (v0.8.0+): open the sandbox in the Explorer
+> and use the **Logs** and **Shell** buttons — the same console tail and
+> interactive vsock exec, in the browser (via the gateway `/sandbox-logs` and
+> `/sandbox-exec` planes).
+
 ```bash
 swiftctl sandbox logs <name> [-f]
 swiftctl sandbox exec <name> [-e KEY=VALUE] [-w DIR] [-i] [-t] -- <cmd> [args...]

--- a/docs/ui/gateway.md
+++ b/docs/ui/gateway.md
@@ -193,6 +193,13 @@ In `insecure` mode these work with no token; in `token` mode add
   `?token=` query param — which **can land in proxy/access logs**; prefer a
   short-lived token, and a TLS-terminating ingress so the URL isn't on the wire.
   `insecure` mode needs no token (and then anyone can open any console).
+- **Sandbox logs & shell** — two sibling raw WebSockets for a `SwiftSandbox`
+  (added in kubeswift v0.13.1): `/sandbox-logs?cluster=&namespace=&name=&token=`
+  (read-only — `tail -F`s the microVM console log) and
+  `/sandbox-exec?…&cmd=/bin/sh` (an interactive shell — pod-exec → the in-guest
+  vsock agent → the `internal/guestagent` frame protocol; the browser sends
+  binary stdin frames and a text `{"resize":{cols,rows}}` control). Same
+  token-on-`?token=` + `pods/exec` RBAC posture as the console.
 - **Console transport — exec-pipe is the chosen transport for the hub** (not
   D5's "serial-on-a-port"). The gateway is a multi-cluster hub: it reaches a
   member's launcher pod *through that member's API server* (the impersonating


### PR DESCRIPTION
Documents the v0.13.1 gateway `/sandbox-logs` + `/sandbox-exec` WebSocket routes (in the gateway reference, alongside `/console`) and cross-references the kubeswift-ui v0.8.0 **Logs**/**Shell** buttons from the sandbox docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)