### PR TITLE
fix(gateway): carry the WebSocket bearer in a subprotocol, police Origin

### DIFF
--- a/cmd/kubeswift-gateway/main.go
+++ b/cmd/kubeswift-gateway/main.go
@@ -130,11 +130,15 @@ func main() {
 	// Console plane (D5 bootstrap): a raw WebSocket at /console that exec-bridges
 	// the guest's serial socket. Not a Connect RPC — browsers can't do bidi
 	// Connect — so it rides RawHandlers, not the generated ConsoleService stub.
-	consoleWS := gateway.NewConsoleHandler(pool, auth)
+	// Cross-origin policy for the raw-WS planes. With a real auth mode the
+	// bearer is the control and "*" is honoured; auth-mode=insecure has no
+	// bearer at all, so Origin becomes the only control and "*" is refused.
+	wsOrigin := gateway.NewOriginPolicy(*corsOrigin, *authMode)
+	consoleWS := gateway.NewConsoleHandler(pool, auth, wsOrigin)
 	// Sandbox logs plane: a raw WebSocket at /sandbox-logs that exec-tails the
 	// microVM's captured console log (read-only). Same raw-WS rationale as /console.
-	sandboxLogsWS := gateway.NewSandboxLogsHandler(pool, auth)
-	sandboxExecWS := gateway.NewSandboxExecHandler(pool, auth)
+	sandboxLogsWS := gateway.NewSandboxLogsHandler(pool, auth, wsOrigin)
+	sandboxExecWS := gateway.NewSandboxExecHandler(pool, auth, wsOrigin)
 
 	srv := &gateway.Server{
 		Addr:          *listen,

--- a/docs/ui/auth.md
+++ b/docs/ui/auth.md
@@ -160,9 +160,11 @@ and manageable with `kubectl`.
 - **The hub holds every member's credential** — restrict who can read Secrets in
   the gateway namespace; scope each member credential to least privilege.
 - **The bearer token is the user's** — served over TLS (terminate at the
-  ingress; the gateway speaks h2c behind it). The console WebSocket carries the
-  token in `?token=` (browsers can't set a WS auth header) — prefer short-lived
-  tokens and TLS so it isn't logged.
+  ingress; the gateway speaks h2c behind it). The raw WebSocket planes carry it
+  in a `Sec-WebSocket-Protocol` subprotocol, not in the URL, so it does not
+  reach access logs; see [gateway.md](gateway.md). The legacy `?token=` query
+  form is still accepted for older clients and is deprecated — it *is* logged,
+  by the UI's nginx and by any ingress in front of it.
 - **`auth-mode=insecure` bypasses all of this** (no impersonation; every user
   inherits the gateway credential). Never use it in production — the gateway
   logs a warning at startup when it is on.

--- a/docs/ui/gateway.md
+++ b/docs/ui/gateway.md
@@ -185,21 +185,42 @@ In `insecure` mode these work with no token; in `token` mode add
   there (see `config/samples/gateway/member-rbac.yaml`); a read-only audience
   gets a clean permission denial. In `token` mode the member's RBAC gates who
   can act.
-- **Console** — a raw WebSocket at `/console?cluster=&namespace=&name=&token=`
+- **Console** — a raw WebSocket at `/console?cluster=&namespace=&name=`
   exec-bridges the guest's serial socket. It execs `socat` in the launcher
   pod, so the acting subject needs `create` on `pods/exec` — **powerful**
-  (arbitrary in-pod commands); grant it only to console users. Because browsers
-  can't set a WebSocket `Authorization` header, the bearer token rides the
-  `?token=` query param — which **can land in proxy/access logs**; prefer a
-  short-lived token, and a TLS-terminating ingress so the URL isn't on the wire.
-  `insecure` mode needs no token (and then anyone can open any console).
+  (arbitrary in-pod commands); grant it only to console users.
+
+  A browser cannot set a WebSocket `Authorization` header, so the bearer travels
+  as a **subprotocol** — `Sec-WebSocket-Protocol:
+  base64url.bearer.authorization.kubeswift.io.<base64url-nopad(token)>,
+  kubeswift.io` — mirroring the Kubernetes apiserver's own convention for
+  `kubectl exec`. That is a header, so it is not part of the URL and no access
+  log on the path records it. A client offering the bearer **must** also offer
+  `kubeswift.io`: a browser fails the connection if the server selects no
+  subprotocol, and the gateway only ever echoes that one back.
+
+  `?token=` is still accepted for clients released before this change, but it is
+  **deprecated and will be removed** — a query string is written to the UI's own
+  nginx access log and to any ingress in front of it, so a live token ends up
+  readable by anyone with `pods/log` on the namespace and by every log shipper.
+  The gateway logs when a caller uses it. `insecure` mode needs no token at all
+  (and then anyone who can reach the gateway can open any console).
 - **Sandbox logs & shell** — two sibling raw WebSockets for a `SwiftSandbox`
   (added in kubeswift v0.13.1): `/sandbox-logs?cluster=&namespace=&name=&token=`
   (read-only — `tail -F`s the microVM console log) and
   `/sandbox-exec?…&cmd=/bin/sh` (an interactive shell — pod-exec → the in-guest
   vsock agent → the `internal/guestagent` frame protocol; the browser sends
   binary stdin frames and a text `{"resize":{cols,rows}}` control). Same
-  token-on-`?token=` + `pods/exec` RBAC posture as the console.
+  subprotocol-bearer + `pods/exec` RBAC posture as the console.
+
+**Cross-origin upgrades.** The three planes above police `Origin` against
+`--cors-allow-origin`. Same-origin is always allowed, and a request with no
+`Origin` (swiftctl, curl) is not a browser and is allowed — the bearer is still
+required. With `auth-mode=oidc`/`token` a `*` setting is honoured, because the
+bearer is the real control and an attacker's page cannot read it. With
+**`auth-mode=insecure` a `*` setting is refused for cross-origin upgrades**:
+there is no bearer, so `Origin` is the only thing standing between a page the
+operator happens to visit and a root console on one of their VMs.
 - **Console transport — exec-pipe is the chosen transport for the hub** (not
   D5's "serial-on-a-port"). The gateway is a multi-cluster hub: it reaches a
   member's launcher pod *through that member's API server* (the impersonating

--- a/internal/gateway/console_ws.go
+++ b/internal/gateway/console_ws.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/klog/v2"
 )
 
 // consoleProvider is the subset of ClientPool the console plane needs: the
@@ -35,13 +36,11 @@ type ConsoleHandler struct {
 	up   websocket.Upgrader
 }
 
-func NewConsoleHandler(pool consoleProvider, auth Authenticator) *ConsoleHandler {
+func NewConsoleHandler(pool consoleProvider, auth Authenticator, origin *OriginPolicy) *ConsoleHandler {
 	return &ConsoleHandler{
 		pool: pool,
 		auth: auth,
-		// The bearer token (not a cookie) is the auth, so a cross-origin upgrade
-		// is safe to accept — mirrors the Connect CORS=* posture.
-		up: websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+		up:   wsUpgrader(origin.Allow),
 	}
 }
 
@@ -56,11 +55,13 @@ func (h *ConsoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Browsers cannot set headers on a WebSocket, so the token rides a query
 	// param (?token=); insecure mode ignores it. (URL-borne tokens can land in
 	// logs — acceptable for the bootstrap path, noted in the operator docs.)
-	hdr := http.Header{}
-	if tok := q.Get("token"); tok != "" {
-		hdr.Set("Authorization", "Bearer "+tok)
-	} else if a := r.Header.Get("Authorization"); a != "" {
-		hdr.Set("Authorization", a)
+	// Bearer via Sec-WebSocket-Protocol; ?token= still accepted but deprecated.
+	// See internal/gateway/wsauth.go.
+	hdr, viaQuery := wsAuthHeader(r)
+	if viaQuery {
+		klog.V(2).InfoS("websocket bearer supplied via the deprecated ?token= query parameter; "+
+			"it is written to every access log on the path — upgrade the client to the "+
+			"Sec-WebSocket-Protocol form", "path", r.URL.Path)
 	}
 	id, err := h.auth.Authenticate(r.Context(), hdr)
 	if err != nil {

--- a/internal/gateway/console_ws_test.go
+++ b/internal/gateway/console_ws_test.go
@@ -13,7 +13,7 @@ import (
 // socket. The exec bridge itself is validated on-cluster.
 func TestConsoleHandler_Preflight(t *testing.T) {
 	boba := fakeDyn(uGuest("default", "vm-a", "Running")) // a guest, but no launcher pod
-	h := NewConsoleHandler(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+	h := NewConsoleHandler(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator(), NewOriginPolicy("*", "oidc"))
 
 	cases := []struct {
 		name, target string

--- a/internal/gateway/sandbox_exec_ws.go
+++ b/internal/gateway/sandbox_exec_ws.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/kubeswift-io/kubeswift/internal/guestagent"
+	"k8s.io/klog/v2"
 )
 
 // agentVsockPort is the AF_VSOCK port the in-guest agent listens on (matches
@@ -37,11 +38,11 @@ type SandboxExecHandler struct {
 	up   websocket.Upgrader
 }
 
-func NewSandboxExecHandler(pool consoleProvider, auth Authenticator) *SandboxExecHandler {
+func NewSandboxExecHandler(pool consoleProvider, auth Authenticator, origin *OriginPolicy) *SandboxExecHandler {
 	return &SandboxExecHandler{
 		pool: pool,
 		auth: auth,
-		up:   websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+		up:   wsUpgrader(origin.Allow),
 	}
 }
 
@@ -64,11 +65,13 @@ func (h *SandboxExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		command = "/bin/sh"
 	}
 
-	hdr := http.Header{}
-	if tok := q.Get("token"); tok != "" {
-		hdr.Set("Authorization", "Bearer "+tok)
-	} else if a := r.Header.Get("Authorization"); a != "" {
-		hdr.Set("Authorization", a)
+	// Bearer via Sec-WebSocket-Protocol; ?token= still accepted but deprecated.
+	// See internal/gateway/wsauth.go.
+	hdr, viaQuery := wsAuthHeader(r)
+	if viaQuery {
+		klog.V(2).InfoS("websocket bearer supplied via the deprecated ?token= query parameter; "+
+			"it is written to every access log on the path — upgrade the client to the "+
+			"Sec-WebSocket-Protocol form", "path", r.URL.Path)
 	}
 	id, err := h.auth.Authenticate(r.Context(), hdr)
 	if err != nil {

--- a/internal/gateway/sandbox_logs_ws.go
+++ b/internal/gateway/sandbox_logs_ws.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/klog/v2"
 )
 
 // sandboxGVR is the SwiftSandbox resource. Kept local to the gateway so the
@@ -34,11 +35,11 @@ type SandboxLogsHandler struct {
 	up   websocket.Upgrader
 }
 
-func NewSandboxLogsHandler(pool consoleProvider, auth Authenticator) *SandboxLogsHandler {
+func NewSandboxLogsHandler(pool consoleProvider, auth Authenticator, origin *OriginPolicy) *SandboxLogsHandler {
 	return &SandboxLogsHandler{
 		pool: pool,
 		auth: auth,
-		up:   websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+		up:   wsUpgrader(origin.Allow),
 	}
 }
 
@@ -51,11 +52,13 @@ func (h *SandboxLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	follow := q.Get("follow") != "false" // default: follow
 
-	hdr := http.Header{}
-	if tok := q.Get("token"); tok != "" {
-		hdr.Set("Authorization", "Bearer "+tok)
-	} else if a := r.Header.Get("Authorization"); a != "" {
-		hdr.Set("Authorization", a)
+	// Bearer via Sec-WebSocket-Protocol; ?token= still accepted but deprecated.
+	// See internal/gateway/wsauth.go.
+	hdr, viaQuery := wsAuthHeader(r)
+	if viaQuery {
+		klog.V(2).InfoS("websocket bearer supplied via the deprecated ?token= query parameter; "+
+			"it is written to every access log on the path — upgrade the client to the "+
+			"Sec-WebSocket-Protocol form", "path", r.URL.Path)
 	}
 	id, err := h.auth.Authenticate(r.Context(), hdr)
 	if err != nil {

--- a/internal/gateway/wsauth.go
+++ b/internal/gateway/wsauth.go
@@ -1,0 +1,151 @@
+package gateway
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+// This file is the shared auth/origin policy for the three raw-WebSocket planes
+// (/console, /sandbox-logs, /sandbox-exec). They are not Connect RPCs, so they
+// do not go through the interceptor chain and have to do this themselves.
+
+const (
+	// WSBearerPrefix carries the bearer token in a WebSocket SUBPROTOCOL rather
+	// than a query parameter.
+	//
+	// The problem it solves: a browser cannot set an Authorization header on a
+	// WebSocket, so the token used to ride ?token=. A query string is echoed by
+	// every access log on the path — the UI's own nginx, and any ingress in
+	// front of it — which put a live, replayable ID token in front of anyone
+	// holding pods/log, plus every log shipper downstream. Subprotocols are sent
+	// as a header (Sec-WebSocket-Protocol), so they are not part of the URL and
+	// are not logged.
+	//
+	// The shape mirrors the Kubernetes apiserver's own convention for
+	// `kubectl exec` over WebSocket. The value must be a valid HTTP token, so it
+	// is base64url WITHOUT padding: '-' and '_' are legal token characters,
+	// while '=' and '/' are not.
+	WSBearerPrefix = "base64url.bearer.authorization.kubeswift.io."
+
+	// WSProtocol is the subprotocol the server echoes back. A browser fails the
+	// connection if it offers subprotocols and the server selects none, so a
+	// client offering the bearer above MUST also offer this one.
+	WSProtocol = "kubeswift.io"
+)
+
+// wsAuthHeader extracts the caller's bearer for a WebSocket upgrade and returns
+// it as an http.Header suitable for Authenticate.
+//
+// Order of preference:
+//
+//  1. Sec-WebSocket-Protocol bearer — header-borne, never logged. What the UI sends.
+//  2. Authorization — non-browser clients (swiftctl, curl) can set it directly.
+//  3. ?token= — DEPRECATED, still accepted so a UI released before this change
+//     keeps working against an upgraded gateway (the two are versioned
+//     separately). deprecated is true in that case so the caller can warn.
+func wsAuthHeader(r *http.Request) (hdr http.Header, deprecated bool) {
+	hdr = http.Header{}
+
+	for _, proto := range websocket.Subprotocols(r) {
+		if !strings.HasPrefix(proto, WSBearerPrefix) {
+			continue
+		}
+		enc := strings.TrimPrefix(proto, WSBearerPrefix)
+		// RawURLEncoding = base64url, no padding. Fall back to the padded form
+		// rather than dropping the credential on a client that adds '='.
+		tok, err := base64.RawURLEncoding.DecodeString(enc)
+		if err != nil {
+			if tok, err = base64.URLEncoding.DecodeString(enc); err != nil {
+				continue
+			}
+		}
+		if len(tok) > 0 {
+			hdr.Set("Authorization", "Bearer "+string(tok))
+			return hdr, false
+		}
+	}
+
+	if a := r.Header.Get("Authorization"); a != "" {
+		hdr.Set("Authorization", a)
+		return hdr, false
+	}
+
+	if tok := r.URL.Query().Get("token"); tok != "" {
+		hdr.Set("Authorization", "Bearer "+tok)
+		return hdr, true
+	}
+
+	return hdr, false
+}
+
+// wsUpgrader builds the upgrader for a raw-WS plane.
+//
+// Subprotocols is set so that gorilla echoes WSProtocol back when the client
+// offers it. The bearer subprotocol is deliberately NOT in this list — it must
+// never be reflected into the response.
+func wsUpgrader(originAllowed func(*http.Request) bool) websocket.Upgrader {
+	return websocket.Upgrader{
+		Subprotocols: []string{WSProtocol},
+		CheckOrigin:  originAllowed,
+	}
+}
+
+// OriginPolicy decides whether a cross-origin WebSocket upgrade is acceptable.
+//
+// The old behaviour was an unconditional `return true`, justified in a comment
+// by "the bearer token (not a cookie) is the auth". That reasoning holds for
+// auth-mode=oidc and auth-mode=token: an attacker's page cannot read the token
+// (localStorage is origin-scoped), so it cannot open an authenticated socket,
+// and Origin buys little.
+//
+// It does NOT hold for auth-mode=insecure, where there is no authentication at
+// all: any page the operator visits could open a console to any VM, or a
+// sandbox exec shell, on a gateway their browser can reach. Origin is the only
+// control left, so in that mode cross-origin is refused unless the operator
+// listed the origin explicitly.
+type OriginPolicy struct {
+	allowed  map[string]bool
+	wildcard bool
+	// strict is true for auth-mode=insecure: never honour "*".
+	strict bool
+}
+
+// NewOriginPolicy builds a policy from --cors-allow-origin and --auth-mode.
+func NewOriginPolicy(corsAllowOrigin, authMode string) *OriginPolicy {
+	p := &OriginPolicy{allowed: map[string]bool{}, strict: authMode == "insecure"}
+	for _, o := range strings.Split(corsAllowOrigin, ",") {
+		o = strings.ToLower(strings.TrimSpace(o))
+		switch {
+		case o == "":
+		case o == "*":
+			p.wildcard = true
+		default:
+			p.allowed[o] = true
+		}
+	}
+	return p
+}
+
+// Allow reports whether the upgrade may proceed. Exported shape matches
+// websocket.Upgrader.CheckOrigin.
+func (p *OriginPolicy) Allow(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		// Not a browser: swiftctl, curl, a test. There is no origin to police,
+		// and the bearer is still required.
+		return true
+	}
+	if p.allowed[strings.ToLower(origin)] {
+		return true
+	}
+	// Same-origin is always fine — this is the UI served from the gateway's own
+	// host, or through the UI's same-origin nginx proxy.
+	if u, err := url.Parse(origin); err == nil && u.Host != "" && strings.EqualFold(u.Host, r.Host) {
+		return true
+	}
+	return p.wildcard && !p.strict
+}

--- a/internal/gateway/wsauth_test.go
+++ b/internal/gateway/wsauth_test.go
@@ -1,0 +1,163 @@
+package gateway
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func wsReq(target string, protos ...string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, target, nil)
+	// Subprotocols are only parsed on a request that looks like an upgrade.
+	r.Header.Set("Connection", "Upgrade")
+	r.Header.Set("Upgrade", "websocket")
+	for _, p := range protos {
+		r.Header.Add("Sec-WebSocket-Protocol", p)
+	}
+	return r
+}
+
+func TestWSAuthHeader_SubprotocolBearer(t *testing.T) {
+	tok := "eyJhbGciOi.PAYLOAD.SIG"
+	enc := base64.RawURLEncoding.EncodeToString([]byte(tok))
+	r := wsReq("/console?cluster=c&namespace=n&name=g", WSBearerPrefix+enc, WSProtocol)
+
+	hdr, deprecated := wsAuthHeader(r)
+	if got, want := hdr.Get("Authorization"), "Bearer "+tok; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
+	if deprecated {
+		t.Error("subprotocol bearer must not be reported as deprecated")
+	}
+}
+
+func TestWSAuthHeader_TokenNeverNeedsTheQueryString(t *testing.T) {
+	// The whole point: a client using the subprotocol form puts NOTHING
+	// sensitive in the URL, so no access log on the path can capture it.
+	tok := "secret-token"
+	enc := base64.RawURLEncoding.EncodeToString([]byte(tok))
+	r := wsReq("/sandbox-exec?cluster=c&namespace=n&name=s", WSBearerPrefix+enc, WSProtocol)
+
+	if r.URL.RawQuery == "" {
+		t.Fatal("test setup: expected a query string")
+	}
+	if got := r.URL.String(); strings.Contains(got, tok) {
+		t.Fatalf("token leaked into the URL: %q", got)
+	}
+	hdr, _ := wsAuthHeader(r)
+	if hdr.Get("Authorization") == "" {
+		t.Fatal("token not recovered from the subprotocol")
+	}
+}
+
+func TestWSAuthHeader_PaddedBase64StillAccepted(t *testing.T) {
+	tok := "abcd" // encodes to a padded value under URLEncoding
+	r := wsReq("/console", WSBearerPrefix+base64.URLEncoding.EncodeToString([]byte(tok)), WSProtocol)
+	hdr, _ := wsAuthHeader(r)
+	if got, want := hdr.Get("Authorization"), "Bearer "+tok; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestWSAuthHeader_QueryFallbackFlaggedDeprecated(t *testing.T) {
+	// A UI released before this change still works, but the caller is told so
+	// it can warn — the query form is what leaks into logs.
+	r := wsReq("/console?token=legacy-token")
+	hdr, deprecated := wsAuthHeader(r)
+	if got, want := hdr.Get("Authorization"), "Bearer legacy-token"; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
+	if !deprecated {
+		t.Error("?token= must be reported as deprecated")
+	}
+}
+
+func TestWSAuthHeader_SubprotocolBeatsQuery(t *testing.T) {
+	enc := base64.RawURLEncoding.EncodeToString([]byte("header-token"))
+	r := wsReq("/console?token=query-token", WSBearerPrefix+enc, WSProtocol)
+	hdr, deprecated := wsAuthHeader(r)
+	if got, want := hdr.Get("Authorization"), "Bearer header-token"; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
+	if deprecated {
+		t.Error("should not warn when the header form was used")
+	}
+}
+
+func TestWSAuthHeader_NoCredential(t *testing.T) {
+	hdr, deprecated := wsAuthHeader(wsReq("/console"))
+	if hdr.Get("Authorization") != "" {
+		t.Error("invented a credential")
+	}
+	if deprecated {
+		t.Error("nothing supplied is not a deprecated form")
+	}
+}
+
+func TestWSAuthHeader_GarbageSubprotocolIsIgnored(t *testing.T) {
+	r := wsReq("/console", WSBearerPrefix+"!!!not-base64!!!", WSProtocol)
+	hdr, _ := wsAuthHeader(r)
+	if hdr.Get("Authorization") != "" {
+		t.Error("undecodable bearer must not produce an Authorization header")
+	}
+}
+
+// --- origin policy ---
+
+func originReq(origin, host string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "http://"+host+"/console", nil)
+	r.Host = host
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	return r
+}
+
+func TestOriginPolicy_NoOriginIsANonBrowserClient(t *testing.T) {
+	// swiftctl / curl send no Origin. The bearer is still required.
+	for _, mode := range []string{"oidc", "insecure"} {
+		p := NewOriginPolicy("https://ui.example.com", mode)
+		if !p.Allow(originReq("", "gw.example.com")) {
+			t.Errorf("mode %s: rejected a request with no Origin", mode)
+		}
+	}
+}
+
+func TestOriginPolicy_SameOriginAlwaysAllowed(t *testing.T) {
+	p := NewOriginPolicy("https://ui.example.com", "insecure")
+	if !p.Allow(originReq("https://gw.example.com", "gw.example.com")) {
+		t.Error("same-origin upgrade rejected")
+	}
+}
+
+func TestOriginPolicy_ExplicitAllowlist(t *testing.T) {
+	p := NewOriginPolicy("https://ui.example.com, https://other.example.com", "oidc")
+	if !p.Allow(originReq("https://other.example.com", "gw.example.com")) {
+		t.Error("listed origin rejected")
+	}
+	if p.Allow(originReq("https://evil.example.com", "gw.example.com")) {
+		t.Error("unlisted origin accepted despite an explicit allowlist")
+	}
+}
+
+func TestOriginPolicy_InsecureModeRefusesWildcard(t *testing.T) {
+	// THE case this exists for. auth-mode=insecure performs no authentication,
+	// so any page the operator visits could otherwise open a console to a VM or
+	// a sandbox exec shell. Origin is the only control left.
+	p := NewOriginPolicy("*", "insecure")
+	if p.Allow(originReq("https://evil.example.com", "gw.example.com")) {
+		t.Fatal("cross-origin upgrade accepted with auth-mode=insecure and CORS=*")
+	}
+}
+
+func TestOriginPolicy_WildcardHonouredWhenAuthenticated(t *testing.T) {
+	// With a real auth mode the bearer is the control and the attacker's page
+	// cannot read it, so "*" stays honoured — no behaviour change for existing
+	// oidc/token deployments.
+	p := NewOriginPolicy("*", "oidc")
+	if !p.Allow(originReq("https://anything.example.com", "gw.example.com")) {
+		t.Error("wildcard not honoured under auth-mode=oidc")
+	}
+}


### PR DESCRIPTION
Phase 1 of the post-review plan. Closes two findings on the three raw-WebSocket
planes (`/console`, `/sandbox-logs`, `/sandbox-exec`), which are not Connect RPCs
and so never went through the interceptor chain.

Pairs with **kubeswift-io/kubeswift-ui#38** — merge this first; the gateway
accepts both forms, the UI only sends the new one.

## 1. The bearer is no longer in the URL

A browser cannot set an `Authorization` header on a WebSocket, so the token rode
`?token=`. A query string is echoed by every access log on the path, so every
handshake wrote a live, replayable ID token into a log readable by anyone with
`pods/log` on the namespace — and by every log shipper downstream. Fixing the
UI's own nginx in kubeswift-ui#37 only removed one hop: the dev hub fronts the UI
with an ingress-nginx that has no log-format override, and it was still
capturing them.

The token now travels as a subprotocol, mirroring what the Kubernetes apiserver
does for `kubectl exec`:

```
Sec-WebSocket-Protocol: base64url.bearer.authorization.kubeswift.io.<base64url-nopad>, kubeswift.io
```

A header, so it is not part of the URL and nothing on the path logs it.
base64url **without padding** because a subprotocol must be a valid HTTP token —
`-` and `_` are legal, `=` and `/` are not. The gateway echoes only
`kubeswift.io`; the bearer is never reflected into a response.

`?token=` still works and is logged as deprecated when used, so a UI released
before this change keeps working against an upgraded gateway — the two are
versioned separately.

## 2. `CheckOrigin: true`

The existing comment justified it: *"the bearer token (not a cookie) is the
auth"*. That reasoning is sound for `auth-mode=oidc`/`token` — an attacker's page
cannot read the token, so it cannot open an authenticated socket, and `Origin`
buys little. I've kept `*` honoured there, so **no behaviour change for existing
oidc/token deployments**.

It does not hold for `auth-mode=insecure`, where there is no authentication at
all: any page the operator visits could open a console to a VM, or a sandbox exec
shell, on a gateway their browser can reach. `Origin` is the only control left,
so `*` is refused for cross-origin upgrades in that mode. Same-origin, and
requests with no `Origin` (swiftctl, curl), are always allowed.

## Verification

- 14 new unit tests. **Negative control**: restoring the unconditional accept
  fails `TestOriginPolicy_InsecureModeRefusesWildcard` and
  `TestOriginPolicy_ExplicitAllowlist`. (My first attempt at that control was
  invalid — deleting the body broke the build rather than failing an assertion,
  which proves nothing; redone as a one-line change.)
- **Cross-language check**: the TypeScript encoder's real output decodes
  byte-exact in Go, using a token deliberately containing `+`, `/` and `=`.
- Full `internal/...` suite green; `gofmt` clean.

Not yet cluster-validated — that needs both sides deployed to dev, which is the
next step once the UI PR is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
