### PR TITLE
fix(sandbox,guest): close the restricted-egress spoof + IPv6 gap; fail #444 loudly

### DIFF
--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -450,6 +450,23 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// SwiftGPU controller's Resolve stamps status.GPU after scheduling
 	// (status-only, not load-bearing for the runtime). Design doc §A2/§A6.
 
+	// Node placement, BEFORE anything that pins to that node (issue #444).
+	//
+	// The root-disk clone Job below pins to spec.nodeName too. If that node is
+	// unschedulable, the Job's pod sits Pending forever, reconcile never reaches
+	// buildPod, and the guest stalls in Scheduling with nothing explaining why.
+	// Checking here turns a silent stall into a terminal failure with a reason.
+	if err := checkNodePlacementFor(ctx, r.Client, &guest, nil); err != nil {
+		status.Phase = swiftv1alpha1.SwiftGuestPhaseFailed
+		SetResolvedCondition(status, false, err.Error())
+		recordGuestMetrics(&guest, &guest.Status, status, nil)
+		if patchErr := r.patchStatus(ctx, &guest, status); patchErr != nil {
+			return ctrl.Result{}, patchErr
+		}
+		logger.Info("rejected guest: unschedulable spec.nodeName", "error", err.Error())
+		return ctrl.Result{}, nil
+	}
+
 	// For disk boot, ensure per-guest root disk clone exists and is ready.
 	// RootDisk.FromOCI (a source-independent full-state clone) has NO prepared
 	// image — its disk is materialized from the snapshot's oci disk artifact

--- a/internal/controller/swiftguest/nodeplacement.go
+++ b/internal/controller/swiftguest/nodeplacement.go
@@ -38,6 +38,18 @@ import (
 // preference the scheduler weighs; it never blocks placement, so enforcing it
 // here would be stricter than Kubernetes itself.
 func checkNodePlacement(ctx context.Context, c client.Reader, guest *swiftv1alpha1.SwiftGuest, pod *corev1.Pod) error {
+	return checkNodePlacementFor(ctx, c, guest, pod.Spec.Tolerations)
+}
+
+// checkNodePlacementFor is the same check against a toleration set directly,
+// so it can run BEFORE the pod is built.
+//
+// That ordering is the point (issue #444): a guest pinned to an unschedulable
+// node used to stall with no diagnosis, because the root-disk clone Job is
+// created first and pins to the SAME node, its pod sits Pending forever, and
+// the reconcile never reaches buildPod where this check lived. The operator saw
+// a guest stuck in Scheduling with nothing saying why.
+func checkNodePlacementFor(ctx context.Context, c client.Reader, guest *swiftv1alpha1.SwiftGuest, tolerations []corev1.Toleration) error {
 	if guest.Spec.NodeName == "" {
 		return nil // not pinned; the scheduler runs normally and applies taints itself
 	}
@@ -48,10 +60,15 @@ func checkNodePlacement(ctx context.Context, c client.Reader, guest *swiftv1alph
 		}
 		return fmt.Errorf("resolve spec.nodeName=%q: %w", guest.Spec.NodeName, err)
 	}
-	if t, ok := untoleratedTaint(node.Spec.Taints, pod.Spec.Tolerations); ok {
+	if t, ok := untoleratedTaint(node.Spec.Taints, tolerations); ok {
+		// NB: SwiftGuest has no spec.tolerations field — the launcher pod is
+		// built with none — so in practice a pinned guest cannot target a
+		// NoSchedule/NoExecute node at all. The message says that, rather than
+		// pointing at a field that does not exist (which the first version of
+		// this check did).
 		return fmt.Errorf(
-			"spec.nodeName=%q has taint %s=%s:%s which this guest does not tolerate; "+
-				"add a matching toleration to spec.tolerations to place a guest there",
+			"spec.nodeName=%q has taint %s=%s:%s and a guest cannot tolerate taints; "+
+				"pin the guest to an untainted node, or remove the taint",
 			guest.Spec.NodeName, t.Key, t.Value, t.Effect)
 	}
 	return nil

--- a/internal/controller/swiftguest/nodeplacement_test.go
+++ b/internal/controller/swiftguest/nodeplacement_test.go
@@ -98,3 +98,45 @@ func TestTolerated_Wildcard(t *testing.T) {
 		t.Error("wildcard toleration should tolerate any taint")
 	}
 }
+
+// TestCheckNodePlacementFor_RunsWithoutAPod is the #444 fix: the check has to be
+// callable BEFORE the pod is built, because the root-disk clone Job pins to the
+// same node and its pod would sit Pending forever, so reconcile never reached
+// the old call site inside buildPod and the guest stalled with no reason set.
+func TestCheckNodePlacementFor_RunsWithoutAPod(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "frida"},
+		Spec: corev1.NodeSpec{Taints: []corev1.Taint{{
+			Key: "node-role.kubernetes.io/control-plane", Effect: corev1.TaintEffectNoSchedule,
+		}}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(node).Build()
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "g1"},
+		Spec:       swiftv1alpha1.SwiftGuestSpec{NodeName: "frida"},
+	}
+
+	err := checkNodePlacementFor(context.Background(), c, guest, nil)
+	if err == nil {
+		t.Fatal("a guest pinned to a NoSchedule node was accepted; it would stall silently")
+	}
+	// The message must not send the operator to a field that does not exist.
+	if strings.Contains(err.Error(), "spec.tolerations") {
+		t.Errorf("error points at spec.tolerations, which SwiftGuest does not have: %v", err)
+	}
+	if !strings.Contains(err.Error(), "frida") {
+		t.Errorf("error does not name the node: %v", err)
+	}
+}
+
+func TestCheckNodePlacementFor_UntaintedNodeIsFine(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}).Build()
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "g1"},
+		Spec:       swiftv1alpha1.SwiftGuestSpec{NodeName: "miles"},
+	}
+	if err := checkNodePlacementFor(context.Background(), c, guest, nil); err != nil {
+		t.Errorf("rejected an untainted node: %v", err)
+	}
+}

--- a/rust/swiftletd/scripts/network-init.sh
+++ b/rust/swiftletd/scripts/network-init.sh
@@ -41,9 +41,25 @@ guest_run_dir() {
 # Node public IPs are NOT blocked (same exposure as any pod); documented.
 apply_restricted_egress() {
     src_net="$1"
+    guest_if="${2:-br0}"
     [ "${KUBESWIFT_SANDBOX_EGRESS:-}" = "restricted" ] || return 0
     chain="KUBESWIFT_SBX_EGRESS"
+
     iptables -N "$chain" 2>/dev/null || iptables -F "$chain"
+
+    # ANTI-SPOOF, and it must be first.
+    #
+    # The chain used to be entered with `-s $src_net`. The guest configures its
+    # own NIC, so it can send with ANY source address -- and a packet whose
+    # source is not in $src_net simply did not match the jump, so it skipped the
+    # whole chain and every DROP below it. Setting a source of 8.8.8.8 was
+    # enough to reach the metadata endpoint and the pod/service CIDRs.
+    #
+    # The jump now keys on the INPUT INTERFACE, which the guest cannot forge
+    # from inside the VM, and anything arriving there with a source outside the
+    # guest subnet is by definition forged.
+    iptables -A "$chain" ! -s "$src_net" -j DROP
+
     iptables -A "$chain" -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN
     for d in $(grep '^nameserver ' /etc/resolv.conf 2>/dev/null | awk '{print $2}'); do
         iptables -A "$chain" -d "$d" -p udp --dport 53 -j RETURN
@@ -53,10 +69,32 @@ apply_restricted_egress() {
     iptables -A "$chain" -d 10.0.0.0/8     -j DROP
     iptables -A "$chain" -d 172.16.0.0/12  -j DROP
     iptables -A "$chain" -d 192.168.0.0/16 -j DROP
-    # Idempotent jump at the top of FORWARD for the VM subnet.
-    iptables -C FORWARD -s "$src_net" -j "$chain" 2>/dev/null \
-        || iptables -I FORWARD 1 -s "$src_net" -j "$chain"
-    echo "Restricted egress: $src_net -> DNS + internet; DROP 169.254/16 + RFC1918 (chain $chain)"
+    iptables -A "$chain" -d 100.64.0.0/10  -j DROP  # CGNAT: some CNIs + cloud LB ranges
+    # Idempotent jump at the top of FORWARD, keyed on the guest interface.
+    iptables -C FORWARD -i "$guest_if" -j "$chain" 2>/dev/null \
+        || iptables -I FORWARD 1 -i "$guest_if" -j "$chain"
+
+    # IPv6: the rules above are iptables-only, so on a dual-stack cluster the
+    # guest could reach every blocked destination over IPv6 with nothing in the
+    # way -- including the metadata service and any ULA-addressed pod.
+    #
+    # `restricted` DROPs IPv6 forwarding outright rather than trying to mirror
+    # the v4 policy: the in-pod dnsmasq hands an IPv4 resolver only, the guest's
+    # internet path is the v4 MASQUERADE, and the cluster's v6 CIDRs are not
+    # knowable here. Blocking is therefore both safe and behaviour-preserving --
+    # and a silent partial policy would be worse than none.
+    if command -v ip6tables >/dev/null 2>&1; then
+        ip6tables -N "$chain" 2>/dev/null || ip6tables -F "$chain"
+        ip6tables -A "$chain" -j DROP
+        ip6tables -C FORWARD -i "$guest_if" -j "$chain" 2>/dev/null \
+            || ip6tables -I FORWARD 1 -i "$guest_if" -j "$chain"
+        echo "Restricted egress: IPv6 forwarding DROPped on $guest_if"
+    else
+        echo "Restricted egress: ip6tables absent; IPv6 unrestricted (kernel likely has no IPv6)"
+    fi
+
+    echo "Restricted egress: $guest_if ($src_net) -> DNS + internet;" \
+         "DROP spoofed sources + 169.254/16 + RFC1918 + 100.64/10 (chain $chain)"
 }
 
 setup_primary_nic() {
@@ -105,7 +143,7 @@ setup_primary_nic() {
     iptables -t nat -A POSTROUTING -s "$bridge_net" ! -d "$bridge_net" -j MASQUERADE
 
     # Sandbox restricted-egress hardening (no-op unless KUBESWIFT_SANDBOX_EGRESS=restricted).
-    apply_restricted_egress "$bridge_net"
+    apply_restricted_egress "$bridge_net" "$bridge"
 
     echo "Primary NIC: $bridge ($bridge_ip, net $bridge_net) with $tap"
 }


### PR DESCRIPTION
Phase 6 of the post-review plan. Closes #444.

## Restricted egress was bypassable by setting a source address

The FORWARD jump into the policy chain was keyed on `-s $src_net`. **The guest configures its own NIC**, so it can send with any source it likes — and a packet whose source was not in $src_net simply did not match the jump, skipping the entire chain and every DROP in it.

Setting a source of `8.8.8.8` was enough to reach the cloud metadata endpoint and the pod/service CIDRs from a sandbox marked `restricted`.

The jump now keys on the guest **interface**, which cannot be forged from inside the VM, and the first rule drops anything arriving there with a source outside the guest subnet. Also adds `100.64.0.0/10` (CGNAT — some CNIs and cloud LB ranges).

## IPv6 had no rules at all

Everything was iptables-only, so on a dual-stack cluster the guest could reach every blocked destination over IPv6 with nothing in the way.

`restricted` now DROPs IPv6 forwarding outright rather than mirroring a partial v4 policy: the in-pod dnsmasq hands an IPv4 resolver, the internet path is the v4 MASQUERADE, and the cluster's v6 CIDRs are not knowable at that point. **A silent partial policy would be worse than none.** Absence of ip6tables is logged, not passed over.

## #444 — silent stall on an unschedulable node

The taint check ran inside `buildPod`, but the root-disk clone Job is created first and pins to the same node, so its pod sat Pending forever and reconcile never reached the check. The operator saw `Scheduling` with no reason.

It now runs **before anything that pins**, and fails the guest terminally with the reason on the Resolved condition.

While moving it I found a message I shipped in #439 telling operators to "add a matching toleration to `spec.tolerations`" — **a field SwiftGuest does not have.** Nothing sets pod tolerations, so a pinned guest cannot target a tainted node at all. The message now says that.

## Verification

The new rules were loaded into a **real netfilter** (container with NET_ADMIN), confirming the anti-spoof DROP lands first and the jump is interface-keyed:

```
-A KUBESWIFT_SBX_EGRESS ! -s 192.168.99.0/24 -j DROP
-A KUBESWIFT_SBX_EGRESS -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
...
-A FORWARD -i br0 -j KUBESWIFT_SBX_EGRESS
```

Being explicit about coverage: the #444 helper has unit tests, but the **ordering** fix is only provable on a cluster — the same gap the issue itself recorded. The egress change is shell and has no unit test; the netfilter load above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)