### PR TITLE
feat(gateway): RBAC-gated native-resource CRUD — CanI + broadened catalog

### DIFF
--- a/gen/kubeswift/v1/kubeswiftv1connect/resource.connect.go
+++ b/gen/kubeswift/v1/kubeswiftv1connect/resource.connect.go
@@ -48,6 +48,8 @@ const (
 	// ResourceServiceDeleteResourceProcedure is the fully-qualified name of the ResourceService's
 	// DeleteResource RPC.
 	ResourceServiceDeleteResourceProcedure = "/kubeswift.v1.ResourceService/DeleteResource"
+	// ResourceServiceCanIProcedure is the fully-qualified name of the ResourceService's CanI RPC.
+	ResourceServiceCanIProcedure = "/kubeswift.v1.ResourceService/CanI"
 )
 
 // ResourceServiceClient is a client for the kubeswift.v1.ResourceService service.
@@ -57,6 +59,7 @@ type ResourceServiceClient interface {
 	GetResource(context.Context, *connect.Request[v1.GetResourceRequest]) (*connect.Response[v1.GetResourceResponse], error)
 	ApplyResource(context.Context, *connect.Request[v1.ApplyResourceRequest]) (*connect.Response[v1.ApplyResourceResponse], error)
 	DeleteResource(context.Context, *connect.Request[v1.DeleteResourceRequest]) (*connect.Response[v1.DeleteResourceResponse], error)
+	CanI(context.Context, *connect.Request[v1.CanIRequest]) (*connect.Response[v1.CanIResponse], error)
 }
 
 // NewResourceServiceClient constructs a client for the kubeswift.v1.ResourceService service. By
@@ -100,6 +103,12 @@ func NewResourceServiceClient(httpClient connect.HTTPClient, baseURL string, opt
 			connect.WithSchema(resourceServiceMethods.ByName("DeleteResource")),
 			connect.WithClientOptions(opts...),
 		),
+		canI: connect.NewClient[v1.CanIRequest, v1.CanIResponse](
+			httpClient,
+			baseURL+ResourceServiceCanIProcedure,
+			connect.WithSchema(resourceServiceMethods.ByName("CanI")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -110,6 +119,7 @@ type resourceServiceClient struct {
 	getResource       *connect.Client[v1.GetResourceRequest, v1.GetResourceResponse]
 	applyResource     *connect.Client[v1.ApplyResourceRequest, v1.ApplyResourceResponse]
 	deleteResource    *connect.Client[v1.DeleteResourceRequest, v1.DeleteResourceResponse]
+	canI              *connect.Client[v1.CanIRequest, v1.CanIResponse]
 }
 
 // ListResourceKinds calls kubeswift.v1.ResourceService.ListResourceKinds.
@@ -137,6 +147,11 @@ func (c *resourceServiceClient) DeleteResource(ctx context.Context, req *connect
 	return c.deleteResource.CallUnary(ctx, req)
 }
 
+// CanI calls kubeswift.v1.ResourceService.CanI.
+func (c *resourceServiceClient) CanI(ctx context.Context, req *connect.Request[v1.CanIRequest]) (*connect.Response[v1.CanIResponse], error) {
+	return c.canI.CallUnary(ctx, req)
+}
+
 // ResourceServiceHandler is an implementation of the kubeswift.v1.ResourceService service.
 type ResourceServiceHandler interface {
 	ListResourceKinds(context.Context, *connect.Request[v1.ListResourceKindsRequest]) (*connect.Response[v1.ListResourceKindsResponse], error)
@@ -144,6 +159,7 @@ type ResourceServiceHandler interface {
 	GetResource(context.Context, *connect.Request[v1.GetResourceRequest]) (*connect.Response[v1.GetResourceResponse], error)
 	ApplyResource(context.Context, *connect.Request[v1.ApplyResourceRequest]) (*connect.Response[v1.ApplyResourceResponse], error)
 	DeleteResource(context.Context, *connect.Request[v1.DeleteResourceRequest]) (*connect.Response[v1.DeleteResourceResponse], error)
+	CanI(context.Context, *connect.Request[v1.CanIRequest]) (*connect.Response[v1.CanIResponse], error)
 }
 
 // NewResourceServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -183,6 +199,12 @@ func NewResourceServiceHandler(svc ResourceServiceHandler, opts ...connect.Handl
 		connect.WithSchema(resourceServiceMethods.ByName("DeleteResource")),
 		connect.WithHandlerOptions(opts...),
 	)
+	resourceServiceCanIHandler := connect.NewUnaryHandler(
+		ResourceServiceCanIProcedure,
+		svc.CanI,
+		connect.WithSchema(resourceServiceMethods.ByName("CanI")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/kubeswift.v1.ResourceService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case ResourceServiceListResourceKindsProcedure:
@@ -195,6 +217,8 @@ func NewResourceServiceHandler(svc ResourceServiceHandler, opts ...connect.Handl
 			resourceServiceApplyResourceHandler.ServeHTTP(w, r)
 		case ResourceServiceDeleteResourceProcedure:
 			resourceServiceDeleteResourceHandler.ServeHTTP(w, r)
+		case ResourceServiceCanIProcedure:
+			resourceServiceCanIHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -222,4 +246,8 @@ func (UnimplementedResourceServiceHandler) ApplyResource(context.Context, *conne
 
 func (UnimplementedResourceServiceHandler) DeleteResource(context.Context, *connect.Request[v1.DeleteResourceRequest]) (*connect.Response[v1.DeleteResourceResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.ResourceService.DeleteResource is not implemented"))
+}
+
+func (UnimplementedResourceServiceHandler) CanI(context.Context, *connect.Request[v1.CanIRequest]) (*connect.Response[v1.CanIResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kubeswift.v1.ResourceService.CanI is not implemented"))
 }

--- a/gen/kubeswift/v1/resource.pb.go
+++ b/gen/kubeswift/v1/resource.pb.go
@@ -760,6 +760,221 @@ func (*DeleteResourceResponse) Descriptor() ([]byte, []int) {
 	return file_kubeswift_v1_resource_proto_rawDescGZIP(), []int{11}
 }
 
+// ResourceAccessCheck asks whether the impersonated user may perform one verb on
+// one catalog kind (the gateway maps kind -> group/resource). namespace is ""
+// for a cluster-scoped kind or an all-namespaces check.
+type ResourceAccessCheck struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kind          string                 `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"` // a ResourceKind.key
+	Verb          string                 `protobuf:"bytes,2,opt,name=verb,proto3" json:"verb,omitempty"` // create | update | delete | get | list | patch
+	Namespace     string                 `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResourceAccessCheck) Reset() {
+	*x = ResourceAccessCheck{}
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResourceAccessCheck) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResourceAccessCheck) ProtoMessage() {}
+
+func (x *ResourceAccessCheck) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResourceAccessCheck.ProtoReflect.Descriptor instead.
+func (*ResourceAccessCheck) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_resource_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ResourceAccessCheck) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *ResourceAccessCheck) GetVerb() string {
+	if x != nil {
+		return x.Verb
+	}
+	return ""
+}
+
+func (x *ResourceAccessCheck) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+// CanIRequest batches access checks so the UI can gate a kind's actions
+// (create/update/delete) in one round-trip.
+type CanIRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Cluster       string                 `protobuf:"bytes,1,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	Checks        []*ResourceAccessCheck `protobuf:"bytes,2,rep,name=checks,proto3" json:"checks,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CanIRequest) Reset() {
+	*x = CanIRequest{}
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CanIRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CanIRequest) ProtoMessage() {}
+
+func (x *CanIRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CanIRequest.ProtoReflect.Descriptor instead.
+func (*CanIRequest) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_resource_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *CanIRequest) GetCluster() string {
+	if x != nil {
+		return x.Cluster
+	}
+	return ""
+}
+
+func (x *CanIRequest) GetChecks() []*ResourceAccessCheck {
+	if x != nil {
+		return x.Checks
+	}
+	return nil
+}
+
+// AccessDecision is the outcome for one check, positionally aligned with the
+// request. allowed=false with an empty reason means "not permitted".
+type AccessDecision struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Allowed       bool                   `protobuf:"varint,1,opt,name=allowed,proto3" json:"allowed,omitempty"`
+	Reason        string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AccessDecision) Reset() {
+	*x = AccessDecision{}
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AccessDecision) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AccessDecision) ProtoMessage() {}
+
+func (x *AccessDecision) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AccessDecision.ProtoReflect.Descriptor instead.
+func (*AccessDecision) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_resource_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *AccessDecision) GetAllowed() bool {
+	if x != nil {
+		return x.Allowed
+	}
+	return false
+}
+
+func (x *AccessDecision) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+type CanIResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Decisions     []*AccessDecision      `protobuf:"bytes,1,rep,name=decisions,proto3" json:"decisions,omitempty"` // aligned 1:1 with CanIRequest.checks
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CanIResponse) Reset() {
+	*x = CanIResponse{}
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CanIResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CanIResponse) ProtoMessage() {}
+
+func (x *CanIResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kubeswift_v1_resource_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CanIResponse.ProtoReflect.Descriptor instead.
+func (*CanIResponse) Descriptor() ([]byte, []int) {
+	return file_kubeswift_v1_resource_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *CanIResponse) GetDecisions() []*AccessDecision {
+	if x != nil {
+		return x.Decisions
+	}
+	return nil
+}
+
 var File_kubeswift_v1_resource_proto protoreflect.FileDescriptor
 
 const file_kubeswift_v1_resource_proto_rawDesc = "" +
@@ -816,13 +1031,26 @@ const file_kubeswift_v1_resource_proto_rawDesc = "" +
 	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x1c\n" +
 	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x12\x12\n" +
 	"\x04name\x18\x04 \x01(\tR\x04name\"\x18\n" +
-	"\x16DeleteResourceResponse2\xdc\x03\n" +
+	"\x16DeleteResourceResponse\"[\n" +
+	"\x13ResourceAccessCheck\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x12\n" +
+	"\x04verb\x18\x02 \x01(\tR\x04verb\x12\x1c\n" +
+	"\tnamespace\x18\x03 \x01(\tR\tnamespace\"b\n" +
+	"\vCanIRequest\x12\x18\n" +
+	"\acluster\x18\x01 \x01(\tR\acluster\x129\n" +
+	"\x06checks\x18\x02 \x03(\v2!.kubeswift.v1.ResourceAccessCheckR\x06checks\"B\n" +
+	"\x0eAccessDecision\x12\x18\n" +
+	"\aallowed\x18\x01 \x01(\bR\aallowed\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\"J\n" +
+	"\fCanIResponse\x12:\n" +
+	"\tdecisions\x18\x01 \x03(\v2\x1c.kubeswift.v1.AccessDecisionR\tdecisions2\x9b\x04\n" +
 	"\x0fResourceService\x12d\n" +
 	"\x11ListResourceKinds\x12&.kubeswift.v1.ListResourceKindsRequest\x1a'.kubeswift.v1.ListResourceKindsResponse\x12X\n" +
 	"\rListResources\x12\".kubeswift.v1.ListResourcesRequest\x1a#.kubeswift.v1.ListResourcesResponse\x12R\n" +
 	"\vGetResource\x12 .kubeswift.v1.GetResourceRequest\x1a!.kubeswift.v1.GetResourceResponse\x12X\n" +
 	"\rApplyResource\x12\".kubeswift.v1.ApplyResourceRequest\x1a#.kubeswift.v1.ApplyResourceResponse\x12[\n" +
-	"\x0eDeleteResource\x12#.kubeswift.v1.DeleteResourceRequest\x1a$.kubeswift.v1.DeleteResourceResponseB@Z>github.com/kubeswift-io/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
+	"\x0eDeleteResource\x12#.kubeswift.v1.DeleteResourceRequest\x1a$.kubeswift.v1.DeleteResourceResponse\x12=\n" +
+	"\x04CanI\x12\x19.kubeswift.v1.CanIRequest\x1a\x1a.kubeswift.v1.CanIResponseB@Z>github.com/kubeswift-io/kubeswift/gen/kubeswift/v1;kubeswiftv1b\x06proto3"
 
 var (
 	file_kubeswift_v1_resource_proto_rawDescOnce sync.Once
@@ -836,7 +1064,7 @@ func file_kubeswift_v1_resource_proto_rawDescGZIP() []byte {
 	return file_kubeswift_v1_resource_proto_rawDescData
 }
 
-var file_kubeswift_v1_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_kubeswift_v1_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_kubeswift_v1_resource_proto_goTypes = []any{
 	(*ResourceKind)(nil),              // 0: kubeswift.v1.ResourceKind
 	(*ListResourceKindsRequest)(nil),  // 1: kubeswift.v1.ListResourceKindsRequest
@@ -850,33 +1078,41 @@ var file_kubeswift_v1_resource_proto_goTypes = []any{
 	(*ApplyResourceResponse)(nil),     // 9: kubeswift.v1.ApplyResourceResponse
 	(*DeleteResourceRequest)(nil),     // 10: kubeswift.v1.DeleteResourceRequest
 	(*DeleteResourceResponse)(nil),    // 11: kubeswift.v1.DeleteResourceResponse
-	nil,                               // 12: kubeswift.v1.Resource.ColumnsEntry
-	(*ObjectRef)(nil),                 // 13: kubeswift.v1.ObjectRef
-	(*timestamppb.Timestamp)(nil),     // 14: google.protobuf.Timestamp
-	(*ClusterError)(nil),              // 15: kubeswift.v1.ClusterError
+	(*ResourceAccessCheck)(nil),       // 12: kubeswift.v1.ResourceAccessCheck
+	(*CanIRequest)(nil),               // 13: kubeswift.v1.CanIRequest
+	(*AccessDecision)(nil),            // 14: kubeswift.v1.AccessDecision
+	(*CanIResponse)(nil),              // 15: kubeswift.v1.CanIResponse
+	nil,                               // 16: kubeswift.v1.Resource.ColumnsEntry
+	(*ObjectRef)(nil),                 // 17: kubeswift.v1.ObjectRef
+	(*timestamppb.Timestamp)(nil),     // 18: google.protobuf.Timestamp
+	(*ClusterError)(nil),              // 19: kubeswift.v1.ClusterError
 }
 var file_kubeswift_v1_resource_proto_depIdxs = []int32{
 	0,  // 0: kubeswift.v1.ListResourceKindsResponse.kinds:type_name -> kubeswift.v1.ResourceKind
-	13, // 1: kubeswift.v1.Resource.ref:type_name -> kubeswift.v1.ObjectRef
-	14, // 2: kubeswift.v1.Resource.created_at:type_name -> google.protobuf.Timestamp
-	12, // 3: kubeswift.v1.Resource.columns:type_name -> kubeswift.v1.Resource.ColumnsEntry
+	17, // 1: kubeswift.v1.Resource.ref:type_name -> kubeswift.v1.ObjectRef
+	18, // 2: kubeswift.v1.Resource.created_at:type_name -> google.protobuf.Timestamp
+	16, // 3: kubeswift.v1.Resource.columns:type_name -> kubeswift.v1.Resource.ColumnsEntry
 	3,  // 4: kubeswift.v1.ListResourcesResponse.resources:type_name -> kubeswift.v1.Resource
-	15, // 5: kubeswift.v1.ListResourcesResponse.error:type_name -> kubeswift.v1.ClusterError
-	1,  // 6: kubeswift.v1.ResourceService.ListResourceKinds:input_type -> kubeswift.v1.ListResourceKindsRequest
-	4,  // 7: kubeswift.v1.ResourceService.ListResources:input_type -> kubeswift.v1.ListResourcesRequest
-	6,  // 8: kubeswift.v1.ResourceService.GetResource:input_type -> kubeswift.v1.GetResourceRequest
-	8,  // 9: kubeswift.v1.ResourceService.ApplyResource:input_type -> kubeswift.v1.ApplyResourceRequest
-	10, // 10: kubeswift.v1.ResourceService.DeleteResource:input_type -> kubeswift.v1.DeleteResourceRequest
-	2,  // 11: kubeswift.v1.ResourceService.ListResourceKinds:output_type -> kubeswift.v1.ListResourceKindsResponse
-	5,  // 12: kubeswift.v1.ResourceService.ListResources:output_type -> kubeswift.v1.ListResourcesResponse
-	7,  // 13: kubeswift.v1.ResourceService.GetResource:output_type -> kubeswift.v1.GetResourceResponse
-	9,  // 14: kubeswift.v1.ResourceService.ApplyResource:output_type -> kubeswift.v1.ApplyResourceResponse
-	11, // 15: kubeswift.v1.ResourceService.DeleteResource:output_type -> kubeswift.v1.DeleteResourceResponse
-	11, // [11:16] is the sub-list for method output_type
-	6,  // [6:11] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	19, // 5: kubeswift.v1.ListResourcesResponse.error:type_name -> kubeswift.v1.ClusterError
+	12, // 6: kubeswift.v1.CanIRequest.checks:type_name -> kubeswift.v1.ResourceAccessCheck
+	14, // 7: kubeswift.v1.CanIResponse.decisions:type_name -> kubeswift.v1.AccessDecision
+	1,  // 8: kubeswift.v1.ResourceService.ListResourceKinds:input_type -> kubeswift.v1.ListResourceKindsRequest
+	4,  // 9: kubeswift.v1.ResourceService.ListResources:input_type -> kubeswift.v1.ListResourcesRequest
+	6,  // 10: kubeswift.v1.ResourceService.GetResource:input_type -> kubeswift.v1.GetResourceRequest
+	8,  // 11: kubeswift.v1.ResourceService.ApplyResource:input_type -> kubeswift.v1.ApplyResourceRequest
+	10, // 12: kubeswift.v1.ResourceService.DeleteResource:input_type -> kubeswift.v1.DeleteResourceRequest
+	13, // 13: kubeswift.v1.ResourceService.CanI:input_type -> kubeswift.v1.CanIRequest
+	2,  // 14: kubeswift.v1.ResourceService.ListResourceKinds:output_type -> kubeswift.v1.ListResourceKindsResponse
+	5,  // 15: kubeswift.v1.ResourceService.ListResources:output_type -> kubeswift.v1.ListResourcesResponse
+	7,  // 16: kubeswift.v1.ResourceService.GetResource:output_type -> kubeswift.v1.GetResourceResponse
+	9,  // 17: kubeswift.v1.ResourceService.ApplyResource:output_type -> kubeswift.v1.ApplyResourceResponse
+	11, // 18: kubeswift.v1.ResourceService.DeleteResource:output_type -> kubeswift.v1.DeleteResourceResponse
+	15, // 19: kubeswift.v1.ResourceService.CanI:output_type -> kubeswift.v1.CanIResponse
+	14, // [14:20] is the sub-list for method output_type
+	8,  // [8:14] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_kubeswift_v1_resource_proto_init() }
@@ -891,7 +1127,7 @@ func file_kubeswift_v1_resource_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kubeswift_v1_resource_proto_rawDesc), len(file_kubeswift_v1_resource_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/gateway/resource_catalog.go
+++ b/internal/gateway/resource_catalog.go
@@ -37,10 +37,17 @@ var resourceCatalog = []resourceKind{
 	{key: "persistentvolumes", displayName: "Persistent Volumes", gvr: gvr("", "v1", "persistentvolumes"), namespaced: false, category: "Cluster", columns: []string{"status", "capacity", "storageClass", "claim"}, project: pvProject},
 
 	// Workloads.
+	{key: "deployments", displayName: "Deployments", gvr: gvr("apps", "v1", "deployments"), namespaced: true, category: "Workloads", columns: []string{"ready", "uptodate", "available"}, project: deploymentProject},
+	{key: "statefulsets", displayName: "Stateful Sets", gvr: gvr("apps", "v1", "statefulsets"), namespaced: true, category: "Workloads", columns: []string{"ready"}, project: replicaReadyProject},
+	{key: "daemonsets", displayName: "Daemon Sets", gvr: gvr("apps", "v1", "daemonsets"), namespaced: true, category: "Workloads", columns: []string{"desired", "ready"}, project: daemonSetProject},
+	{key: "replicasets", displayName: "Replica Sets", gvr: gvr("apps", "v1", "replicasets"), namespaced: true, category: "Workloads", columns: []string{"ready"}, project: replicaReadyProject},
+	{key: "jobs", displayName: "Jobs", gvr: gvr("batch", "v1", "jobs"), namespaced: true, category: "Workloads", columns: []string{"completions", "status"}, project: jobProject},
+	{key: "cronjobs", displayName: "Cron Jobs", gvr: gvr("batch", "v1", "cronjobs"), namespaced: true, category: "Workloads", columns: []string{"schedule", "suspend", "lastRun"}, project: scheduleProject},
 	{key: "pods", displayName: "Pods", gvr: gvr("", "v1", "pods"), namespaced: true, category: "Workloads", columns: []string{"status", "ready", "node", "ip"}, project: podProject},
 
 	// Networking.
 	{key: "services", displayName: "Services", gvr: gvr("", "v1", "services"), namespaced: true, category: "Networking", columns: []string{"type", "clusterIP", "ports"}, project: serviceProject},
+	{key: "ingresses", displayName: "Ingresses", gvr: gvr("networking.k8s.io", "v1", "ingresses"), namespaced: true, category: "Networking", columns: []string{"class", "hosts"}, project: ingressProject},
 	{key: "network-attachment-definitions", displayName: "Network Attachments", gvr: gvr("k8s.cni.cncf.io", "v1", "network-attachment-definitions"), namespaced: true, category: "Networking", columns: nil, project: nilProject},
 	{key: "networkpolicies", displayName: "Network Policies", gvr: gvr("networking.k8s.io", "v1", "networkpolicies"), namespaced: true, category: "Networking", columns: []string{"podSelector"}, project: netpolProject},
 
@@ -50,6 +57,13 @@ var resourceCatalog = []resourceKind{
 	// Config.
 	{key: "secrets", displayName: "Secrets", gvr: gvr("", "v1", "secrets"), namespaced: true, category: "Config", columns: []string{"type", "keys"}, project: secretProject},
 	{key: "configmaps", displayName: "Config Maps", gvr: gvr("", "v1", "configmaps"), namespaced: true, category: "Config", columns: []string{"keys"}, project: configMapProject},
+
+	// Access control (RBAC + identities).
+	{key: "serviceaccounts", displayName: "Service Accounts", gvr: gvr("", "v1", "serviceaccounts"), namespaced: true, category: "Access", columns: []string{"secrets"}, project: serviceAccountProject},
+	{key: "roles", displayName: "Roles", gvr: gvr("rbac.authorization.k8s.io", "v1", "roles"), namespaced: true, category: "Access", columns: []string{"rules"}, project: ruleCountProject},
+	{key: "rolebindings", displayName: "Role Bindings", gvr: gvr("rbac.authorization.k8s.io", "v1", "rolebindings"), namespaced: true, category: "Access", columns: []string{"role", "subjects"}, project: roleBindingProject},
+	{key: "clusterroles", displayName: "Cluster Roles", gvr: gvr("rbac.authorization.k8s.io", "v1", "clusterroles"), namespaced: false, category: "Access", columns: []string{"rules"}, project: ruleCountProject},
+	{key: "clusterrolebindings", displayName: "Cluster Role Bindings", gvr: gvr("rbac.authorization.k8s.io", "v1", "clusterrolebindings"), namespaced: false, category: "Access", columns: []string{"role", "subjects"}, project: roleBindingProject},
 
 	// KubeSwift CRDs without a dedicated view.
 	{key: "swiftimages", displayName: "Images", gvr: gvr("image.kubeswift.io", "v1alpha1", "swiftimages"), namespaced: true, category: "KubeSwift", columns: []string{"phase"}, project: phaseStatusProject},
@@ -307,6 +321,108 @@ func sandboxPoolProject(u *unstructured.Unstructured) map[string]string {
 		"claimed": nestedIntStr(u, "status", "claimedReplicas"),
 		"min":     nestedIntStr(u, "spec", "minWarm"),
 	}
+}
+
+// deploymentProject reports a Deployment's ready/desired, up-to-date, and
+// available replica counts.
+func deploymentProject(u *unstructured.Unstructured) map[string]string {
+	return map[string]string{
+		"ready":     readyOverDesired(u),
+		"uptodate":  nestedIntStr(u, "status", "updatedReplicas"),
+		"available": nestedIntStr(u, "status", "availableReplicas"),
+	}
+}
+
+// replicaReadyProject reports ready/desired for StatefulSets and ReplicaSets.
+func replicaReadyProject(u *unstructured.Unstructured) map[string]string {
+	return map[string]string{"ready": readyOverDesired(u)}
+}
+
+// daemonSetProject reports a DaemonSet's desired and ready scheduled counts.
+func daemonSetProject(u *unstructured.Unstructured) map[string]string {
+	return map[string]string{
+		"desired": nestedIntStr(u, "status", "desiredNumberScheduled"),
+		"ready":   nestedIntStr(u, "status", "numberReady"),
+	}
+}
+
+// jobProject reports a Job's succeeded/desired completions and a coarse status.
+func jobProject(u *unstructured.Unstructured) map[string]string {
+	succeeded := nestedIntStr(u, "status", "succeeded")
+	if succeeded == "" {
+		succeeded = "0"
+	}
+	completions := nestedIntStr(u, "spec", "completions")
+	if completions == "" {
+		completions = "1"
+	}
+	status := "Running"
+	conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+	for _, c := range conds {
+		cm, ok := c.(map[string]interface{})
+		if !ok || cm["status"] != "True" {
+			continue
+		}
+		switch cm["type"] {
+		case "Complete":
+			status = "Complete"
+		case "Failed":
+			status = "Failed"
+		}
+	}
+	return map[string]string{"completions": succeeded + "/" + completions, "status": status}
+}
+
+// ingressProject reports an Ingress's class and the hosts it routes.
+func ingressProject(u *unstructured.Unstructured) map[string]string {
+	rules, _, _ := unstructured.NestedSlice(u.Object, "spec", "rules")
+	var hosts []string
+	for _, r := range rules {
+		if rm, ok := r.(map[string]interface{}); ok {
+			if h, _ := rm["host"].(string); h != "" {
+				hosts = append(hosts, h)
+			}
+		}
+	}
+	return map[string]string{
+		"class": nestedStr(u, "spec", "ingressClassName"),
+		"hosts": strings.Join(hosts, ","),
+	}
+}
+
+// serviceAccountProject reports how many secrets a ServiceAccount references.
+func serviceAccountProject(u *unstructured.Unstructured) map[string]string {
+	secrets, _, _ := unstructured.NestedSlice(u.Object, "secrets")
+	return map[string]string{"secrets": strconv.Itoa(len(secrets))}
+}
+
+// ruleCountProject reports the number of policy rules on a (Cluster)Role.
+func ruleCountProject(u *unstructured.Unstructured) map[string]string {
+	rules, _, _ := unstructured.NestedSlice(u.Object, "rules")
+	return map[string]string{"rules": strconv.Itoa(len(rules))}
+}
+
+// roleBindingProject reports a (Cluster)RoleBinding's target role + subject count.
+func roleBindingProject(u *unstructured.Unstructured) map[string]string {
+	subjects, _, _ := unstructured.NestedSlice(u.Object, "subjects")
+	return map[string]string{
+		"role":     nestedStr(u, "roleRef", "name"),
+		"subjects": strconv.Itoa(len(subjects)),
+	}
+}
+
+// readyOverDesired renders "<status.readyReplicas>/<spec.replicas>" with sane
+// defaults (ready→0, desired→1) — shared by Deployments/StatefulSets/ReplicaSets.
+func readyOverDesired(u *unstructured.Unstructured) string {
+	ready := nestedIntStr(u, "status", "readyReplicas")
+	if ready == "" {
+		ready = "0"
+	}
+	desired := nestedIntStr(u, "spec", "replicas")
+	if desired == "" {
+		desired = "1"
+	}
+	return ready + "/" + desired
 }
 
 // --- helpers --------------------------------------------------------------

--- a/internal/gateway/resource_service.go
+++ b/internal/gateway/resource_service.go
@@ -9,9 +9,12 @@ import (
 	"strings"
 
 	connect "connectrpc.com/connect"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/yaml"
 
 	kubeswiftv1 "github.com/kubeswift-io/kubeswift/gen/kubeswift/v1"
@@ -274,4 +277,74 @@ func sortResources(rs []*kubeswiftv1.Resource) {
 		}
 		return a.GetName() < b.GetName()
 	})
+}
+
+// restConfigProvider is the subset of the pool CanI needs: an impersonated
+// rest.Config to build a typed client for SelfSubjectAccessReview. The concrete
+// *ClientPool satisfies it; kept narrow so the shared clientProvider interface
+// (and its test fakes) are untouched.
+type restConfigProvider interface {
+	RestConfigFor(cluster string, id Identity) (*rest.Config, error)
+}
+
+// CanI answers, per (kind, verb, namespace) check, whether the impersonated user
+// may perform it — via a SelfSubjectAccessReview run through the user's own
+// (impersonated) client, so the apiserver is the sole decider. This lets the UI
+// hide actions the user can't take instead of firing them and surfacing a
+// denial. Decisions are positionally aligned with the request; an unknown kind
+// or a review error yields allowed=false (fail-closed).
+func (s *ResourceService) CanI(ctx context.Context, req *connect.Request[kubeswiftv1.CanIRequest]) (*connect.Response[kubeswiftv1.CanIResponse], error) {
+	id, err := s.auth.Authenticate(ctx, req.Header())
+	if err != nil {
+		return nil, err
+	}
+	cluster := req.Msg.GetCluster()
+	if cluster == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cluster is required"))
+	}
+	rcp, ok := s.pool.(restConfigProvider)
+	if !ok {
+		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("access review not supported"))
+	}
+	cfg, err := rcp.RestConfigFor(cluster, id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	out := &kubeswiftv1.CanIResponse{}
+	for _, chk := range req.Msg.GetChecks() {
+		out.Decisions = append(out.Decisions, reviewAccess(ctx, cs, chk))
+	}
+	return connect.NewResponse(out), nil
+}
+
+// reviewAccess maps one catalog-kind check to a SelfSubjectAccessReview and
+// returns the apiserver's verdict. namespace is ignored for cluster-scoped kinds.
+func reviewAccess(ctx context.Context, cs kubernetes.Interface, chk *kubeswiftv1.ResourceAccessCheck) *kubeswiftv1.AccessDecision {
+	kind := lookupKind(chk.GetKind())
+	if kind == nil {
+		return &kubeswiftv1.AccessDecision{Allowed: false, Reason: fmt.Sprintf("unknown kind %q", chk.GetKind())}
+	}
+	ns := chk.GetNamespace()
+	if !kind.namespaced {
+		ns = ""
+	}
+	ssar := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: ns,
+				Verb:      chk.GetVerb(),
+				Group:     kind.gvr.Group,
+				Resource:  kind.gvr.Resource,
+			},
+		},
+	}
+	res, err := cs.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, ssar, metav1.CreateOptions{})
+	if err != nil {
+		return &kubeswiftv1.AccessDecision{Allowed: false, Reason: err.Error()}
+	}
+	return &kubeswiftv1.AccessDecision{Allowed: res.Status.Allowed, Reason: res.Status.Reason}
 }

--- a/proto/kubeswift/v1/resource.proto
+++ b/proto/kubeswift/v1/resource.proto
@@ -109,15 +109,44 @@ message DeleteResourceRequest {
 
 message DeleteResourceResponse {}
 
+// ResourceAccessCheck asks whether the impersonated user may perform one verb on
+// one catalog kind (the gateway maps kind -> group/resource). namespace is ""
+// for a cluster-scoped kind or an all-namespaces check.
+message ResourceAccessCheck {
+  string kind = 1; // a ResourceKind.key
+  string verb = 2; // create | update | delete | get | list | patch
+  string namespace = 3;
+}
+
+// CanIRequest batches access checks so the UI can gate a kind's actions
+// (create/update/delete) in one round-trip.
+message CanIRequest {
+  string cluster = 1;
+  repeated ResourceAccessCheck checks = 2;
+}
+
+// AccessDecision is the outcome for one check, positionally aligned with the
+// request. allowed=false with an empty reason means "not permitted".
+message AccessDecision {
+  bool allowed = 1;
+  string reason = 2;
+}
+
+message CanIResponse {
+  repeated AccessDecision decisions = 1; // aligned 1:1 with CanIRequest.checks
+}
+
 // ResourceService is the cluster explorer + object editor. ListResourceKinds /
-// ListResources / GetResource read; ApplyResource / DeleteResource write. Every
-// call impersonates the end user, so both the read and write planes are gated
-// entirely by that user's Kubernetes RBAC — a denial surfaces as a permission
-// error, never a silent success.
+// ListResources / GetResource read; ApplyResource / DeleteResource write; CanI
+// answers whether the user may write (so the UI can hide actions it can't do).
+// Every call impersonates the end user, so both the read and write planes are
+// gated entirely by that user's Kubernetes RBAC — a denial surfaces as a
+// permission error, never a silent success.
 service ResourceService {
   rpc ListResourceKinds(ListResourceKindsRequest) returns (ListResourceKindsResponse);
   rpc ListResources(ListResourcesRequest) returns (ListResourcesResponse);
   rpc GetResource(GetResourceRequest) returns (GetResourceResponse);
   rpc ApplyResource(ApplyResourceRequest) returns (ApplyResourceResponse);
   rpc DeleteResource(DeleteResourceRequest) returns (DeleteResourceResponse);
+  rpc CanI(CanIRequest) returns (CanIResponse);
 }


### PR DESCRIPTION
Backend enablement for permission-aware, general-purpose Kubernetes resource CRUD in the Explorer (the UI side is kubeswift-io/kubeswift-ui#33).

## CanI (proactive RBAC gating)
Adds `ResourceService.CanI`: a batch access-review plane so the UI can hide create/update/delete the user can't perform instead of firing the call and surfacing a denial. Each check names a catalog kind (mapped to group/resource server-side) + a verb + namespace; the review runs as a **SelfSubjectAccessReview through the user's own impersonated client**, so the apiserver is the sole decider and the gateway needs **no extra RBAC**. Fail-closed (unknown kind / review error → allowed=false).

Passed an independent security review (self-check that reports-never-grants; real enforcement stays on the CRUD path; no info leak; auth-gated). No findings.

## Broadened catalog (YAML-first)
Adds the common native kinds — all inheriting the impersonated read/write plane + CanI gating:
- **Workloads:** Deployments, StatefulSets, DaemonSets, ReplicaSets, Jobs, CronJobs
- **Networking:** Ingresses
- **Access (new category):** ServiceAccounts, Roles, RoleBindings, ClusterRoles, ClusterRoleBindings

Each gets a small total projector for its table columns.

## Test
`go build` / `vet` / `test` + `gofmt` clean. Branch gateway image (`sha-9f48316`) built + deployed to the dev hub: boots healthy, `CanI` route serves 401 (auth-gated, not 404), `ListResourceKinds` serves the broadened catalog. Authenticated gating is exercised through the OIDC UI.

Ships in the next kubeswift release (gateway image).