### PR TITLE
release: v0.13.5 — the gateway records what it was asked to do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.13.5] — 2026-08-09
+
+An incident release. Two SwiftGuests were deleted from a lab cluster and the
+cause could not be established — not because the evidence was ambiguous, but
+because none existed. The gateway had served traffic for 42 hours and written
+three lines, all from start-up.
+
+### Added
+
+- **The gateway records every RPC.** Mutations are logged unconditionally with
+  the service, method, impersonated user, cluster, namespace, object name and
+  outcome; reads sit at `-v=1` because list/watch/telemetry poll continuously.
+
+  Classification is *default-mutating*: a procedure counts as a read only if its
+  name begins with a known read verb, so an RPC added later that nobody
+  classifies is logged loudly rather than skipped silently.
+
+  This matters more than it looks for this object. A SwiftGuest carries no
+  finalizer and no owner reference, so a delete takes the object, its launcher
+  pod and its events together and leaves nothing behind to inspect. The gateway
+  is the only place such a call can be observed at all.
+
+  **This records calls that go through the gateway.** A `kubectl delete` still
+  leaves no KubeSwift-side trace — for that, enable apiserver audit logging.
+
+### Fixed
+
+- **The fleet view reported an unreachable cluster as an empty one**
+  (kubeswift-ui #42). `ListGuests` is partial-fleet: a member that fails yields
+  an `errors` entry while the RPC still returns OK. The UI cleared its table and
+  repopulated from an empty list, then set the state to "live" — so a failed
+  query rendered as a confident **"No VMs across the fleet."**, and self-healed
+  on the next 3-second poll, making it near-impossible to catch in the act.
+
+  A cluster that errors now keeps its last-known rows flagged stale, "live"
+  means the whole fleet answered (a partial answer is "degraded"), and the
+  "No VMs" message is only shown when every member actually replied.
+
+- Deleting a VM from the UI now requires typing its name. The previous yes/no
+  confirm was not an adequate gate for an irreversible action that leaves
+  nothing behind, and afterwards is indistinguishable from a delete nobody
+  performed.
+
+### Upgrade notes
+
+No API, CRD or chart-value changes. **kubeswift-ui v0.12.2** carries the fleet
+fix; the gateway change is independent and needs no UI update.
+
+---
+
 ## [v0.13.4] — 2026-07-28
 
 Second security pass. A UI-focused review found a class of defect in the v0.11.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.4 \
+  --version 0.13.5 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.4
-appVersion: "0.13.4"
+version: 0.13.5
+appVersion: "0.13.5"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.4 \
+  --set controllerManager.image.tag=v0.13.5 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.4
+  --set swiftletd.image.tag=v0.13.5
 ```
 
 ### Release workflow

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.4 -n kubeswift-system --create-namespace \
+  --version 0.13.5 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.4 \
+  --version 0.13.5 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.4 \
+  --version 0.13.5 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.4 \
+  --version 0.13.5 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.4 \
+  --set controllerManager.image.tag=v0.13.5 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.4
+  --set swiftletd.image.tag=v0.13.5
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.4 \
+  --version 0.13.5 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.4 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.4 \
-    --set swiftletd.image.tag=v0.13.4
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.5 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.5 \
+    --set swiftletd.image.tag=v0.13.5
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.4 \
+  --version 0.13.5 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.4 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.5 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows


### PR DESCRIPTION
Cuts **v0.13.5**. Chart + appVersion `0.13.4` → `0.13.5`. **No API, CRD or values changes.**

## What's in it

Both already merged to `main`, both currently undeployed:

- **[#451](https://github.com/kubeswift-io/kubeswift/pull/451)** — the gateway records every RPC. Mutations unconditionally (service, method, impersonated user, cluster, namespace, name, outcome); reads at `-v=1`. Classification is *default-mutating*, so an RPC nobody classifies is logged loudly rather than skipped.
- **[kubeswift-ui#42](https://github.com/kubeswift-io/kubeswift-ui/pull/42)** — the fleet view no longer reports an unreachable cluster as an empty one, and VM delete requires typing the name.

## Why now

Two SwiftGuests were deleted from a lab cluster and the cause could not be established — not because the evidence was ambiguous, but because **none existed**. The gateway had been up 42 hours with zero restarts, so its log covered the whole window, and it contained three lines, all from start-up.

A SwiftGuest carries no finalizer and no owner reference, so a delete takes the object, its launcher pod and its events together. The gateway was the only place the call could ever have been observed.

## Version-reference discipline

Install instructions move to `0.13.5` (quickstart, helm-oci, remote-cluster, deploy, releases, troubleshooting, dra-allocation, README).

Historical statements deliberately **do not**: `"changed in v0.13.4"`, `"hostPath needs an operator opt-in (v0.13.4+)"` and the gpucellpool design notes' `"verified against v0.13.4"` are facts about the past.

## Still open after this

`#451` only records calls that go **through the gateway**. A `kubectl delete` still leaves no KubeSwift-side trace — closing that needs apiserver audit logging on the cluster, which is operator-side config and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)