### PR TITLE
docs: correct the launcher privilege claim to match the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Boot your first VM → [Quickstart](docs/quickstart.md).
 - **OCI registry artifacts** — golden VM images (`SwiftImage.spec.source.oci` + `swiftctl image publish`, cosign-signed with verify-on-pull) and VM snapshots / full-state cold migration (`SwiftSnapshot` `backend.type: oci`) stored in any OCI registry, for cross-cluster and edge distribution.
 - **Migration** — offline migration on any storage, and live migration (sub-second downtime) with optional mTLS transport and `kubectl drain` integration.
 - **Fleets** — `SwiftGuestPool` gives ReplicaSet-style scaling with rolling updates, topology spread, and a PVC per replica.
-- **Operations** — `swiftctl` for console/SSH/lifecycle/describe; Prometheus metrics and Grafana dashboards across every feature; cloud-init via NoCloud; security-hardened containers (drop-ALL, no privileged).
+- **Operations** — `swiftctl` for console/SSH/lifecycle/describe; Prometheus metrics and Grafana dashboards across every feature; cloud-init via NoCloud; hardened supporting containers (gpu-discovery, DRA driver, gateway and UI run non-root / drop-ALL). The VM **launcher** pod is privileged by design — it manages KVM, tap devices and VFIO — so it is a node-level trust boundary; see [`docs/security-audit.md`](docs/security-audit.md).
 
 ## Custom Resources
 

--- a/docs/gpu-passthrough.md
+++ b/docs/gpu-passthrough.md
@@ -101,7 +101,7 @@ Discovery preserves controller-owned fields during status patches by reading the
 
 ### Security
 
-- **No privileged containers**: drops ALL capabilities, readOnlyRootFilesystem
+- **Hardened discovery**: the gpu-discovery DaemonSet drops ALL capabilities and uses readOnlyRootFilesystem (the GPU *launcher* pod is privileged by design — see `docs/security-audit.md`)
 - **/sys and /dev mounted read-only**: sysfs and lspci reads only, no host state modification
 - **hostPID=false, hostNetwork=false**
 - **Separate RBAC**: only `swiftgpunodes` (get/list/create/patch) + `swiftgpunodes/status` (get/patch) + `nodes` (get)

--- a/docs/operator-checklist-ubuntu-x86_64.md
+++ b/docs/operator-checklist-ubuntu-x86_64.md
@@ -311,7 +311,7 @@ See [OVN-Kubernetes Integration](networking/ovn-kubernetes.md#4-tenant-isolation
 
 ### Security contexts
 
-All containers run with minimum capabilities (not privileged):
+Supporting containers run with minimum capabilities. The VM launcher pod is privileged by design (KVM/tap/VFIO) — see `docs/security-audit.md`:
 
 | Container | Capabilities |
 |-----------|-------------|

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -11,9 +11,9 @@
 
 | ID | Severity | Component | Finding |
 |----|----------|-----------|---------|
-| SEC-01 | ~~CRITICAL~~ RESOLVED | launcher container | ~~`privileged: true`~~ Replaced with drop ALL + NET_ADMIN, SYS_ADMIN (non-GPU) / + SYS_RESOURCE, DAC_OVERRIDE (GPU) |
-| SEC-02 | ~~CRITICAL~~ RESOLVED | network-init container | ~~`privileged: true`~~ Replaced with drop ALL + NET_ADMIN, NET_RAW |
-| SEC-03 | ~~HIGH~~ RESOLVED | gpu-init container | ~~`privileged: true`~~ Replaced with drop ALL + SYS_ADMIN; sysfs-pci hostPath volume added |
+| SEC-01 | ACCEPTED (was CRITICAL) | launcher container | `privileged: true`. The capability-based replacement was implemented, then **reverted** — see the note below. |
+| SEC-02 | ACCEPTED (was CRITICAL) | network-init container | `privileged: true`. Same revert as SEC-01. |
+| SEC-03 | ACCEPTED (was HIGH) | gpu-init container | `privileged: true`. Same revert as SEC-01. |
 | SEC-04 | HIGH (mitigated) | /dev/vfio hostPath | Entire `/dev/vfio` directory mounted — documented why scoping is impractical (VFIO group files created during bind) |
 | SEC-05 | ~~HIGH~~ RESOLVED | PCI address injection | BDF format validation added to gpu-init.sh (regex: `^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$`) |
 | SEC-06 | ~~HIGH~~ RESOLVED | Fabric Manager partition isolation | Partition ownership validated against SwiftGPUNode allocatedTo before pod creation |
@@ -28,6 +28,31 @@
 | SEC-15 | LOW | Kernel pull job runs as root | Pull job uses `runAsUser: 0` for hostPath write; could be scoped tighter |
 | SEC-16 | LOW | VFIO bind interrupted state | gpu-init.sh unbind/rebind is not atomic; crash leaves device driverless |
 | SEC-17 | LOW | Guest-to-pod network reachability | Bridge subnet is hardcoded; no network policy enforcement on guest traffic |
+
+> **Correction (2026-07-25).** SEC-01/02/03 were marked RESOLVED in the April
+> audit because the capability-based security contexts had just landed. That
+> approach was subsequently **reverted**: dropping to explicit capabilities
+> produced a cascade of runtime failures during QEMU boot validation
+> (`/dev/net/tun` unavailable, `/proc/sys/net/ipv4/ip_forward` unwritable,
+> sysctl allowlist), each needing a rebuild + redeploy + cluster config change.
+>
+> The decision taken was that a VM platform managing KVM, VFIO, tap devices and
+> iptables inherently needs deep host access, and that capability
+> micromanagement added complexity without proportionate benefit. So
+> `internal/controller/swiftguest/security.go` returns `privileged: true` for
+> the launcher, network-init, gpu-init and clone-grow-init containers, and that
+> is deliberate.
+>
+> **The launcher pod is therefore a node-level trust boundary, not a
+> container-level one.** Anything a SwiftGuest can make the launcher do — mount
+> a host path, open a socket, reach a device — is node-root. That is why host
+> paths are confined to an operator allowlist
+> (`swiftGuest.allowedHostPathPrefixes`) rather than accepted verbatim.
+>
+> Components that genuinely do not need host access are still hardened and
+> should stay that way: gpu-discovery and the DRA driver run `privileged:
+> false` + drop-ALL + read-only rootfs, and the gateway and UI run non-root.
+
 | SEC-18 | LOW | No seccomp profile | No containers specify a seccomp profile |
 | SEC-19 | LOW | OVMF_VARS template world-readable | Writable UEFI variable store copied without restrictive permissions |
 

--- a/internal/controller/swiftguest/security.go
+++ b/internal/controller/swiftguest/security.go
@@ -135,7 +135,26 @@ func gpuInitSecurityContext() *corev1.SecurityContext {
 }
 
 // launcherSecurityContext returns the security context for the launcher
-// (swiftletd) container.
+// (swiftletd) container: privileged, GPU or not.
+//
+// This is deliberate, not an oversight. A capability-scoped launcher was
+// implemented and then reverted — dropping to explicit capabilities broke QEMU
+// boot in a cascade (/dev/net/tun unavailable, /proc/sys/net/ipv4/ip_forward
+// unwritable, sysctl allowlist), each round needing a rebuild + redeploy. A VMM
+// that manages KVM, VFIO, tap devices and iptables needs deep host access;
+// capability micromanagement added complexity without proportionate benefit.
+// See docs/security-audit.md (SEC-01/02/03) for the record.
+//
+// The consequence is that the launcher pod is a NODE-level trust boundary, not
+// a container-level one: anything a SwiftGuest can make the launcher do is
+// node-root. That is why host paths reaching this pod are confined to an
+// operator allowlist in the webhook (internal/webhook/hostpath) instead of
+// being taken verbatim from the CR.
+//
+// hasGPU is retained because the callers are GPU-aware and a future split
+// (e.g. only the GPU path needing VFIO privileges) would key on it; today both
+// paths are identical.
 func launcherSecurityContext(hasGPU bool) *corev1.SecurityContext {
+	_ = hasGPU // both paths are privileged today; see the comment above
 	return privilegedContext()
 }


### PR DESCRIPTION
From the security review. Two independent reviewers flagged that **the documented threat model does not describe the system**.

## What the docs said vs what ships
- `README.md` — "security-hardened containers (drop-ALL, no privileged)"
- `docs/security-audit.md` — SEC-01/02/03 marked **RESOLVED**, "replaced with drop ALL + NET_ADMIN…"
- `docs/gpu-passthrough.md`, `docs/operator-checklist-*` — repeated the claim

`internal/controller/swiftguest/security.go:139`:
```go
func launcherSecurityContext(hasGPU bool) *corev1.SecurityContext {
	return privilegedContext()   // hasGPU ignored; Privileged: true, nothing else
}
```
Every launcher plus network-init, gpu-init and clone-grow-init is privileged.

## Why the code is right
The April audit wasn't wrong when written — the capability contexts had just landed. They were then **reverted**, because dropping to explicit capabilities broke QEMU boot in a cascade (`/dev/net/tun` unavailable, `ip_forward` unwritable, sysctl allowlist), each round costing a rebuild + redeploy. A VMM managing KVM, VFIO, tap devices and iptables needs deep host access. **That decision stands; only the docs were left behind.**

So: privileged stays, the description gets fixed.

## What changed
- Audit rows: RESOLVED → **ACCEPTED**, with the revert and its rationale recorded.
- A note states the consequence plainly: **the launcher pod is a NODE-level trust boundary, not a container-level one** — anything a CR can make it mount or open is node-root. That is the reasoning behind the host-path allowlist in #437.
- `launcherSecurityContext` keeps `hasGPU` (callers are GPU-aware, a future split would key on it) but now says both paths are identical today rather than implying a differentiation that doesn't exist.
- Components that genuinely **are** hardened — gpu-discovery, DRA driver, gateway, UI — are called out, so this isn't read as permission to relax them.

Local `CLAUDE.md` / `kubeswift_context.md` (untracked) corrected in the working tree too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)