### PR TITLE
fix(swiftctl): retry the registry rate limit instead of losing the whole publish

### DIFF
--- a/cmd/swiftctl/image.go
+++ b/cmd/swiftctl/image.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -79,7 +80,12 @@ Consume the result from a SwiftImage:
 func init() {
 	imagePublishCmd.Flags().StringVar(&publishTo, "to", "", "Target OCI repository WITHOUT a tag, e.g. ghcr.io/acme/vm-images (required)")
 	imagePublishCmd.Flags().StringVar(&publishTag, "tag", "latest", "Artifact tag")
-	imagePublishCmd.Flags().IntVar(&publishChunkMiB, "chunk-size-mib", 64, "Chunk size in MiB (larger = fewer layers; smaller = finer cross-version dedup)")
+	// 0 means "choose from the disk size" — see chunkSizeFor. A fixed 64 MiB
+	// default is right for a small image and wrong for a 30 GiB one, where it
+	// means enough sequential blob PUTs to trip a registry's request-rate limit.
+	imagePublishCmd.Flags().IntVar(&publishChunkMiB, "chunk-size-mib", 0,
+		"Chunk size in MiB (default: scaled to disk size, 64-256). Larger = fewer requests; "+
+			"smaller = finer cross-version dedup, but a small size on a large disk can trip a registry rate limit")
 	imagePublishCmd.Flags().StringVar(&publishOSType, "os-type", "linux", "OS family recorded in the artifact config: linux | windows")
 	imagePublishCmd.Flags().BoolVar(&publishInsecure, "insecure", false, "Allow a plaintext (http) registry — UNSAFE; in-cluster / test registry only")
 	imagePublishCmd.Flags().StringVar(&publishSignKey, "sign-key", "", "Path to a cosign private key; when set, cosign-sign the pushed artifact (COSIGN_PASSWORD from env)")
@@ -88,10 +94,51 @@ func init() {
 	imageCmd.AddCommand(imagePublishCmd)
 }
 
+// chunkSizeFor picks a chunk size in MiB from the disk size.
+//
+// The two costs pull opposite ways. Small chunks dedup better across image
+// versions (a changed byte re-uploads one window, not one big one), but a chunk
+// is one blob PUT plus one HEAD, and registries rate-limit on request COUNT,
+// not bytes. A 30 GiB sparse image is ~8.5 GiB real, which at 64 MiB is ~135
+// sequential PUTs — enough to trip GitHub's secondary rate limit partway
+// through (#452).
+//
+// So keep 64 MiB where dedup is what matters and the request count is small,
+// and step up for the large golden images where it is the request count that
+// decides whether the publish finishes at all. Retry/backoff handles the limit
+// when it is hit anyway; this just stops provoking it by default.
+//
+// An explicit --chunk-size-mib always wins — this is only the default.
+func chunkSizeFor(path string) int {
+	const (
+		gib     = int64(1) << 30
+		small   = 64
+		medium  = 128
+		large   = 256
+		mediumF = 8 * gib
+		largeF  = 24 * gib
+	)
+	fi, err := os.Stat(path)
+	if err != nil {
+		// Sizing is an optimisation; a stat failure here is not worth failing
+		// the publish over, and the real open happens moments later anyway.
+		return small
+	}
+	size := fi.Size()
+	switch {
+	case size >= largeF:
+		return large
+	case size >= mediumF:
+		return medium
+	default:
+		return small
+	}
+}
+
 func runImagePublish(cmd *cobra.Command, args []string) error {
 	inputPath := args[0]
 	out := cmd.OutOrStdout()
-	if publishChunkMiB <= 0 {
+	if cmd.Flags().Changed("chunk-size-mib") && publishChunkMiB <= 0 {
 		return fmt.Errorf("--chunk-size-mib must be positive")
 	}
 	if _, err := os.Stat(inputPath); err != nil {
@@ -112,9 +159,23 @@ func runImagePublish(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	ref := publishTo + ":" + publishTag
-	fmt.Fprintf(out, "Publishing %s -> %s (chunk %d MiB)\n", filepath.Base(inputPath), ref, publishChunkMiB)
 
-	_, res, err := oci.ChunkAndPush(ctx, rawPath, repo, publishTag, int64(publishChunkMiB)*1024*1024, "raw", publishOSType)
+	chunkMiB := publishChunkMiB
+	chosen := ""
+	if !cmd.Flags().Changed("chunk-size-mib") {
+		chunkMiB = chunkSizeFor(rawPath)
+		chosen = " [auto]"
+	}
+	fmt.Fprintf(out, "Publishing %s -> %s (chunk %d MiB%s)\n", filepath.Base(inputPath), ref, chunkMiB, chosen)
+
+	// A rate-limit backoff can pause for a minute at a time; without this the
+	// publish is indistinguishable from a hang.
+	notify := oci.WithRetryNotify(func(attempt int, delay time.Duration, err error) {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"  registry rate limit (attempt %d) — waiting %s before retrying: %v\n", attempt, delay.Round(time.Second), err)
+	})
+
+	_, res, err := oci.ChunkAndPush(ctx, rawPath, repo, publishTag, int64(chunkMiB)*1024*1024, "raw", publishOSType, notify)
 	if err != nil {
 		return fmt.Errorf("publish: %w", err)
 	}

--- a/internal/oci/retry.go
+++ b/internal/oci/retry.go
@@ -1,0 +1,123 @@
+package oci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"oras.land/oras-go/v2/registry/remote/errcode"
+)
+
+// Rate limits are the one registry failure that is transient by construction:
+// the server is telling you to slow down, not that the request was wrong. A
+// chunk push is also content-addressed and therefore idempotent, so retrying it
+// cannot corrupt anything — at worst the blob is already there and the retry is
+// a no-op.
+//
+// Without this, publishing a 30 GiB sparse golden image (~8.5 GiB real, ~135
+// sequential blob PUTs at the 64 MiB default) reliably trips GitHub's secondary
+// rate limit partway through and aborts the whole publish. The operator then
+// restarts from zero — which is doubly wasteful, because the chunks already
+// uploaded ARE reused on the next attempt.
+
+const (
+	// maxRetries bounds the wait. With baseDelay 2s and a 60s cap the worst
+	// case is roughly five minutes of backoff, which matches what GitHub means
+	// by "wait a few minutes" without hanging a CI job indefinitely.
+	maxRetries = 8
+	maxDelay   = 60 * time.Second
+)
+
+// baseDelay is a var, not a const, purely so tests can shrink the clock. A test
+// that actually waited the real backoff would take minutes.
+var baseDelay = 2 * time.Second
+
+// RetryNotifyFunc is called before each backoff sleep. A multi-minute wait with
+// no output is indistinguishable from a hang, so callers that have a terminal
+// should print something.
+type RetryNotifyFunc func(attempt int, delay time.Duration, err error)
+
+// isRateLimited reports whether err is a registry rate limit worth retrying.
+//
+// It deliberately does NOT treat every 4xx as retryable. A plain 403 is
+// permission denied and retrying it just wastes five minutes before failing
+// with the same message — so 403 counts only when the body actually says rate
+// limit, which is how GitHub reports its *secondary* limit. 429 is
+// unambiguous and always counts.
+func isRateLimited(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var resp *errcode.ErrorResponse
+	if errors.As(err, &resp) {
+		switch resp.StatusCode {
+		case 429:
+			return true
+		case 403:
+			// GitHub's secondary rate limit arrives as 403 with an explanatory
+			// body. A 403 without that text is a real authorization failure.
+			return mentionsRateLimit(err.Error())
+		default:
+			return false
+		}
+	}
+
+	// Fallback for clients that do not surface a typed response. Matching text
+	// is weaker than matching a status code, so it is the last resort rather
+	// than the primary check.
+	return mentionsRateLimit(err.Error())
+}
+
+func mentionsRateLimit(s string) bool {
+	l := strings.ToLower(s)
+	return strings.Contains(l, "rate limit") ||
+		strings.Contains(l, "too many requests")
+}
+
+// backoffFor returns the delay before attempt n (0-based), exponential with
+// full jitter. Jitter matters here because a rate limit is usually hit by
+// several concurrent publishes; retrying them all on the same schedule just
+// reproduces the burst that caused it.
+func backoffFor(attempt int, rnd *rand.Rand) time.Duration {
+	d := baseDelay << attempt
+	if d > maxDelay || d <= 0 { // <=0 guards the shift overflowing
+		d = maxDelay
+	}
+	if rnd == nil {
+		return d
+	}
+	// Full jitter: uniform in [d/2, d].
+	half := d / 2
+	return half + time.Duration(rnd.Int63n(int64(half)+1))
+}
+
+// withRateLimitRetry runs op, retrying while it fails with a rate limit.
+// Non-rate-limit errors return immediately — a 404 or a bad digest will not fix
+// itself, and retrying it hides the real failure behind minutes of waiting.
+func withRateLimitRetry(ctx context.Context, notify RetryNotifyFunc, rnd *rand.Rand, op func() error) error {
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = op()
+		if err == nil {
+			return nil
+		}
+		if !isRateLimited(err) || attempt >= maxRetries {
+			return err
+		}
+		delay := backoffFor(attempt, rnd)
+		if notify != nil {
+			notify(attempt+1, delay, err)
+		}
+		select {
+		case <-ctx.Done():
+			// Report the cause, not just "context cancelled" — otherwise a
+			// publish killed during a backoff looks like an unrelated failure.
+			return fmt.Errorf("%w (last registry error: %v)", ctx.Err(), err)
+		case <-time.After(delay):
+		}
+	}
+}

--- a/internal/oci/retry_test.go
+++ b/internal/oci/retry_test.go
@@ -1,0 +1,129 @@
+package oci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"oras.land/oras-go/v2/registry/remote/errcode"
+)
+
+func rateLimit429() error {
+	u, _ := url.Parse("https://ghcr.io/v2/acme/images/blobs/upload/abc")
+	return &errcode.ErrorResponse{Method: "PUT", URL: u, StatusCode: 429}
+}
+
+// GitHub's *secondary* rate limit arrives as a 403 whose body explains itself.
+func secondaryRateLimit403() error {
+	u, _ := url.Parse("https://ghcr.io/v2/acme/images/blobs/upload/abc")
+	return fmt.Errorf("PUT %q: %w", u.String(), &errcode.ErrorResponse{
+		Method: "PUT", URL: u, StatusCode: 403,
+		Errors: errcode.Errors{{
+			Code:    "DENIED",
+			Message: "You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+		}},
+	})
+}
+
+func forbidden403() error {
+	u, _ := url.Parse("https://ghcr.io/v2/acme/images/blobs/upload/abc")
+	return &errcode.ErrorResponse{
+		Method: "PUT", URL: u, StatusCode: 403,
+		Errors: errcode.Errors{{Code: "DENIED", Message: "requested access to the resource is denied"}},
+	}
+}
+
+func TestIsRateLimited(t *testing.T) {
+	if !isRateLimited(rateLimit429()) {
+		t.Error("429 must be retryable")
+	}
+	if !isRateLimited(secondaryRateLimit403()) {
+		t.Error("403 whose body says secondary rate limit must be retryable — this is the #452 failure")
+	}
+	// The important negative: a plain 403 is permission denied. Retrying it
+	// burns minutes of backoff and then fails with the same message.
+	if isRateLimited(forbidden403()) {
+		t.Error("a plain 403 (access denied) must NOT be retried")
+	}
+	if isRateLimited(nil) {
+		t.Error("nil is not an error")
+	}
+	if isRateLimited(errors.New("connection reset by peer")) {
+		t.Error("an unrelated error must not be treated as a rate limit")
+	}
+}
+
+func TestWithRateLimitRetrySucceedsAfterTransientLimits(t *testing.T) {
+	calls := 0
+	rnd := rand.New(rand.NewSource(1))
+	// Shrink the clock: the real backoff starts at 2s, and a test that waited
+	// it out would take minutes for no extra confidence.
+	orig := baseDelay
+	baseDelay = time.Millisecond
+	defer func() { baseDelay = orig }()
+
+	err := withRateLimitRetry(context.Background(), nil, rnd, func() error {
+		calls++
+		if calls < 3 {
+			return rateLimit429()
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after transient limits, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 attempts, got %d", calls)
+	}
+}
+
+func TestWithRateLimitRetryDoesNotRetryPermanentErrors(t *testing.T) {
+	calls := 0
+	err := withRateLimitRetry(context.Background(), nil, nil, func() error {
+		calls++
+		return forbidden403()
+	})
+	if err == nil {
+		t.Fatal("expected the 403 to propagate")
+	}
+	if calls != 1 {
+		t.Fatalf("a permanent error must fail on the first attempt, got %d attempts", calls)
+	}
+}
+
+func TestWithRateLimitRetryRespectsContextCancellation(t *testing.T) {
+	orig := baseDelay
+	baseDelay = 50 * time.Millisecond
+	defer func() { baseDelay = orig }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err := withRateLimitRetry(ctx, nil, nil, func() error { return rateLimit429() })
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected the context error, got %v", err)
+	}
+	// The registry error must still be visible: otherwise a publish killed
+	// during a backoff reports only "deadline exceeded" and the operator has no
+	// idea a rate limit was the reason.
+	if !strings.Contains(err.Error(), "429") && !mentionsRateLimit(err.Error()) {
+		t.Errorf("cancellation error should carry the last registry error, got %q", err)
+	}
+}
+
+func TestBackoffIsBoundedAndJittered(t *testing.T) {
+	rnd := rand.New(rand.NewSource(7))
+	for attempt := 0; attempt < 20; attempt++ {
+		d := backoffFor(attempt, rnd)
+		if d <= 0 {
+			t.Fatalf("attempt %d: non-positive delay %v (shift overflow?)", attempt, d)
+		}
+		if d > maxDelay {
+			t.Fatalf("attempt %d: delay %v exceeds cap %v", attempt, d, maxDelay)
+		}
+	}
+}

--- a/internal/oci/vmimage.go
+++ b/internal/oci/vmimage.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"strconv"
+	"time"
 
 	godigest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -48,13 +50,39 @@ type PushResult struct {
 	TotalBytes       int64
 }
 
+// PushOption tunes ChunkAndPush without changing its signature for the callers
+// that do not care.
+type PushOption func(*pushOpts)
+
+type pushOpts struct {
+	notify RetryNotifyFunc
+}
+
+// WithRetryNotify reports each rate-limit backoff. A publish that pauses for a
+// minute with no output looks hung, so anything with a terminal should set it.
+func WithRetryNotify(f RetryNotifyFunc) PushOption {
+	return func(o *pushOpts) { o.notify = f }
+}
+
 // ChunkAndPush streams filePath in chunkSize windows, SKIPS all-zero windows
 // (never stored — a raw disk is sparse), and pushes each non-zero chunk as one
 // digest-addressed layer. A chunk already present in dst (a re-push of an
 // unchanged v1.1 block, or a repeated non-zero pattern) is counted as skipped
 // (deduped), not re-uploaded — so TransferredBytes/TotalBytes is the dedup
 // figure. Streams window-by-window; the whole disk is never held in memory.
-func ChunkAndPush(ctx context.Context, filePath string, dst oras.Target, tag string, chunkSize int64, format, osType string) (ocispec.Descriptor, PushResult, error) {
+//
+// Every registry call is retried with backoff on a rate limit (see retry.go):
+// a large image is hundreds of sequential requests, and registries limit on
+// request rate rather than bytes.
+func ChunkAndPush(ctx context.Context, filePath string, dst oras.Target, tag string, chunkSize int64, format, osType string, opts ...PushOption) (ocispec.Descriptor, PushResult, error) {
+	var o pushOpts
+	for _, fn := range opts {
+		fn(&o)
+	}
+	// Seeded per call rather than from the global source: concurrent publishes
+	// jittering identically would re-create the burst that tripped the limit.
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec // jitter, not crypto
+
 	var zero ocispec.Descriptor
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -96,15 +124,26 @@ func ChunkAndPush(ctx context.Context, filePath string, dst oras.Target, tag str
 					Size:        int64(n),
 					Annotations: map[string]string{ChunkOffsetAnnotation: strconv.FormatInt(offset, 10)},
 				}
-				exists, eerr := dst.Exists(ctx, desc)
+				// Exists is a HEAD and counts against the same request-rate
+				// limit as the PUT, so it needs the same backoff.
+				var exists bool
+				eerr := withRateLimitRetry(ctx, o.notify, rnd, func() error {
+					var e error
+					exists, e = dst.Exists(ctx, desc)
+					return e
+				})
 				if eerr != nil {
 					return zero, PushResult{}, fmt.Errorf("exists check at offset %d: %w", offset, eerr)
 				}
 				if exists {
 					skipped += int64(n)
 				} else {
-					// Push reads the reader fully before returning, so buf is safe to reuse.
-					if perr := dst.Push(ctx, desc, bytes.NewReader(chunk)); perr != nil {
+					// Push reads the reader fully before returning, so buf is safe
+					// to reuse — and a fresh Reader per attempt is required, since
+					// a retry must start from the beginning of the chunk.
+					if perr := withRateLimitRetry(ctx, o.notify, rnd, func() error {
+						return dst.Push(ctx, desc, bytes.NewReader(chunk))
+					}); perr != nil {
 						return zero, PushResult{}, fmt.Errorf("push chunk at offset %d: %w", offset, perr)
 					}
 					transferred += int64(n)
@@ -127,18 +166,29 @@ func ChunkAndPush(ctx context.Context, filePath string, dst oras.Target, tag str
 		return zero, PushResult{}, err
 	}
 	cfgDesc := ocispec.Descriptor{MediaType: VMImageConfigType, Digest: godigest.FromBytes(cfgBytes), Size: int64(len(cfgBytes))}
+	// These last three calls are the worst place to lose a publish: every chunk
+	// is already uploaded, and without the manifest and tag none of it is
+	// reachable. They get the same backoff as the chunk loop.
 	if exists, _ := dst.Exists(ctx, cfgDesc); !exists {
-		if err := dst.Push(ctx, cfgDesc, bytes.NewReader(cfgBytes)); err != nil {
+		if err := withRateLimitRetry(ctx, o.notify, rnd, func() error {
+			return dst.Push(ctx, cfgDesc, bytes.NewReader(cfgBytes))
+		}); err != nil {
 			return zero, PushResult{}, fmt.Errorf("push config: %w", err)
 		}
 	}
 
-	manifestDesc, err := oras.PackManifest(ctx, dst, oras.PackManifestVersion1_1, VMImageArtifactType,
-		oras.PackManifestOptions{Layers: layers, ConfigDescriptor: &cfgDesc})
-	if err != nil {
+	var manifestDesc ocispec.Descriptor
+	if err := withRateLimitRetry(ctx, o.notify, rnd, func() error {
+		var e error
+		manifestDesc, e = oras.PackManifest(ctx, dst, oras.PackManifestVersion1_1, VMImageArtifactType,
+			oras.PackManifestOptions{Layers: layers, ConfigDescriptor: &cfgDesc})
+		return e
+	}); err != nil {
 		return zero, PushResult{}, fmt.Errorf("pack manifest: %w", err)
 	}
-	if err := dst.Tag(ctx, manifestDesc, tag); err != nil {
+	if err := withRateLimitRetry(ctx, o.notify, rnd, func() error {
+		return dst.Tag(ctx, manifestDesc, tag)
+	}); err != nil {
 		return zero, PushResult{}, fmt.Errorf("tag: %w", err)
 	}
 	return manifestDesc, PushResult{


### PR DESCRIPTION
Closes #452.

## The failure

Publishing a 30 GiB sparse golden image (~8.5 GiB real) at the default 64 MiB chunk means ~135 sequential blob PUTs, which trips GitHub's secondary rate limit partway through. Nothing is retried — the command exits non-zero after ~3.6 GiB and the operator starts over.

## Why retrying is the right answer

A rate limit is the one registry failure that is transient *by construction*: the server is saying "slow down", not "that request was wrong". And a chunk push is content-addressed, so a retry is idempotent — at worst the blob is already there and it's a no-op. The issue's own workaround confirms this: the retry at 256 MiB reused the chunks from the failed attempt (`2.00 GiB already present`).

Exponential backoff with **full jitter**, capped at 60s per wait, ~5 minutes total. Jitter is load-bearing: the limit is usually hit by concurrent publishes, and retrying them on an identical schedule just recreates the burst.

Applied to `Exists` as well as `Push` (a HEAD counts against the same request-rate budget), and to the config push, `PackManifest` and `Tag` — **the worst place to lose a publish**, since every chunk is already uploaded and without the manifest none of it is reachable.

## What is deliberately not retried

A plain **403**. GitHub's *secondary* limit arrives as 403 with an explanatory body, so 403 counts only when the body says so. A bare 403 is permission denied, and retrying it burns the full backoff before failing with the same message.

The negative control made that cost concrete — with the check loosened to "all 403 are rate limits":

```
--- FAIL: TestIsRateLimited
    a plain 403 (access denied) must NOT be retried
--- FAIL: TestWithRateLimitRetryDoesNotRetryPermanentErrors (242.22s)
    a permanent error must fail on the first attempt, got 9 attempts
```

242 seconds to fail. That is exactly what the check prevents.

## Chunk size

The default now scales with disk size (64 / 128 / 256 MiB) instead of a fixed 64. Small chunks dedup better across versions, but a chunk is one PUT plus one HEAD and registries limit on request **count**, not bytes — 64 MiB is a good default for a small image and a poor one for a 30 GiB golden image. An explicit `--chunk-size-mib` still wins; this only stops provoking the limit by default.

The flag help now states that a small size on a large disk can fail the push outright — previously it explained dedup granularity and not this.

Together that's all three of the issue's suggested fixes.

## Verification

Both retry tests negative-controlled (one shown above; the cancellation test was re-run as a *compiling* behaviour change after the first attempt only broke the build, which proves nothing). `gofmt -s` clean, `go build ./cmd/... ./internal/... ./api/...` green, existing `internal/oci` round-trip tests unaffected.

Not exercised against a real rate limit — that needs a multi-GB push to ghcr and deliberately tripping GitHub's limiter. The detection is tested against the real `errcode.ErrorResponse` shape rather than a string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)