### PR TITLE
fix(chart,ci): harden the controller-manager pod; pin release Actions to SHAs

### DIFF
--- a/.github/workflows/release-rc.yaml
+++ b/.github/workflows/release-rc.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Build and push images + chart
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set version from tag
         id: version
@@ -34,10 +34,10 @@ jobs:
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build and push controller-manager
         id: build-controller-manager
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/controller-manager/Containerfile
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build and push gpu-discovery
         id: build-gpu-discovery
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/gpu-discovery/Containerfile
@@ -88,7 +88,7 @@ jobs:
 
       - name: Build and push kubeswift-dra-driver
         id: build-dra-driver
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/kubeswift-dra-driver/Containerfile
@@ -106,7 +106,7 @@ jobs:
 
       - name: Build and push snapshot-s3
         id: build-snapshot-s3
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/snapshot-s3/Containerfile
@@ -127,7 +127,7 @@ jobs:
 
       - name: Build and push snapshot-oras
         id: build-snapshot-oras
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/snapshot-oras/Containerfile
@@ -145,7 +145,7 @@ jobs:
 
       - name: Build and push sandbox-materialize
         id: build-sandbox-materialize
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/sandbox-materialize/Containerfile
@@ -163,7 +163,7 @@ jobs:
 
       - name: Build and push swiftletd
         id: build-swiftletd
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/swiftletd/Containerfile
@@ -184,7 +184,7 @@ jobs:
 
       - name: Build and push migration-stunnel
         id: build-migration-stunnel
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/migration-stunnel/Containerfile
@@ -203,7 +203,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       # Keyless signing: the signing identity is THIS workflow run's GitHub
       # OIDC identity (repo + workflow path + tag ref); the signature and
@@ -225,7 +225,7 @@ jobs:
           cosign sign "${{ env.IMAGE_PREFIX }}/migration-stunnel@${{ steps.build-migration-stunnel.outputs.digest }}"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.16.0
 
@@ -250,7 +250,7 @@ jobs:
       # page (previously only release-stable.yaml created releases; RC releases
       # had to be created by hand — v0.3.0-rc.1 gap).
       - name: Create GitHub pre-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ github.ref_name }}
           name: KubeSwift ${{ github.ref_name }}

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -25,7 +25,7 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
@@ -40,10 +40,10 @@ jobs:
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push controller-manager
         id: build-controller-manager
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/controller-manager/Containerfile
@@ -72,7 +72,7 @@ jobs:
 
       - name: Build and push gpu-discovery
         id: build-gpu-discovery
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/gpu-discovery/Containerfile
@@ -94,7 +94,7 @@ jobs:
 
       - name: Build and push kubeswift-dra-driver
         id: build-dra-driver
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/kubeswift-dra-driver/Containerfile
@@ -112,7 +112,7 @@ jobs:
 
       - name: Build and push snapshot-s3
         id: build-snapshot-s3
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/snapshot-s3/Containerfile
@@ -133,7 +133,7 @@ jobs:
 
       - name: Build and push snapshot-oras
         id: build-snapshot-oras
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/snapshot-oras/Containerfile
@@ -151,7 +151,7 @@ jobs:
 
       - name: Build and push sandbox-materialize
         id: build-sandbox-materialize
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/sandbox-materialize/Containerfile
@@ -169,7 +169,7 @@ jobs:
 
       - name: Build and push swiftletd
         id: build-swiftletd
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/swiftletd/Containerfile
@@ -190,7 +190,7 @@ jobs:
 
       - name: Build and push migration-stunnel
         id: build-migration-stunnel
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/migration-stunnel/Containerfile
@@ -210,7 +210,7 @@ jobs:
 
       - name: Build and push kubeswift-gateway
         id: build-gateway
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./images/kubeswift-gateway/Containerfile
@@ -227,7 +227,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       # Keyless signing: the signing identity is THIS workflow run's GitHub
       # OIDC identity (repo + workflow path + tag ref); the signature and
@@ -250,7 +250,7 @@ jobs:
           cosign sign "${{ env.IMAGE_PREFIX }}/kubeswift-gateway@${{ steps.build-gateway.outputs.digest }}"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.16.0
 
@@ -258,7 +258,7 @@ jobs:
         run: helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: 'go.mod'
 
@@ -289,12 +289,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: 'go.mod'
 
@@ -313,7 +313,7 @@ jobs:
         run: cd dist && sha256sum swiftctl-* > SHA256SUMS
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       # Keyless blob signing of the checksums file. Verifying SHA256SUMS via
       # the .sig/.pem pair transitively authenticates every binary it lists.
@@ -327,7 +327,7 @@ jobs:
             dist/SHA256SUMS
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ github.ref_name }}
           name: KubeSwift ${{ github.ref_name }}

--- a/charts/kubeswift/templates/controller-manager/deployment.yaml
+++ b/charts/kubeswift/templates/controller-manager/deployment.yaml
@@ -19,6 +19,16 @@ spec:
         app.kubernetes.io/component: controller-manager
     spec:
       serviceAccountName: controller-manager
+      # The controller-manager is a plain Go binary on
+      # distroless/static-debian12:nonroot — it needs no host access at all, so
+      # it gets the same hardened context as the gateway, UI and gpu-discovery.
+      # (The LAUNCHER pods are privileged, deliberately, and separately — see
+      # docs/security-audit.md SEC-01/02/03. That is not a reason for the
+      # controller to be.)
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: controller-manager
           image: {{ .Values.controllerManager.image.registry }}/controller-manager:{{ include "kubeswift.imageTag" (dict "tag" .Values.controllerManager.image.tag "appVersion" .Chart.AppVersion) }}
@@ -53,6 +63,12 @@ spec:
           ports:
             - containerPort: 9443
               name: webhook
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           resources:
             {{- toYaml .Values.controllerManager.resources | nindent 12 }}
           {{- if .Values.webhook.enabled }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -365,12 +365,33 @@ monitoring:
 # Live migration settings.
 migration:
   # mTLS transport for cross-node live migration (Phase 3c, Option B per-node
-  # identity). When enabled the chart provisions a per-namespace cert-manager
-  # PKI (selfSigned Issuer -> CA -> CA Issuer) in .Values.namespace and the
-  # controller-manager runs with --migration-mtls-enabled=true (issues one
-  # leaf Certificate per worker node). Requires cert-manager installed
-  # cluster-side. Off by default — default clusters incur no cert-manager
-  # dependency and no behavior change.
+  # identity).
+  #
+  # WHAT IS ON THE WIRE WITH THIS OFF (the default): a cross-node live
+  # migration streams the guest's RAM between launcher pods in the CLEAR, over
+  # the pod network. That memory contains whatever the guest holds at that
+  # moment — SSH host keys, in-memory secrets, disk-encryption keys, database
+  # buffers. Anyone able to observe pod-to-pod traffic on the migration path
+  # (a compromised node, a CNI with no encryption, a span port) can read it.
+  # Offline migration does not stream memory and is unaffected.
+  #
+  # ENABLING IT IS A HARD DEPENDENCY ON cert-manager. The chart provisions a
+  # per-namespace PKI (selfSigned Issuer -> CA -> CA Issuer) in
+  # .Values.namespace and the controller-manager runs with
+  # --migration-mtls-enabled=true, issuing one leaf Certificate per worker
+  # node. cert-manager must ALREADY be installed and its CRDs established, on
+  # every cluster running this chart, before you flip this — the templates
+  # render Issuer/Certificate objects and the install fails if those kinds do
+  # not exist. It is not a soft or optional dependency, and there is no
+  # fallback path.
+  #
+  # It stays OFF by default deliberately: a default install should not acquire
+  # a cluster-wide operator dependency it did not ask for. Turn it on where the
+  # pod network is untrusted and you already run cert-manager.
+  #
+  # See docs/migration/ for the transport detail (a stunnel sidecar; CH's own
+  # native migration TLS was evaluated and rejected — it connects by DNS name,
+  # which UDN/OVN-K launcher pods cannot resolve).
   mtls:
     enabled: false
 


### PR DESCRIPTION
Phase 4 of the post-review plan. Three items, no behaviour change.

## controller-manager had no `securityContext`

Every other component this project controls — gateway, UI, gpu-discovery, DRA
driver — runs drop-ALL / non-root / read-only-rootfs. The controller-manager was
the one that did not, and it is a plain Go binary on
`distroless/static-debian12:nonroot` that needs no host access at all.

Worth being explicit, because it comes up every time: this is **unrelated to the
launcher pods being privileged**. That is deliberate, was re-confirmed during the
v0.13.3 review, and is documented in `docs/security-audit.md` SEC-01/02/03. It is
not a reason for the controller to be unhardened as well.

Verified by rendering the chart:

```
pod securityContext : {'runAsNonRoot': True, 'seccompProfile': {'type': 'RuntimeDefault'}}
ctr securityContext : {'allowPrivilegeEscalation': False, 'readOnlyRootFilesystem': True, 'capabilities': {'drop': ['ALL']}}
```

## Release workflows ran Actions on floating tags

`release-stable.yaml` and `release-rc.yaml` hold `id-token: write` for cosign
keyless signing. A moved tag on any Action they use would run attacker-controlled
code in a job that can mint an OIDC identity and **sign artifacts as this repo** —
which is the whole point of keyless signing being trustworthy.

All eight are pinned to full commit SHAs, tag retained as a trailing comment so
they stay legible and updatable.

`ci.yaml` is deliberately left alone: it has no `id-token` permission, so
`dtolnay/rust-toolchain@stable` there is a materially smaller surface. Pinning it
too is fine later, but it is not the same class of problem and I did not want to
imply it was.

## `migration.mtls` documentation

Per your call: **default stays off**, with the dependency made explicit.

What the comment now says, and did not before:

- With mTLS off, a cross-node **live** migration streams the guest's RAM between
  launcher pods **in the clear** over the pod network — host keys, in-memory
  secrets, disk-encryption keys, whatever the guest holds at that moment. Offline
  migration streams no memory and is unaffected.
- Enabling it is a **hard** dependency on cert-manager: the templates render
  Issuer/Certificate objects, so cert-manager and its CRDs must already exist on
  every cluster running the chart or the install fails outright. No soft path, no
  fallback.
- Why it stays off: a default install should not acquire a cluster-wide operator
  dependency it did not ask for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
