### PR TITLE
feat(rbac): give launchers their own ServiceAccounts, converging off `default`

### DIFF
--- a/charts/kubeswift/templates/controller-manager/deployment.yaml
+++ b/charts/kubeswift/templates/controller-manager/deployment.yaml
@@ -35,6 +35,14 @@ spec:
           env:
             - name: KUBESWIFT_LAUNCHER_IMAGE
               value: {{ .Values.swiftletd.image.registry }}/swiftletd:{{ include "kubeswift.imageTag" (dict "tag" .Values.swiftletd.image.tag "appVersion" .Chart.AppVersion) }}
+            {{- with .Values.swiftletd.imagePullSecrets }}
+            # Launcher pods run as a dedicated ServiceAccount from v0.13.6, so
+            # they no longer inherit imagePullSecrets attached to the namespace
+            # `default` SA. Set these when the launcher image is on a private
+            # registry — otherwise the switch shows up as ImagePullBackOff.
+            - name: KUBESWIFT_LAUNCHER_IMAGE_PULL_SECRETS
+              value: {{ join "," . | quote }}
+            {{- end }}
             - name: KUBESWIFT_SNAPSHOT_S3_IMAGE
               value: {{ .Values.snapshotS3.image.registry }}/snapshot-s3:{{ include "kubeswift.imageTag" (dict "tag" .Values.snapshotS3.image.tag "appVersion" .Chart.AppVersion) }}
             - name: KUBESWIFT_SNAPSHOT_ORAS_IMAGE

--- a/charts/kubeswift/templates/controller-manager/rbac.yaml
+++ b/charts/kubeswift/templates/controller-manager/rbac.yaml
@@ -186,9 +186,18 @@ rules:
   # operator-applied RoleBinding pattern (snapshot walkthrough finding
   # F2 + Phase 2 walkthrough finding W3). list+watch are required by
   # controller-runtime's cached client (Phase 2 W3 follow-up).
+  # core ServiceAccounts — the controller creates the per-namespace launcher
+  # SAs (kubeswift-launcher / kubeswift-sandbox-launcher) so a launcher pod no
+  # longer runs as the namespace `default` SA (#443). list+watch are REQUIRED,
+  # not optional: controller-runtime's cached client opens an informer per
+  # GETable type and blocks indefinitely without them — the same trap as W7
+  # (rolebindings) and W8 (storageclasses).
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "watch", "create"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
-    verbs: ["get", "list", "watch", "create"]
+    verbs: ["get", "list", "watch", "create", "update"]
   # cert-manager.io Certificates — the Phase 3c migrationcert controller
   # (migration.mtls.enabled) creates one per-node leaf Certificate
   # (SAN=nodeName, Option B) and deletes stale ones. list+watch are
@@ -232,7 +241,24 @@ metadata:
 rules:
   - apiGroups: ["swift.kubeswift.io"]
     resources: ["swiftguests/status"]
-    verbs: ["get", "patch", "update"]
+    verbs: ["get", "patch"]
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "patch", "update"]
+    verbs: ["get", "patch"]
+---
+# The SANDBOX launcher's role. Strictly smaller than the guest reporter: no
+# swiftguests/status. A sandbox sets KUBESWIFT_REPORT_GUEST_CR=false and never
+# patches a SwiftGuest, and it is the workload class that runs untrusted code —
+# granting it status:patch would let an escaped sandbox forge GuestRunning or
+# Failed on any SwiftGuest in the namespace, which the controller state machine
+# and the drain path both consume. (#443)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeswift-sandbox-reporter
+  labels:
+    app.kubernetes.io/name: kubeswift
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "patch"]

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -38,6 +38,13 @@ swiftletd:
     limits:
       cpu: 2
       memory: 2Gi
+  # Secrets attached to every LAUNCHER pod for pulling the swiftletd image.
+  # From v0.13.6 launcher pods run as a dedicated ServiceAccount
+  # (kubeswift-launcher / kubeswift-sandbox-launcher) instead of the namespace
+  # `default` SA, so they no longer inherit pull secrets patched onto `default`.
+  # Set this if the launcher image lives on a private registry; leaving it empty
+  # is correct for a public registry.
+  imagePullSecrets: []
 
 # snapshot-s3: the uploader/downloader image for the Tier C (s3 / object-storage)
 # snapshot backend. The controller passes this to the per-snapshot upload Job and

--- a/config/manager/controller-manager-rbac.yaml
+++ b/config/manager/controller-manager-rbac.yaml
@@ -200,9 +200,18 @@ rules:
   # No update/delete — the RoleBinding is owned by the namespace
   # lifecycle, not by individual SwiftGuests; deleting all SwiftGuests
   # in a namespace doesn't remove the binding.
+  # core ServiceAccounts — the controller creates the per-namespace launcher
+  # SAs (kubeswift-launcher / kubeswift-sandbox-launcher) so a launcher pod no
+  # longer runs as the namespace `default` SA (#443). list+watch are REQUIRED,
+  # not optional: controller-runtime's cached client opens an informer per
+  # GETable type and blocks indefinitely without them — the same trap as W7
+  # (rolebindings) and W8 (storageclasses).
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "watch", "create"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
-    verbs: ["get", "list", "watch", "create"]
+    verbs: ["get", "list", "watch", "create", "update"]
   # cert-manager.io Certificates — the Phase 3c migrationcert controller
   # (--migration-mtls-enabled) creates one per-node leaf Certificate
   # (SAN=nodeName, Option B) and deletes stale ones. list+watch are

--- a/config/rbac/swiftletd-role.yaml
+++ b/config/rbac/swiftletd-role.yaml
@@ -24,7 +24,24 @@ metadata:
 rules:
   - apiGroups: ["swift.kubeswift.io"]
     resources: ["swiftguests/status"]
-    verbs: ["get", "patch", "update"]
+    verbs: ["get", "patch"]
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "patch", "update"]
+    verbs: ["get", "patch"]
+---
+# The SANDBOX launcher's role. Strictly smaller than the guest reporter: no
+# swiftguests/status. A sandbox sets KUBESWIFT_REPORT_GUEST_CR=false and never
+# patches a SwiftGuest, and it is the workload class that runs untrusted code —
+# granting it status:patch would let an escaped sandbox forge GuestRunning or
+# Failed on any SwiftGuest in the namespace, which the controller state machine
+# and the drain path both consume. (#443)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeswift-sandbox-reporter
+  labels:
+    app.kubernetes.io/name: kubeswift
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "patch"]

--- a/internal/controller/swiftguest/gpu.go
+++ b/internal/controller/swiftguest/gpu.go
@@ -566,8 +566,12 @@ func BuildGPUDiskBootPod(
 			},
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:  corev1.RestartPolicyNever,
-			InitContainers: initContainers,
+			// Without this the pod silently inherits `default`, and loses its
+			// grant the moment the legacy subject retires (#443).
+			ServiceAccountName: LauncherServiceAccountFor(GuestLauncher),
+			ImagePullSecrets:   LauncherImagePullSecrets(),
+			RestartPolicy:      corev1.RestartPolicyNever,
+			InitContainers:     initContainers,
 			// Pin to the specific node where GPUs were allocated.
 			NodeSelector: map[string]string{
 				"kubernetes.io/hostname": nodeName,

--- a/internal/controller/swiftguest/pod.go
+++ b/internal/controller/swiftguest/pod.go
@@ -467,8 +467,12 @@ func buildKernelBootPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGu
 			Labels:      podLabels(guest),
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:  corev1.RestartPolicyNever,
-			InitContainers: initContainers,
+			// Without this the pod silently inherits `default`, and loses its
+			// grant the moment the legacy subject retires (#443).
+			ServiceAccountName: LauncherServiceAccountFor(GuestLauncher),
+			ImagePullSecrets:   LauncherImagePullSecrets(),
+			RestartPolicy:      corev1.RestartPolicyNever,
+			InitContainers:     initContainers,
 			NodeSelector: map[string]string{
 				"kubeswift.io/kernel-node": "true",
 			},
@@ -592,8 +596,12 @@ func buildDiskBootPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGues
 			Labels:      podLabels(guest),
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:  corev1.RestartPolicyNever,
-			InitContainers: initContainers,
+			// Without this the pod silently inherits `default`, and loses its
+			// grant the moment the legacy subject retires (#443).
+			ServiceAccountName: LauncherServiceAccountFor(GuestLauncher),
+			ImagePullSecrets:   LauncherImagePullSecrets(),
+			RestartPolicy:      corev1.RestartPolicyNever,
+			InitContainers:     initContainers,
 			Containers: []corev1.Container{
 				{
 					Name:            "launcher",

--- a/internal/controller/swiftguest/rbac.go
+++ b/internal/controller/swiftguest/rbac.go
@@ -1,38 +1,72 @@
-// Per-namespace RBAC bootstrapping for swiftletd.
+// Per-namespace RBAC bootstrapping for swiftletd launcher pods.
 //
-// The launcher pod runs as the workload namespace's `default`
-// ServiceAccount (kubelet-default; no `serviceAccountName` set in the
-// pod spec). swiftletd needs `pods/get,patch` and
-// `swiftguests/status:patch` to write the IP / runtime / status
-// annotations the controller observes. Phase 2 PR-B added the
-// `kubeswift-swiftletd-reporter` ClusterRole that grants exactly
-// these verbs.
+// swiftletd needs `pods: get,patch` (to write the IP / runtime / status
+// annotations the controller observes) and, for a SwiftGuest launcher only,
+// `swiftguests/status: get,patch` (the GuestRunning condition).
 //
-// Prior to 2026-04-29 the matching RoleBinding had to be applied
-// manually per workload namespace (see snapshot walkthrough finding
-// F2, Phase 2 walkthrough finding W3, and the
-// `config/rbac/swiftletd-role.yaml` history note). Operators following
-// the SwiftGuest sample manifests in any non-default namespace hit
-// silent failures: the lease poller's IP-annotation patch returned
-// 403, the action loop's `pods/get` returned 403, and the
-// SwiftGuest's `status.network.primaryIP` stayed empty forever
-// (compounded by lease.rs's prior buggy "return on first patch
-// attempt regardless of result" — fixed in the same change as this
-// helper).
+// # Why a dedicated ServiceAccount, and what it does NOT buy
 //
-// `EnsureSwiftletdRBAC` runs idempotently at the start of every
-// SwiftGuest reconcile. It creates a `swiftletd-reporter` RoleBinding
-// in the SwiftGuest's namespace if absent; on `IsAlreadyExists` it
-// returns success (the binding from a prior reconcile is
-// load-bearing across all SwiftGuests in that namespace, not owned
-// by any single one).
+// Until v0.13.6 the launcher ran as the workload namespace's `default`
+// ServiceAccount, and the reporter ClusterRole was bound to `default`. That
+// meant EVERY pod in the namespace — every Job, sidecar, CronJob and kubectl
+// debug pod — silently inherited `pods: patch`. Since `spec.containers[*].image`
+// is mutable and kubelet restarts a container whose spec hash changed
+// (regardless of `restartPolicy: Never`), any tenant who could create a pod
+// could repoint the PRIVILEGED launcher's image and obtain node root.
+//
+// Be precise about what the dedicated SA fixes, because it is easy to overclaim:
+// Kubernetes has NO RBAC gate on which ServiceAccount a pod may reference. A
+// tenant who can create pods can still write `serviceAccountName:
+// kubeswift-launcher` on their own pod and receive the token, and
+// `automountServiceAccountToken: false` on the SA does not help — the attacker
+// sets `true` on theirs. So this change buys three things:
+//
+//   - no INCIDENTAL inheritance (the common case: ordinary workloads in the
+//     namespace no longer hold pods:patch by accident),
+//   - the grant becomes attributable in an audit log,
+//   - it is the prerequisite for the fix that actually closes the hole —
+//     `resourceNames`-scoping pods:get,patch to the launcher pod names.
+//
+// The residual (namespace-wide pods:get,patch for anything that names the SA)
+// is tracked in #443 and recorded in docs/security-audit.md. A change that only
+// renames the SA must not claim the escalation is closed.
+//
+// # Two roles, not one
+//
+// A sandbox launcher provably does not need `swiftguests/status`: pod.go stamps
+// `KUBESWIFT_REPORT_GUEST_CR=false` and swiftletd gates the CR patch on it.
+// Granting it anyway would let an escaped sandbox — the one workload class
+// KubeSwift markets as running untrusted code — forge GuestRunning/Failed on
+// any SwiftGuest in the namespace, which the controller's state machine and the
+// drain path both consume.
+//
+// # Convergence, not create-once
+//
+// The previous implementation early-returned when the binding existed. Renaming
+// the SA under that logic would leave an upgraded cluster with
+// `subjects: [default]`, the new SA unbound, and every annotation patch
+// returning 403 — the guest boots and runs fine while
+// `status.network.primaryIP` stays empty forever. This codebase has been burned
+// by exactly that silent shape twice (findings F2 and W3).
+//
+// Equally, dropping `default` outright would break already-running launcher
+// pods, which keep their original SA until the VM is stopped or migrated —
+// potentially weeks.
+//
+// So the subject set converges on observed reality: the new SA is always bound,
+// and `default` stays bound only while a non-terminal launcher pod in that
+// namespace is still running as it. Operator-added subjects are preserved
+// untouched.
 
 package swiftguest
 
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,87 +74,264 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// SwiftletdReporterClusterRoleName is the name of the cluster-scoped
-// Role swiftletd uses. Defined as a const here (and matched in
-// `config/rbac/swiftletd-role.yaml` + the Helm chart) so a future
-// rename has one source of truth.
-const SwiftletdReporterClusterRoleName = "kubeswift-swiftletd-reporter"
+// LauncherClass distinguishes the two launcher kinds, which get different
+// ServiceAccounts and different ClusterRoles.
+type LauncherClass int
 
-// SwiftletdReporterRoleBindingName is the per-namespace RoleBinding
-// name created by `EnsureSwiftletdRBAC`. Same name in every namespace.
-const SwiftletdReporterRoleBindingName = "swiftletd-reporter"
+const (
+	// GuestLauncher is a SwiftGuest launcher: needs swiftguests/status.
+	GuestLauncher LauncherClass = iota
+	// SandboxLauncher is a SwiftSandbox (or warm-pool slot) launcher: pods only.
+	SandboxLauncher
+)
 
-// LauncherServiceAccountName is the ServiceAccount the launcher pod
-// runs as. Currently hardcoded to `default` (kubelet-default when
-// `serviceAccountName` is absent from the pod spec). If we later
-// switch to a dedicated `swiftletd-launcher` SA, update both here
-// and the pod-builder.
-const LauncherServiceAccountName = "default"
+const (
+	// GuestLauncherServiceAccountName is the SA a SwiftGuest launcher runs as.
+	GuestLauncherServiceAccountName = "kubeswift-launcher"
+	// SandboxLauncherServiceAccountName is the SA a SwiftSandbox launcher runs
+	// as. Separate from the guest SA so it can hold a strictly smaller role.
+	SandboxLauncherServiceAccountName = "kubeswift-sandbox-launcher"
 
-// EnsureSwiftletdRBAC creates the `swiftletd-reporter` RoleBinding in
-// the given namespace if it does not already exist. The binding
-// references the cluster-scoped `kubeswift-swiftletd-reporter`
-// ClusterRole and binds it to the namespace's `default` ServiceAccount.
-//
-// Idempotent: returns nil on AlreadyExists. Safe to call from every
-// SwiftGuest reconcile; the binding is shared across all SwiftGuests
-// in the namespace (no controller-reference; the binding outlives
-// individual SwiftGuests by design — deleting all SwiftGuests in a
-// namespace does not remove the binding).
-//
-// Failure path: returns the underlying error. Callers (the SwiftGuest
-// controller's `Reconcile`) should NOT proceed to pod creation if this
-// fails — without the binding the launcher pod boots but its
-// annotation-writing paths are silently broken. Better to surface the
-// RBAC error to the operator via a status condition than to ship a
-// pod that looks Running but has no IP annotation.
+	// SwiftletdReporterClusterRoleName grants pods:get,patch +
+	// swiftguests/status:get,patch. Matched in config/rbac/swiftletd-role.yaml
+	// and the Helm chart.
+	SwiftletdReporterClusterRoleName = "kubeswift-swiftletd-reporter"
+	// SandboxReporterClusterRoleName grants pods:get,patch only.
+	SandboxReporterClusterRoleName = "kubeswift-sandbox-reporter"
+
+	// SwiftletdReporterRoleBindingName is the per-namespace binding for the
+	// guest launcher. Unchanged from previous releases so an upgrade converges
+	// the existing object rather than orphaning it.
+	SwiftletdReporterRoleBindingName = "swiftletd-reporter"
+	// SandboxReporterRoleBindingName is the per-namespace binding for the
+	// sandbox launcher.
+	SandboxReporterRoleBindingName = "sandbox-reporter"
+
+	// legacyServiceAccountName is the SA launchers used before v0.13.6. Retired
+	// automatically once no launcher pod is running as it — see the file
+	// comment.
+	legacyServiceAccountName = "default"
+
+	// LauncherContainerName is the swiftletd container's name in every launcher
+	// pod — guest, GPU, restore and sandbox builders all use it. Verified
+	// against all four; the legacy-SA sweep below selects on it, and a mismatch
+	// there would retire `default` while a running pod still needed it.
+	// (swiftmigration declares its own copy for the dst-pod builder.)
+	LauncherContainerName = "launcher"
+)
+
+// launcherRBACNames returns the SA, ClusterRole and RoleBinding names for a class.
+func launcherRBACNames(class LauncherClass) (sa, clusterRole, binding string) {
+	if class == SandboxLauncher {
+		return SandboxLauncherServiceAccountName, SandboxReporterClusterRoleName, SandboxReporterRoleBindingName
+	}
+	return GuestLauncherServiceAccountName, SwiftletdReporterClusterRoleName, SwiftletdReporterRoleBindingName
+}
+
+// LauncherServiceAccountFor returns the ServiceAccount name a launcher pod of
+// the given class must run as. Pod builders MUST call this — a builder that
+// omits ServiceAccountName silently keeps `default` and loses its grant once
+// the legacy subject retires.
+func LauncherServiceAccountFor(class LauncherClass) string {
+	sa, _, _ := launcherRBACNames(class)
+	return sa
+}
+
+func rbacLabels(component string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":       "kubeswift",
+		"app.kubernetes.io/component":  component,
+		"app.kubernetes.io/managed-by": "kubeswift-controller-manager",
+	}
+}
+
+// EnsureSwiftletdRBAC provisions the guest launcher's SA and binding.
+// Kept under its original name because three controllers call it.
 func EnsureSwiftletdRBAC(ctx context.Context, c client.Client, namespace string) error {
-	// Fast-path: check if the binding already exists. Avoids hitting
-	// the apiserver for create+AlreadyExists on every reconcile.
-	var existing rbacv1.RoleBinding
-	err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: SwiftletdReporterRoleBindingName}, &existing)
+	return EnsureLauncherRBAC(ctx, c, namespace, GuestLauncher)
+}
+
+// EnsureLauncherRBAC creates the launcher ServiceAccount and its RoleBinding in
+// namespace, and converges the binding's subject set.
+//
+// Idempotent and safe to call from every reconcile. The objects are shared by
+// all launchers in the namespace and carry no owner reference: they must
+// outlive any individual SwiftGuest or SwiftSandbox.
+//
+// Callers must NOT proceed to pod creation if this fails. Without the binding
+// the launcher pod boots and looks healthy while every annotation write 403s,
+// which surfaces to the operator as a guest that never reports an IP.
+func EnsureLauncherRBAC(ctx context.Context, c client.Client, namespace string, class LauncherClass) error {
+	saName, clusterRole, bindingName := launcherRBACNames(class)
+
+	if err := ensureServiceAccount(ctx, c, namespace, saName); err != nil {
+		return err
+	}
+	return ensureConvergedBinding(ctx, c, namespace, bindingName, clusterRole, saName)
+}
+
+func ensureServiceAccount(ctx context.Context, c client.Client, namespace, name string) error {
+	var existing corev1.ServiceAccount
+	err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &existing)
 	if err == nil {
-		// Binding present. We do NOT mutate (operators may have
-		// customized subjects to add their own SA); the controller's
-		// only invariant is that SOME binding for this Role exists.
+		// Present. Never mutate: operators attach imagePullSecrets to this SA
+		// for private registries, and rewriting it would drop them.
 		return nil
 	}
 	if !apierrors.IsNotFound(err) {
-		return fmt.Errorf("get rolebinding %s/%s: %w", namespace, SwiftletdReporterRoleBindingName, err)
+		return fmt.Errorf("get serviceaccount %s/%s: %w", namespace, name, err)
 	}
 
-	rb := &rbacv1.RoleBinding{
+	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      SwiftletdReporterRoleBindingName,
+			Name:      name,
 			Namespace: namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/name":       "kubeswift",
-				"app.kubernetes.io/component":  "swiftletd-rbac",
-				"app.kubernetes.io/managed-by": "kubeswift-controller-manager",
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: rbacv1.GroupName,
-			Kind:     "ClusterRole",
-			Name:     SwiftletdReporterClusterRoleName,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      LauncherServiceAccountName,
-				Namespace: namespace,
-			},
+			Labels:    rbacLabels("launcher-rbac"),
 		},
 	}
-
-	if err := c.Create(ctx, rb); err != nil {
-		// AlreadyExists race: another reconcile (or a parallel
-		// SwiftGuest in the same namespace) created the binding
-		// between our Get and our Create. Treat as success.
-		if apierrors.IsAlreadyExists(err) {
-			return nil
-		}
-		return fmt.Errorf("create rolebinding %s/%s: %w", namespace, SwiftletdReporterRoleBindingName, err)
+	if err := c.Create(ctx, sa); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create serviceaccount %s/%s: %w", namespace, name, err)
 	}
 	return nil
+}
+
+// ensureConvergedBinding creates the RoleBinding if absent, and otherwise
+// converges its subjects: the launcher SA is always bound; `default` is bound
+// only while a launcher pod still runs as it; everything else is preserved.
+func ensureConvergedBinding(ctx context.Context, c client.Client, namespace, bindingName, clusterRole, saName string) error {
+	legacyInUse, err := legacyLauncherPodRunning(ctx, c, namespace)
+	if err != nil {
+		return err
+	}
+
+	var existing rbacv1.RoleBinding
+	err = c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: bindingName}, &existing)
+	if apierrors.IsNotFound(err) {
+		rb := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bindingName,
+				Namespace: namespace,
+				Labels:    rbacLabels("swiftletd-rbac"),
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     clusterRole,
+			},
+			Subjects: desiredSubjects(nil, namespace, saName, legacyInUse),
+		}
+		if cerr := c.Create(ctx, rb); cerr != nil && !apierrors.IsAlreadyExists(cerr) {
+			return fmt.Errorf("create rolebinding %s/%s: %w", namespace, bindingName, cerr)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get rolebinding %s/%s: %w", namespace, bindingName, err)
+	}
+
+	want := desiredSubjects(existing.Subjects, namespace, saName, legacyInUse)
+	if subjectsEqual(existing.Subjects, want) {
+		// No-op guard. Without it every reconcile writes, the watch re-enqueues,
+		// and the controller spins.
+		return nil
+	}
+	existing.Subjects = want
+	if err := c.Update(ctx, &existing); err != nil {
+		return fmt.Errorf("update rolebinding %s/%s: %w", namespace, bindingName, err)
+	}
+	return nil
+}
+
+// desiredSubjects computes the converged subject list: preserve everything the
+// controller does not manage, always bind saName, and bind `default` only while
+// a legacy launcher pod still needs it.
+func desiredSubjects(current []rbacv1.Subject, namespace, saName string, legacyInUse bool) []rbacv1.Subject {
+	managed := map[string]bool{saName: true, legacyServiceAccountName: true}
+
+	out := make([]rbacv1.Subject, 0, len(current)+2)
+	for _, s := range current {
+		// Anything that is not one of ours is operator-added — keep it verbatim.
+		if s.Kind != rbacv1.ServiceAccountKind || s.Namespace != namespace || !managed[s.Name] {
+			out = append(out, s)
+		}
+	}
+	out = append(out, rbacv1.Subject{
+		Kind: rbacv1.ServiceAccountKind, Name: saName, Namespace: namespace,
+	})
+	if legacyInUse {
+		out = append(out, rbacv1.Subject{
+			Kind: rbacv1.ServiceAccountKind, Name: legacyServiceAccountName, Namespace: namespace,
+		})
+	}
+	return out
+}
+
+func subjectsEqual(a, b []rbacv1.Subject) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// legacyLauncherPodRunning reports whether any non-terminal launcher pod in the
+// namespace is still running as the legacy `default` ServiceAccount.
+//
+// Selecting on the container name rather than a label is deliberate: guest,
+// sandbox and warm-pool slot pods label themselves differently, and a missed
+// label here would drop `default` from the binding while a pod still depended
+// on it — breaking a running VM's status reporting with no error anywhere.
+func legacyLauncherPodRunning(ctx context.Context, c client.Client, namespace string) (bool, error) {
+	var pods corev1.PodList
+	if err := c.List(ctx, &pods, client.InNamespace(namespace)); err != nil {
+		return false, fmt.Errorf("list pods in %s: %w", namespace, err)
+	}
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		// An empty ServiceAccountName means kubelet defaulted it.
+		if p.Spec.ServiceAccountName != "" && p.Spec.ServiceAccountName != legacyServiceAccountName {
+			continue
+		}
+		for j := range p.Spec.Containers {
+			if p.Spec.Containers[j].Name == LauncherContainerName {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// LauncherImagePullSecretsEnv carries a comma-separated list of Secret names to
+// attach to every launcher pod.
+//
+// This exists because of the switch away from `default`. Operators on private
+// registries conventionally patch `imagePullSecrets` onto the namespace's
+// `default` ServiceAccount, and a pod inherits its SA's pull secrets. Moving
+// the launcher to a dedicated SA silently drops that inheritance and yields
+// cluster-wide ImagePullBackOff on the next guest — a regression that would
+// look nothing like an RBAC change. Setting them on the pod is explicit and
+// works regardless of which SA the pod names. (#443)
+const LauncherImagePullSecretsEnv = "KUBESWIFT_LAUNCHER_IMAGE_PULL_SECRETS"
+
+// LauncherImagePullSecrets returns the pull secrets every launcher pod should
+// carry, or nil when unset (the overwhelmingly common public-registry case).
+func LauncherImagePullSecrets() []corev1.LocalObjectReference {
+	raw := os.Getenv(LauncherImagePullSecretsEnv)
+	if raw == "" {
+		return nil
+	}
+	var out []corev1.LocalObjectReference
+	for _, name := range strings.Split(raw, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			out = append(out, corev1.LocalObjectReference{Name: name})
+		}
+	}
+	return out
 }

--- a/internal/controller/swiftguest/rbac_test.go
+++ b/internal/controller/swiftguest/rbac_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,8 +62,10 @@ func TestEnsureSwiftletdRBAC_CreatesBindingWhenAbsent(t *testing.T) {
 	if rb.Subjects[0].Kind != rbacv1.ServiceAccountKind {
 		t.Errorf("Subjects[0].Kind = %q, want %q", rb.Subjects[0].Kind, rbacv1.ServiceAccountKind)
 	}
-	if rb.Subjects[0].Name != LauncherServiceAccountName {
-		t.Errorf("Subjects[0].Name = %q, want %q", rb.Subjects[0].Name, LauncherServiceAccountName)
+	// The dedicated SA, not `default`. In a fresh namespace no launcher pod is
+	// running as the legacy SA, so it is not bound at all (#443).
+	if rb.Subjects[0].Name != GuestLauncherServiceAccountName {
+		t.Errorf("Subjects[0].Name = %q, want %q", rb.Subjects[0].Name, GuestLauncherServiceAccountName)
 	}
 	// Subject namespace MUST equal the binding's namespace — this is
 	// the part that the kustomize-based pattern got wrong (the
@@ -73,12 +76,10 @@ func TestEnsureSwiftletdRBAC_CreatesBindingWhenAbsent(t *testing.T) {
 	}
 }
 
-// TestEnsureSwiftletdRBAC_IdempotentOnExisting pins the idempotency
-// contract — running the helper a second time on a namespace that
-// already has the binding is a no-op (no error, no mutation).
-// EnsureSwiftletdRBAC runs at the start of every SwiftGuest reconcile,
-// so non-idempotent behaviour would either error every reconcile or
-// mutate operator-customized subjects.
+// TestEnsureSwiftletdRBAC_IdempotentOnExisting pins the convergence contract on
+// a pre-existing binding: operator-added subjects survive untouched, the
+// dedicated SA is added, and the legacy `default` subject is retired because no
+// launcher pod in the namespace is running as it (#443).
 func TestEnsureSwiftletdRBAC_IdempotentOnExisting(t *testing.T) {
 	scheme := rbacScheme(t)
 	preExisting := &rbacv1.RoleBinding{
@@ -112,11 +113,22 @@ func TestEnsureSwiftletdRBAC_IdempotentOnExisting(t *testing.T) {
 	}, &rb); err != nil {
 		t.Fatalf("expected RoleBinding to still exist: %v", err)
 	}
-	// The operator-added subject MUST still be there — the helper's
-	// invariant is "ensure the binding exists", NOT "reset the
-	// subjects to the controller-default set".
-	if len(rb.Subjects) != 2 {
-		t.Errorf("Subjects mutated: got len=%d, want 2 (operator-added subject preserved)", len(rb.Subjects))
+	// The operator-added subject MUST survive: the helper manages only its own
+	// two names and never resets the subject list.
+	names := map[string]bool{}
+	for _, sub := range rb.Subjects {
+		names[sub.Name] = true
+	}
+	if !names["operator-tooling"] {
+		t.Errorf("operator-added subject was dropped; subjects = %+v", rb.Subjects)
+	}
+	if !names[GuestLauncherServiceAccountName] {
+		t.Errorf("dedicated launcher SA was not bound; subjects = %+v", rb.Subjects)
+	}
+	// No launcher pod in team-b runs as `default`, so the legacy subject retires.
+	// Leaving it bound is the vulnerability this change exists to remove.
+	if names["default"] {
+		t.Errorf("legacy `default` subject should have retired; subjects = %+v", rb.Subjects)
 	}
 }
 
@@ -189,4 +201,174 @@ func (a *alreadyExistsCreateClient) Create(ctx context.Context, obj client.Objec
 		)
 	}
 	return a.Client.Create(ctx, obj, opts...)
+}
+
+// launcherPod builds a pod that looks like a launcher to legacyLauncherPodRunning.
+func launcherPod(ns, name, sa string, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: sa,
+			Containers:         []corev1.Container{{Name: LauncherContainerName, Image: "x"}},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+// THE upgrade hazard. On an upgraded cluster the binding already exists with
+// subjects [default] and a launcher pod is still running as it. If the helper
+// early-returns (the pre-#443 behaviour) the new SA is never bound and every
+// annotation patch 403s — the guest boots and works while
+// status.network.primaryIP stays empty forever. Silent, and this codebase has
+// shipped that exact shape twice (F2, W3).
+func TestEnsureLauncherRBAC_UpgradeBindsBothWhileLegacyPodRuns(t *testing.T) {
+	scheme := rbacScheme(t)
+	legacyBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: SwiftletdReporterRoleBindingName, Namespace: "prod"},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: SwiftletdReporterClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Name: "default", Namespace: "prod"},
+		},
+	}
+	running := launcherPod("prod", "vm-1", "default", corev1.PodRunning)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(legacyBinding, running).Build()
+
+	if err := EnsureSwiftletdRBAC(context.Background(), c, "prod"); err != nil {
+		t.Fatalf("EnsureSwiftletdRBAC: %v", err)
+	}
+
+	var rb rbacv1.RoleBinding
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Namespace: "prod", Name: SwiftletdReporterRoleBindingName}, &rb); err != nil {
+		t.Fatalf("get binding: %v", err)
+	}
+	names := map[string]bool{}
+	for _, s := range rb.Subjects {
+		names[s.Name] = true
+	}
+	if !names[GuestLauncherServiceAccountName] {
+		t.Errorf("new SA unbound on upgrade — every annotation patch would 403 silently; subjects=%+v", rb.Subjects)
+	}
+	if !names["default"] {
+		t.Errorf("`default` dropped while a launcher pod still runs as it — that breaks the RUNNING guest; subjects=%+v", rb.Subjects)
+	}
+}
+
+// A terminal pod must not pin the legacy subject: otherwise one Completed
+// launcher left in a namespace keeps `default` bound forever and the
+// vulnerability never actually retires.
+func TestEnsureLauncherRBAC_TerminalPodDoesNotPinLegacySubject(t *testing.T) {
+	scheme := rbacScheme(t)
+	done := launcherPod("stale", "vm-old", "default", corev1.PodSucceeded)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(done).Build()
+
+	if err := EnsureSwiftletdRBAC(context.Background(), c, "stale"); err != nil {
+		t.Fatalf("EnsureSwiftletdRBAC: %v", err)
+	}
+	var rb rbacv1.RoleBinding
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Namespace: "stale", Name: SwiftletdReporterRoleBindingName}, &rb); err != nil {
+		t.Fatalf("get binding: %v", err)
+	}
+	for _, s := range rb.Subjects {
+		if s.Name == "default" {
+			t.Errorf("a Succeeded launcher pinned `default`; subjects=%+v", rb.Subjects)
+		}
+	}
+}
+
+// A pod with no explicit ServiceAccountName was defaulted by kubelet to
+// `default`, so it counts as legacy. Missing this would retire the subject out
+// from under a running guest.
+func TestLegacyDetectionTreatsEmptySAAsDefault(t *testing.T) {
+	scheme := rbacScheme(t)
+	p := launcherPod("impl", "vm-implicit", "", corev1.PodRunning)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(p).Build()
+
+	inUse, err := legacyLauncherPodRunning(context.Background(), c, "impl")
+	if err != nil {
+		t.Fatalf("legacyLauncherPodRunning: %v", err)
+	}
+	if !inUse {
+		t.Error("an empty ServiceAccountName means kubelet defaulted it — must count as legacy")
+	}
+}
+
+// A non-launcher pod running as `default` (an ordinary workload) must NOT keep
+// the legacy subject alive — that is precisely the incidental grant being removed.
+func TestLegacyDetectionIgnoresNonLauncherPods(t *testing.T) {
+	scheme := rbacScheme(t)
+	other := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "some-job", Namespace: "mixed"},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "default",
+			Containers:         []corev1.Container{{Name: "worker", Image: "busybox"}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(other).Build()
+
+	inUse, err := legacyLauncherPodRunning(context.Background(), c, "mixed")
+	if err != nil {
+		t.Fatalf("legacyLauncherPodRunning: %v", err)
+	}
+	if inUse {
+		t.Error("an ordinary pod on `default` must not pin the legacy subject")
+	}
+}
+
+// The sandbox launcher gets its own SA and a role WITHOUT swiftguests/status.
+func TestSandboxLauncherUsesItsOwnSAAndRole(t *testing.T) {
+	scheme := rbacScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	if err := EnsureLauncherRBAC(context.Background(), c, "sbx", SandboxLauncher); err != nil {
+		t.Fatalf("EnsureLauncherRBAC(sandbox): %v", err)
+	}
+	var rb rbacv1.RoleBinding
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Namespace: "sbx", Name: SandboxReporterRoleBindingName}, &rb); err != nil {
+		t.Fatalf("get sandbox binding: %v", err)
+	}
+	if rb.RoleRef.Name != SandboxReporterClusterRoleName {
+		t.Errorf("sandbox bound to %q — granting swiftguests/status would let an escaped sandbox forge GuestRunning", rb.RoleRef.Name)
+	}
+	if rb.Subjects[0].Name != SandboxLauncherServiceAccountName {
+		t.Errorf("Subjects[0].Name = %q, want %q", rb.Subjects[0].Name, SandboxLauncherServiceAccountName)
+	}
+
+	var sa corev1.ServiceAccount
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Namespace: "sbx", Name: SandboxLauncherServiceAccountName}, &sa); err != nil {
+		t.Fatalf("sandbox launcher SA was not created: %v", err)
+	}
+}
+
+// The no-op guard: a converged binding must not be rewritten, or every reconcile
+// writes, the watch re-enqueues, and the controller spins.
+func TestEnsureLauncherRBAC_ConvergedIsANoOp(t *testing.T) {
+	scheme := rbacScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ctx := context.Background()
+
+	if err := EnsureSwiftletdRBAC(ctx, c, "quiet"); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	var first rbacv1.RoleBinding
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "quiet", Name: SwiftletdReporterRoleBindingName}, &first); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if err := EnsureSwiftletdRBAC(ctx, c, "quiet"); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	var second rbacv1.RoleBinding
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "quiet", Name: SwiftletdReporterRoleBindingName}, &second); err != nil {
+		t.Fatalf("get again: %v", err)
+	}
+	if first.ResourceVersion != second.ResourceVersion {
+		t.Errorf("binding rewritten on a converged reconcile (%s -> %s) — hot-loop risk",
+			first.ResourceVersion, second.ResourceVersion)
+	}
 }

--- a/internal/controller/swiftguest/restore.go
+++ b/internal/controller/swiftguest/restore.go
@@ -396,9 +396,13 @@ func BuildRestorePod(
 			},
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:  corev1.RestartPolicyNever,
-			NodeSelector:   map[string]string{"kubernetes.io/hostname": params.NodeName},
-			InitContainers: initContainers,
+			// Without this the pod silently inherits `default`, and loses its
+			// grant the moment the legacy subject retires (#443).
+			ServiceAccountName: LauncherServiceAccountFor(GuestLauncher),
+			ImagePullSecrets:   LauncherImagePullSecrets(),
+			RestartPolicy:      corev1.RestartPolicyNever,
+			NodeSelector:       map[string]string{"kubernetes.io/hostname": params.NodeName},
+			InitContainers:     initContainers,
 			Containers: []corev1.Container{
 				{
 					Name:            "launcher",

--- a/internal/controller/swiftsandbox/controller.go
+++ b/internal/controller/swiftsandbox/controller.go
@@ -66,7 +66,7 @@ func (r *SwiftSandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.handleRetention(ctx, &sb)
 	}
 
-	if err := swiftguest.EnsureSwiftletdRBAC(ctx, r.Client, sb.Namespace); err != nil {
+	if err := swiftguest.EnsureLauncherRBAC(ctx, r.Client, sb.Namespace, swiftguest.SandboxLauncher); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/swiftsandbox/pod.go
+++ b/internal/controller/swiftsandbox/pod.go
@@ -451,9 +451,17 @@ func buildPod(sb *sandboxv1alpha1.SwiftSandbox, kernelName string) *corev1.Pod {
 			Labels:    map[string]string{SandboxLabelKey: sb.Name},
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:  corev1.RestartPolicyNever,
-			NodeSelector:   nodeSelector,
-			InitContainers: initContainers,
+			// The SANDBOX launcher SA, not the guest one: a sandbox provably does
+			// not need swiftguests/status (KUBESWIFT_REPORT_GUEST_CR=false below),
+			// and granting it would let an escaped sandbox — the workload class
+			// that runs untrusted code — forge GuestRunning/Failed on any
+			// SwiftGuest in the namespace. Also covers warm-pool slots, which are
+			// built by this same function (#443).
+			ServiceAccountName: swiftguest.LauncherServiceAccountFor(swiftguest.SandboxLauncher),
+			ImagePullSecrets:   swiftguest.LauncherImagePullSecrets(),
+			RestartPolicy:      corev1.RestartPolicyNever,
+			NodeSelector:       nodeSelector,
+			InitContainers:     initContainers,
 			Containers: []corev1.Container{{
 				Name:            launcherName,
 				Image:           swiftguest.LauncherImage(),

--- a/internal/controller/swiftsandbox/pool_controller.go
+++ b/internal/controller/swiftsandbox/pool_controller.go
@@ -81,7 +81,7 @@ func (r *SwiftSandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	// Warm slots run swiftletd, which reports via pod annotations — ensure the
 	// per-namespace reporter RoleBinding (idempotent), as the sandbox controller does.
-	if err := swiftguest.EnsureSwiftletdRBAC(ctx, r.Client, pool.Namespace); err != nil {
+	if err := swiftguest.EnsureLauncherRBAC(ctx, r.Client, pool.Namespace, swiftguest.SandboxLauncher); err != nil {
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
Part 1 of #443. **Opened as a draft: not yet cluster-validated, and the failure modes here are silent and cluster-only.**

## The problem

The launcher ran as the workload namespace's `default` ServiceAccount, with the reporter ClusterRole bound to `default`. Every pod in that namespace — Job, sidecar, CronJob, `kubectl debug` — inherited `pods: patch`.

`spec.containers[*].image` is mutable and kubelet restarts a container whose spec hash changed **regardless of `restartPolicy: Never`**. So any tenant who could create a pod could repoint the *privileged* launcher's image and get node root, without ever touching a SwiftGuest.

## This does not close it, and #443 stays open

Kubernetes has **no RBAC gate on which ServiceAccount a pod may reference.** A tenant who can create pods can still write `serviceAccountName: kubeswift-launcher` on their own pod and get the token; `automountServiceAccountToken: false` on the SA doesn't help because they set `true` on theirs.

What this buys:
- removal of **incidental** inheritance — the common case,
- an **attributable** grant in audit logs,
- the **prerequisite** for the fix that does close it: `resourceNames`-scoping `pods: get,patch` to launcher pod names.

Following the design note's instruction that a rename-only PR must not claim otherwise.

## Two SAs, not one

A sandbox launcher provably does not need `swiftguests/status` — `pod.go` stamps `KUBESWIFT_REPORT_GUEST_CR=false` and swiftletd gates the CR patch on it. It gets `kubeswift-sandbox-launcher` bound to a pods-only role.

Granting it `status: patch` would let an **escaped sandbox** — the workload class KubeSwift markets as running untrusted code — forge `GuestRunning`/`Failed` on any SwiftGuest in the namespace, which the controller state machine and the drain path both consume.

## Convergence, not create-once

The old helper early-returned when the binding existed. Under a rename that leaves an upgraded cluster with `subjects: [default]`, the new SA unbound, and every annotation patch 403ing — **the guest boots and runs fine while `status.network.primaryIP` stays empty forever.** This repo has shipped that exact silent shape twice (F2, W3).

Dropping `default` outright is equally wrong: already-running launchers keep their original SA until stopped or migrated, potentially weeks.

So `default` stays bound while a non-terminal launcher pod is still running as it, and retires by itself once the last one is gone. Operator-added subjects are preserved. A no-op guard before `Update` prevents a write/watch hot-loop.

**Negative-controlled** — restoring the early-return reproduces the silent break in a test:

```
--- FAIL: TestEnsureLauncherRBAC_UpgradeBindsBothWhileLegacyPodRuns
    new SA unbound on upgrade — every annotation patch would 403 silently;
    subjects=[{Kind:ServiceAccount Name:default Namespace:prod}]
```

## imagePullSecrets ships here, not later

The design note calls this the biggest operational risk and it's inseparable from the switch: operators on private registries patch `imagePullSecrets` onto the namespace `default` SA, and a pod inherits its SA's secrets. Moving to a dedicated SA drops that into cluster-wide `ImagePullBackOff`.

`swiftletd.imagePullSecrets` is plumbed to all five builders and set on the **pod**, which works regardless of which SA it names. Verified: renders when set, absent when unset.

## Also

- The reporter role's `update` verb was dead — swiftletd only ever PATCHes. Now `get,patch`.
- Controller gains `serviceaccounts: get,list,watch,create`. **`list`+`watch` are required, not optional** — controller-runtime's cached client opens an informer per GETable type and blocks forever without them (the W7/W8 trap, hit twice before).
- Controller gains `rolebindings: update` for the convergence.

## Before merge

Needs the cluster sequence from the design note: pre-upgrade guest as a legacy fixture → upgrade → binding holds **both** subjects and the running guest still updates status → recreate → `default` auto-retires → fresh namespace probe → sandbox + warm pool → live migration → GPU.

Local: `gofmt -s` clean, `go build ./cmd/... ./internal/... ./api/...`, 35 test packages green.

## Follow-ups

- `resourceNames` scoping (the actual close).
- `automountServiceAccountToken: false` on the ~13 helper pods/Jobs that have no k8s client — deliberately **not** the launcher, which needs its token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)