### PR TITLE
fix(gateway): authenticate the fleet-list plane + close the Secret redaction hole + reject reserved claims

### DIFF
--- a/internal/gateway/auth_oidc.go
+++ b/internal/gateway/auth_oidc.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 
 	connect "connectrpc.com/connect"
@@ -137,10 +138,30 @@ func identityFromClaims(claims map[string]interface{}, cfg OIDCClaimConfig) (Ide
 		return Identity{}, fmt.Errorf("token has no %q claim for the username", cfg.UsernameClaim)
 	}
 	id := Identity{User: cfg.UsernamePrefix + user}
+	if isReservedSubject(id.User) {
+		return Identity{}, fmt.Errorf("username %q uses the reserved %q prefix", id.User, reservedSubjectPrefix)
+	}
 	for _, g := range stringSliceClaim(claims, cfg.GroupsClaim) {
-		id.Groups = append(id.Groups, cfg.GroupsPrefix+g)
+		g = cfg.GroupsPrefix + g
+		if isReservedSubject(g) {
+			return Identity{}, fmt.Errorf("group %q uses the reserved %q prefix", g, reservedSubjectPrefix)
+		}
+		id.Groups = append(id.Groups, g)
 	}
 	return id, nil
+}
+
+// reservedSubjectPrefix is Kubernetes' reserved namespace for built-in subjects.
+// system:masters is a hardcoded superuser and system:serviceaccount:… names a
+// real SA, so a claim that lands in this namespace must never be impersonated.
+const reservedSubjectPrefix = "system:"
+
+// isReservedSubject rejects a claim-derived user/group in the system: namespace.
+// Without a groups prefix configured (the default), an IdP that lets a user
+// influence their own groups claim could otherwise assert system:masters and
+// obtain cluster-admin on every federated member.
+func isReservedSubject(s string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(s)), reservedSubjectPrefix)
 }
 
 func stringClaim(claims map[string]interface{}, key string) string {

--- a/internal/gateway/auth_oidc_test.go
+++ b/internal/gateway/auth_oidc_test.go
@@ -113,3 +113,42 @@ func TestHTTPClientWithCA(t *testing.T) {
 		t.Error("expected error for a file with no PEM certificates")
 	}
 }
+
+// A claim landing in the system: namespace must be refused outright. Without a
+// groups prefix (the default), an IdP where a user can influence their own
+// groups claim could otherwise assert system:masters — a hardcoded Kubernetes
+// superuser — and get cluster-admin on every federated member.
+func TestIdentityFromClaims_RejectsReservedSubjects(t *testing.T) {
+	cfg := OIDCClaimConfig{UsernameClaim: "email", GroupsClaim: "groups"}
+	cases := []struct {
+		name   string
+		claims map[string]interface{}
+	}{
+		{"masters group", map[string]interface{}{
+			"email": "alice@corp", "groups": []interface{}{"devs", "system:masters"}}},
+		{"serviceaccount group", map[string]interface{}{
+			"email": "alice@corp", "groups": []interface{}{"system:serviceaccount:kube-system:default"}}},
+		{"system username", map[string]interface{}{
+			"email": "system:masters", "groups": []interface{}{"devs"}}},
+		{"case and space evasion", map[string]interface{}{
+			"email": "alice@corp", "groups": []interface{}{" System:Masters"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := identityFromClaims(tc.claims, cfg)
+			if err == nil {
+				t.Fatalf("accepted a reserved subject: user=%q groups=%v", id.User, id.Groups)
+			}
+		})
+	}
+}
+
+// A prefix that pushes an otherwise-innocent claim into system: must also be
+// caught — the check runs on the final impersonated value, not the raw claim.
+func TestIdentityFromClaims_RejectsReservedAfterPrefix(t *testing.T) {
+	cfg := OIDCClaimConfig{UsernameClaim: "email", GroupsClaim: "groups", GroupsPrefix: "system:"}
+	claims := map[string]interface{}{"email": "alice@corp", "groups": []interface{}{"masters"}}
+	if id, err := identityFromClaims(claims, cfg); err == nil {
+		t.Fatalf("accepted groups=%v after the prefix pushed it into system:", id.Groups)
+	}
+}

--- a/internal/gateway/cluster_service.go
+++ b/internal/gateway/cluster_service.go
@@ -44,7 +44,15 @@ func NewClusterService(hub client.Reader, namespace string, watcher *ClusterWatc
 
 // ListClusters returns every registered member cluster. The fleet is small, so
 // P0 does not paginate (the page field is reserved for later scale).
-func (s *ClusterService) ListClusters(ctx context.Context, _ *connect.Request[kubeswiftv1.ListClustersRequest]) (*connect.Response[kubeswiftv1.ListClustersResponse], error) {
+//
+// The response carries each member's apiserver URL and version, so it is
+// authenticated like every other RPC — an unauthenticated caller must not be
+// able to enumerate the fleet. The identity is not used beyond that: these are
+// hub-cache reads, not impersonated member calls.
+func (s *ClusterService) ListClusters(ctx context.Context, req *connect.Request[kubeswiftv1.ListClustersRequest]) (*connect.Response[kubeswiftv1.ListClustersResponse], error) {
+	if _, err := s.auth.Authenticate(ctx, req.Header()); err != nil {
+		return nil, err
+	}
 	var list fleetv1alpha1.ClusterList
 	if err := s.hub.List(ctx, &list, client.InNamespace(s.namespace)); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -59,7 +67,13 @@ func (s *ClusterService) ListClusters(ctx context.Context, _ *connect.Request[ku
 // WatchClusters streams an initial ADDED snapshot followed by live deltas.
 // It subscribes BEFORE listing so no change is missed in the list→watch gap;
 // any resulting duplicate is harmless because the UI upserts by cluster name.
-func (s *ClusterService) WatchClusters(ctx context.Context, _ *connect.Request[kubeswiftv1.WatchClustersRequest], stream *connect.ServerStream[kubeswiftv1.ClusterEvent]) error {
+//
+// Authenticated for the same reason as ListClusters: the stream carries member
+// apiserver URLs, versions, and condition messages.
+func (s *ClusterService) WatchClusters(ctx context.Context, req *connect.Request[kubeswiftv1.WatchClustersRequest], stream *connect.ServerStream[kubeswiftv1.ClusterEvent]) error {
+	if _, err := s.auth.Authenticate(ctx, req.Header()); err != nil {
+		return err
+	}
 	sub := s.watcher.subscribe()
 	defer s.watcher.unsubscribe(sub)
 

--- a/internal/gateway/cluster_service_test.go
+++ b/internal/gateway/cluster_service_test.go
@@ -2,6 +2,8 @@ package gateway
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"testing"
 
 	connect "connectrpc.com/connect"
@@ -20,7 +22,10 @@ func TestClusterService_ListClusters_NamespaceScoped(t *testing.T) {
 		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "elsewhere", Namespace: "other"}},
 	).Build()
 
-	svc := NewClusterService(hub, "kubeswift-system", nil, nil, nil) // ListClusters uses only the hub cache
+	// ListClusters uses only the hub cache, but it DOES authenticate — passing a
+	// nil Authenticator here is what let the unauthenticated-fleet-enumeration
+	// bug ship (a nil auth would panic, not pass).
+	svc := NewClusterService(hub, "kubeswift-system", nil, nil, NewInsecureAuthenticator())
 	resp, err := svc.ListClusters(context.Background(), connect.NewRequest(&kubeswiftv1.ListClustersRequest{}))
 	if err != nil {
 		t.Fatalf("ListClusters: %v", err)
@@ -71,4 +76,47 @@ func TestClusterWatcher_NonBlockingOnSlowSubscriber(t *testing.T) {
 			&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "x"}})
 	}
 	// Reaching here without deadlock is the assertion.
+}
+
+// rejectingAuthenticator stands in for a real authenticator refusing a caller
+// with no/!valid credentials.
+type rejectingAuthenticator struct{}
+
+func (rejectingAuthenticator) Authenticate(context.Context, http.Header) (Identity, error) {
+	return Identity{}, connect.NewError(connect.CodeUnauthenticated, errors.New("no credentials"))
+}
+
+// The fleet list carries every member's apiserver URL and version, so an
+// unauthenticated caller must not be able to enumerate it. Both RPCs shipped
+// without an Authenticate call; these pin them.
+func TestClusterService_ListClusters_RequiresAuth(t *testing.T) {
+	hub := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
+		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "boba", Namespace: "kubeswift-system"}},
+	).Build()
+
+	svc := NewClusterService(hub, "kubeswift-system", nil, nil, rejectingAuthenticator{})
+	resp, err := svc.ListClusters(context.Background(), connect.NewRequest(&kubeswiftv1.ListClustersRequest{}))
+	if err == nil {
+		t.Fatalf("ListClusters accepted an unauthenticated caller and returned %d clusters", len(resp.Msg.GetClusters()))
+	}
+	if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+		t.Errorf("code = %v, want %v", got, connect.CodeUnauthenticated)
+	}
+}
+
+func TestClusterService_WatchClusters_RequiresAuth(t *testing.T) {
+	hub := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
+		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "boba", Namespace: "kubeswift-system"}},
+	).Build()
+
+	// nil watcher + nil stream on purpose: the auth check must reject BEFORE
+	// subscribe() or the first Send, so neither is ever reached.
+	svc := NewClusterService(hub, "kubeswift-system", nil, nil, rejectingAuthenticator{})
+	err := svc.WatchClusters(context.Background(), connect.NewRequest(&kubeswiftv1.WatchClustersRequest{}), nil)
+	if err == nil {
+		t.Fatal("WatchClusters accepted an unauthenticated caller")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+		t.Errorf("code = %v, want %v", got, connect.CodeUnauthenticated)
+	}
 }

--- a/internal/gateway/resource_service.go
+++ b/internal/gateway/resource_service.go
@@ -254,13 +254,23 @@ func (s *ResourceService) DeleteResource(ctx context.Context, req *connect.Reque
 	return connect.NewResponse(&kubeswiftv1.DeleteResourceResponse{}), nil
 }
 
+// lastAppliedAnnotation is kubectl's client-side-apply record. For a Secret it
+// contains the ENTIRE submitted manifest — including data (base64) or
+// stringData (plaintext) — so stripping only data/stringData would still leak
+// the values to anyone who reads the object.
+const lastAppliedAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
+
 // redactSecret strips Secret values so the gateway never exposes them (E4),
 // even via GetResource / ApplyResource which return the full object.
 func redactSecret(obj *unstructured.Unstructured, kind *resourceKind) {
-	if kind.gvr.Group == "" && kind.gvr.Resource == "secrets" {
-		unstructured.RemoveNestedField(obj.Object, "data")
-		unstructured.RemoveNestedField(obj.Object, "stringData")
+	if kind.gvr.Group != "" || kind.gvr.Resource != "secrets" {
+		return
 	}
+	unstructured.RemoveNestedField(obj.Object, "data")
+	unstructured.RemoveNestedField(obj.Object, "stringData")
+	// A Secret created with `kubectl apply` carries the plaintext manifest in
+	// this annotation; dropping only data/stringData above left it readable.
+	unstructured.RemoveNestedField(obj.Object, "metadata", "annotations", lastAppliedAnnotation)
 }
 
 func resourcesErr(cluster, msg string) *connect.Response[kubeswiftv1.ListResourcesResponse] {

--- a/internal/gateway/resource_service_test.go
+++ b/internal/gateway/resource_service_test.go
@@ -47,11 +47,24 @@ func mkNode(name string, ready bool) *unstructured.Unstructured {
 
 // uSecret carries real (base64) values so the redaction test can assert none
 // of them — base64 or decoded — reach the wire.
+//
+// It also carries kubectl's last-applied-configuration annotation, because that
+// is how a Secret created with `kubectl apply` really looks: the annotation
+// holds the ENTIRE submitted manifest, stringData in PLAINTEXT. Redaction that
+// drops only data/stringData leaves it readable, so the fixture must have it or
+// the leak is invisible to these tests.
 func uSecret(ns, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "v1", "kind": "Secret",
-		"metadata": map[string]interface{}{"namespace": ns, "name": name},
-		"type":     "Opaque",
+		"metadata": map[string]interface{}{
+			"namespace": ns, "name": name,
+			"annotations": map[string]interface{}{
+				"kubectl.kubernetes.io/last-applied-configuration": `{"apiVersion":"v1","kind":"Secret",` +
+					`"metadata":{"name":"` + name + `","namespace":"` + ns + `"},` +
+					`"stringData":{"password":"super-secret","apitoken":"top-secret"}}`,
+			},
+		},
+		"type": "Opaque",
 		"data": map[string]interface{}{
 			"password": "c3VwZXItc2VjcmV0", // base64("super-secret")
 			"apitoken": "dG9wLXNlY3JldA==", // base64("top-secret")


### PR DESCRIPTION
First batch from the security review. Three gateway fixes, each with a regression test **verified to fail without the source change** (negative control run locally).

### 1. `ListClusters` / `WatchClusters` were unauthenticated — High
Every other RPC calls `Authenticate`; these two never did (0 call sites in `cluster_service.go` vs 8 in `guest_service.go`). Both carry each member's **apiserver URL**, Kubernetes version, and condition messages — which include raw connection/credential errors — so anyone who could reach the port could enumerate the fleet, and `WatchClusters` streams it live.

Why it was invisible: `cluster_service_test.go` built the service with a **nil** `Authenticator` and passed. A nil auth would have panicked if it were ever called — the test encoded the bug.

### 2. Secret redaction (E4) was bypassed by the kubectl annotation — High
`redactSecret` dropped only `data`/`stringData`. A Secret created with `kubectl apply` also carries the whole submitted manifest in `kubectl.kubernetes.io/last-applied-configuration` — **`stringData` in plaintext** — so values survived on `GetResource` and `ApplyResource`. This contradicted `docs/ui/explorer.md`'s explicit claim that the console never receives values.

The `uSecret` fixture had no annotations, so no test could see it. It now carries a realistic one, and the **existing** leak assertions catch the regression.

### 3. Claim values could assert `system:masters` — Medium (total blast radius)
`identityFromClaims` copied claims verbatim into the impersonation headers, and both prefixes default to empty. An IdP where a user can influence their own groups claim could assert `system:masters` — a hardcoded Kubernetes superuser — for cluster-admin on **every** federated member. Reserved `system:` subjects are now rejected, checked on the final prefixed value and resistant to case/whitespace evasion.

### Deliberately not in this PR
`Identity.empty()` still overloads "insecure mode" and "no identity resolved", so a future authenticator that forgets to set `User` escalates to the member credential instead of failing closed. That needs an explicit `impersonate bool` and a look at every call site — separate change.

`go build`/`vet`/`test` green, `gofmt -s` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)