### PR TITLE
release: v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.13.2] — 2026-07-24
+
+Gateway enablement for permission-aware, general-purpose Kubernetes resource CRUD
+in the kubeswift-ui Explorer. **No runtime, CRD, or migration change** — the
+launcher and controller behave exactly as in v0.13.1; this release is the gateway
++ docs.
+
+### Added
+- **`ResourceService.CanI`** — a batch access-review RPC. The gateway runs a
+  `SelfSubjectAccessReview` per (kind, verb, namespace) check through the user's
+  own impersonated client, so the UI can hide create/update/delete actions the
+  user can't perform instead of firing them and surfacing a denial. Fail-closed;
+  needs no extra gateway RBAC (it is a self-review).
+- **Broadened explorer catalog** — the ResourceService now surfaces the common
+  native kinds for browse + (RBAC-gated) CRUD: Deployments, StatefulSets,
+  DaemonSets, ReplicaSets, Jobs, CronJobs, Ingresses, and a new **Access**
+  category (ServiceAccounts, Roles, RoleBindings, ClusterRoles,
+  ClusterRoleBindings). Every call stays impersonated and gated by the user's
+  Kubernetes RBAC; Secret values remain redacted on read.
+
+Pairs with kubeswift-ui v0.10.0 (the proactive action gating + guided
+Secret / ConfigMap / Service create forms).
+
 ## [v0.13.1] — 2026-07-23
 
 Adds the sandbox-interactivity backend for kubeswift-ui and folds in the v0.13.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.1 \
+  --version 0.13.2 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.1
-appVersion: "0.13.1"
+version: 0.13.2
+appVersion: "0.13.2"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.1 \
+  --set controllerManager.image.tag=v0.13.2 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.1
+  --set swiftletd.image.tag=v0.13.2
 ```
 
 ### Release workflow

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.1 -n kubeswift-system --create-namespace \
+  --version 0.13.2 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.1 \
+  --version 0.13.2 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.1 \
+  --version 0.13.2 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.1 \
+  --version 0.13.2 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.1 \
+  --set controllerManager.image.tag=v0.13.2 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.1
+  --set swiftletd.image.tag=v0.13.2
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.1 \
+  --version 0.13.2 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.1 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.1 \
-    --set swiftletd.image.tag=v0.13.1
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.2 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.2 \
+    --set swiftletd.image.tag=v0.13.2
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.1 \
+  --version 0.13.2 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.1 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.2 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows


### PR DESCRIPTION
Cut **v0.13.2**: gateway RBAC-gated native-resource CRUD (CanI RPC + broadened catalog, #431).

- Chart `0.13.1` → `0.13.2` (version + appVersion)
- CHANGELOG v0.13.2 entry
- install/deploy version-pin sweep (README + docs); the historical "added in v0.13.1" note is preserved

No runtime/CRD/migration change. Pairs with kubeswift-ui v0.10.0.