### PR TITLE
fix(webhook): confine SwiftGuest host paths to an operator-configured allowlist

### DIFF
--- a/charts/kubeswift/templates/controller-manager/deployment.yaml
+++ b/charts/kubeswift/templates/controller-manager/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             {{- if .Values.migration.mtls.enabled }}
             - --migration-mtls-enabled=true
             {{- end }}
+            {{- range .Values.swiftGuest.allowedHostPathPrefixes }}
+            - --allowed-hostpath-prefix={{ . }}
+            {{- end }}
           ports:
             - containerPort: 9443
               name: webhook

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -359,3 +359,22 @@ migration:
   # dependency and no behavior change.
   mtls:
     enabled: false
+
+# SwiftGuest admission policy.
+swiftGuest:
+  # Host-path prefixes a SwiftGuest may mount into its launcher pod, via
+  # spec.filesystems[].source.hostPath (virtio-fs share) or a vhost-user socket
+  # directory.
+  #
+  # The launcher container is privileged, so a host path it mounts is
+  # effectively node-root access granted to whoever authored the SwiftGuest.
+  # An EMPTY list (the default) denies every host path: these fields are niche,
+  # so a cluster opts in explicitly rather than shipping an escape hatch.
+  # ".." is always rejected, and prefixes match whole path segments
+  # ("/srv/vm" allows "/srv/vm/a" but not "/srv/vmsecrets").
+  #
+  # Enforced by the validating webhook, so it requires webhook.enabled=true.
+  #
+  #   allowedHostPathPrefixes:
+  #     - /srv/kubeswift-shares
+  allowedHostPathPrefixes: []

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
@@ -59,6 +60,15 @@ const (
 	defaultLeaderElectionNS = "kubeswift-system"
 )
 
+// stringSliceFlag collects a repeatable string flag.
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string { return strings.Join(*s, ",") }
+func (s *stringSliceFlag) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
 func main() {
 	showVersion := flag.Bool("version", false, "Print version and exit")
 	webhookEnabled := flag.Bool("webhook-enabled", false, "Enable admission webhooks (requires TLS certs)")
@@ -68,6 +78,11 @@ func main() {
 	webhookHost := flag.String("webhook-host", defaultWebhookHost, "Host for webhook server")
 	webhookCertDir := flag.String("webhook-cert-dir", defaultCertDir, "Directory containing webhook TLS certs (tls.crt, tls.key)")
 	metricsAddr := flag.String("metrics-bind-address", ":8080", "Address for metrics endpoint")
+	var allowedHostPaths stringSliceFlag
+	flag.Var(&allowedHostPaths, "allowed-hostpath-prefix",
+		"Host-path prefix a SwiftGuest may mount into the (privileged) launcher pod "+
+			"-- spec.filesystems[].source.hostPath and vhost-user socket dirs. Repeatable. "+
+			"EMPTY DENIES ALL, which is the default: opt in per cluster.")
 	klog.InitFlags(nil)
 	flag.Parse()
 
@@ -301,7 +316,7 @@ func main() {
 
 	if *webhookEnabled {
 		if err = ctrl.NewWebhookManagedBy(mgr, &swiftv1alpha1.SwiftGuest{}).
-			WithCustomValidator(&swiftguestwebhook.Validator{}).
+			WithCustomValidator(&swiftguestwebhook.Validator{AllowedHostPathPrefixes: allowedHostPaths}).
 			WithCustomDefaulter(&swiftguestwebhook.Defaulter{}).
 			Complete(); err != nil {
 			klog.ErrorS(err, "unable to create SwiftGuest webhook")

--- a/internal/webhook/hostpath/hostpath.go
+++ b/internal/webhook/hostpath/hostpath.go
@@ -1,0 +1,88 @@
+// Package hostpath confines operator- and tenant-supplied host paths that the
+// controller turns into hostPath volumes on the launcher pod.
+//
+// This exists because the launcher container is privileged (see
+// internal/controller/swiftguest/security.go), so a hostPath it mounts is
+// effectively node-root access handed to whoever authored the CR. Fields like
+// SwiftGuest spec.filesystems[].source.hostPath were validated only as
+// non-empty, which let a namespaced tenant mount "/" read-write into their own
+// VM via virtiofsd.
+//
+// The rules are deliberately boring:
+//
+//   - "..'" is ALWAYS rejected, regardless of configuration. A prefix check is
+//     a string comparison, so "/var/lib/kubeswift/../../etc" would otherwise
+//     satisfy it. There is no legitimate use of ".." in these fields.
+//   - The path must be absolute and clean.
+//   - The path must sit under one of the operator-configured allowed prefixes.
+//     An EMPTY allowlist denies every path: the fields are niche, so the safe
+//     default is that a cluster admin opts in per deployment
+//     (swiftGuest.allowedHostPathPrefixes in the chart) rather than every
+//     install shipping an escape hatch.
+//
+// Prefix matching is path-segment aware: "/srv/vm" allows "/srv/vm/a" but NOT
+// "/srv/vmsecrets", which a naive strings.HasPrefix would wave through.
+package hostpath
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// Validate checks p against the allowlist. field names the CR field for the
+// error message (e.g. "spec.filesystems[0].source.hostPath").
+func Validate(field, p string, allowed []string) error {
+	if p == "" {
+		return fmt.Errorf("%s must not be empty", field)
+	}
+	// Checked on the raw input, before any cleaning, so a caller cannot smuggle
+	// traversal past us by relying on normalization.
+	if strings.Contains(p, "..") {
+		return fmt.Errorf("%s must not contain '..' (got %q)", field, p)
+	}
+	if !filepath.IsAbs(p) {
+		return fmt.Errorf("%s must be an absolute path (got %q)", field, p)
+	}
+	if filepath.Clean(p) != strings.TrimRight(p, "/") && filepath.Clean(p) != p {
+		return fmt.Errorf("%s must be a clean path (got %q, want %q)", field, p, filepath.Clean(p))
+	}
+	if len(allowed) == 0 {
+		return fmt.Errorf("%s is not permitted: no host-path prefixes are allowed on this cluster "+
+			"(set swiftGuest.allowedHostPathPrefixes in the chart to opt in)", field)
+	}
+	clean := filepath.Clean(p)
+	for _, pref := range allowed {
+		if underPrefix(clean, filepath.Clean(pref)) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s must be under one of the allowed prefixes %v (got %q)", field, allowed, p)
+}
+
+// ValidateDir applies the same rules to the DIRECTORY of a socket path, which
+// is what the pod builder actually mounts for vhost-user sockets.
+func ValidateDir(field, sock string, allowed []string) error {
+	if sock == "" {
+		return fmt.Errorf("%s must not be empty", field)
+	}
+	if strings.Contains(sock, "..") {
+		return fmt.Errorf("%s must not contain '..' (got %q)", field, sock)
+	}
+	if !filepath.IsAbs(sock) {
+		return fmt.Errorf("%s must be an absolute path (got %q)", field, sock)
+	}
+	return Validate(field, filepath.Dir(sock), allowed)
+}
+
+// underPrefix reports whether p is prefix itself or a path beneath it,
+// comparing whole segments so "/srv/vm" does not match "/srv/vmsecrets".
+func underPrefix(p, prefix string) bool {
+	if prefix == "/" {
+		return true
+	}
+	if p == prefix {
+		return true
+	}
+	return strings.HasPrefix(p, strings.TrimSuffix(prefix, "/")+"/")
+}

--- a/internal/webhook/hostpath/hostpath_test.go
+++ b/internal/webhook/hostpath/hostpath_test.go
@@ -1,0 +1,79 @@
+package hostpath
+
+import "testing"
+
+func TestValidate_RejectsTraversalRegardlessOfAllowlist(t *testing.T) {
+	// ".." is rejected even when the prefix check would otherwise pass — that is
+	// the whole point of checking it separately. A prefix test is a string
+	// comparison; "/var/lib/kubeswift/../../etc" satisfies HasPrefix.
+	allowed := []string{"/var/lib/kubeswift"}
+	for _, p := range []string{
+		"/var/lib/kubeswift/../../etc",
+		"/var/lib/kubeswift/..",
+		"/../etc/kubernetes/pki",
+		"/var/lib/kubeswift/a/../../../root",
+	} {
+		if err := Validate("f", p, allowed); err == nil {
+			t.Errorf("accepted traversal path %q", p)
+		}
+	}
+}
+
+func TestValidate_EmptyAllowlistDeniesEverything(t *testing.T) {
+	// The safe default: an install that has not opted in cannot mount ANY host
+	// path, including otherwise-innocent ones.
+	for _, p := range []string{"/", "/srv/vm", "/var/lib/kubeswift/x"} {
+		if err := Validate("f", p, nil); err == nil {
+			t.Errorf("empty allowlist accepted %q", p)
+		}
+	}
+}
+
+func TestValidate_TheOriginalExploit(t *testing.T) {
+	// hostPath: "/" mounted RW into a tenant VM was the reported Critical.
+	if err := Validate("spec.filesystems[0].source.hostPath", "/", []string{"/srv/vm"}); err == nil {
+		t.Fatal("accepted hostPath / — the reported node-root escape")
+	}
+}
+
+func TestValidate_PrefixIsSegmentAware(t *testing.T) {
+	allowed := []string{"/srv/vm"}
+	if err := Validate("f", "/srv/vmsecrets", allowed); err == nil {
+		t.Error("accepted /srv/vmsecrets for prefix /srv/vm (naive HasPrefix bug)")
+	}
+	if err := Validate("f", "/srv/vm", allowed); err != nil {
+		t.Errorf("rejected the prefix itself: %v", err)
+	}
+	if err := Validate("f", "/srv/vm/disks/a.raw", allowed); err != nil {
+		t.Errorf("rejected a path under the prefix: %v", err)
+	}
+}
+
+func TestValidate_RequiresAbsolute(t *testing.T) {
+	if err := Validate("f", "srv/vm", []string{"/srv/vm"}); err == nil {
+		t.Error("accepted a relative path")
+	}
+}
+
+func TestValidateDir_ConfinesTheSocketDirectory(t *testing.T) {
+	// The pod builder mounts filepath.Dir(socket), so THAT is what must be
+	// confined — /etc/kubernetes/pki/x.sock would mount the PKI directory.
+	allowed := []string{"/var/run/vhost"}
+	if err := ValidateDir("spec.interfaces[0].socket", "/etc/kubernetes/pki/x.sock", allowed); err == nil {
+		t.Error("accepted a socket whose directory is /etc/kubernetes/pki")
+	}
+	if err := ValidateDir("spec.interfaces[0].socket", "/var/run/vhost/net0.sock", allowed); err != nil {
+		t.Errorf("rejected a legitimate vhost socket: %v", err)
+	}
+	if err := ValidateDir("f", "/var/run/vhost/../../etc/x.sock", allowed); err == nil {
+		t.Error("accepted traversal in a socket path")
+	}
+}
+
+func TestValidate_RootPrefixAllowsAll(t *testing.T) {
+	// An operator who explicitly configures "/" gets what they asked for — the
+	// allowlist is a policy knob, not a hard ceiling.
+	if err := Validate("f", "/etc/kubernetes", []string{"/"}); err != nil {
+		t.Errorf("explicit / prefix should permit any path: %v", err)
+	}
+}

--- a/internal/webhook/swiftguest/validator.go
+++ b/internal/webhook/swiftguest/validator.go
@@ -10,17 +10,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/webhook/hostpath"
 )
 
 // Validator validates SwiftGuest resources.
-type Validator struct{}
+//
+// AllowedHostPathPrefixes confines the host paths a SwiftGuest may ask the
+// (privileged) launcher pod to mount -- spec.filesystems[].source.hostPath and
+// the vhost-user socket directories. It comes from the operator via
+// --allowed-hostpath-prefix / swiftGuest.allowedHostPathPrefixes. EMPTY MEANS
+// DENY ALL: these fields are niche, so an install opts in explicitly rather
+// than shipping a node-root escape hatch by default.
+type Validator struct {
+	AllowedHostPathPrefixes []string
+}
 
 func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	g, ok := obj.(*swiftv1alpha1.SwiftGuest)
 	if !ok {
 		return nil, fmt.Errorf("expected SwiftGuest, got %T", obj)
 	}
-	return nil, validateSwiftGuest(g)
+	return nil, validateSwiftGuest(g, v.AllowedHostPathPrefixes)
 }
 
 func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
@@ -28,14 +38,14 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	if !ok {
 		return nil, fmt.Errorf("expected SwiftGuest, got %T", newObj)
 	}
-	return nil, validateSwiftGuest(g)
+	return nil, validateSwiftGuest(g, v.AllowedHostPathPrefixes)
 }
 
 func (v *Validator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func validateSwiftGuest(g *swiftv1alpha1.SwiftGuest) error {
+func validateSwiftGuest(g *swiftv1alpha1.SwiftGuest, allowedHostPaths []string) error {
 	spec := &g.Spec
 	hasImage := spec.ImageRef != nil && spec.ImageRef.Name != ""
 	hasKernel := spec.KernelRef != nil && spec.KernelRef.Name != ""
@@ -113,13 +123,13 @@ func validateSwiftGuest(g *swiftv1alpha1.SwiftGuest) error {
 		}
 	}
 
-	if err := validateFilesystems(spec); err != nil {
+	if err := validateFilesystems(spec, allowedHostPaths); err != nil {
 		return err
 	}
-	if err := validateInterfaces(spec); err != nil {
+	if err := validateInterfaces(spec, allowedHostPaths); err != nil {
 		return err
 	}
-	if err := validateVhostUserDevices(spec); err != nil {
+	if err := validateVhostUserDevices(spec, allowedHostPaths); err != nil {
 		return err
 	}
 	if err := validateNetworkPorts(spec); err != nil {
@@ -289,7 +299,7 @@ func usesGPU(spec *swiftv1alpha1.SwiftGuestSpec) bool {
 // names, a socket per device, virtioId required for generic devices, and the
 // v1 scope limit (Cloud Hypervisor only — a gpuProfileRef may select the QEMU
 // runtime, which v1 does not wire for vhost-user).
-func validateVhostUserDevices(spec *swiftv1alpha1.SwiftGuestSpec) error {
+func validateVhostUserDevices(spec *swiftv1alpha1.SwiftGuestSpec, allowedHostPaths []string) error {
 	if len(spec.VhostUserDevices) == 0 {
 		return nil
 	}
@@ -310,6 +320,12 @@ func validateVhostUserDevices(spec *swiftv1alpha1.SwiftGuestSpec) error {
 		if d.Socket == "" {
 			return fmt.Errorf("spec.vhostUserDevices[%d].socket is required", i)
 		}
+		// The pod builder mounts filepath.Dir(socket) as a hostPath into the
+		// privileged launcher, so the DIRECTORY must be confined.
+		if err := hostpath.ValidateDir(
+			fmt.Sprintf("spec.vhostUserDevices[%d].socket", i), d.Socket, allowedHostPaths); err != nil {
+			return err
+		}
 		switch d.Type {
 		case swiftv1alpha1.VhostUserDeviceTypeBlk:
 			// nothing extra
@@ -328,7 +344,7 @@ func validateVhostUserDevices(spec *swiftv1alpha1.SwiftGuestSpec) error {
 // is required, the bridge/sriov-only fields are not set, and the v1 scope limit
 // (Cloud Hypervisor only — a gpuProfileRef may select the QEMU runtime, which
 // v1 does not wire for vhost-user). bridge/sriov interfaces are unchanged.
-func validateInterfaces(spec *swiftv1alpha1.SwiftGuestSpec) error {
+func validateInterfaces(spec *swiftv1alpha1.SwiftGuestSpec, allowedHostPaths []string) error {
 	hasVhostUser := false
 	for i := range spec.Interfaces {
 		iface := &spec.Interfaces[i]
@@ -338,6 +354,11 @@ func validateInterfaces(spec *swiftv1alpha1.SwiftGuestSpec) error {
 		hasVhostUser = true
 		if iface.Socket == "" {
 			return fmt.Errorf("spec.interfaces[%d] (type vhost-user) requires a socket path", i)
+		}
+		// Same hostPath primitive as vhostUserDevices above.
+		if err := hostpath.ValidateDir(
+			fmt.Sprintf("spec.interfaces[%d].socket", i), iface.Socket, allowedHostPaths); err != nil {
+			return err
 		}
 		if iface.NetworkRef != nil {
 			return fmt.Errorf("spec.interfaces[%d]: vhost-user does not use networkRef", i)
@@ -374,7 +395,7 @@ func validateInterfaces(spec *swiftv1alpha1.SwiftGuestSpec) error {
 // unique name + tag per guest, exactly one source, and the v1 scope limits
 // (Cloud Hypervisor + Linux only — the QEMU path is a later phase and a
 // Windows virtio-fs driver is out of scope).
-func validateFilesystems(spec *swiftv1alpha1.SwiftGuestSpec) error {
+func validateFilesystems(spec *swiftv1alpha1.SwiftGuestSpec, allowedHostPaths []string) error {
 	if len(spec.Filesystems) == 0 {
 		return nil
 	}
@@ -417,8 +438,14 @@ func validateFilesystems(spec *swiftv1alpha1.SwiftGuestSpec) error {
 		case !hasHostPath && !hasPVC:
 			return fmt.Errorf("spec.filesystems[%d].source: exactly one of hostPath or pvcRef is required", i)
 		}
-		if hasHostPath && *fs.Source.HostPath == "" {
-			return fmt.Errorf("spec.filesystems[%d].source.hostPath must not be empty", i)
+		if hasHostPath {
+			// The launcher is privileged and virtiofsd is handed this directory
+			// verbatim, so an unconfined value is node-root in the guest.
+			if err := hostpath.Validate(
+				fmt.Sprintf("spec.filesystems[%d].source.hostPath", i),
+				*fs.Source.HostPath, allowedHostPaths); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/webhook/swiftguest/validator_dra_test.go
+++ b/internal/webhook/swiftguest/validator_dra_test.go
@@ -15,13 +15,13 @@ func TestValidate_GPUResourceClaim(t *testing.T) {
 	// Valid: a single template reference.
 	if err := validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.GPUResourceClaim = &swiftv1alpha1.GPUResourceClaimSpec{ResourceClaimTemplateName: "gpu-tmpl", Tier: "pcie"}
-	})); err != nil {
+	}), testAllowAllHostPaths); err != nil {
 		t.Errorf("a single-template gpuResourceClaim should be valid: %v", err)
 	}
 	// Valid: a single shared-claim reference.
 	if err := validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.GPUResourceClaim = &swiftv1alpha1.GPUResourceClaimSpec{ResourceClaimName: "gpu-claim"}
-	})); err != nil {
+	}), testAllowAllHostPaths); err != nil {
 		t.Errorf("a single shared-claim gpuResourceClaim should be valid: %v", err)
 	}
 
@@ -29,19 +29,19 @@ func TestValidate_GPUResourceClaim(t *testing.T) {
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "prof"}
 		g.Spec.GPUResourceClaim = &swiftv1alpha1.GPUResourceClaimSpec{ResourceClaimName: "c"}
-	})), "mutually exclusive")
+	}), testAllowAllHostPaths), "mutually exclusive")
 
 	// Neither claimName nor templateName: rejected.
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.GPUResourceClaim = &swiftv1alpha1.GPUResourceClaimSpec{Tier: "pcie"}
-	})), "exactly one of resourceClaimName or resourceClaimTemplateName")
+	}), testAllowAllHostPaths), "exactly one of resourceClaimName or resourceClaimTemplateName")
 
 	// Both claimName and templateName: rejected.
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.GPUResourceClaim = &swiftv1alpha1.GPUResourceClaimSpec{
 			ResourceClaimName: "c", ResourceClaimTemplateName: "t",
 		}
-	})), "exactly one of resourceClaimName or resourceClaimTemplateName")
+	}), testAllowAllHostPaths), "exactly one of resourceClaimName or resourceClaimTemplateName")
 }
 
 // TestValidate_GPUResourceClaim_SharesGPUConstraints proves the DRA backend is
@@ -56,13 +56,13 @@ func TestValidate_GPUResourceClaim_SharesGPUConstraints(t *testing.T) {
 		g.Spec.ImageRef = nil
 		g.Spec.CloneFromSnapshot = &swiftv1alpha1.CloneFromSnapshotSource{SnapshotRef: corev1.LocalObjectReference{Name: "snap"}}
 		withClaim(g)
-	})), "mutually exclusive with GPU passthrough")
+	}), testAllowAllHostPaths), "mutually exclusive with GPU passthrough")
 
 	// osType: windows + DRA GPU: rejected.
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.OSType = swiftv1alpha1.OSTypeWindows
 		withClaim(g)
-	})), "GPU passthrough to Windows is out of scope")
+	}), testAllowAllHostPaths), "GPU passthrough to Windows is out of scope")
 
 	// virtiofs + DRA GPU: rejected.
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -71,5 +71,5 @@ func TestValidate_GPUResourceClaim_SharesGPUConstraints(t *testing.T) {
 			{Name: "share", Source: swiftv1alpha1.FilesystemSource{HostPath: &hp}},
 		}
 		withClaim(g)
-	})), "not supported with GPU passthrough")
+	}), testAllowAllHostPaths), "not supported with GPU passthrough")
 }

--- a/internal/webhook/swiftguest/validator_ports_test.go
+++ b/internal/webhook/swiftguest/validator_ports_test.go
@@ -12,7 +12,7 @@ func withNetwork(n *swiftv1alpha1.GuestNetworkSpec) func(*swiftv1alpha1.SwiftGue
 
 func TestValidate_NetworkPorts(t *testing.T) {
 	// nil network: OK (today's behavior).
-	if err := validateSwiftGuest(guest(nil)); err != nil {
+	if err := validateSwiftGuest(guest(nil), testAllowAllHostPaths); err != nil {
 		t.Fatalf("nil network should be valid: %v", err)
 	}
 
@@ -20,7 +20,7 @@ func TestValidate_NetworkPorts(t *testing.T) {
 	if err := validateSwiftGuest(guest(withNetwork(&swiftv1alpha1.GuestNetworkSpec{
 		Binding: "nat",
 		Ports:   []swiftv1alpha1.GuestPort{{Port: 22, Expose: "ClusterIP"}},
-	}))); err != nil {
+	})), testAllowAllHostPaths); err != nil {
 		t.Errorf("single nat ClusterIP port should be valid: %v", err)
 	}
 
@@ -30,14 +30,14 @@ func TestValidate_NetworkPorts(t *testing.T) {
 			{Name: "ssh", Port: 22, Expose: "ClusterIP"},
 			{Name: "http", Port: 80, Expose: "ClusterIP"},
 		},
-	}))); err != nil {
+	})), testAllowAllHostPaths); err != nil {
 		t.Errorf("two named ClusterIP ports should be valid: %v", err)
 	}
 
 	// ports without expose: OK (DNAT-only).
 	if err := validateSwiftGuest(guest(withNetwork(&swiftv1alpha1.GuestNetworkSpec{
 		Ports: []swiftv1alpha1.GuestPort{{Port: 22}},
-	}))); err != nil {
+	})), testAllowAllHostPaths); err != nil {
 		t.Errorf("exposeless port should be valid: %v", err)
 	}
 
@@ -45,25 +45,25 @@ func TestValidate_NetworkPorts(t *testing.T) {
 	if err := validateSwiftGuest(guest(withNetwork(&swiftv1alpha1.GuestNetworkSpec{
 		Binding: "bridge",
 		Ports:   []swiftv1alpha1.GuestPort{{Port: 22}},
-	}))); err != nil {
+	})), testAllowAllHostPaths); err != nil {
 		t.Errorf("exposeless port on bridge should be valid: %v", err)
 	}
 
 	// >1 port, missing name: rejected.
 	errContains(t, validateSwiftGuest(guest(withNetwork(&swiftv1alpha1.GuestNetworkSpec{
 		Ports: []swiftv1alpha1.GuestPort{{Port: 22, Expose: "ClusterIP"}, {Port: 80, Expose: "ClusterIP"}},
-	}))), "name is required when more than one port")
+	})), testAllowAllHostPaths), "name is required when more than one port")
 
 	// duplicate proto/port: rejected.
 	errContains(t, validateSwiftGuest(guest(withNetwork(&swiftv1alpha1.GuestNetworkSpec{
 		Ports: []swiftv1alpha1.GuestPort{{Name: "a", Port: 22}, {Name: "b", Port: 22}},
-	}))), "duplicate TCP port 22")
+	})), testAllowAllHostPaths), "duplicate TCP port 22")
 
 	// expose on a bridge guest: rejected.
 	errContains(t, validateSwiftGuest(guest(withNetwork(&swiftv1alpha1.GuestNetworkSpec{
 		Binding: "bridge",
 		Ports:   []swiftv1alpha1.GuestPort{{Port: 22, Expose: "ClusterIP"}},
-	}))), "binding is bridge")
+	})), testAllowAllHostPaths), "binding is bridge")
 
 	// mixed expose values: rejected (one Service, one type).
 	errContains(t, validateSwiftGuest(guest(withNetwork(&swiftv1alpha1.GuestNetworkSpec{
@@ -71,7 +71,7 @@ func TestValidate_NetworkPorts(t *testing.T) {
 			{Name: "a", Port: 22, Expose: "ClusterIP"},
 			{Name: "b", Port: 80, Expose: "LoadBalancer"},
 		},
-	}))), "same expose value")
+	})), testAllowAllHostPaths), "same expose value")
 
 	// expose with an sriov primary is rejected — caught earlier by
 	// validateInterfaces (a primary sriov interface is invalid outright), so the
@@ -80,5 +80,5 @@ func TestValidate_NetworkPorts(t *testing.T) {
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.Interfaces = []swiftv1alpha1.GuestInterface{{Name: "p", Type: swiftv1alpha1.InterfaceTypeSRIOV, Primary: true}}
 		g.Spec.Network = &swiftv1alpha1.GuestNetworkSpec{Ports: []swiftv1alpha1.GuestPort{{Port: 22, Expose: "ClusterIP"}}}
-	})), "bridge interface")
+	}), testAllowAllHostPaths), "bridge interface")
 }

--- a/internal/webhook/swiftguest/validator_test.go
+++ b/internal/webhook/swiftguest/validator_test.go
@@ -12,6 +12,11 @@ import (
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 )
 
+// testAllowAllHostPaths is used by tests that predate host-path confinement and
+// are not exercising it. Confinement is covered by internal/webhook/hostpath
+// and by TestValidateFilesystems_HostPathConfinement below.
+var testAllowAllHostPaths = []string{"/"}
+
 func guest(mut func(*swiftv1alpha1.SwiftGuest)) *swiftv1alpha1.SwiftGuest {
 	g := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "ns"},
@@ -35,14 +40,14 @@ func errContains(t *testing.T, err error, want string) {
 
 func TestValidate_BootSourceExclusivity(t *testing.T) {
 	// imageRef alone: OK.
-	if err := validateSwiftGuest(guest(nil)); err != nil {
+	if err := validateSwiftGuest(guest(nil), testAllowAllHostPaths); err != nil {
 		t.Errorf("imageRef-only should be valid: %v", err)
 	}
 	// kernelRef alone: OK.
 	if err := validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.ImageRef = nil
 		g.Spec.KernelRef = &corev1.LocalObjectReference{Name: "k"}
-	})); err != nil {
+	}), testAllowAllHostPaths); err != nil {
 		t.Errorf("kernelRef-only should be valid: %v", err)
 	}
 	// cloneFromSnapshot (with guestClassRef, which the CRD requires): OK.
@@ -51,7 +56,7 @@ func TestValidate_BootSourceExclusivity(t *testing.T) {
 		g.Spec.CloneFromSnapshot = &swiftv1alpha1.CloneFromSnapshotSource{
 			SnapshotRef: corev1.LocalObjectReference{Name: "snap"},
 		}
-	})); err != nil {
+	}), testAllowAllHostPaths); err != nil {
 		t.Errorf("cloneFromSnapshot should be valid: %v", err)
 	}
 	// cloneFromSnapshot without guestClassRef: rejected (CRD requires it; webhook aligned).
@@ -59,31 +64,31 @@ func TestValidate_BootSourceExclusivity(t *testing.T) {
 		g.Spec.ImageRef = nil
 		g.Spec.GuestClassRef = corev1.LocalObjectReference{}
 		g.Spec.CloneFromSnapshot = &swiftv1alpha1.CloneFromSnapshotSource{SnapshotRef: corev1.LocalObjectReference{Name: "snap"}}
-	})), "spec.guestClassRef.name is required")
+	}), testAllowAllHostPaths), "spec.guestClassRef.name is required")
 	// none set.
-	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) { g.Spec.ImageRef = nil })),
+	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) { g.Spec.ImageRef = nil }), testAllowAllHostPaths),
 		"exactly one of spec.imageRef")
 	// two set (imageRef + cloneFromSnapshot).
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.CloneFromSnapshot = &swiftv1alpha1.CloneFromSnapshotSource{SnapshotRef: corev1.LocalObjectReference{Name: "snap"}}
-	})), "exactly one of spec.imageRef")
+	}), testAllowAllHostPaths), "exactly one of spec.imageRef")
 }
 
 func TestValidate_OSType(t *testing.T) {
 	// default (unset) osType + imageRef: OK (no behaviour change for existing guests).
-	if err := validateSwiftGuest(guest(nil)); err != nil {
+	if err := validateSwiftGuest(guest(nil), testAllowAllHostPaths); err != nil {
 		t.Errorf("unset osType should be valid: %v", err)
 	}
 	// explicit linux + imageRef: OK.
 	if err := validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.OSType = swiftv1alpha1.OSTypeLinux
-	})); err != nil {
+	}), testAllowAllHostPaths); err != nil {
 		t.Errorf("linux + imageRef should be valid: %v", err)
 	}
 	// windows + imageRef (disk boot): OK.
 	if err := validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.OSType = swiftv1alpha1.OSTypeWindows
-	})); err != nil {
+	}), testAllowAllHostPaths); err != nil {
 		t.Errorf("windows + imageRef should be valid: %v", err)
 	}
 	// windows + kernelRef: rejected (Windows is disk-boot only).
@@ -91,16 +96,16 @@ func TestValidate_OSType(t *testing.T) {
 		g.Spec.ImageRef = nil
 		g.Spec.KernelRef = &corev1.LocalObjectReference{Name: "k"}
 		g.Spec.OSType = swiftv1alpha1.OSTypeWindows
-	})), "windows requires disk boot")
+	}), testAllowAllHostPaths), "windows requires disk boot")
 	// windows + gpuProfileRef: rejected (GPU-to-Windows out of scope v1).
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.OSType = swiftv1alpha1.OSTypeWindows
 		g.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu"}
-	})), "GPU passthrough")
+	}), testAllowAllHostPaths), "GPU passthrough")
 	// invalid enum value: rejected (defense-in-depth beyond the CRD schema).
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.OSType = swiftv1alpha1.OSType("bsd")
-	})), "spec.osType must be linux or windows")
+	}), testAllowAllHostPaths), "spec.osType must be linux or windows")
 }
 
 func TestValidate_CloneFromSnapshotRules(t *testing.T) {
@@ -119,17 +124,17 @@ func TestValidate_CloneFromSnapshotRules(t *testing.T) {
 	// missing snapshotRef.name.
 	errContains(t, validateSwiftGuest(cloneGuest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.CloneFromSnapshot.SnapshotRef.Name = ""
-	})), "snapshotRef.name is required")
+	}), testAllowAllHostPaths), "snapshotRef.name is required")
 	// gpuProfileRef + cloneFromSnapshot: rejected.
 	errContains(t, validateSwiftGuest(cloneGuest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu"}
-	})), "mutually exclusive with GPU passthrough")
+	}), testAllowAllHostPaths), "mutually exclusive with GPU passthrough")
 }
 
 func TestValidate_GuestClassRequiredForImageBoot(t *testing.T) {
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.GuestClassRef = corev1.LocalObjectReference{}
-	})), "spec.guestClassRef.name is required")
+	}), testAllowAllHostPaths), "spec.guestClassRef.name is required")
 }
 
 func hostPathFS(name string, mut func(*swiftv1alpha1.Filesystem)) swiftv1alpha1.Filesystem {
@@ -153,7 +158,7 @@ func TestValidate_Filesystems(t *testing.T) {
 				PVCRef: &corev1.LocalObjectReference{Name: "claim"}}},
 		}
 	})
-	if err := validateSwiftGuest(g); err != nil {
+	if err := validateSwiftGuest(g, testAllowAllHostPaths); err != nil {
 		t.Fatalf("valid filesystems rejected: %v", err)
 	}
 
@@ -161,7 +166,7 @@ func TestValidate_Filesystems(t *testing.T) {
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.Filesystems = []swiftv1alpha1.Filesystem{hostPathFS("dup", nil), hostPathFS("dup", nil)}
 	})
-	errContains(t, validateSwiftGuest(g), "is duplicated")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "is duplicated")
 
 	// Duplicate effective tag (one explicit, one defaulted from name).
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -170,7 +175,7 @@ func TestValidate_Filesystems(t *testing.T) {
 			hostPathFS("shared", nil),
 		}
 	})
-	errContains(t, validateSwiftGuest(g), "tag")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "tag")
 
 	// Both sources set.
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -180,27 +185,27 @@ func TestValidate_Filesystems(t *testing.T) {
 			}),
 		}
 	})
-	errContains(t, validateSwiftGuest(g), "not both")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "not both")
 
 	// No source set.
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.Filesystems = []swiftv1alpha1.Filesystem{{Name: "empty"}}
 	})
-	errContains(t, validateSwiftGuest(g), "exactly one of hostPath or pvcRef")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "exactly one of hostPath or pvcRef")
 
 	// Rejected with gpuProfileRef (CH-only in v1).
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu"}
 		g.Spec.Filesystems = []swiftv1alpha1.Filesystem{hostPathFS("data", nil)}
 	})
-	errContains(t, validateSwiftGuest(g), "gpuProfileRef")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "gpuProfileRef")
 
 	// Rejected with Windows (no virtio-fs guest driver in v1).
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
 		g.Spec.OSType = swiftv1alpha1.OSTypeWindows
 		g.Spec.Filesystems = []swiftv1alpha1.Filesystem{hostPathFS("data", nil)}
 	})
-	errContains(t, validateSwiftGuest(g), "windows")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "windows")
 }
 
 func TestValidate_VhostUserInterfaces(t *testing.T) {
@@ -211,7 +216,7 @@ func TestValidate_VhostUserInterfaces(t *testing.T) {
 			{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser, Socket: "/var/run/vhost/fast0.sock"},
 		}
 	})
-	if err := validateSwiftGuest(g); err != nil {
+	if err := validateSwiftGuest(g, testAllowAllHostPaths); err != nil {
 		t.Fatalf("valid vhost-user rejected: %v", err)
 	}
 
@@ -221,7 +226,7 @@ func TestValidate_VhostUserInterfaces(t *testing.T) {
 			{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser},
 		}
 	})
-	errContains(t, validateSwiftGuest(g), "requires a socket")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "requires a socket")
 
 	// networkRef not allowed.
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -230,7 +235,7 @@ func TestValidate_VhostUserInterfaces(t *testing.T) {
 				Socket: "/s.sock", NetworkRef: &swiftv1alpha1.NetworkReference{Name: "nad"}},
 		}
 	})
-	errContains(t, validateSwiftGuest(g), "networkRef")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "networkRef")
 
 	// resourceName not allowed.
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -239,7 +244,7 @@ func TestValidate_VhostUserInterfaces(t *testing.T) {
 				Socket: "/s.sock", ResourceName: "intel.com/sriov"},
 		}
 	})
-	errContains(t, validateSwiftGuest(g), "resourceName")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "resourceName")
 
 	// Rejected with gpuProfileRef (CH-only in v1).
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -248,7 +253,7 @@ func TestValidate_VhostUserInterfaces(t *testing.T) {
 			{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser, Socket: "/s.sock"},
 		}
 	})
-	errContains(t, validateSwiftGuest(g), "gpuProfileRef")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "gpuProfileRef")
 }
 
 func TestValidate_VhostUserDevices(t *testing.T) {
@@ -259,7 +264,7 @@ func TestValidate_VhostUserDevices(t *testing.T) {
 			{Name: "gen0", Type: swiftv1alpha1.VhostUserDeviceTypeGeneric, Socket: "/run/x/g", VirtioID: "block"},
 		}
 	})
-	if err := validateSwiftGuest(g); err != nil {
+	if err := validateSwiftGuest(g, testAllowAllHostPaths); err != nil {
 		t.Fatalf("valid vhost-user devices rejected: %v", err)
 	}
 
@@ -269,7 +274,7 @@ func TestValidate_VhostUserDevices(t *testing.T) {
 			{Name: "d", Type: swiftv1alpha1.VhostUserDeviceTypeBlk},
 		}
 	})
-	errContains(t, validateSwiftGuest(g), "socket is required")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "socket is required")
 
 	// Generic without virtioId.
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -277,7 +282,7 @@ func TestValidate_VhostUserDevices(t *testing.T) {
 			{Name: "d", Type: swiftv1alpha1.VhostUserDeviceTypeGeneric, Socket: "/s"},
 		}
 	})
-	errContains(t, validateSwiftGuest(g), "virtioId")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "virtioId")
 
 	// Bad type.
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -285,7 +290,7 @@ func TestValidate_VhostUserDevices(t *testing.T) {
 			{Name: "d", Type: "weird", Socket: "/s"},
 		}
 	})
-	errContains(t, validateSwiftGuest(g), "must be blk or generic")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "must be blk or generic")
 
 	// Duplicate name.
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -294,7 +299,7 @@ func TestValidate_VhostUserDevices(t *testing.T) {
 			{Name: "d", Type: swiftv1alpha1.VhostUserDeviceTypeBlk, Socket: "/b"},
 		}
 	})
-	errContains(t, validateSwiftGuest(g), "duplicated")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "duplicated")
 
 	// Rejected with gpuProfileRef.
 	g = guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -303,7 +308,7 @@ func TestValidate_VhostUserDevices(t *testing.T) {
 			{Name: "d", Type: swiftv1alpha1.VhostUserDeviceTypeBlk, Socket: "/s"},
 		}
 	})
-	errContains(t, validateSwiftGuest(g), "gpuProfileRef")
+	errContains(t, validateSwiftGuest(g, testAllowAllHostPaths), "gpuProfileRef")
 }
 
 func TestValidate_DataDisks(t *testing.T) {
@@ -315,7 +320,7 @@ func TestValidate_DataDisks(t *testing.T) {
 	if err := validateSwiftGuest(gi(swiftv1alpha1.DataDiskRef{
 		Name:  "db",
 		Blank: &swiftv1alpha1.BlankDiskSpec{Size: resource.MustParse("100Gi")},
-	})); err != nil {
+	}), testAllowAllHostPaths); err != nil {
 		t.Errorf("blank Block disk should be valid: %v", err)
 	}
 
@@ -323,7 +328,7 @@ func TestValidate_DataDisks(t *testing.T) {
 	if err := validateSwiftGuest(gi(swiftv1alpha1.DataDiskRef{
 		Name:  "fs",
 		Blank: &swiftv1alpha1.BlankDiskSpec{Size: resource.MustParse("10Gi"), VolumeMode: corev1.PersistentVolumeFilesystem},
-	})); err != nil {
+	}), testAllowAllHostPaths); err != nil {
 		t.Errorf("blank Filesystem disk should be valid: %v", err)
 	}
 
@@ -332,12 +337,12 @@ func TestValidate_DataDisks(t *testing.T) {
 		swiftv1alpha1.DataDiskRef{Name: "img", ImageRef: &corev1.LocalObjectReference{Name: "i"}},
 		swiftv1alpha1.DataDiskRef{Name: "vmpvc", PVCRef: &corev1.LocalObjectReference{Name: "p"}, AttachAsDisk: true},
 		swiftv1alpha1.DataDiskRef{Name: "fspvc", PVCRef: &corev1.LocalObjectReference{Name: "q"}},
-	)); err != nil {
+	), testAllowAllHostPaths); err != nil {
 		t.Errorf("mixed image/pvc disks should be valid: %v", err)
 	}
 
 	// Invalid: no source kind.
-	errContains(t, validateSwiftGuest(gi(swiftv1alpha1.DataDiskRef{Name: "empty"})),
+	errContains(t, validateSwiftGuest(gi(swiftv1alpha1.DataDiskRef{Name: "empty"}), testAllowAllHostPaths),
 		"exactly one of imageRef, pvcRef, or blank")
 
 	// Invalid: two source kinds.
@@ -345,26 +350,26 @@ func TestValidate_DataDisks(t *testing.T) {
 		Name:     "two",
 		ImageRef: &corev1.LocalObjectReference{Name: "i"},
 		Blank:    &swiftv1alpha1.BlankDiskSpec{Size: resource.MustParse("1Gi")},
-	})), "exactly one of imageRef, pvcRef, or blank")
+	}), testAllowAllHostPaths), "exactly one of imageRef, pvcRef, or blank")
 
 	// Invalid: blank size 0.
 	errContains(t, validateSwiftGuest(gi(swiftv1alpha1.DataDiskRef{
 		Name:  "zero",
 		Blank: &swiftv1alpha1.BlankDiskSpec{Size: resource.MustParse("0")},
-	})), "blank.size must be greater than 0")
+	}), testAllowAllHostPaths), "blank.size must be greater than 0")
 
 	// Invalid: attachAsDisk without pvcRef.
 	errContains(t, validateSwiftGuest(gi(swiftv1alpha1.DataDiskRef{
 		Name:         "bad",
 		Blank:        &swiftv1alpha1.BlankDiskSpec{Size: resource.MustParse("1Gi")},
 		AttachAsDisk: true,
-	})), "attachAsDisk is only valid with pvcRef")
+	}), testAllowAllHostPaths), "attachAsDisk is only valid with pvcRef")
 
 	// Invalid: duplicate names.
 	errContains(t, validateSwiftGuest(gi(
 		swiftv1alpha1.DataDiskRef{Name: "dup", Blank: &swiftv1alpha1.BlankDiskSpec{Size: resource.MustParse("1Gi")}},
 		swiftv1alpha1.DataDiskRef{Name: "dup", Blank: &swiftv1alpha1.BlankDiskSpec{Size: resource.MustParse("2Gi")}},
-	)), "duplicated")
+	), testAllowAllHostPaths), "duplicated")
 
 	// Invalid: a plural entry named "data" collides with the singular shorthand.
 	errContains(t, validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -372,14 +377,14 @@ func TestValidate_DataDisks(t *testing.T) {
 		g.Spec.DataDiskRefs = []swiftv1alpha1.DataDiskRef{
 			{Name: "data", Blank: &swiftv1alpha1.BlankDiskSpec{Size: resource.MustParse("1Gi")}},
 		}
-	})), "collides with the implicit name of spec.dataDiskRef")
+	}), testAllowAllHostPaths), "collides with the implicit name of spec.dataDiskRef")
 
 	// Invalid: more than 8 data disks.
 	many := make([]swiftv1alpha1.DataDiskRef, 9)
 	for i := range many {
 		many[i] = swiftv1alpha1.DataDiskRef{Name: "d" + strconv.Itoa(i), Blank: &swiftv1alpha1.BlankDiskSpec{Size: resource.MustParse("1Gi")}}
 	}
-	errContains(t, validateSwiftGuest(gi(many...)), "at most 8 data disks")
+	errContains(t, validateSwiftGuest(gi(many...), testAllowAllHostPaths), "at most 8 data disks")
 
 	// Valid: data disks compose with GPU (no usesGPU rejection).
 	if err := validateSwiftGuest(guest(func(g *swiftv1alpha1.SwiftGuest) {
@@ -387,7 +392,38 @@ func TestValidate_DataDisks(t *testing.T) {
 		g.Spec.DataDiskRefs = []swiftv1alpha1.DataDiskRef{
 			{Name: "db", Blank: &swiftv1alpha1.BlankDiskSpec{Size: resource.MustParse("50Gi")}},
 		}
-	})); err != nil {
+	}), testAllowAllHostPaths); err != nil {
 		t.Errorf("data disk + GPU should be valid: %v", err)
+	}
+}
+
+// TestValidateFilesystems_HostPathConfinement pins the reported Critical: a
+// namespaced tenant could set spec.filesystems[].source.hostPath to "/" and get
+// the node root mounted read-write into their own VM, because the launcher is
+// privileged and virtiofsd is handed the directory verbatim.
+func TestValidateFilesystems_HostPathConfinement(t *testing.T) {
+	withFS := func(hp string) *swiftv1alpha1.SwiftGuest {
+		return guest(func(g *swiftv1alpha1.SwiftGuest) {
+			g.Spec.Filesystems = []swiftv1alpha1.Filesystem{{
+				Name:   "share",
+				Source: swiftv1alpha1.FilesystemSource{HostPath: &hp},
+			}}
+		})
+	}
+	allowed := []string{"/srv/vm"}
+
+	// The exploit, and the traversal that defeats a naive prefix check.
+	for _, bad := range []string{"/", "/etc/kubernetes/pki", "/srv/vm/../../etc", "/srv/vmsecrets"} {
+		if err := validateSwiftGuest(withFS(bad), allowed); err == nil {
+			t.Errorf("accepted hostPath %q", bad)
+		}
+	}
+	// The legitimate case still works.
+	if err := validateSwiftGuest(withFS("/srv/vm/share1"), allowed); err != nil {
+		t.Errorf("rejected an allowed hostPath: %v", err)
+	}
+	// Default posture: no allowlist configured -> nothing is mountable.
+	if err := validateSwiftGuest(withFS("/srv/vm/share1"), nil); err == nil {
+		t.Error("empty allowlist should deny every hostPath")
 	}
 }


### PR DESCRIPTION
Fourth batch from the security review. **Critical** — the tenant→node-root primitive.

## The bug
`spec.filesystems[].source.hostPath` was validated only as **non-empty**, then turned into a `DirectoryOrCreate` hostPath volume mounted into the launcher — which is privileged — and handed to `virtiofsd --shared-dir`. `ReadOnly` defaults to **false**. So a namespaced tenant who can create a SwiftGuest sets:

```yaml
filesystems:
  - {name: x, source: {hostPath: /}}   # readOnly omitted -> RW
```

and gets the node root read-write inside a VM they control. The vhost-user `socket` fields are the same primitive by another route: the pod builder mounts `filepath.Dir(socket)`, so `/etc/kubernetes/pki/x.sock` mounts the PKI directory.

## The fix
New `internal/webhook/hostpath` applies the rules the **snapshot backend already enforced** and these fields did not:

- **`..` rejected unconditionally**, on the raw input before normalization. A prefix test is a string comparison — without this, `/var/lib/kubeswift/../../etc` passes it.
- Absolute + clean.
- Under an operator-configured prefix, matched by **whole path segments** so `/srv/vm` does not admit `/srv/vmsecrets`.

The allowlist is `--allowed-hostpath-prefix` (repeatable), surfaced as **`swiftGuest.allowedHostPathPrefixes`**. It defaults to **empty = deny all**: these fields are niche, so a cluster opts in rather than every install shipping the escape hatch. Operators who legitimately share host dirs set their own prefixes, and `/` stays expressible for anyone who wants the old behaviour deliberately.

## Verification
Negative control — with the check removed the test **accepts** `/`, `/etc/kubernetes/pki`, the traversal, and the segment-prefix bypass; with it in place all four are rejected and a legitimate path under the prefix still works. `helm template` emits no flags at the default and one per prefix when set; `helm lint` clean. Existing validator tests (62 call sites) pass an explicit allow-all — they predate this and aren't exercising it.

## Still open, deliberately
- **This is webhook-enforced, and `webhook.enabled` is `false` by default.** Same structural gap as the snapshot hostPath guard. Worth a separate decision about defaulting webhooks on.
- **`spec.nodeName`** is still written straight to `pod.Spec.NodeName`, bypassing the scheduler so control-plane taints don't apply. Fixing it properly means a nodeSelector, which changes scheduling behaviour (and interacts with GPU pinning that asserts `NodeName == GPU.NodeName`) — not something to bundle into a validation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)