### PR TITLE
fix(supply-chain): verify the Cloud Hypervisor binary, pin the verified digest, least-privilege CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,13 @@ on:
       - 'tools/lint-dashboards.sh'
       - '.github/workflows/**'
 
+# Least privilege: CI only reads the repo. Without this the workflow inherits the
+# repo/org default, which may be read-write -- handing a write-scoped
+# GITHUB_TOKEN to third-party actions and to `go build`/`cargo build` of
+# PR-authored code.
+permissions:
+  contents: read
+
 jobs:
   go:
     name: Go

--- a/cmd/sandbox-materialize/main.go
+++ b/cmd/sandbox-materialize/main.go
@@ -68,6 +68,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "sandbox-materialize: %v\n", verr)
 			os.Exit(1)
 		}
+		// Materialize the digest we just verified, not the original ref. Otherwise
+		// Materialize re-resolves the tag independently and an attacker with push
+		// rights but no signing key could swap the tag between the verify and the
+		// pull -- we would verify a good image and boot a different one. The
+		// sibling snapshot-oras download-image path pins the same way.
+		opts.ImageRef = repo + "@" + digest
 		fmt.Fprintf(os.Stderr, "sandbox-materialize: cosign-verified %s@%s\n", repo, digest)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	k8s.io/dynamic-resource-allocation v0.35.0
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
-	oras.land/oras-go/v2 v2.6.1
+	oras.land/oras-go/v2 v2.6.2
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -83,7 +83,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,8 @@ golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
@@ -260,6 +262,8 @@ k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0x
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 oras.land/oras-go/v2 v2.6.1 h1:bonOEkjLfp8tt6qXWRRWP6p1F+9octchOf2EqnWB4Zs=
 oras.land/oras-go/v2 v2.6.1/go.mod h1:dhtFrFOuZuDtAVeZ9FUnaa5zfzplG3ZnFX9/uH1J/Yk=
+oras.land/oras-go/v2 v2.6.2 h1:N04RXngAp1LJKTG6ifz3xHPipasEkWr+hFmInja5YKo=
+oras.land/oras-go/v2 v2.6.2/go.mod h1:PlTtg4JTDJkDe8yVHpM2wz7/YDc00GVas+i4jAW2TZ4=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/images/swiftletd/Containerfile
+++ b/images/swiftletd/Containerfile
@@ -110,9 +110,24 @@ COPY --from=builder /usr/local/bin/virtiofsd /usr/libexec/virtiofsd
 # v53.0 binary (no re-pair needed).
 ARG CH_VERSION=53.0
 ARG TARGETARCH=amd64
+# Checksum-pinned like CLOUDHV.fd below. This binary IS the hypervisor — it runs
+# every VM on every node — so an unverified fetch would let a compromised
+# upstream release asset (or a re-uploaded one on the same tag) bake a foreign
+# VMM into every KubeSwift image. Both digests were taken from the published
+# v53.0 assets and verified locally (`cloud-hypervisor v53.0`).
+# Re-pin BOTH when bumping CH_VERSION:
+#   curl -sSL .../cloud-hypervisor-static{,-aarch64} | sha256sum
+ARG CH_SHA256_AMD64=448af3d4e59b22c2987f7df94c213ad40fb53a10d437e42b5ee6c4fce7c29ecc
+ARG CH_SHA256_ARM64=f192b510eea1c710cbc439d716bb0573c223fc463dbe3e6523788a2b7ef62850
 RUN CH_ARCH=$(echo "${TARGETARCH}" | sed 's/amd64//;s/arm64/-aarch64/') && \
+    case "${TARGETARCH}" in \
+      amd64) CH_SHA256="${CH_SHA256_AMD64}" ;; \
+      arm64) CH_SHA256="${CH_SHA256_ARM64}" ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
     curl -sSL -o /usr/local/bin/cloud-hypervisor \
     "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v${CH_VERSION}/cloud-hypervisor-static${CH_ARCH}" && \
+    echo "${CH_SHA256}  /usr/local/bin/cloud-hypervisor" | sha256sum -c - && \
     chmod +x /usr/local/bin/cloud-hypervisor
 
 # CLOUDHV.fd — Cloud Hypervisor UEFI firmware (EDK2/OVMF build for CH)


### PR DESCRIPTION
Third batch from the security review — supply chain.

### 1. The Cloud Hypervisor binary was fetched unverified — High
`images/swiftletd/Containerfile` `curl`ed `cloud-hypervisor-static` with no checksum, while **`CLOUDHV.fd` eight lines below was already SHA256-pinned**, and both cosign fetches (`snapshot-oras`, `sandbox-materialize`) verify against the upstream checksums file. That asymmetry is the tell.

This binary **is the hypervisor** — the VMM process running every VM on every node. A compromised upstream release asset, or a re-uploaded asset on the same tag, would be baked into every KubeSwift image and picked up silently by any CI rebuild.

Both arch digests are now pinned and checked. I took them from the published v53.0 assets and confirmed the binary is genuine by running it (`cloud-hypervisor v53.0`, static-pie ELF), then verified the gate **accepts** it and **rejects** a byte-appended copy.

### 2. sandbox-materialize verified one digest and booted another — Medium (TOCTOU)
`Resolve` → `oci.Verify(digest)` → `Materialize(opts)` — but `Materialize` re-resolves `opts.ImageRef` from scratch, so the verified digest was never carried forward. An attacker with **push rights but no signing key** — exactly the threat `verifyKeySecretRef` exists to stop — could swap the tag inside that window, and a warm pool replenishing slots retries until they win.

Now pins `opts.ImageRef` to the verified digest, matching what `snapshot-oras download-image` already does (its comment even calls out the TOCTOU).

### 3. oras-go v2.6.1 → v2.6.2 — Medium
GO-2026-5880 (hardlink path traversal), reachable via the file-store destination in the snapshot download path — and that path has **no** signature verification (`--verify-key` is `download-image` only), so a tampered artifact reaches the vulnerable extractor unauthenticated.

### 4. Neither CI workflow declared `permissions` — Low/contingent
Both inherited the repo/org default. Every other workflow in both repos declares one; CI was the outlier, and it hands the token to third-party actions and to a build of PR-authored code. Both now declare `contents: read`. (Companion PR in kubeswift-ui.)

### Not in this PR
Actions are still floating on mutable tags/branches (incl. `dtolnay/rust-toolchain@stable`) in workflows holding `id-token: write` — SHA-pinning is a bigger sweep. Base images are likewise unpinned. Both tracked.

`go build`/`test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)