### PR TITLE
release: v0.13.3 — security review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,80 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.13.3] — 2026-07-26
+
+Security release. A five-domain review (gateway auth, RBAC/chart/containers, UI,
+VM runtime, supply chain) produced eight fixes. Every one carries a regression
+test that was verified to fail without its source change.
+
+### Action required on upgrade
+
+- **`gateway.authMode` now defaults to `oidc`** (was `insecure`, which performs no
+  authentication at all). The gateway is not deployed unless `gateway.enabled=true`
+  or `federation.role=hub`, so a bare install is unaffected — but if you enable the
+  gateway you must now configure an IdP, or set `gateway.authMode=insecure`
+  deliberately. The chart also refuses `authMode=insecure` together with
+  `gateway.ingress.enabled`; override with `gateway.allowInsecureIngress=true`.
+- **SwiftGuest host paths are confined to an allowlist that is empty by default.**
+  `spec.filesystems[].source.hostPath` and vhost-user socket directories are
+  rejected until an operator opts in with `swiftGuest.allowedHostPathPrefixes`.
+  `pvcRef` shares are unaffected. See `docs/virtiofs.md`.
+- **`spec.interfaces[].mac` must be a canonical MAC.** Previously unvalidated.
+- **The `manage-rbac` capability no longer grants `escalate`/`bind`**, so the UI's
+  Admin role can no longer grant permissions its holder does not already have.
+
+### Fixed
+
+- **Gateway `ListClusters`/`WatchClusters` were unauthenticated** — both returned
+  every member cluster's apiserver URL, version and condition messages to any
+  caller that could reach the port, and `WatchClusters` streamed it live. (#434)
+- **Secret redaction was bypassed by the kubectl annotation.** Only `data` and
+  `stringData` were stripped, so a Secret created with `kubectl apply` still
+  carried its plaintext `stringData` in
+  `kubectl.kubernetes.io/last-applied-configuration`. (#434)
+- **OIDC claims could assert `system:masters`.** Claim values were copied verbatim
+  into the impersonation headers with no reserved-prefix guard. (#434)
+- **Command injection in the image-import and kernel-pull Jobs.** `fmt.Sprintf("%q")`
+  is a Go quoter, not a shell quoter — it leaves `$` and backticks intact — and the
+  result was placed inside shell double quotes. A SwiftImage URL or SwiftKernel OCI
+  reference containing `$(...)` executed as root in a privileged container. Values
+  now ride as environment variables. (#435)
+- **The Cloud Hypervisor binary was downloaded without integrity verification**,
+  while the firmware beside it was already checksum-pinned. Both architectures are
+  now pinned. (#436)
+- **Verify-before-boot had a TOCTOU in `sandbox-materialize`** — it verified one
+  digest and then re-resolved the tag, so a tag swap between the two defeated
+  `verifyKeySecretRef`. It now materializes the digest it verified. (#436)
+- **Unconfined SwiftGuest host paths.** `hostPath: /` mounted the node root
+  read-write into a tenant's VM. (#437)
+- **`spec.interfaces[].mac` reached a sourced shell file**, so a MAC containing a
+  command substitution executed in the privileged launcher. (#439)
+- **`spec.nodeName` bypassed the scheduler's taint check.** Direct pod binding is
+  deliberate (live migration depends on it), so the taint predicate is now
+  reproduced in the controller instead of changing the binding. (#439)
+- oras-go bumped for GO-2026-5880; both CI workflows declare least-privilege
+  `permissions`. (#436)
+
+### Changed
+
+- The host-path allowlist is enforced in the controller as well as the validating
+  webhook, so it holds on installs running with `webhook.enabled=false`. (#441)
+- `docs/security-audit.md` SEC-01/02/03 move from RESOLVED to **ACCEPTED**: the
+  capability-scoped launcher was implemented and then reverted because it broke
+  QEMU boot, so every launcher is privileged by design. README and the GPU and
+  operator docs said otherwise and are corrected. The consequence is recorded
+  plainly — the launcher pod is a node-level trust boundary. (#438)
+
+### Known
+
+- The launcher pod runs as the namespace `default` ServiceAccount, which is bound
+  `pods: get,patch`. Anyone able to create a pod in that namespace inherits it and
+  can patch the privileged launcher's image. A dedicated ServiceAccount is planned
+  but does not by itself close this — Kubernetes does not gate which ServiceAccount
+  a pod may reference. Tracked.
+
+---
+
 ## [v0.13.2] — 2026-07-24
 
 Gateway enablement for permission-aware, general-purpose Kubernetes resource CRUD

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.2 \
+  --version 0.13.3 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.2
-appVersion: "0.13.2"
+version: 0.13.3
+appVersion: "0.13.3"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/config/samples/virtiofs/swiftguest-virtiofs-hostpath.yaml
+++ b/config/samples/virtiofs/swiftguest-virtiofs-hostpath.yaml
@@ -20,6 +20,13 @@ spec:
     - name: scratch          # per-guest id; drives the socket name
       tag: scratch           # guest: mount -t virtiofs scratch /mnt/scratch
       source:
+        # REQUIRES OPT-IN (v0.13.3+): host paths are confined to an operator
+        # allowlist, which is EMPTY by default, so this sample is rejected
+        # until the cluster admin permits the prefix:
+        #   --set swiftGuest.allowedHostPathPrefixes[0]=/srv/kubeswift
+        # The launcher is privileged, so a host path it mounts is node-root
+        # access granted to whoever authored the SwiftGuest. '..' is always
+        # rejected, and prefixes match whole path segments.
         hostPath: /srv/kubeswift/scratch   # created on the node if absent
   # In-guest, after boot:
   #   sudo mkdir -p /mnt/scratch

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.2 \
+  --set controllerManager.image.tag=v0.13.3 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.2
+  --set swiftletd.image.tag=v0.13.3
 ```
 
 ### Release workflow

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.2 -n kubeswift-system --create-namespace \
+  --version 0.13.3 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.2 \
+  --version 0.13.3 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.2 \
+  --version 0.13.3 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.2 \
+  --version 0.13.3 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.2 \
+  --set controllerManager.image.tag=v0.13.3 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.2
+  --set swiftletd.image.tag=v0.13.3
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.2 \
+  --version 0.13.3 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.2 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.2 \
-    --set swiftletd.image.tag=v0.13.2
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.3 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.3 \
+    --set swiftletd.image.tag=v0.13.3
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.2 \
+  --version 0.13.3 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.2 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.3 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows

--- a/docs/virtiofs.md
+++ b/docs/virtiofs.md
@@ -58,6 +58,25 @@ Rules the admission webhook enforces:
 - `source` sets **exactly one** of `hostPath` / `pvcRef`.
 - not combinable with `gpuProfileRef`, nor with `osType: windows`.
 
+## hostPath needs an operator opt-in (v0.13.3+)
+
+`hostPath` shares are confined to an allowlist that is **empty by default**, so a
+guest using one is rejected until a cluster admin permits the prefix:
+
+```bash
+helm upgrade kubeswift ... \
+  --set swiftGuest.allowedHostPathPrefixes[0]=/srv/data
+```
+
+The launcher container is privileged, so a host path it mounts is effectively
+node-root access handed to whoever authored the SwiftGuest — which is why the
+default is deny rather than allow. `..` is always rejected regardless of the
+allowlist, and prefixes match whole path segments (`/srv/data` permits
+`/srv/data/x` but not `/srv/database`). Enforced by both the validating webhook
+and the controller, so it holds even with `webhook.enabled=false`.
+
+`pvcRef` shares are unaffected — they carry no host path.
+
 `readOnly: true` is enforced at the launcher pod's volumeMount (and the PVC
 volume), so the guest physically cannot mutate the backing content.
 


### PR DESCRIPTION
Release prep for **v0.13.3**, a security release carrying the eight fixes from the five-domain review (#434–#441).

Chart `version`+`appVersion` → 0.13.3, CHANGELOG entry, version sweep across README/quickstart/deploy/install/operator docs.

### The CHANGELOG leads with action-required, because three fixes change behaviour
- `gateway.authMode` now defaults to **`oidc`** (was `insecure`). Bare installs unaffected — the gateway isn't deployed unless enabled.
- SwiftGuest **host paths need an operator opt-in** (`swiftGuest.allowedHostPathPrefixes`, empty by default).
- `spec.interfaces[].mac` must be a **canonical MAC**.
- `manage-rbac` no longer grants `escalate`/`bind`.

### Artefacts that needed more than a version bump
The **virtiofs hostPath sample** is rejected under the empty default allowlist, so it now carries the helm flag that permits it, and **`docs/virtiofs.md`** gains a section explaining why the default is deny (the launcher is privileged, so a host path it mounts is node-root granted to whoever authored the guest).

**Field-testing scenarios need no change** — I checked: none carries a version pin, and none uses a confined field.

### Cluster validation on dev (sha-f66cfa4, helm rev 27)
- **No regression**: a SwiftGuest booted end-to-end on `miles` — `GuestRunning=True`, `Resolved=True`, `StorageReady=True`, `PodScheduled=True`, pod 1/1.
- MAC injection payload **rejected by the CRD pattern**; `hostPath: /` and a `..` traversal **rejected by the webhook**; a valid MAC still **accepted**.
- Controller started clean — no informer hang from the new cached reads.

**One thing I could not exercise on-cluster, stated plainly:** the `nodeName` taint gate did not fire, because a guest pinned to the tainted control-plane node stalls *earlier* — its root-disk clone Job pins to the same node and its pod stays Pending on the taint. So the gate remains unit-tested only. That stall is **pre-existing** (the clone Job has always pinned to `spec.nodeName`), not introduced here, but it does mean a guest pinned to an unschedulable node hangs in `Scheduling` with no condition explaining why. Filed as a follow-up, along with moving the taint check earlier so the refusal is loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)