### PR TITLE
feat(gateway): record every RPC, so a mutation can be attributed afterwards

### DIFF
--- a/cmd/kubeswift-gateway/main.go
+++ b/cmd/kubeswift-gateway/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	"connectrpc.com/connect"
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -101,31 +102,37 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Audit: every RPC is recorded; mutations unconditionally, reads at V(1).
+	// The gateway previously logged nothing at all, which is why a SwiftGuest
+	// deletion could not be attributed after the fact. See internal/gateway/audit.go.
+	audit := connect.WithInterceptors(gateway.NewAuditInterceptor(
+		ctrl.Log.WithName("kubeswift-gateway").WithName("audit"), auth))
+
 	clusterSvc := gateway.NewClusterService(mgr.GetClient(), *clustersNS, watcher, pool, auth)
-	clusterPath, clusterHandler := kubeswiftv1connect.NewClusterServiceHandler(clusterSvc)
+	clusterPath, clusterHandler := kubeswiftv1connect.NewClusterServiceHandler(clusterSvc, audit)
 
 	guestSvc := gateway.NewGuestService(pool, auth)
-	guestPath, guestHandler := kubeswiftv1connect.NewGuestServiceHandler(guestSvc)
+	guestPath, guestHandler := kubeswiftv1connect.NewGuestServiceHandler(guestSvc, audit)
 
 	// Migrations (P2): read plane over SwiftMigrations (the UI polls it live).
 	migSvc := gateway.NewMigrationService(pool, auth)
-	migPath, migHandler := kubeswiftv1connect.NewMigrationServiceHandler(migSvc)
+	migPath, migHandler := kubeswiftv1connect.NewMigrationServiceHandler(migSvc, audit)
 
 	// Telemetry (P1): per-VM range metrics from each member's Prometheus.
 	telSvc := gateway.NewTelemetryService(pool, auth)
-	telPath, telHandler := kubeswiftv1connect.NewTelemetryServiceHandler(telSvc)
+	telPath, telHandler := kubeswiftv1connect.NewTelemetryServiceHandler(telSvc, audit)
 
 	// Explorer (P2): read-only generic resource browser (nodes, namespaces,
 	// networking, storage, secrets — metadata only — and the KubeSwift CRDs).
 	resSvc := gateway.NewResourceService(pool, auth)
-	resPath, resHandler := kubeswiftv1connect.NewResourceServiceHandler(resSvc)
+	resPath, resHandler := kubeswiftv1connect.NewResourceServiceHandler(resSvc, audit)
 
 	// Access (B3): the RBAC editor backend — list/create KubeSwift roles + assign
 	// them to OIDC users/groups (cluster-wide or per-namespace), as the user.
 	accessSvc := gateway.NewAccessService(pool, auth)
-	accessPath, accessHandler := kubeswiftv1connect.NewAccessServiceHandler(accessSvc)
+	accessPath, accessHandler := kubeswiftv1connect.NewAccessServiceHandler(accessSvc, audit)
 	// Console stays a P0 stub (CodeUnimplemented) until the console plane lands.
-	conPath, conHandler := kubeswiftv1connect.NewConsoleServiceHandler(kubeswiftv1connect.UnimplementedConsoleServiceHandler{})
+	conPath, conHandler := kubeswiftv1connect.NewConsoleServiceHandler(kubeswiftv1connect.UnimplementedConsoleServiceHandler{}, audit)
 
 	// Console plane (D5 bootstrap): a raw WebSocket at /console that exec-bridges
 	// the guest's serial socket. Not a Connect RPC — browsers can't do bidi

--- a/internal/gateway/audit.go
+++ b/internal/gateway/audit.go
@@ -1,0 +1,196 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/go-logr/logr"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// AuditInterceptor logs every RPC the gateway serves.
+//
+// Why this exists: two SwiftGuests were deleted from a dev cluster and the
+// cause could not be determined, because the gateway had served traffic for 42
+// hours and written three lines -- all from start-up. Every mutation it had
+// ever proxied was unrecorded. A SwiftGuest carries no finalizer and no owner
+// reference, so a delete leaves nothing behind to inspect: the object, its
+// launcher pod and its events all go at once. This interceptor is the only
+// place such a call can be observed at all.
+//
+// The rule it enforces: a mutation the gateway performs on a user's behalf MUST
+// leave a trace that outlives the request, naming who asked and what was
+// touched. Reads stay at V(1) because list/watch/telemetry poll continuously,
+// and their absence is not what makes an incident unsolvable.
+//
+// Classification is deliberately default-mutating: a procedure counts as a read
+// only if its name starts with a known read verb. An RPC added later that
+// nobody thinks to classify is logged loudly rather than skipped silently -- the
+// cost of forgetting is noise, not another blind spot.
+type AuditInterceptor struct {
+	log  logr.Logger
+	auth Authenticator
+}
+
+// NewAuditInterceptor returns an interceptor that records RPCs. auth may be nil,
+// in which case the caller is logged as unknown rather than the interceptor
+// being skipped: a mutation with an unidentified actor is still worth recording.
+func NewAuditInterceptor(log logr.Logger, auth Authenticator) *AuditInterceptor {
+	return &AuditInterceptor{log: log, auth: auth}
+}
+
+// readVerbs are the procedure-name prefixes that do not change state.
+var readVerbs = []string{"List", "Get", "Watch", "CanI", "Stream", "Describe"}
+
+// splitProcedure reduces "/kubeswift.v1.GuestService/DeleteGuest" to
+// ("GuestService", "DeleteGuest").
+func splitProcedure(procedure string) (service, method string) {
+	parts := strings.Split(strings.TrimPrefix(procedure, "/"), "/")
+	if len(parts) != 2 {
+		return "", procedure
+	}
+	svc := parts[0]
+	if i := strings.LastIndex(svc, "."); i >= 0 {
+		svc = svc[i+1:]
+	}
+	return svc, parts[1]
+}
+
+// isMutating reports whether a method changes state. Unknown verbs count as
+// mutating on purpose -- see the type comment.
+func isMutating(method string) bool {
+	for _, v := range readVerbs {
+		if strings.HasPrefix(method, v) {
+			return false
+		}
+	}
+	return true
+}
+
+// requestTarget extracts a human-meaningful subject from a request message
+// without the interceptor having to know every request type. It follows a
+// nested `ref` (the common ObjectRef shape) and otherwise reads flat
+// cluster/namespace/name fields. Anything unrecognised yields "", which is
+// omitted from the log rather than guessed at.
+func requestTarget(msg any) (cluster, namespace, name string) {
+	pm, ok := msg.(proto.Message)
+	if !ok {
+		return "", "", ""
+	}
+	m := pm.ProtoReflect()
+	fields := m.Descriptor().Fields()
+
+	if rf := fields.ByName("ref"); rf != nil && rf.Kind() == protoreflect.MessageKind && m.Has(rf) {
+		return requestTarget(m.Get(rf).Message().Interface())
+	}
+
+	str := func(n string) string {
+		f := fields.ByName(protoreflect.Name(n))
+		if f == nil || f.Kind() != protoreflect.StringKind {
+			return ""
+		}
+		return m.Get(f).String()
+	}
+	return str("cluster"), str("namespace"), str("name")
+}
+
+// WrapUnary records unary RPCs. Every mutation lands here.
+func (a *AuditInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		start := time.Now()
+		resp, err := next(ctx, req)
+
+		svc, method := splitProcedure(req.Spec().Procedure)
+		cluster, namespace, name := requestTarget(req.Any())
+
+		kv := []any{
+			"service", svc,
+			"method", method,
+			"user", a.actor(ctx, req.Header()),
+			"durationMs", time.Since(start).Milliseconds(),
+			"outcome", outcomeOf(err),
+		}
+		kv = appendIfSet(kv, "cluster", cluster)
+		kv = appendIfSet(kv, "namespace", namespace)
+		kv = appendIfSet(kv, "name", name)
+		kv = appendIfSet(kv, "err", errText(err))
+
+		if isMutating(method) {
+			// Always on. This is the line that has to exist a day later.
+			a.log.Info("rpc mutation", kv...)
+		} else {
+			a.log.V(1).Info("rpc", kv...)
+		}
+		return resp, err
+	}
+}
+
+// WrapStreamingHandler records the open and close of a server stream. Individual
+// events are not logged: a watch can run for hours and emit thousands of
+// updates, none of which is a mutation.
+func (a *AuditInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+		start := time.Now()
+		err := next(ctx, conn)
+		svc, method := splitProcedure(conn.Spec().Procedure)
+		a.log.V(1).Info("rpc stream closed",
+			"service", svc,
+			"method", method,
+			"user", a.actor(ctx, conn.RequestHeader()),
+			"durationMs", time.Since(start).Milliseconds(),
+			"outcome", outcomeOf(err))
+		return err
+	}
+}
+
+// WrapStreamingClient satisfies the interceptor interface. The gateway is a
+// server and never originates Connect calls, so this is a pass-through.
+func (a *AuditInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+// actor names the end user on whose behalf the call ran. It re-verifies the
+// token rather than reaching into handler state; that costs one extra signature
+// check on a cached JWKS, which is a fair price for the audit line being
+// trustworthy on its own.
+func (a *AuditInterceptor) actor(ctx context.Context, h http.Header) string {
+	if a.auth == nil || h == nil {
+		return "<unknown>"
+	}
+	id, err := a.auth.Authenticate(ctx, h)
+	if err != nil {
+		return "<unauthenticated>"
+	}
+	if id.User == "" {
+		// auth-mode=insecure: member queries run as the gateway's own
+		// credential, so there is no end user to name. Say that explicitly
+		// rather than logging "" , which reads like a bug in the logger.
+		return "<gateway-credential>"
+	}
+	return id.User
+}
+
+func appendIfSet(kv []any, key, val string) []any {
+	if val == "" {
+		return kv
+	}
+	return append(kv, key, val)
+}
+
+func outcomeOf(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	return connect.CodeOf(err).String()
+}
+
+func errText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/gateway/audit_test.go
+++ b/internal/gateway/audit_test.go
@@ -1,0 +1,77 @@
+package gateway
+
+import (
+	"testing"
+
+	kubeswiftv1 "github.com/kubeswift-io/kubeswift/gen/kubeswift/v1"
+)
+
+func TestSplitProcedure(t *testing.T) {
+	for _, tc := range []struct {
+		in, svc, method string
+	}{
+		{"/kubeswift.v1.GuestService/DeleteGuest", "GuestService", "DeleteGuest"},
+		{"/kubeswift.v1.ResourceService/ApplyResource", "ResourceService", "ApplyResource"},
+		{"garbage", "", "garbage"},
+	} {
+		svc, m := splitProcedure(tc.in)
+		if svc != tc.svc || m != tc.method {
+			t.Errorf("splitProcedure(%q) = (%q,%q), want (%q,%q)", tc.in, svc, m, tc.svc, tc.method)
+		}
+	}
+}
+
+// The classification is the whole point of the interceptor: a method that
+// changes state and is NOT recognised as mutating becomes an invisible
+// deletion, which is the exact failure this file exists to prevent.
+func TestIsMutating(t *testing.T) {
+	mutations := []string{
+		"DeleteGuest", "DeleteResource", "ApplyResource", "StartGuest",
+		"StopGuest", "MigrateGuest", "DeleteRole", "CreateRoleBinding",
+	}
+	for _, m := range mutations {
+		if !isMutating(m) {
+			t.Errorf("%s must be classified as mutating", m)
+		}
+	}
+
+	reads := []string{"ListGuests", "GetGuestDetail", "WatchGuests", "CanI", "ListResourceKinds"}
+	for _, m := range reads {
+		if isMutating(m) {
+			t.Errorf("%s should be a read", m)
+		}
+	}
+
+	// An RPC nobody has classified must default to mutating, so that forgetting
+	// costs a noisy log line instead of another unattributable deletion.
+	for _, unknown := range []string{"FrobnicateGuest", "", "Reap"} {
+		if !isMutating(unknown) {
+			t.Errorf("unknown method %q must default to mutating", unknown)
+		}
+	}
+}
+
+func TestRequestTargetFollowsRef(t *testing.T) {
+	req := &kubeswiftv1.DeleteGuestRequest{
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "dev", Namespace: "field-testing", Name: "ft-vm"},
+	}
+	c, ns, n := requestTarget(req)
+	if c != "dev" || ns != "field-testing" || n != "ft-vm" {
+		t.Fatalf("requestTarget = (%q,%q,%q), want (dev,field-testing,ft-vm)", c, ns, n)
+	}
+}
+
+func TestRequestTargetUnknownShapeIsEmptyNotGuessed(t *testing.T) {
+	// A request with no ref and no flat fields must yield "" so the log omits
+	// the keys, rather than inventing a target.
+	c, ns, n := requestTarget(&kubeswiftv1.ListGuestsRequest{})
+	if c != "" || n != "" {
+		t.Fatalf("expected empty target for a fieldless request, got (%q,%q,%q)", c, ns, n)
+	}
+}
+
+func TestRequestTargetNonProtoIsSafe(t *testing.T) {
+	if c, ns, n := requestTarget("not a proto"); c != "" || ns != "" || n != "" {
+		t.Fatalf("non-proto message must not panic or invent fields, got (%q,%q,%q)", c, ns, n)
+	}
+}


### PR DESCRIPTION
## Why

Two SwiftGuests were deleted from the dev cluster and the cause could not be established — **not because the evidence was ambiguous, but because there was none.**

The gateway had been up **42 hours with zero restarts**, so its log covered the entire incident window. It contained **three lines**, all from start-up:

```
auth-mode=oidc: impersonate the OIDC-token user
starting kubeswift-gateway
gateway listening
```

Every mutation it had ever proxied on a user's behalf was unrecorded.

That is unusually unrecoverable for this object. A SwiftGuest carries **no finalizer and no owner reference**, so a delete takes the object, its launcher pod and its events together and leaves nothing behind to inspect. The gateway was the only place the call could ever have been observed.

The investigation could rule mechanisms *out* — the auth paths don't mutate, there's no delete-then-recreate, `listOwnedGuests` selects strictly by `metav1.IsControlledBy` — but it could not say what *did* happen, and no further reading would have changed that.

## What this does

A mutation the gateway performs for a user now leaves a trace that outlives the request, naming **who asked** and **what was touched**:

```
rpc mutation  service=GuestService method=DeleteGuest user=… cluster=… namespace=… name=… outcome=ok durationMs=12
```

Reads stay at `V(1)` — list/watch/telemetry poll continuously, and their absence is not what makes an incident unsolvable.

## Design notes

**Classification is default-mutating.** A procedure counts as a read only if it starts with a known read verb. An RPC added later that nobody classifies is logged loudly rather than skipped silently — the cost of forgetting is noise, not another blind spot.

**Target extraction uses protoreflect** (follow `ref`, else flat `cluster`/`namespace`/`name`), so the interceptor needs no table of request types and omits what it cannot recognise rather than guessing.

**`actor()` re-verifies the bearer** instead of reading handler state. One signature check against a cached JWKS, in exchange for an audit line that is true on its own terms. `auth-mode=insecure` logs `<gateway-credential>` explicitly, because an empty user field reads like a logger bug rather than a deployment mode.

## Verification

`audit_test.go` pins the classification including the unknown-verb case, and was **negative-controlled** by flipping the default to read:

```
audit_test.go:34: DeleteRole must be classified as mutating
audit_test.go:34: CreateRoleBinding must be classified as mutating
audit_test.go:49: unknown method "FrobnicateGuest" must default to mutating
audit_test.go:49: unknown method "" must default to mutating
audit_test.go:49: unknown method "Reap" must default to mutating
FAIL
```

Restored → passes. `gofmt -s` clean, `go build ./cmd/... ./internal/... ./api/...` green.

## What this does NOT do

It does not explain the original deletion — nothing can, now. It makes the next one attributable. Enabling apiserver audit logging on the lab clusters would close the remaining gap (a `kubectl delete` still leaves no KubeSwift-side trace), and is an operator-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)