### PR TITLE
fix(security): secure-by-default gateway auth + enforce host paths in the controller too

### DIFF
--- a/charts/kubeswift/templates/gateway/deployment.yaml
+++ b/charts/kubeswift/templates/gateway/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --cors-allow-origin={{ .Values.gateway.corsAllowOrigin }}
             - --prometheus-discovery-namespaces={{ join "," .Values.gateway.prometheusDiscovery.namespaces }}
             {{- if eq .Values.gateway.authMode "oidc" }}
-            - --oidc-issuer-url={{ required "gateway.oidc.issuerURL is required when gateway.authMode=oidc" .Values.gateway.oidc.issuerURL }}
+            - --oidc-issuer-url={{ required "gateway.oidc.issuerURL is required when gateway.authMode=oidc (the default). Configure your IdP -- see docs/ui/auth.md -- or set gateway.authMode=insecure for an isolated lab." .Values.gateway.oidc.issuerURL }}
             - --oidc-client-id={{ required "gateway.oidc.clientID is required when gateway.authMode=oidc" .Values.gateway.oidc.clientID }}
             - --oidc-username-claim={{ .Values.gateway.oidc.usernameClaim }}
             - --oidc-groups-claim={{ .Values.gateway.oidc.groupsClaim }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -178,7 +178,16 @@ gateway:
   #   insecure - member queries run as the gateway's own credential, with NO
   #              per-user impersonation. DEV/LAB ONLY: every UI user inherits
   #              whatever the member credentials grant. Do not use in production.
-  authMode: insecure
+  # SECURE BY DEFAULT: oidc. authMode=insecure performs NO authentication at all
+  # -- every caller runs as the member cluster credential across the whole API
+  # plus the console and sandbox-exec planes -- so it is opt-in, never inherited.
+  # The gateway is not deployed unless gateway.enabled=true (or role=hub), so
+  # this only asks operators who are deliberately standing up the browser-facing
+  # control plane to pick an auth mode.
+  #   oidc      verify the IdP token, impersonate the user (see docs/ui/auth.md)
+  #   token     Kubernetes TokenReview
+  #   insecure  DEV/LAB ONLY -- no authentication
+  authMode: oidc
   # Escape hatch for authMode=insecure + ingress.enabled, which the chart
   # otherwise refuses: that combination puts an UNAUTHENTICATED control plane
   # (VM console, sandbox exec, RBAC editor) on the network. Only set this if the

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -190,7 +190,8 @@ func main() {
 		SystemNamespace:      leaderElectionNS,
 		SnapshotS3Image:      swiftsnapshot.SnapshotS3Image(),
 		SnapshotORASImage:    swiftsnapshot.SnapshotORASImage(),
-	}).SetupWithManager(mgr); err != nil {
+
+		AllowedHostPathPrefixes: allowedHostPaths}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftGuest controller")
 		os.Exit(1)
 	}

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -68,6 +68,10 @@ type SwiftGuestReconciler struct {
 	// source pod. When false (default) the launcher pod is byte-for-byte
 	// unchanged from Phase 3a/3b.
 	MigrationMTLSEnabled bool
+	// AllowedHostPathPrefixes mirrors the webhook's host-path allowlist. The
+	// webhook is the primary gate but is disabled by default (it needs
+	// cert-manager), so the controller enforces it too -- see hostpathguard.go.
+	AllowedHostPathPrefixes []string
 
 	// SystemNamespace is the controller-manager's own namespace, where the
 	// migration CA Issuer, the per-node identity Secrets, and the

--- a/internal/controller/swiftguest/gpu.go
+++ b/internal/controller/swiftguest/gpu.go
@@ -300,6 +300,12 @@ func (r *SwiftGuestReconciler) buildPod(
 	if err != nil {
 		return nil, err
 	}
+	// Re-apply the host-path allowlist here, not only in the webhook: the
+	// webhook is off by default, and the launcher is privileged. See
+	// hostpathguard.go.
+	if err := checkHostPaths(guest, r.AllowedHostPathPrefixes); err != nil {
+		return nil, err
+	}
 	// spec.NodeName binds the pod directly, skipping the scheduler -- so the
 	// taint predicate never runs. Reproduce it here; see nodeplacement.go.
 	if err := checkNodePlacement(ctx, r.Client, guest, pod); err != nil {

--- a/internal/controller/swiftguest/hostpathguard.go
+++ b/internal/controller/swiftguest/hostpathguard.go
@@ -1,0 +1,54 @@
+package swiftguest
+
+import (
+	"fmt"
+
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/webhook/hostpath"
+)
+
+// checkHostPaths re-applies the host-path allowlist in the CONTROLLER, not only
+// in the validating webhook.
+//
+// The webhook is the primary gate, but `webhook.enabled` defaults to false
+// (it requires cert-manager), so on a default install nothing would enforce
+// this at all. The same structural gap already bit the snapshot backend, whose
+// hostPath prefix rule also lives only in its webhook — a comment there even
+// says "the webhook ensures", which is not a control.
+//
+// Since the launcher is privileged, an unconfined host path is node-root. A
+// guard that only runs in an optional component is not a guard, so it is
+// enforced here too: the controller refuses to build the pod, which surfaces
+// as a Resolved=False condition rather than a silently over-privileged VM.
+func checkHostPaths(guest *swiftv1alpha1.SwiftGuest, allowed []string) error {
+	spec := &guest.Spec
+	for i := range spec.Filesystems {
+		fs := &spec.Filesystems[i]
+		if fs.Source.HostPath == nil {
+			continue
+		}
+		if err := hostpath.Validate(
+			fmt.Sprintf("spec.filesystems[%d].source.hostPath", i),
+			*fs.Source.HostPath, allowed); err != nil {
+			return err
+		}
+	}
+	// vhost-user sockets: the pod builder mounts filepath.Dir(socket).
+	for i := range spec.Interfaces {
+		if sock := spec.Interfaces[i].Socket; sock != "" {
+			if err := hostpath.ValidateDir(
+				fmt.Sprintf("spec.interfaces[%d].socket", i), sock, allowed); err != nil {
+				return err
+			}
+		}
+	}
+	for i := range spec.VhostUserDevices {
+		if sock := spec.VhostUserDevices[i].Socket; sock != "" {
+			if err := hostpath.ValidateDir(
+				fmt.Sprintf("spec.vhostUserDevices[%d].socket", i), sock, allowed); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/controller/swiftguest/hostpathguard_test.go
+++ b/internal/controller/swiftguest/hostpathguard_test.go
@@ -1,0 +1,31 @@
+package swiftguest
+
+import (
+	"testing"
+
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+)
+
+// The webhook is the primary gate but defaults to disabled (it needs
+// cert-manager), so the controller must refuse an unconfined host path too --
+// otherwise a default install has no enforcement at all.
+func TestCheckHostPaths_EnforcedWithoutTheWebhook(t *testing.T) {
+	hp := "/"
+	g := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{
+		Filesystems: []swiftv1alpha1.Filesystem{{
+			Name: "share", Source: swiftv1alpha1.FilesystemSource{HostPath: &hp},
+		}},
+	}}
+	if err := checkHostPaths(g, []string{"/srv/vm"}); err == nil {
+		t.Fatal("controller accepted hostPath / — the webhook is not the only gate")
+	}
+	ok := "/srv/vm/share"
+	g.Spec.Filesystems[0].Source.HostPath = &ok
+	if err := checkHostPaths(g, []string{"/srv/vm"}); err != nil {
+		t.Errorf("rejected an allowed path: %v", err)
+	}
+	// Empty allowlist denies, matching the webhook's posture.
+	if err := checkHostPaths(g, nil); err == nil {
+		t.Error("empty allowlist should deny")
+	}
+}


### PR DESCRIPTION
Closes the two items I deliberately left open in #440.

### 1. `gateway.authMode` default: `insecure` → `oidc`
#440 refused the worst combination (insecure behind an ingress), but insecure was still what you got by omission — and it's reachable from inside the cluster network regardless of an ingress.

**Safe to flip:** `gateway.enabled` is `false` by default, so a bare install is unaffected. This only asks operators deliberately standing up the browser-facing control plane to pick an auth mode. Verified against the fleet before changing it — dev sets `authMode: oidc` explicitly, sov and ntx run no gateway at all, so no cluster breaks on upgrade.

The resulting error names the fix on both sides: configure the IdP (with a docs link), or set `authMode=insecure` deliberately for an isolated lab.

### 2. Host-path allowlist now enforced in the controller, not only the webhook
`webhook.enabled` defaults to **false** (it requires cert-manager), so on a default install **nothing enforced #437's allowlist**. Flipping that default would break every install without cert-manager — so the controller re-applies the same check before building the pod.

This is the same structural gap the snapshot backend already has: its prefix rule also lives only in its webhook, and `local.go` literally comments *"the webhook ensures"*. A comment is not a control, and since the launcher is privileged, a guard that only runs in an optional component is not a guard.

The allowlist reaches the controller from the **same** `--allowed-hostpath-prefix` flag the webhook uses — one source of truth, no way for the two to disagree.

### Verification
`helm template` across all four auth paths + `helm lint`; controller-side test asserts `hostPath: /` is refused with the webhook out of the picture, and that an allowed path still works. Full `go build`/`test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)