### PR TITLE
fix(security): drop escalate/bind from manage-rbac; refuse an insecure gateway behind an ingress

### DIFF
--- a/charts/kubeswift/templates/gateway/deployment.yaml
+++ b/charts/kubeswift/templates/gateway/deployment.yaml
@@ -34,6 +34,22 @@ spec:
           args:
             - --listen=:{{ .Values.gateway.port }}
             - --clusters-namespace={{ .Values.namespace }}
+            {{- /*
+              auth-mode=insecure performs NO authentication: insecureAuthenticator
+              returns an empty identity with no error, so every caller runs as the
+              member cluster credential -- the whole Connect surface plus the
+              console/exec WebSocket planes, unauthenticated. That is a documented
+              dev/lab mode, but combined with an Ingress it puts an unauthenticated
+              control plane on the network, and CheckOrigin is permissive on the
+              WebSocket upgrades so any web page can drive it.
+
+              Refuse the combination rather than rely on the operator reading a
+              comment. gateway.allowInsecureIngress is the explicit override for
+              anyone who genuinely wants it (an isolated lab behind other controls).
+            */ -}}
+            {{- if and (eq .Values.gateway.authMode "insecure") .Values.gateway.ingress.enabled (not .Values.gateway.allowInsecureIngress) }}
+              {{- fail "gateway.authMode=insecure with gateway.ingress.enabled exposes an UNAUTHENTICATED control plane (VM console, sandbox exec, RBAC editor). Set gateway.authMode=oidc (or token), or set gateway.allowInsecureIngress=true to accept the risk deliberately." }}
+            {{- end }}
             - --auth-mode={{ .Values.gateway.authMode }}
             - --cors-allow-origin={{ .Values.gateway.corsAllowOrigin }}
             - --prometheus-discovery-namespaces={{ join "," .Values.gateway.prometheusDiscovery.namespaces }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -179,6 +179,11 @@ gateway:
   #              per-user impersonation. DEV/LAB ONLY: every UI user inherits
   #              whatever the member credentials grant. Do not use in production.
   authMode: insecure
+  # Escape hatch for authMode=insecure + ingress.enabled, which the chart
+  # otherwise refuses: that combination puts an UNAUTHENTICATED control plane
+  # (VM console, sandbox exec, RBAC editor) on the network. Only set this if the
+  # gateway is isolated by other means.
+  allowInsecureIngress: false
   # OIDC settings (used only when authMode=oidc). The gateway verifies the
   # browser-supplied ID token against issuerURL's JWKS and impersonates the
   # claim-derived user+groups onto each member. issuerURL must resolve to ONE URL

--- a/internal/gateway/access_capabilities.go
+++ b/internal/gateway/access_capabilities.go
@@ -90,9 +90,21 @@ var capabilities = []capability{
 	},
 	{
 		key: "manage-rbac", displayName: "Manage access (RBAC)",
-		description: "Create roles and assign them to users (manage Kubernetes RBAC).",
+		description: "Create roles and assign them to users (manage Kubernetes RBAC). " +
+			"Cannot grant permissions the assigner does not already hold.",
+		// NO "escalate" and NO "bind".
+		//
+		// escalate is precisely the verb that disables Kubernetes' privilege-
+		// escalation prevention: with it, a holder can author a ClusterRole
+		// granting * / * and bind it to themselves, so "manage-rbac" silently
+		// became cluster-admin -- and the capability description shown to the
+		// operator granting it said nothing of the sort.
+		//
+		// Without escalate, the apiserver applies its normal rule: you may only
+		// grant permissions you already hold. That is the correct semantics for
+		// a delegated access editor, and it is what the description now claims.
 		rules: []rbacv1.PolicyRule{
-			rule([]string{"rbac.authorization.k8s.io"}, []string{"roles", "rolebindings", "clusterroles", "clusterrolebindings"}, []string{"get", "list", "watch", "create", "update", "patch", "delete", "bind", "escalate"}),
+			rule([]string{"rbac.authorization.k8s.io"}, []string{"roles", "rolebindings", "clusterroles", "clusterrolebindings"}, []string{"get", "list", "watch", "create", "update", "patch", "delete"}),
 		},
 	},
 }


### PR DESCRIPTION
Sixth batch.

### 1. `manage-rbac` granted `escalate` — High
`escalate` is the verb that **disables Kubernetes' privilege-escalation prevention**. A holder could author a ClusterRole granting `*/*/*` and bind it to themselves — so the UI's **"Admin" role was silently cluster-admin**, while the capability description shown to whoever granted it said only *"Create roles and assign them to users"*. The graduated viewer/operator/admin ladder was an illusion.

Both `escalate` and `bind` are removed. Without them the apiserver applies its normal rule — you may only grant permissions you already hold — which is the correct semantics for a delegated access editor, and is what the description now states.

### 2. `authMode: insecure` + an Ingress — High
`insecureAuthenticator.Authenticate` returns an empty identity **with no error**, so every caller runs as the member credential across the whole Connect surface plus the console and sandbox-exec WebSocket planes. It's documented dev/lab, but it's also the **chart default**, and with `gateway.ingress.enabled` that's an unauthenticated control plane on the network — with permissive `CheckOrigin`, so any web page can drive it.

The chart now **refuses that specific combination** with an explanatory `fail()` instead of trusting the operator to read a comment. `gateway.allowInsecureIngress=true` is the deliberate override for an isolated lab.

Verified the guard fires **only** on insecure+ingress — gateway without ingress, oidc with ingress, the explicit override, and the chart default all still render; `helm lint` clean.

### What I deliberately did NOT change
**The `authMode: insecure` default itself.** Flipping it to `oidc` makes every install fail until an IdP is configured — a UX decision bigger than a security fix should make unilaterally. The guard closes the dangerous combination; the default is yours to call.

**`webhook.enabled: false` default.** `webhook.enabled=true` **requires cert-manager**, so flipping it would break installs that don't have it. The better answer is enforcing the host-path rule in the controller too, so it holds regardless of the webhook — tracked, not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)