### PR TITLE
fix(seed): render cloud-init user-data into a Secret, not a ConfigMap

### DIFF
--- a/charts/kubeswift/templates/controller-manager/rbac.yaml
+++ b/charts/kubeswift/templates/controller-manager/rbac.yaml
@@ -69,11 +69,15 @@ rules:
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # secrets — get,list,watch for general reads; create,update added for
-  # the Phase 3c live-migration mTLS path (migration.mtls.enabled): the
-  # migrationcert controller copies a node's cert-manager-issued identity
-  # Secret into guest namespaces (distribution, not issuance). The verbs
-  # are harmless when mTLS is disabled (the reconciler is not registered).
+  # secrets — get,list,watch for general reads. create,update have two
+  # consumers:
+  #   1. the rendered cloud-init seed, which is a Secret rather than a
+  #      ConfigMap (user-data carries SSH keys, passwords and join tokens,
+  #      and a seed profile can source it from a Secret);
+  #   2. the live-migration mTLS path (migration.mtls.enabled): the
+  #      migrationcert controller copies a node's cert-manager-issued
+  #      identity Secret into guest namespaces (distribution, not issuance),
+  #      and is not registered at all when mTLS is disabled.
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch", "create", "update"]

--- a/cmd/kubeswift-gateway/main.go
+++ b/cmd/kubeswift-gateway/main.go
@@ -130,11 +130,15 @@ func main() {
 	// Console plane (D5 bootstrap): a raw WebSocket at /console that exec-bridges
 	// the guest's serial socket. Not a Connect RPC — browsers can't do bidi
 	// Connect — so it rides RawHandlers, not the generated ConsoleService stub.
-	consoleWS := gateway.NewConsoleHandler(pool, auth)
+	// Cross-origin policy for the raw-WS planes. With a real auth mode the
+	// bearer is the control and "*" is honoured; auth-mode=insecure has no
+	// bearer at all, so Origin becomes the only control and "*" is refused.
+	wsOrigin := gateway.NewOriginPolicy(*corsOrigin, *authMode)
+	consoleWS := gateway.NewConsoleHandler(pool, auth, wsOrigin)
 	// Sandbox logs plane: a raw WebSocket at /sandbox-logs that exec-tails the
 	// microVM's captured console log (read-only). Same raw-WS rationale as /console.
-	sandboxLogsWS := gateway.NewSandboxLogsHandler(pool, auth)
-	sandboxExecWS := gateway.NewSandboxExecHandler(pool, auth)
+	sandboxLogsWS := gateway.NewSandboxLogsHandler(pool, auth, wsOrigin)
+	sandboxExecWS := gateway.NewSandboxExecHandler(pool, auth, wsOrigin)
 
 	srv := &gateway.Server{
 		Addr:          *listen,

--- a/docs/ui/auth.md
+++ b/docs/ui/auth.md
@@ -160,9 +160,11 @@ and manageable with `kubectl`.
 - **The hub holds every member's credential** — restrict who can read Secrets in
   the gateway namespace; scope each member credential to least privilege.
 - **The bearer token is the user's** — served over TLS (terminate at the
-  ingress; the gateway speaks h2c behind it). The console WebSocket carries the
-  token in `?token=` (browsers can't set a WS auth header) — prefer short-lived
-  tokens and TLS so it isn't logged.
+  ingress; the gateway speaks h2c behind it). The raw WebSocket planes carry it
+  in a `Sec-WebSocket-Protocol` subprotocol, not in the URL, so it does not
+  reach access logs; see [gateway.md](gateway.md). The legacy `?token=` query
+  form is still accepted for older clients and is deprecated — it *is* logged,
+  by the UI's nginx and by any ingress in front of it.
 - **`auth-mode=insecure` bypasses all of this** (no impersonation; every user
   inherits the gateway credential). Never use it in production — the gateway
   logs a warning at startup when it is on.

--- a/docs/ui/gateway.md
+++ b/docs/ui/gateway.md
@@ -185,21 +185,42 @@ In `insecure` mode these work with no token; in `token` mode add
   there (see `config/samples/gateway/member-rbac.yaml`); a read-only audience
   gets a clean permission denial. In `token` mode the member's RBAC gates who
   can act.
-- **Console** — a raw WebSocket at `/console?cluster=&namespace=&name=&token=`
+- **Console** — a raw WebSocket at `/console?cluster=&namespace=&name=`
   exec-bridges the guest's serial socket. It execs `socat` in the launcher
   pod, so the acting subject needs `create` on `pods/exec` — **powerful**
-  (arbitrary in-pod commands); grant it only to console users. Because browsers
-  can't set a WebSocket `Authorization` header, the bearer token rides the
-  `?token=` query param — which **can land in proxy/access logs**; prefer a
-  short-lived token, and a TLS-terminating ingress so the URL isn't on the wire.
-  `insecure` mode needs no token (and then anyone can open any console).
+  (arbitrary in-pod commands); grant it only to console users.
+
+  A browser cannot set a WebSocket `Authorization` header, so the bearer travels
+  as a **subprotocol** — `Sec-WebSocket-Protocol:
+  base64url.bearer.authorization.kubeswift.io.<base64url-nopad(token)>,
+  kubeswift.io` — mirroring the Kubernetes apiserver's own convention for
+  `kubectl exec`. That is a header, so it is not part of the URL and no access
+  log on the path records it. A client offering the bearer **must** also offer
+  `kubeswift.io`: a browser fails the connection if the server selects no
+  subprotocol, and the gateway only ever echoes that one back.
+
+  `?token=` is still accepted for clients released before this change, but it is
+  **deprecated and will be removed** — a query string is written to the UI's own
+  nginx access log and to any ingress in front of it, so a live token ends up
+  readable by anyone with `pods/log` on the namespace and by every log shipper.
+  The gateway logs when a caller uses it. `insecure` mode needs no token at all
+  (and then anyone who can reach the gateway can open any console).
 - **Sandbox logs & shell** — two sibling raw WebSockets for a `SwiftSandbox`
   (added in kubeswift v0.13.1): `/sandbox-logs?cluster=&namespace=&name=&token=`
   (read-only — `tail -F`s the microVM console log) and
   `/sandbox-exec?…&cmd=/bin/sh` (an interactive shell — pod-exec → the in-guest
   vsock agent → the `internal/guestagent` frame protocol; the browser sends
   binary stdin frames and a text `{"resize":{cols,rows}}` control). Same
-  token-on-`?token=` + `pods/exec` RBAC posture as the console.
+  subprotocol-bearer + `pods/exec` RBAC posture as the console.
+
+**Cross-origin upgrades.** The three planes above police `Origin` against
+`--cors-allow-origin`. Same-origin is always allowed, and a request with no
+`Origin` (swiftctl, curl) is not a browser and is allowed — the bearer is still
+required. With `auth-mode=oidc`/`token` a `*` setting is honoured, because the
+bearer is the real control and an attacker's page cannot read it. With
+**`auth-mode=insecure` a `*` setting is refused for cross-origin upgrades**:
+there is no bearer, so `Origin` is the only thing standing between a page the
+operator happens to visit and a root console on one of their VMs.
 - **Console transport — exec-pipe is the chosen transport for the hub** (not
   D5's "serial-on-a-port"). The gateway is a multi-cluster hub: it reaches a
   member's launcher pod *through that member's API server* (the impersonating

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -34,6 +34,9 @@ import (
 const gpuHypervisorAnnotation = "kubeswift.io/hypervisor-override"
 
 const (
+	// SeedConfigMapSuffix names the rendered seed. It is a SECRET despite the
+	// constant name (kept to avoid churn across the pod builders): user-data
+	// carries SSH keys, passwords and join tokens.
 	SeedConfigMapSuffix = "-seed"
 
 	// defaultNetworkConfig is used when SwiftSeedProfile has no networkData.
@@ -216,27 +219,37 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			networkData = defaultNetworkConfig
 		}
 		seedConfigMapName = guest.Name + SeedConfigMapSuffix
-		desiredCM := seed.BuildConfigMap(seedConfigMapName, guest.Namespace, userData, metaData, networkData)
-		if err := controllerutil.SetControllerReference(&guest, desiredCM, r.Scheme); err != nil {
+		// Rendered as a SECRET: user-data routinely carries SSH keys, passwords
+		// and join tokens, and a seed profile can source it from a Secret — which
+		// this used to copy into a ConfigMap, in the clear.
+		desiredSeed := seed.BuildSecret(seedConfigMapName, guest.Namespace, userData, metaData, networkData)
+		if err := controllerutil.SetControllerReference(&guest, desiredSeed, r.Scheme); err != nil {
 			return ctrl.Result{}, err
 		}
-		var existingCM corev1.ConfigMap
-		if err := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: seedConfigMapName}, &existingCM); err != nil {
+		var existingSeed corev1.Secret
+		if err := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: seedConfigMapName}, &existingSeed); err != nil {
 			if client.IgnoreNotFound(err) != nil {
 				return ctrl.Result{}, err
 			}
-			if err := r.Create(ctx, desiredCM); err != nil {
+			if err := r.Create(ctx, desiredSeed); err != nil {
 				return ctrl.Result{}, err
 			}
 		} else {
-			if !equality.Semantic.DeepEqual(existingCM.Data, desiredCM.Data) ||
-				!equality.Semantic.DeepEqual(existingCM.OwnerReferences, desiredCM.OwnerReferences) {
-				existingCM.Data = desiredCM.Data
-				existingCM.OwnerReferences = desiredCM.OwnerReferences
-				if err := r.Update(ctx, &existingCM); err != nil {
+			// Compare against the rendered form: the apiserver returns Data
+			// (decoded), never StringData, so DeepEqual on StringData would
+			// differ on every reconcile and hot-loop.
+			if !equality.Semantic.DeepEqual(existingSeed.Data, renderedSeedData(desiredSeed)) ||
+				!equality.Semantic.DeepEqual(existingSeed.OwnerReferences, desiredSeed.OwnerReferences) {
+				existingSeed.Data = renderedSeedData(desiredSeed)
+				existingSeed.StringData = nil
+				existingSeed.OwnerReferences = desiredSeed.OwnerReferences
+				if err := r.Update(ctx, &existingSeed); err != nil {
 					return ctrl.Result{}, err
 				}
 			}
+		}
+		if err := r.retireLegacySeedConfigMap(ctx, &guest, seedConfigMapName); err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/internal/controller/swiftguest/pod.go
+++ b/internal/controller/swiftguest/pod.go
@@ -685,15 +685,20 @@ func AddVolumeMounts(mounts *[]corev1.VolumeMount, devices *[]corev1.VolumeDevic
 	}
 }
 
-// AddSeedVolume adds the seed ConfigMap volume to the pod. Use when ResolvedGuest has Seed.
-// ConfigMap name should be guestName + SeedConfigMapSuffix.
-func AddSeedVolume(volumes *[]corev1.Volume, configMapName string) {
+// AddSeedVolume adds the rendered seed volume to the pod. Use when
+// ResolvedGuest has Seed. The name is guestName + SeedConfigMapSuffix.
+//
+// This is a SECRET, not a ConfigMap. cloud-init user-data routinely carries SSH
+// keys, passwords and join tokens, and a SwiftSeedProfile can source it from a
+// Secret via valueFrom.secretKeyRef — which the controller then rendered into a
+// ConfigMap, re-materializing the credential in the clear for anyone with `get
+// configmaps` in the namespace. Same three keys, same mount path, so the guest
+// side is unchanged.
+func AddSeedVolume(volumes *[]corev1.Volume, seedName string) {
 	*volumes = append(*volumes, corev1.Volume{
 		Name: "seed",
 		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
-			},
+			Secret: &corev1.SecretVolumeSource{SecretName: seedName},
 		},
 	})
 }

--- a/internal/controller/swiftguest/restore_test.go
+++ b/internal/controller/swiftguest/restore_test.go
@@ -366,11 +366,16 @@ func TestBuildRestorePod_SeedMountWhenSourceHadSeed(t *testing.T) {
 	if seedVol == nil {
 		t.Fatal("restore pod missing seed volume despite source having a seed")
 	}
-	if seedVol.ConfigMap == nil {
-		t.Fatal("seed volume must be a ConfigMap")
+	// A Secret, not a ConfigMap: user-data carries SSH keys and join tokens, and
+	// the restore path renders the same seed as the boot path.
+	if seedVol.Secret == nil {
+		t.Fatal("seed volume must be a Secret")
 	}
-	if seedVol.ConfigMap.Name != "g1-seed" {
-		t.Errorf("seed ConfigMap name = %q, want g1-seed", seedVol.ConfigMap.Name)
+	if seedVol.ConfigMap != nil {
+		t.Error("seed volume must not be a ConfigMap — that re-materialized the credential in the clear")
+	}
+	if seedVol.Secret.SecretName != "g1-seed" {
+		t.Errorf("seed Secret name = %q, want g1-seed", seedVol.Secret.SecretName)
 	}
 	launcher := pod.Spec.Containers[0]
 	mount := findMount(&launcher, "seed")

--- a/internal/controller/swiftguest/seedsecret.go
+++ b/internal/controller/swiftguest/seedsecret.go
@@ -1,0 +1,76 @@
+package swiftguest
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crlog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+)
+
+// renderedSeedData converts a freshly built seed Secret's StringData into the
+// Data form the apiserver stores and returns.
+//
+// This exists so the reconcile comparison is apples-to-apples. A Secret written
+// with StringData comes back with Data and StringData nil, so comparing the two
+// directly would differ on every pass and write on every reconcile — which the
+// watch then re-enqueues, i.e. a hot loop.
+func renderedSeedData(s *corev1.Secret) map[string][]byte {
+	out := make(map[string][]byte, len(s.StringData)+len(s.Data))
+	for k, v := range s.Data {
+		out[k] = v
+	}
+	for k, v := range s.StringData {
+		out[k] = []byte(v)
+	}
+	return out
+}
+
+// retireLegacySeedConfigMap deletes the pre-v0.13.4 plaintext seed ConfigMap
+// once nothing is mounting it any more.
+//
+// Upgrade shape: the seed is now a Secret sharing the ConfigMap's name (they are
+// different resource types, so both can exist). A guest that was already running
+// keeps its launcher pod, and that pod still mounts the ConfigMap — deleting it
+// out from under a live pod would break the guest on its next restart, when
+// kubelet re-projects the volume and cannot find it.
+//
+// So: delete only when no pod for this guest still references it. A running
+// guest therefore keeps the plaintext copy until it is next recreated, which is
+// the honest trade — the alternative is breaking running VMs on upgrade. Guests
+// created after this change never get a ConfigMap at all.
+func (r *SwiftGuestReconciler) retireLegacySeedConfigMap(ctx context.Context, guest *swiftv1alpha1.SwiftGuest, name string) error {
+	logger := crlog.FromContext(ctx)
+
+	var cm corev1.ConfigMap
+	if err := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: name}, &cm); err != nil {
+		return client.IgnoreNotFound(err) // already gone: nothing to do
+	}
+
+	var pods corev1.PodList
+	if err := r.List(ctx, &pods, client.InNamespace(guest.Namespace),
+		client.MatchingLabels{guestPodLabelKey: guest.Name}); err != nil {
+		return err
+	}
+	for i := range pods.Items {
+		if pods.Items[i].DeletionTimestamp != nil {
+			continue
+		}
+		for _, v := range pods.Items[i].Spec.Volumes {
+			if v.ConfigMap != nil && v.ConfigMap.Name == name {
+				// Still in use — leave it and try again on a later reconcile.
+				return nil
+			}
+		}
+	}
+
+	if err := r.Delete(ctx, &cm); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	logger.Info("retired the legacy plaintext seed ConfigMap; the seed is a Secret now",
+		"configMap", name, "namespace", guest.Namespace)
+	return nil
+}

--- a/internal/controller/swiftguest/seedsecret_test.go
+++ b/internal/controller/swiftguest/seedsecret_test.go
@@ -1,0 +1,145 @@
+package swiftguest
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/seed"
+)
+
+func seedScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	// Only ConfigMaps and Pods are touched; the guest is just a name/namespace.
+	return s
+}
+
+func legacyCM(ns, name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Data:       map[string]string{seed.KeyUserData: "#cloud-config\npassword: hunter2\n"},
+	}
+}
+
+func podMounting(ns, guest, cmName string, viaConfigMap bool) *corev1.Pod {
+	vol := corev1.Volume{Name: "seed"}
+	if viaConfigMap {
+		vol.ConfigMap = &corev1.ConfigMapVolumeSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+		}
+	} else {
+		vol.Secret = &corev1.SecretVolumeSource{SecretName: cmName}
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns, Name: guest + "-launcher",
+			Labels: map[string]string{guestPodLabelKey: guest},
+		},
+		Spec: corev1.PodSpec{Volumes: []corev1.Volume{vol}},
+	}
+}
+
+func TestRetireLegacySeedConfigMap_KeepsItWhileAPodStillMountsIt(t *testing.T) {
+	// The upgrade hazard: a guest that was already running keeps its launcher
+	// pod, and that pod still mounts the ConfigMap. Deleting it out from under
+	// the pod breaks the guest on its next restart, when kubelet re-projects the
+	// volume and cannot find it.
+	s := seedScheme(t)
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "g1"}}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(legacyCM("ns", "g1-seed"), podMounting("ns", "g1", "g1-seed", true)).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: s}
+
+	if err := r.retireLegacySeedConfigMap(context.Background(), guest, "g1-seed"); err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+	var cm corev1.ConfigMap
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "g1-seed"}, &cm); err != nil {
+		t.Fatalf("legacy ConfigMap was deleted while a live pod still mounted it: %v", err)
+	}
+}
+
+func TestRetireLegacySeedConfigMap_DeletesOnceThePodMovedToTheSecret(t *testing.T) {
+	s := seedScheme(t)
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "g1"}}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(legacyCM("ns", "g1-seed"), podMounting("ns", "g1", "g1-seed", false)).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: s}
+
+	if err := r.retireLegacySeedConfigMap(context.Background(), guest, "g1-seed"); err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+	var cm corev1.ConfigMap
+	err := c.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "g1-seed"}, &cm)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("plaintext ConfigMap survived after the pod moved to the Secret (err=%v)", err)
+	}
+}
+
+func TestRetireLegacySeedConfigMap_NoPodsAtAll(t *testing.T) {
+	s := seedScheme(t)
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "g1"}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(legacyCM("ns", "g1-seed")).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: s}
+
+	if err := r.retireLegacySeedConfigMap(context.Background(), guest, "g1-seed"); err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+	var cm corev1.ConfigMap
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "g1-seed"},
+		&cm); !apierrors.IsNotFound(err) {
+		t.Fatalf("stopped guest should have had its plaintext ConfigMap retired (err=%v)", err)
+	}
+}
+
+func TestRetireLegacySeedConfigMap_AbsentIsNotAnError(t *testing.T) {
+	s := seedScheme(t)
+	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "g1"}}
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: s}
+	if err := r.retireLegacySeedConfigMap(context.Background(), guest, "g1-seed"); err != nil {
+		t.Fatalf("a guest created after the change has no ConfigMap; must be a no-op, got %v", err)
+	}
+}
+
+func TestRenderedSeedData_MatchesWhatTheAPIServerReturns(t *testing.T) {
+	// A Secret written with StringData comes back with Data and StringData nil.
+	// Comparing the built object directly against the stored one would differ on
+	// every reconcile -> write -> watch event -> reconcile: a hot loop.
+	built := seed.BuildSecret("g1-seed", "ns", "user", "meta", "net")
+	got := renderedSeedData(built)
+	want := map[string][]byte{
+		seed.KeyUserData:      []byte("user"),
+		seed.KeyMetaData:      []byte("meta"),
+		seed.KeyNetworkConfig: []byte("net"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("rendered %d keys, want %d: %v", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if string(got[k]) != string(v) {
+			t.Errorf("key %q = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestBuildSecret_CarriesNoPlaintextConfigMap(t *testing.T) {
+	s := seed.BuildSecret("g1-seed", "ns", "#cloud-config\npassword: hunter2\n", "", "")
+	if s.StringData[seed.KeyUserData] == "" {
+		t.Fatal("user-data missing from the rendered seed Secret")
+	}
+	if s.TypeMeta.Kind != "" && s.TypeMeta.Kind != "Secret" {
+		t.Errorf("rendered seed is a %s, want Secret", s.TypeMeta.Kind)
+	}
+}

--- a/internal/gateway/console_ws.go
+++ b/internal/gateway/console_ws.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/klog/v2"
 )
 
 // consoleProvider is the subset of ClientPool the console plane needs: the
@@ -35,13 +36,11 @@ type ConsoleHandler struct {
 	up   websocket.Upgrader
 }
 
-func NewConsoleHandler(pool consoleProvider, auth Authenticator) *ConsoleHandler {
+func NewConsoleHandler(pool consoleProvider, auth Authenticator, origin *OriginPolicy) *ConsoleHandler {
 	return &ConsoleHandler{
 		pool: pool,
 		auth: auth,
-		// The bearer token (not a cookie) is the auth, so a cross-origin upgrade
-		// is safe to accept — mirrors the Connect CORS=* posture.
-		up: websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+		up:   wsUpgrader(origin.Allow),
 	}
 }
 
@@ -56,11 +55,13 @@ func (h *ConsoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Browsers cannot set headers on a WebSocket, so the token rides a query
 	// param (?token=); insecure mode ignores it. (URL-borne tokens can land in
 	// logs — acceptable for the bootstrap path, noted in the operator docs.)
-	hdr := http.Header{}
-	if tok := q.Get("token"); tok != "" {
-		hdr.Set("Authorization", "Bearer "+tok)
-	} else if a := r.Header.Get("Authorization"); a != "" {
-		hdr.Set("Authorization", a)
+	// Bearer via Sec-WebSocket-Protocol; ?token= still accepted but deprecated.
+	// See internal/gateway/wsauth.go.
+	hdr, viaQuery := wsAuthHeader(r)
+	if viaQuery {
+		klog.V(2).InfoS("websocket bearer supplied via the deprecated ?token= query parameter; "+
+			"it is written to every access log on the path — upgrade the client to the "+
+			"Sec-WebSocket-Protocol form", "path", r.URL.Path)
 	}
 	id, err := h.auth.Authenticate(r.Context(), hdr)
 	if err != nil {

--- a/internal/gateway/console_ws_test.go
+++ b/internal/gateway/console_ws_test.go
@@ -13,7 +13,7 @@ import (
 // socket. The exec bridge itself is validated on-cluster.
 func TestConsoleHandler_Preflight(t *testing.T) {
 	boba := fakeDyn(uGuest("default", "vm-a", "Running")) // a guest, but no launcher pod
-	h := NewConsoleHandler(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+	h := NewConsoleHandler(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator(), NewOriginPolicy("*", "oidc"))
 
 	cases := []struct {
 		name, target string

--- a/internal/gateway/sandbox_exec_ws.go
+++ b/internal/gateway/sandbox_exec_ws.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/kubeswift-io/kubeswift/internal/guestagent"
+	"k8s.io/klog/v2"
 )
 
 // agentVsockPort is the AF_VSOCK port the in-guest agent listens on (matches
@@ -37,11 +38,11 @@ type SandboxExecHandler struct {
 	up   websocket.Upgrader
 }
 
-func NewSandboxExecHandler(pool consoleProvider, auth Authenticator) *SandboxExecHandler {
+func NewSandboxExecHandler(pool consoleProvider, auth Authenticator, origin *OriginPolicy) *SandboxExecHandler {
 	return &SandboxExecHandler{
 		pool: pool,
 		auth: auth,
-		up:   websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+		up:   wsUpgrader(origin.Allow),
 	}
 }
 
@@ -64,11 +65,13 @@ func (h *SandboxExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		command = "/bin/sh"
 	}
 
-	hdr := http.Header{}
-	if tok := q.Get("token"); tok != "" {
-		hdr.Set("Authorization", "Bearer "+tok)
-	} else if a := r.Header.Get("Authorization"); a != "" {
-		hdr.Set("Authorization", a)
+	// Bearer via Sec-WebSocket-Protocol; ?token= still accepted but deprecated.
+	// See internal/gateway/wsauth.go.
+	hdr, viaQuery := wsAuthHeader(r)
+	if viaQuery {
+		klog.V(2).InfoS("websocket bearer supplied via the deprecated ?token= query parameter; "+
+			"it is written to every access log on the path — upgrade the client to the "+
+			"Sec-WebSocket-Protocol form", "path", r.URL.Path)
 	}
 	id, err := h.auth.Authenticate(r.Context(), hdr)
 	if err != nil {

--- a/internal/gateway/sandbox_logs_ws.go
+++ b/internal/gateway/sandbox_logs_ws.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/klog/v2"
 )
 
 // sandboxGVR is the SwiftSandbox resource. Kept local to the gateway so the
@@ -34,11 +35,11 @@ type SandboxLogsHandler struct {
 	up   websocket.Upgrader
 }
 
-func NewSandboxLogsHandler(pool consoleProvider, auth Authenticator) *SandboxLogsHandler {
+func NewSandboxLogsHandler(pool consoleProvider, auth Authenticator, origin *OriginPolicy) *SandboxLogsHandler {
 	return &SandboxLogsHandler{
 		pool: pool,
 		auth: auth,
-		up:   websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+		up:   wsUpgrader(origin.Allow),
 	}
 }
 
@@ -51,11 +52,13 @@ func (h *SandboxLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	follow := q.Get("follow") != "false" // default: follow
 
-	hdr := http.Header{}
-	if tok := q.Get("token"); tok != "" {
-		hdr.Set("Authorization", "Bearer "+tok)
-	} else if a := r.Header.Get("Authorization"); a != "" {
-		hdr.Set("Authorization", a)
+	// Bearer via Sec-WebSocket-Protocol; ?token= still accepted but deprecated.
+	// See internal/gateway/wsauth.go.
+	hdr, viaQuery := wsAuthHeader(r)
+	if viaQuery {
+		klog.V(2).InfoS("websocket bearer supplied via the deprecated ?token= query parameter; "+
+			"it is written to every access log on the path — upgrade the client to the "+
+			"Sec-WebSocket-Protocol form", "path", r.URL.Path)
 	}
 	id, err := h.auth.Authenticate(r.Context(), hdr)
 	if err != nil {

--- a/internal/gateway/wsauth.go
+++ b/internal/gateway/wsauth.go
@@ -1,0 +1,151 @@
+package gateway
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+// This file is the shared auth/origin policy for the three raw-WebSocket planes
+// (/console, /sandbox-logs, /sandbox-exec). They are not Connect RPCs, so they
+// do not go through the interceptor chain and have to do this themselves.
+
+const (
+	// WSBearerPrefix carries the bearer token in a WebSocket SUBPROTOCOL rather
+	// than a query parameter.
+	//
+	// The problem it solves: a browser cannot set an Authorization header on a
+	// WebSocket, so the token used to ride ?token=. A query string is echoed by
+	// every access log on the path — the UI's own nginx, and any ingress in
+	// front of it — which put a live, replayable ID token in front of anyone
+	// holding pods/log, plus every log shipper downstream. Subprotocols are sent
+	// as a header (Sec-WebSocket-Protocol), so they are not part of the URL and
+	// are not logged.
+	//
+	// The shape mirrors the Kubernetes apiserver's own convention for
+	// `kubectl exec` over WebSocket. The value must be a valid HTTP token, so it
+	// is base64url WITHOUT padding: '-' and '_' are legal token characters,
+	// while '=' and '/' are not.
+	WSBearerPrefix = "base64url.bearer.authorization.kubeswift.io."
+
+	// WSProtocol is the subprotocol the server echoes back. A browser fails the
+	// connection if it offers subprotocols and the server selects none, so a
+	// client offering the bearer above MUST also offer this one.
+	WSProtocol = "kubeswift.io"
+)
+
+// wsAuthHeader extracts the caller's bearer for a WebSocket upgrade and returns
+// it as an http.Header suitable for Authenticate.
+//
+// Order of preference:
+//
+//  1. Sec-WebSocket-Protocol bearer — header-borne, never logged. What the UI sends.
+//  2. Authorization — non-browser clients (swiftctl, curl) can set it directly.
+//  3. ?token= — DEPRECATED, still accepted so a UI released before this change
+//     keeps working against an upgraded gateway (the two are versioned
+//     separately). deprecated is true in that case so the caller can warn.
+func wsAuthHeader(r *http.Request) (hdr http.Header, deprecated bool) {
+	hdr = http.Header{}
+
+	for _, proto := range websocket.Subprotocols(r) {
+		if !strings.HasPrefix(proto, WSBearerPrefix) {
+			continue
+		}
+		enc := strings.TrimPrefix(proto, WSBearerPrefix)
+		// RawURLEncoding = base64url, no padding. Fall back to the padded form
+		// rather than dropping the credential on a client that adds '='.
+		tok, err := base64.RawURLEncoding.DecodeString(enc)
+		if err != nil {
+			if tok, err = base64.URLEncoding.DecodeString(enc); err != nil {
+				continue
+			}
+		}
+		if len(tok) > 0 {
+			hdr.Set("Authorization", "Bearer "+string(tok))
+			return hdr, false
+		}
+	}
+
+	if a := r.Header.Get("Authorization"); a != "" {
+		hdr.Set("Authorization", a)
+		return hdr, false
+	}
+
+	if tok := r.URL.Query().Get("token"); tok != "" {
+		hdr.Set("Authorization", "Bearer "+tok)
+		return hdr, true
+	}
+
+	return hdr, false
+}
+
+// wsUpgrader builds the upgrader for a raw-WS plane.
+//
+// Subprotocols is set so that gorilla echoes WSProtocol back when the client
+// offers it. The bearer subprotocol is deliberately NOT in this list — it must
+// never be reflected into the response.
+func wsUpgrader(originAllowed func(*http.Request) bool) websocket.Upgrader {
+	return websocket.Upgrader{
+		Subprotocols: []string{WSProtocol},
+		CheckOrigin:  originAllowed,
+	}
+}
+
+// OriginPolicy decides whether a cross-origin WebSocket upgrade is acceptable.
+//
+// The old behaviour was an unconditional `return true`, justified in a comment
+// by "the bearer token (not a cookie) is the auth". That reasoning holds for
+// auth-mode=oidc and auth-mode=token: an attacker's page cannot read the token
+// (localStorage is origin-scoped), so it cannot open an authenticated socket,
+// and Origin buys little.
+//
+// It does NOT hold for auth-mode=insecure, where there is no authentication at
+// all: any page the operator visits could open a console to any VM, or a
+// sandbox exec shell, on a gateway their browser can reach. Origin is the only
+// control left, so in that mode cross-origin is refused unless the operator
+// listed the origin explicitly.
+type OriginPolicy struct {
+	allowed  map[string]bool
+	wildcard bool
+	// strict is true for auth-mode=insecure: never honour "*".
+	strict bool
+}
+
+// NewOriginPolicy builds a policy from --cors-allow-origin and --auth-mode.
+func NewOriginPolicy(corsAllowOrigin, authMode string) *OriginPolicy {
+	p := &OriginPolicy{allowed: map[string]bool{}, strict: authMode == "insecure"}
+	for _, o := range strings.Split(corsAllowOrigin, ",") {
+		o = strings.ToLower(strings.TrimSpace(o))
+		switch {
+		case o == "":
+		case o == "*":
+			p.wildcard = true
+		default:
+			p.allowed[o] = true
+		}
+	}
+	return p
+}
+
+// Allow reports whether the upgrade may proceed. Exported shape matches
+// websocket.Upgrader.CheckOrigin.
+func (p *OriginPolicy) Allow(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		// Not a browser: swiftctl, curl, a test. There is no origin to police,
+		// and the bearer is still required.
+		return true
+	}
+	if p.allowed[strings.ToLower(origin)] {
+		return true
+	}
+	// Same-origin is always fine — this is the UI served from the gateway's own
+	// host, or through the UI's same-origin nginx proxy.
+	if u, err := url.Parse(origin); err == nil && u.Host != "" && strings.EqualFold(u.Host, r.Host) {
+		return true
+	}
+	return p.wildcard && !p.strict
+}

--- a/internal/gateway/wsauth_test.go
+++ b/internal/gateway/wsauth_test.go
@@ -1,0 +1,163 @@
+package gateway
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func wsReq(target string, protos ...string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, target, nil)
+	// Subprotocols are only parsed on a request that looks like an upgrade.
+	r.Header.Set("Connection", "Upgrade")
+	r.Header.Set("Upgrade", "websocket")
+	for _, p := range protos {
+		r.Header.Add("Sec-WebSocket-Protocol", p)
+	}
+	return r
+}
+
+func TestWSAuthHeader_SubprotocolBearer(t *testing.T) {
+	tok := "eyJhbGciOi.PAYLOAD.SIG"
+	enc := base64.RawURLEncoding.EncodeToString([]byte(tok))
+	r := wsReq("/console?cluster=c&namespace=n&name=g", WSBearerPrefix+enc, WSProtocol)
+
+	hdr, deprecated := wsAuthHeader(r)
+	if got, want := hdr.Get("Authorization"), "Bearer "+tok; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
+	if deprecated {
+		t.Error("subprotocol bearer must not be reported as deprecated")
+	}
+}
+
+func TestWSAuthHeader_TokenNeverNeedsTheQueryString(t *testing.T) {
+	// The whole point: a client using the subprotocol form puts NOTHING
+	// sensitive in the URL, so no access log on the path can capture it.
+	tok := "secret-token"
+	enc := base64.RawURLEncoding.EncodeToString([]byte(tok))
+	r := wsReq("/sandbox-exec?cluster=c&namespace=n&name=s", WSBearerPrefix+enc, WSProtocol)
+
+	if r.URL.RawQuery == "" {
+		t.Fatal("test setup: expected a query string")
+	}
+	if got := r.URL.String(); strings.Contains(got, tok) {
+		t.Fatalf("token leaked into the URL: %q", got)
+	}
+	hdr, _ := wsAuthHeader(r)
+	if hdr.Get("Authorization") == "" {
+		t.Fatal("token not recovered from the subprotocol")
+	}
+}
+
+func TestWSAuthHeader_PaddedBase64StillAccepted(t *testing.T) {
+	tok := "abcd" // encodes to a padded value under URLEncoding
+	r := wsReq("/console", WSBearerPrefix+base64.URLEncoding.EncodeToString([]byte(tok)), WSProtocol)
+	hdr, _ := wsAuthHeader(r)
+	if got, want := hdr.Get("Authorization"), "Bearer "+tok; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestWSAuthHeader_QueryFallbackFlaggedDeprecated(t *testing.T) {
+	// A UI released before this change still works, but the caller is told so
+	// it can warn — the query form is what leaks into logs.
+	r := wsReq("/console?token=legacy-token")
+	hdr, deprecated := wsAuthHeader(r)
+	if got, want := hdr.Get("Authorization"), "Bearer legacy-token"; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
+	if !deprecated {
+		t.Error("?token= must be reported as deprecated")
+	}
+}
+
+func TestWSAuthHeader_SubprotocolBeatsQuery(t *testing.T) {
+	enc := base64.RawURLEncoding.EncodeToString([]byte("header-token"))
+	r := wsReq("/console?token=query-token", WSBearerPrefix+enc, WSProtocol)
+	hdr, deprecated := wsAuthHeader(r)
+	if got, want := hdr.Get("Authorization"), "Bearer header-token"; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
+	if deprecated {
+		t.Error("should not warn when the header form was used")
+	}
+}
+
+func TestWSAuthHeader_NoCredential(t *testing.T) {
+	hdr, deprecated := wsAuthHeader(wsReq("/console"))
+	if hdr.Get("Authorization") != "" {
+		t.Error("invented a credential")
+	}
+	if deprecated {
+		t.Error("nothing supplied is not a deprecated form")
+	}
+}
+
+func TestWSAuthHeader_GarbageSubprotocolIsIgnored(t *testing.T) {
+	r := wsReq("/console", WSBearerPrefix+"!!!not-base64!!!", WSProtocol)
+	hdr, _ := wsAuthHeader(r)
+	if hdr.Get("Authorization") != "" {
+		t.Error("undecodable bearer must not produce an Authorization header")
+	}
+}
+
+// --- origin policy ---
+
+func originReq(origin, host string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "http://"+host+"/console", nil)
+	r.Host = host
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	return r
+}
+
+func TestOriginPolicy_NoOriginIsANonBrowserClient(t *testing.T) {
+	// swiftctl / curl send no Origin. The bearer is still required.
+	for _, mode := range []string{"oidc", "insecure"} {
+		p := NewOriginPolicy("https://ui.example.com", mode)
+		if !p.Allow(originReq("", "gw.example.com")) {
+			t.Errorf("mode %s: rejected a request with no Origin", mode)
+		}
+	}
+}
+
+func TestOriginPolicy_SameOriginAlwaysAllowed(t *testing.T) {
+	p := NewOriginPolicy("https://ui.example.com", "insecure")
+	if !p.Allow(originReq("https://gw.example.com", "gw.example.com")) {
+		t.Error("same-origin upgrade rejected")
+	}
+}
+
+func TestOriginPolicy_ExplicitAllowlist(t *testing.T) {
+	p := NewOriginPolicy("https://ui.example.com, https://other.example.com", "oidc")
+	if !p.Allow(originReq("https://other.example.com", "gw.example.com")) {
+		t.Error("listed origin rejected")
+	}
+	if p.Allow(originReq("https://evil.example.com", "gw.example.com")) {
+		t.Error("unlisted origin accepted despite an explicit allowlist")
+	}
+}
+
+func TestOriginPolicy_InsecureModeRefusesWildcard(t *testing.T) {
+	// THE case this exists for. auth-mode=insecure performs no authentication,
+	// so any page the operator visits could otherwise open a console to a VM or
+	// a sandbox exec shell. Origin is the only control left.
+	p := NewOriginPolicy("*", "insecure")
+	if p.Allow(originReq("https://evil.example.com", "gw.example.com")) {
+		t.Fatal("cross-origin upgrade accepted with auth-mode=insecure and CORS=*")
+	}
+}
+
+func TestOriginPolicy_WildcardHonouredWhenAuthenticated(t *testing.T) {
+	// With a real auth mode the bearer is the control and the attacker's page
+	// cannot read it, so "*" stays honoured — no behaviour change for existing
+	// oidc/token deployments.
+	p := NewOriginPolicy("*", "oidc")
+	if !p.Allow(originReq("https://anything.example.com", "gw.example.com")) {
+		t.Error("wildcard not honoured under auth-mode=oidc")
+	}
+}

--- a/internal/seed/configmap.go
+++ b/internal/seed/configmap.go
@@ -13,6 +13,39 @@ const (
 
 // BuildConfigMap creates a ConfigMap with NoCloud-standard keys.
 // Omit keys for empty values. Caller should set OwnerReferences for garbage collection.
+// BuildSecret renders the seed as a Secret.
+//
+// cloud-init user-data routinely carries SSH authorized keys, passwords and
+// cluster join tokens, and a SwiftSeedProfile can source it from a Secret
+// (valueFrom.secretKeyRef). Rendering that into a ConfigMap re-materialized the
+// credential in the clear for anyone holding `get configmaps` in the namespace —
+// a strictly weaker grant than `get secrets`, and one that RBAC policies
+// routinely hand out. Same keys and same layout as BuildConfigMap, so nothing
+// downstream of the mount changes.
+func BuildSecret(name, namespace string, userData, metaData, networkData string) *corev1.Secret {
+	data := make(map[string]string)
+	if userData != "" {
+		data[KeyUserData] = userData
+	}
+	if metaData != "" {
+		data[KeyMetaData] = metaData
+	}
+	if networkData != "" {
+		data[KeyNetworkConfig] = networkData
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		StringData: data,
+	}
+}
+
+// BuildConfigMap is the legacy renderer, kept only so the migration path can
+// recognise and retire a pre-existing seed ConfigMap. New guests get a Secret.
+//
+// Deprecated: use BuildSecret.
 func BuildConfigMap(name, namespace string, userData, metaData, networkData string) *corev1.ConfigMap {
 	data := make(map[string]string)
 	if userData != "" {


### PR DESCRIPTION
Phase 2 of the post-review plan.

## The finding

A `SwiftSeedProfile` can source cloud-init user-data from a Secret
(`valueFrom.secretKeyRef`). The controller then rendered the result into a
**ConfigMap** (`internal/controller/swiftguest/controller.go:219`), which
re-materialized the credential in the clear for anyone holding `get configmaps`
in the namespace — a strictly weaker grant than `get secrets`, and one RBAC
policies routinely hand out.

cloud-init user-data is exactly where SSH authorized keys, passwords and cluster
join tokens live, so this is the highest-value plaintext in the namespace.

The seed is now a Secret, same three keys at the same mount path. Nothing on the
guest side changes.

## Two things this had to get right

**The reconcile comparison.** A Secret written with `StringData` comes back from
the apiserver with `Data`, and `StringData` nil. A direct `DeepEqual` against the
built object would differ on *every* pass → write on every reconcile → watch
event → reconcile. `renderedSeedData` normalises to the stored form so the
comparison is apples-to-apples. (This codebase has been bitten by
write-on-every-reconcile before, which is why it's called out.)

**Upgrade must not break running guests.** A guest that was already running keeps
its launcher pod, and that pod still mounts the ConfigMap. Deleting it out from
under a live pod breaks the VM on its *next restart*, when kubelet re-projects
the volume and cannot find it — a failure that would land days later, far from
the change that caused it.

`retireLegacySeedConfigMap` therefore deletes it only once no pod for that guest
still references it. The honest trade: **a long-running guest keeps its plaintext
copy until it is next recreated.** The alternative is breaking running VMs on
upgrade, which is worse. Guests created after this change never get a ConfigMap
at all.

## RBAC

None needed. The controller already held `secrets: create,update` (for the
migration mTLS cert distribution) and `configmaps: delete`. The comment on the
secrets rule now names both consumers, rather than implying mTLS is the only one.

## Verification

- 6 new tests covering both upgrade branches (pod still on the ConfigMap → keep;
  pod moved to the Secret → delete), the no-pods case, the absent case, and the
  `StringData`/`Data` normalisation.
- The **existing** restore-pod test asserted the seed volume was a ConfigMap and
  failed — the assertion doing its job. Updated to the new contract.
- **Negative control**: reverting `AddSeedVolume` to a ConfigMap source fails it
  again.
- Full `./internal/...` suite green; `gofmt` clean.

Not yet cluster-validated: needs a real boot plus a clone/restore check on dev,
since the seed is on the restore path too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
