### PR TITLE
release: v0.13.4 — second security pass, dev-validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,76 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.13.4] — 2026-07-28
+
+Second security pass. A UI-focused review found a class of defect in the v0.11.0
+guided forms, and closing out every remaining finding from both reviews produced
+six more fixes across the gateway, controller, chart and launcher. Validated on
+the dev cluster — including the two items previous releases could only unit-test.
+
+### Action required on upgrade
+
+- **The rendered cloud-init seed is now a Secret, not a ConfigMap.** Anything
+  reading `<guest>-seed` as a ConfigMap must read the Secret instead. A guest
+  that is already running keeps its ConfigMap until it is next recreated (the
+  controller will not delete it out from under a live pod); guests created after
+  the upgrade never get one.
+- **The console and sandbox WebSocket planes now expect the bearer as a
+  `Sec-WebSocket-Protocol` subprotocol.** `?token=` still works and is logged as
+  deprecated, so an older UI keeps functioning — but **kubeswift-ui must be at
+  v0.12.0 or later** to use the new form. Upgrade both.
+- **`auth-mode=insecure` now refuses cross-origin WebSocket upgrades** even with
+  `gateway.corsAllowOrigin="*"`. Set an explicit origin, or use a real auth mode.
+  No change for `oidc`/`token` deployments.
+- **SwiftKernel is now validated at admission.** An `ociRef.image` containing
+  shell metacharacters or `..`, or a `kernelCmdline` with a newline, is rejected.
+- `make deploy` (kustomize) now installs 9 webhooks instead of 7 — SwiftSnapshot
+  and SwiftRestore were silently missing.
+
+### Fixed
+
+- **Guided forms silently rewrote fields the operator never touched**
+  (kubeswift-ui #37). `hydrate()` failed to recognise a variant and `build()`
+  overwrote the subtree. The PodSpec editor rebuilt from scratch, dropping
+  `automountServiceAccountToken`, `initContainers`, `envFrom`, `capabilities`,
+  `seccompProfile`, `affinity`, probe tuning, extended resources like
+  `nvidia.com/gpu`, env `valueFrom` and volumeMount `subPath`;
+  `allowPrivilegeEscalation: false` was not even expressible; unmodelled volume
+  types became `emptyDir` while keeping the name, so mounts still resolved onto
+  an empty tmpdir. A SwiftSnapshotSchedule on the s3 or oci backend was rewritten
+  to `local`, silently redirecting offsite backups to node disk; a SwiftImage on
+  the oci source lost its cosign `verifyKeySecretRef`.
+- **The WebSocket bearer travelled in the query string** (#445) and so was
+  written to every access log on the path — the UI's nginx and any ingress in
+  front of it — leaving replayable ID tokens readable by anyone with `pods/log`.
+- **`CheckOrigin` accepted every origin** (#445). Harmless under a real auth mode,
+  but under `auth-mode=insecure` any page the operator visited could open a
+  console or a sandbox shell.
+- **Cloud-init user-data sourced from a Secret was re-materialized into a
+  plaintext ConfigMap** (#446) — SSH keys, passwords and join tokens readable
+  with `get configmaps`.
+- **controller-manager ran with no `securityContext`** (#447), alone among the
+  components this project ships.
+- **Release workflows ran Actions on floating tags** while holding
+  `id-token: write` for cosign keyless signing (#447).
+- **SwiftKernel had no validating webhook at all** (#448), and the snapshot
+  host-path guard existed only in the webhook — which is disabled by default.
+- **A SwiftGuest pinned to an unschedulable node stalled silently** (#449,
+  closes #444). The taint check ran after the root-disk clone Job had already
+  pinned to the same node, so reconcile never reached it.
+- **Sandbox `restricted` egress was bypassable by source-address spoofing**
+  (#449). The policy chain was entered on `-s <subnet>`; the guest configures its
+  own NIC, so a forged source did not match the jump and skipped every DROP.
+  IPv6 had no rules at all.
+
+### Changed
+
+- `migration.mtls` stays **off** by default; its documentation now states plainly
+  that a cross-node live migration streams guest RAM in the clear when it is off,
+  and that enabling it is a hard cert-manager dependency.
+
+---
+
 ## [v0.13.3] — 2026-07-26
 
 Security release. A five-domain review (gateway auth, RBAC/chart/containers, UI,

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.3 \
+  --version 0.13.4 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.3
-appVersion: "0.13.3"
+version: 0.13.4
+appVersion: "0.13.4"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/config/samples/virtiofs/swiftguest-virtiofs-hostpath.yaml
+++ b/config/samples/virtiofs/swiftguest-virtiofs-hostpath.yaml
@@ -20,7 +20,7 @@ spec:
     - name: scratch          # per-guest id; drives the socket name
       tag: scratch           # guest: mount -t virtiofs scratch /mnt/scratch
       source:
-        # REQUIRES OPT-IN (v0.13.3+): host paths are confined to an operator
+        # REQUIRES OPT-IN (v0.13.4+): host paths are confined to an operator
         # allowlist, which is EMPTY by default, so this sample is rejected
         # until the cluster admin permits the prefix:
         #   --set swiftGuest.allowedHostPathPrefixes[0]=/srv/kubeswift

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -210,7 +210,7 @@ cloud-hypervisor \
   --serial socket=serial.sock
 ```
 
-No root disk PVC, no seed ConfigMap, no cloud-init. The kernel artifact path is deterministic: `/var/lib/kubeswift/kernels/<namespace>-<name>/`.
+No root disk PVC, no seed Secret, no cloud-init. The kernel artifact path is deterministic: `/var/lib/kubeswift/kernels/<namespace>-<name>/`.
 
 ### Windows boot (osType: windows)
 

--- a/docs/architecture/control-plane.md
+++ b/docs/architecture/control-plane.md
@@ -19,7 +19,7 @@ The control plane runs in the **controller-manager** Deployment (`kubeswift-syst
 | Step | Behavior |
 |------|----------|
 | Resolve | Fetches SwiftGuestClass + either SwiftImage (disk boot) or SwiftKernel (kernel boot) + optional SwiftSeedProfile; fails if refs missing or not Ready |
-| Seed | Renders NoCloud user-data/meta-data/network-config from SwiftSeedProfile into ConfigMap `<guest>-seed` (disk boot only) |
+| Seed | Renders NoCloud user-data/meta-data/network-config from SwiftSeedProfile into Secret `<guest>-seed` (disk boot only) |
 | Intent | Builds runtime-intent JSON into ConfigMap `<guest>-runtime-intent`. Includes `kernelBoot` field for kernel boot or `rootDisk` for disk boot. |
 | Pod (disk boot) | Creates pod with root-disk PVC, seed volume (optional), intent volume; launcher = swiftletd |
 | Pod (kernel boot) | Creates pod with kernel-artifacts hostPath volume, intent volume, nodeSelector `kubeswift.io/kernel-node=true`; no PVC, no seed, no network-init |

--- a/docs/architecture/diagrams.md
+++ b/docs/architecture/diagrams.md
@@ -166,7 +166,7 @@ flowchart TB
     subgraph perguest["Per-guest provisioning (SwiftGuest controller)"]
         clone["root-disk clone<br/>copy: Copy Job (cp / qemu-img to<br/>volumeDevice for Block) ·<br/>snapshot: CSI clone of clone-seed"]
         gpvc[("per-guest root PVC<br/>RWO+Filesystem (default) or<br/>RWX+Block (live-migratable)")]
-        seedcm["&lt;guest&gt;-seed ConfigMap<br/>(NoCloud user-data/meta-data)"]
+        seedcm["&lt;guest&gt;-seed Secret<br/>(NoCloud user-data/meta-data)"]
         intentcm["&lt;guest&gt;-runtime-intent ConfigMap<br/>(JSON: cpu, memory, disks, network,<br/>gpu, lifecycle, restore...)"]
     end
 

--- a/docs/architecture/node-runtime.md
+++ b/docs/architecture/node-runtime.md
@@ -44,7 +44,7 @@ No `--disk`, no `--kernel CLOUDHV.fd`, no `--net` in kernel boot mode.
 | Volume       | Mount path                      | Purpose                          |
 |--------------|----------------------------------|----------------------------------|
 | root-disk    | `/var/lib/kubeswift/disks/root` | Root disk image (PVC)            |
-| seed         | `/var/lib/kubeswift/seed`       | Seed ConfigMap (when present)    |
+| seed         | `/var/lib/kubeswift/seed`       | Seed Secret (when present)       |
 | runtime-intent | `/var/lib/kubeswift/intent`   | Runtime intent ConfigMap         |
 | run          | `/var/lib/kubeswift/run`        | Per-guest runtime directory (emptyDir) |
 | dev-kvm      | `/dev/kvm`                      | KVM device passthrough           |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.3 \
+  --set controllerManager.image.tag=v0.13.4 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.3
+  --set swiftletd.image.tag=v0.13.4
 ```
 
 ### Release workflow

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.3 -n kubeswift-system --create-namespace \
+  --version 0.13.4 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.3 \
+  --version 0.13.4 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.3 \
+  --version 0.13.4 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.3 \
+  --version 0.13.4 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.3 \
+  --set controllerManager.image.tag=v0.13.4 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.3
+  --set swiftletd.image.tag=v0.13.4
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.3 \
+  --version 0.13.4 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/smoke-verification.md
+++ b/docs/operator/smoke-verification.md
@@ -105,15 +105,15 @@ Check Events in the describe output for scheduling failures.
 
 ### Stage 3: Seed rendering and mount path
 
-**Expected:** When SwiftGuest has seedProfileRef, seed ConfigMap exists and pod has seed volume mounted at `/var/lib/kubeswift/seed`.
+**Expected:** When SwiftGuest has seedProfileRef, the seed **Secret** exists and the pod has the seed volume mounted at `/var/lib/kubeswift/seed`.
 
 **Verify:**
 ```bash
-kubectl get configmap sample-seed -n <namespace>
+kubectl get secret sample-seed -n <namespace>
 kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.containers[0].volumeMounts}' | jq .
 ```
 
-**On failure:** Check SwiftSeedProfile exists; verify controller created seed ConfigMap; ensure pod spec includes seed volume mount.
+**On failure:** Check SwiftSeedProfile exists; verify the controller created the seed Secret; ensure pod spec includes seed volume mount.
 
 ### Stage 4: swiftletd launches Cloud Hypervisor
 
@@ -168,7 +168,7 @@ kubectl logs <pod-name> -n <namespace> -c launcher | grep -E "lease|guest IP|tim
 |--------------|----------|
 | SwiftImage not Ready | `kubectl describe swiftimage ubuntu-noble -n <namespace>` |
 | Pod not scheduled | `kubectl describe pod <pod-name> -n <namespace>` |
-| Seed missing | `kubectl get configmap sample-seed -n <namespace>`; `kubectl get pod <pod> -o yaml` |
+| Seed missing | `kubectl get secret sample-seed -n <namespace>`; `kubectl get pod <pod> -o yaml` |
 | swiftletd error | `kubectl logs <pod-name> -n <namespace> -c launcher` |
 | SwiftGuest not Running | `kubectl describe swiftguest sample -n <namespace>`; `kubectl logs <pod-name> -n <namespace> -c launcher` |
 | primaryIP not populated | `kubectl get swiftguest sample -o jsonpath='{.status.network}'`; launcher logs |

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.3 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.3 \
-    --set swiftletd.image.tag=v0.13.3
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.4 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.4 \
+    --set swiftletd.image.tag=v0.13.4
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.3 \
+  --version 0.13.4 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.3 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.4 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows

--- a/docs/seed-rendering.md
+++ b/docs/seed-rendering.md
@@ -5,7 +5,7 @@ KubeSwift delivers cloud-init-compatible NoCloud datasource media without reimpl
 ## Overview
 
 1. **Control plane (Go)**: Resolves user-data, meta-data, network-config from SwiftSeedProfile (inline or Secret/ConfigMap refs), creates a ConfigMap with NoCloud-standard keys, mounts it into the guest pod.
-2. **Node runtime (Rust, swiftletd)**: Reads ConfigMap contents from the mounted path, builds NoCloud directory layout via swift-seed, passes path to Cloud Hypervisor.
+2. **Node runtime (Rust, swiftletd)**: Reads the mounted seed contents, builds NoCloud directory layout via swift-seed, passes path to Cloud Hypervisor.
 
 ## Control Plane Flow
 
@@ -14,7 +14,10 @@ KubeSwift delivers cloud-init-compatible NoCloud datasource media without reimpl
 3. Seed renderer (`internal/seed.Render`) resolves Secret/ConfigMap refs, produces final strings.
 4. Controller creates ConfigMap with keys: `user-data`, `meta-data`, `network-config`.
 5. Controller adds ConfigMap volume to pod spec, mounts at `/var/lib/kubeswift/seed`.
-6. ConfigMap name: `<guest-name>-seed`.
+6. Secret name: `<guest-name>-seed`. It is a **Secret**, not a ConfigMap:
+   user-data routinely carries SSH keys, passwords and join tokens, and a
+   SwiftSeedProfile can source it from a Secret — rendering that into a
+   ConfigMap re-materialized the credential in the clear (changed in v0.13.4).
 
 ## ConfigMap Contract
 
@@ -24,15 +27,15 @@ KubeSwift delivers cloud-init-compatible NoCloud datasource media without reimpl
 | meta-data | openstack/latest/meta_data.json |
 | network-config | openstack/latest/network_config.json |
 
-Empty values are omitted. The node runtime (swift-seed) copies from ConfigMap mount to NoCloud layout.
+Empty values are omitted. The node runtime (swift-seed) copies from the seed mount to the NoCloud layout.
 
 ## Node Runtime Flow
 
 1. swiftletd loads runtime intent from `/var/lib/kubeswift/intent/runtime-intent.json`.
-2. If `seed_path` is non-empty, swiftletd calls swift-seed `build_nocloud_dir(configmap_path, output_path)`.
+2. If `seed_path` is non-empty, swiftletd calls swift-seed `build_nocloud_dir(seed_path, output_path)`.
 3. swift-seed reads user-data, meta-data, network-config from ConfigMap mount and writes NoCloud v2 layout to output.
 4. swiftletd passes path to Cloud Hypervisor for VM launch.
 
 ## When No Seed
 
-If SwiftGuest does not reference SwiftSeedProfile, no seed ConfigMap is created. No seed volume is mounted. `seed_path` in runtime intent is empty. VM boots without cloud-init.
+If SwiftGuest does not reference SwiftSeedProfile, no seed Secret is created. No seed volume is mounted. `seed_path` in runtime intent is empty. VM boots without cloud-init.

--- a/docs/smoke-verification.md
+++ b/docs/smoke-verification.md
@@ -141,15 +141,15 @@ Check Events in the describe output for scheduling failures.
 
 ### Stage 3: Seed rendering and mount path
 
-**Expected:** When SwiftGuest has seedProfileRef, seed ConfigMap exists and pod has seed volume mounted at `/var/lib/kubeswift/seed`.
+**Expected:** When SwiftGuest has seedProfileRef, the seed **Secret** exists and the pod has the seed volume mounted at `/var/lib/kubeswift/seed`.
 
 **Verify:**
 ```bash
-kubectl get configmap sample-seed -n <namespace>
+kubectl get secret sample-seed -n <namespace>
 kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.containers[0].volumeMounts}' | jq .
 ```
 
-**On failure:** Check SwiftSeedProfile exists; verify controller created seed ConfigMap; ensure pod spec includes seed volume mount.
+**On failure:** Check SwiftSeedProfile exists; verify the controller created the seed Secret; ensure the pod spec includes the seed volume mount.
 
 ### Stage 4: swiftletd launches Cloud Hypervisor
 
@@ -209,7 +209,7 @@ kubectl logs <pod-name> -n <namespace> -c launcher | grep -E "lease|guest IP|tim
 |--------------|----------|
 | SwiftImage not Ready | `kubectl describe swiftimage ubuntu-noble -n <namespace>` |
 | Pod not scheduled | `kubectl describe pod <pod-name> -n <namespace>` |
-| Seed missing | `kubectl get configmap sample-seed -n <namespace>`; `kubectl get pod <pod> -o yaml` |
+| Seed missing | `kubectl get secret sample-seed -n <namespace>`; `kubectl get pod <pod> -o yaml` |
 | swiftletd error | `kubectl logs <pod-name> -n <namespace> -c launcher` |
 | SwiftGuest not Running | `kubectl describe swiftguest sample -n <namespace>`; `kubectl logs <pod-name> -n <namespace> -c launcher` |
 | primaryIP not populated | `kubectl get swiftguest sample -o jsonpath='{.status.network}'`; launcher logs |

--- a/docs/swiftguest-reconcile.md
+++ b/docs/swiftguest-reconcile.md
@@ -6,7 +6,7 @@ The SwiftGuest controller reconciles SwiftGuest resources by resolving reference
 
 1. **Resolve** – Resolver fetches SwiftGuestClass, SwiftImage, SwiftSeedProfile and produces ResolvedGuest. On failure: set `Resolved=False`, `phase=Failed`, return.
 
-2. **Seed rendering** – When ResolvedGuest has Seed, render userData/metaData/networkData and create ConfigMap `<guest-name>-seed`.
+2. **Seed rendering** – When ResolvedGuest has Seed, render userData/metaData/networkData and create Secret `<guest-name>-seed`.
 
 3. **Intent ConfigMap** – Build RuntimeIntent from ResolvedGuest, serialize to JSON, create ConfigMap `<guest-name>-runtime-intent` with key `runtime-intent.json`.
 

--- a/docs/swiftletd-mvp.md
+++ b/docs/swiftletd-mvp.md
@@ -6,7 +6,7 @@ swiftletd is the node-side launcher that runs inside each SwiftGuest pod. It rea
 
 1. **Read intent** – Load `runtime-intent.json` from `KUBESWIFT_INTENT_PATH` (default `/var/lib/kubeswift/intent/runtime-intent.json`).
 2. **Create runtime dir** – Per-guest directory at `KUBESWIFT_RUN_DIR/<guest-id>/` with `seed/` subdir and `ch.sock` socket path.
-3. **Build NoCloud** – If seed is present, copy and transform seed ConfigMap into `runtime_dir/seed/` via `swift-seed`.
+3. **Build NoCloud** – If seed is present, copy and transform the seed Secret into `runtime_dir/seed/` via `swift-seed`.
 4. **Lifecycle check** – If `lifecycle=stop`, report Stopped and exit.
 5. **Launch CH** – Spawn Cloud Hypervisor with `--kernel CLOUDHV.fd`, `--api-socket`, `--disk` (root.raw + seed.iso), `--memory`, `--cpus`, `--serial socket=`, `--net tap=tap0`.
 6. **Wait for socket** – Poll until CH creates the API socket.
@@ -20,7 +20,7 @@ The pod must mount:
 | Volume       | Mount path                      | Purpose                          |
 |--------------|----------------------------------|----------------------------------|
 | root-disk    | `/var/lib/kubeswift/disks/root` | Root disk image (PVC)            |
-| seed         | `/var/lib/kubeswift/seed`       | Seed ConfigMap (when present)    |
+| seed         | `/var/lib/kubeswift/seed`       | Seed Secret (when present)       |
 | runtime-intent | `/var/lib/kubeswift/intent`   | Runtime intent ConfigMap          |
 
 The runtime directory is created under `KUBESWIFT_RUN_DIR` (default `/var/lib/kubeswift/run`). Ensure this path is writable (e.g. emptyDir or hostPath).

--- a/docs/virtiofs.md
+++ b/docs/virtiofs.md
@@ -58,7 +58,7 @@ Rules the admission webhook enforces:
 - `source` sets **exactly one** of `hostPath` / `pvcRef`.
 - not combinable with `gpuProfileRef`, nor with `osType: windows`.
 
-## hostPath needs an operator opt-in (v0.13.3+)
+## hostPath needs an operator opt-in (v0.13.4+)
 
 `hostPath` shares are confined to an allowlist that is **empty by default**, so a
 guest using one is rejected until a cluster admin permits the prefix:


### PR DESCRIPTION
Cuts **v0.13.4**: the UI-focused review (#37) plus the six-phase remediation of every remaining finding from both security reviews — #445, #446, #447, #448, #449.

## Validated on dev before cutting

Not just built — **run**, on helm rev 29/30 with `sha-1b85330`:

| check | result |
|---|---|
| guest boot (seed→Secret regression) | Running on `miles`, 4/4 conditions True |
| seed is a Secret | 3 keys; **no** ConfigMap of that name; canary password in **no** ConfigMap in the namespace but present in the Secret; pod mounts `secret=` |
| **#444** pinned to a tainted node | `Failed` + exact reason — **not** a silent stall |
| SwiftKernel webhook | `$(id)` rejected; image change warns with the remediation command |
| snapshot `..` hostPath | rejected |
| controller securityContext | applied, pod healthy with `readOnlyRootFilesystem` |
| CSP / WS routes / WS auth | header correct, 3 planes routed, unauthenticated WS → 401 |
| sandbox restricted egress | anti-spoof DROP **first**, `FORWARD -i br0`, IPv6 jump present |
| **browser sign-in** | confirmed working by the operator against the real IdP |

The last two rows are the ones prior releases could only unit-test. #444 in particular was recorded as "unit-tested only" — it is now proven against a real tainted control-plane node.

## Docs

Beyond the version sweep, **nine docs were corrected** because the seed change made them wrong. Two were smoke-verification runbooks whose `kubectl get configmap <guest>-seed` step now returns NotFound and reads as a failure — that would have sent an operator debugging a non-problem. The runtime-intent ConfigMap is deliberately untouched; that one really is still a ConfigMap. One historical validation record is left as-is, since it describes what was true when written.

**Field-testing scenarios needed no change** — verified: no version pins, and none touch the seed, the WS bearer, or the changed admission surfaces.

## Companion release

Requires **kubeswift-ui ≥ v0.12.0** for the new WebSocket bearer form. That release also carries a fix for a CSP regression this batch introduced: `connect-src` omitted the IdP origin, which blocked the OIDC token exchange and bounced sign-in back to the login page. Found by the operator on dev, fixed in ui#40, and the corrected build is what the sign-in above was confirmed against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)