### PR TITLE
feat(pool): let a guest name a scheduler profile, so spread can follow load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`spec.schedulerName` on SwiftGuest**, and therefore on every SwiftGuestPool
+  replica (the pool copies its template spec wholesale). It sets
+  `pod.spec.schedulerName` on the launcher, which lets a guest opt into a
+  kube-scheduler profile configured with the `NodeResourcesFit`
+  `LeastAllocated` scoring strategy.
+
+  This closes the gap in #418. `spreadPolicy: Spread` counts pods, so it will
+  place the next replica on a node that is already nearly full as long as that
+  node holds no more pods of the pool than its neighbours. The launcher has
+  always requested the guest's real footprint — cpu equal to the vCPU count,
+  memory equal to guest RAM plus overhead, requests equal to limits — so the
+  scheduler could already score on utilization; what an operator had no way to
+  express was how heavily free capacity should weigh. Naming a profile is that
+  expression. The two compose: spread keeps replicas off one node,
+  `LeastAllocated` breaks the tie toward the emptiest.
+
+  `nodeName` still wins — direct binding skips the scheduler entirely, so the
+  field is left unset on the pod rather than written as configuration that
+  never ran. An unknown profile name leaves the pod Pending indefinitely and
+  KubeSwift cannot warn about it, because the set of scheduler profiles is not
+  exposed through the API; the guide says so plainly.
+
+---
+
 ## [v0.13.5] — 2026-08-09
 
 An incident release. Two SwiftGuests were deleted from a lab cluster and the

--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -185,6 +185,27 @@ type SwiftGuestSpec struct {
 	// refuses to build with a Resolved=False condition if they disagree.
 	// +optional
 	NodeName string `json:"nodeName,omitempty"`
+	// SchedulerName routes the launcher pod to a specific kube-scheduler
+	// profile (pod.spec.schedulerName). Empty means the cluster default.
+	//
+	// The launcher pod already carries accurate requests — cpu equal to the
+	// guest's vCPU count and memory equal to guest RAM plus the launcher
+	// overhead, with requests == limits — so the scheduler scores nodes on
+	// the guest's real footprint. What the default profile does NOT let an
+	// operator choose is how heavily free capacity weighs against the other
+	// scoring terms. A profile configured with the NodeResourcesFit
+	// LeastAllocated strategy biases placement toward less-loaded nodes;
+	// naming it here is how a guest (or every replica of a pool, via the
+	// pool template) opts into it.
+	//
+	// This is placement policy, not placement: an unknown scheduler name
+	// leaves the pod Pending forever, because no scheduler claims it. Set it
+	// only to a profile that exists in the cluster's scheduler config.
+	//
+	// Ignored when NodeName is set — direct binding bypasses the scheduler
+	// entirely, so no profile ever sees the pod.
+	// +optional
+	SchedulerName string `json:"schedulerName,omitempty"`
 	// Migration is the per-guest migration policy. If nil, migration is
 	// permitted with default settings (preferredMode: auto). Set
 	// migration.enabled=false to pin a guest in place — the SwiftMigration

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestpools.yaml
@@ -863,6 +863,28 @@ spec:
                         - RestartOnFailure
                         - Always
                         type: string
+                      schedulerName:
+                        description: |-
+                          SchedulerName routes the launcher pod to a specific kube-scheduler
+                          profile (pod.spec.schedulerName). Empty means the cluster default.
+
+                          The launcher pod already carries accurate requests — cpu equal to the
+                          guest's vCPU count and memory equal to guest RAM plus the launcher
+                          overhead, with requests == limits — so the scheduler scores nodes on
+                          the guest's real footprint. What the default profile does NOT let an
+                          operator choose is how heavily free capacity weighs against the other
+                          scoring terms. A profile configured with the NodeResourcesFit
+                          LeastAllocated strategy biases placement toward less-loaded nodes;
+                          naming it here is how a guest (or every replica of a pool, via the
+                          pool template) opts into it.
+
+                          This is placement policy, not placement: an unknown scheduler name
+                          leaves the pod Pending forever, because no scheduler claims it. Set it
+                          only to a profile that exists in the cluster's scheduler config.
+
+                          Ignored when NodeName is set — direct binding bypasses the scheduler
+                          entirely, so no profile ever sees the pod.
+                        type: string
                       seedProfileRef:
                         description: SeedProfileRef references a SwiftSeedProfile
                           for cloud-init (disk boot only).

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguests.yaml
@@ -713,6 +713,28 @@ spec:
                 - RestartOnFailure
                 - Always
                 type: string
+              schedulerName:
+                description: |-
+                  SchedulerName routes the launcher pod to a specific kube-scheduler
+                  profile (pod.spec.schedulerName). Empty means the cluster default.
+
+                  The launcher pod already carries accurate requests — cpu equal to the
+                  guest's vCPU count and memory equal to guest RAM plus the launcher
+                  overhead, with requests == limits — so the scheduler scores nodes on
+                  the guest's real footprint. What the default profile does NOT let an
+                  operator choose is how heavily free capacity weighs against the other
+                  scoring terms. A profile configured with the NodeResourcesFit
+                  LeastAllocated strategy biases placement toward less-loaded nodes;
+                  naming it here is how a guest (or every replica of a pool, via the
+                  pool template) opts into it.
+
+                  This is placement policy, not placement: an unknown scheduler name
+                  leaves the pod Pending forever, because no scheduler claims it. Set it
+                  only to a profile that exists in the cluster's scheduler config.
+
+                  Ignored when NodeName is set — direct binding bypasses the scheduler
+                  entirely, so no profile ever sees the pod.
+                type: string
               seedProfileRef:
                 description: SeedProfileRef references a SwiftSeedProfile for cloud-init
                   (disk boot only).

--- a/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestpools.yaml
@@ -863,6 +863,28 @@ spec:
                         - RestartOnFailure
                         - Always
                         type: string
+                      schedulerName:
+                        description: |-
+                          SchedulerName routes the launcher pod to a specific kube-scheduler
+                          profile (pod.spec.schedulerName). Empty means the cluster default.
+
+                          The launcher pod already carries accurate requests — cpu equal to the
+                          guest's vCPU count and memory equal to guest RAM plus the launcher
+                          overhead, with requests == limits — so the scheduler scores nodes on
+                          the guest's real footprint. What the default profile does NOT let an
+                          operator choose is how heavily free capacity weighs against the other
+                          scoring terms. A profile configured with the NodeResourcesFit
+                          LeastAllocated strategy biases placement toward less-loaded nodes;
+                          naming it here is how a guest (or every replica of a pool, via the
+                          pool template) opts into it.
+
+                          This is placement policy, not placement: an unknown scheduler name
+                          leaves the pod Pending forever, because no scheduler claims it. Set it
+                          only to a profile that exists in the cluster's scheduler config.
+
+                          Ignored when NodeName is set — direct binding bypasses the scheduler
+                          entirely, so no profile ever sees the pod.
+                        type: string
                       seedProfileRef:
                         description: SeedProfileRef references a SwiftSeedProfile
                           for cloud-init (disk boot only).

--- a/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguests.yaml
@@ -713,6 +713,28 @@ spec:
                 - RestartOnFailure
                 - Always
                 type: string
+              schedulerName:
+                description: |-
+                  SchedulerName routes the launcher pod to a specific kube-scheduler
+                  profile (pod.spec.schedulerName). Empty means the cluster default.
+
+                  The launcher pod already carries accurate requests — cpu equal to the
+                  guest's vCPU count and memory equal to guest RAM plus the launcher
+                  overhead, with requests == limits — so the scheduler scores nodes on
+                  the guest's real footprint. What the default profile does NOT let an
+                  operator choose is how heavily free capacity weighs against the other
+                  scoring terms. A profile configured with the NodeResourcesFit
+                  LeastAllocated strategy biases placement toward less-loaded nodes;
+                  naming it here is how a guest (or every replica of a pool, via the
+                  pool template) opts into it.
+
+                  This is placement policy, not placement: an unknown scheduler name
+                  leaves the pod Pending forever, because no scheduler claims it. Set it
+                  only to a profile that exists in the cluster's scheduler config.
+
+                  Ignored when NodeName is set — direct binding bypasses the scheduler
+                  entirely, so no profile ever sees the pod.
+                type: string
               seedProfileRef:
                 description: SeedProfileRef references a SwiftSeedProfile for cloud-init
                   (disk boot only).

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -50,6 +50,7 @@ Represents a running virtual machine instance.
 | `seedProfileRef.name` | string | No | — | SwiftSeedProfile for cloud-init (disk boot only). Optional. |
 | `runPolicy` | enum | No | `Running` | `Running`, `Stopped`, `RestartOnFailure`, or `Always`. |
 | `gpuProfileRef.name` | string | No | — | SwiftGPUProfile for GPU passthrough. Mutually exclusive with `kernelRef`. |
+| `schedulerName` | string | No | — | kube-scheduler profile for the launcher pod. Use a profile with the `NodeResourcesFit` `LeastAllocated` strategy to bias placement toward less-loaded nodes. Ignored when `nodeName` pins the guest. An unknown name leaves the pod Pending — KubeSwift cannot validate it, since scheduler profiles are not exposed through the API. |
 
 **RunPolicy values:**
 
@@ -430,6 +431,7 @@ Manages a fleet of identical VMs with ReplicaSet-style semantics: rolling update
 | `template` | SwiftGuestTemplateSpec | The per-replica SwiftGuest spec (boot source, class, seed, etc.). |
 | `updateStrategy` | UpdateStrategy | Rolling-update parameters (e.g. `maxUnavailable`, `maxSurge`). |
 | `spreadPolicy` / `topologySpreadConstraints` | string / []TopologySpreadConstraint | How replicas are spread across nodes/zones. |
+| `template.spec.schedulerName` | string | Routes every replica to a named scheduler profile — the utilization-aware complement to topology spread, which only counts pods. See the [guide](swiftguestpool-guide.md). |
 | `volumeClaimTemplates` | []PersistentVolumeClaimTemplate | Per-replica PVCs (owned by the pool, not the individual SwiftGuests). |
 | `service` | PoolServiceSpec | One load-balanced Service across all replicas (`ports`, `type`, `headless`). See [Service exposure](networking/service-exposure.md). |
 

--- a/docs/swiftguestpool-guide.md
+++ b/docs/swiftguestpool-guide.md
@@ -217,6 +217,75 @@ spec:
 
 When `topologySpreadConstraints` is set, `spreadPolicy` is ignored.
 
+### Spreading by utilization, not just by count
+
+Topology spread counts pods. It will happily put the seventh replica on a node
+that is already 90% committed, because that node holds no more *pods* of this
+pool than its neighbours.
+
+Node utilization is not invisible to the scheduler — the launcher pod requests
+the guest's real footprint (`cpu` = vCPU count, `memory` = guest RAM plus
+launcher overhead, with requests equal to limits), so `NodeResourcesFit` scores
+on the true cost of the VM. What the default profile does not offer is a way to
+say *how much* free capacity should matter relative to the other scoring terms.
+
+`schedulerName` on the guest template is that lever. Add a second scheduler
+profile that scores with `LeastAllocated`, then point the pool's template at it:
+
+```yaml
+# kube-scheduler config (KubeSchedulerConfiguration), alongside the default profile
+profiles:
+  - schedulerName: default-scheduler
+  - schedulerName: least-allocated
+    pluginConfig:
+      - name: NodeResourcesFit
+        args:
+          scoringStrategy:
+            type: LeastAllocated
+            resources:
+              - name: cpu
+                weight: 1
+              - name: memory
+                weight: 1
+```
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestPool
+spec:
+  replicas: 6
+  spreadPolicy: Spread          # still spreads across nodes
+  template:
+    spec:
+      schedulerName: least-allocated   # ...and prefers the emptier ones
+      imageRef:
+        name: ubuntu-noble
+      guestClassRef:
+        name: default
+```
+
+Both mechanisms compose: topology spread keeps replicas off a single node,
+`LeastAllocated` breaks the tie toward whichever node has the most headroom.
+That tie-break is the case worth having once every node already runs a replica.
+
+`schedulerName` also works on a standalone SwiftGuest — it is a field on
+`SwiftGuestSpec`, and a pool simply passes its template through.
+
+Two things to know before using it:
+
+- **An unknown profile name means Pending forever.** No scheduler claims a pod
+  whose `schedulerName` matches no configured profile, so nothing ever writes
+  an `Unschedulable` condition to explain it. KubeSwift cannot validate the
+  name — the set of scheduler profiles is not exposed through the API. Check it
+  against your cluster's scheduler config.
+- **`nodeName` wins.** Pinning a guest binds the pod directly and skips the
+  scheduler, so `schedulerName` is ignored and left unset on the pod rather
+  than written as configuration that never ran. This also applies to the target
+  side of a live migration, which pins by design.
+
+On a managed control plane you may not be able to add a scheduler profile at
+all. In that case topology spread remains the available lever.
+
 ### Node failure handling
 
 If a node goes down, the launcher pods on that node enter `Terminating` state. Once Kubernetes marks the pods as terminated (controlled by the node's `pod-eviction-timeout`, default 5 minutes), the SwiftGuestPool controller detects the missing replicas and creates replacements on healthy nodes.

--- a/internal/controller/swiftguest/gpu.go
+++ b/internal/controller/swiftguest/gpu.go
@@ -359,6 +359,7 @@ func (r *SwiftGuestReconciler) buildBasePod(
 	if params, ok := RestoreParamsFromAnnotations(guest.Annotations); ok {
 		pod := BuildRestorePod(guest, rg, seedConfigMapName, intentConfigMapName, rootDiskClone, params)
 		applyNodeName(pod, guest)
+		applySchedulerName(pod, guest)
 		return pod, nil
 	}
 	if guest.Spec.GPUProfileRef != nil && guest.Status.GPU != nil {

--- a/internal/controller/swiftguest/pod.go
+++ b/internal/controller/swiftguest/pod.go
@@ -40,6 +40,7 @@ func BuildPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGuest, seedC
 	}
 	applyTopologyConstraints(pod, guest)
 	applyNodeName(pod, guest)
+	applySchedulerName(pod, guest)
 	applyDataDiskRefs(pod, guest)
 	applyFilesystems(pod, guest)
 	applyVhostUserSocketVolumes(pod, guest)
@@ -273,6 +274,22 @@ func applyTopologyConstraints(pod *corev1.Pod, guest *swiftv1alpha1.SwiftGuest) 
 func applyNodeName(pod *corev1.Pod, guest *swiftv1alpha1.SwiftGuest) {
 	if guest.Spec.NodeName != "" {
 		pod.Spec.NodeName = guest.Spec.NodeName
+	}
+}
+
+// applySchedulerName routes the launcher pod to a named kube-scheduler
+// profile. The launcher's requests already describe the guest's real
+// footprint (vCPU + RAM + overhead, requests == limits), so a profile using
+// the NodeResourcesFit LeastAllocated strategy will bias replicas toward
+// less-loaded nodes; this is how a guest opts into such a profile.
+//
+// NodeName wins: direct binding skips the scheduler entirely, so writing a
+// schedulerName alongside it would be inert configuration that reads as if
+// it did something. Leave the field empty in that case so the pod spec says
+// what actually happened.
+func applySchedulerName(pod *corev1.Pod, guest *swiftv1alpha1.SwiftGuest) {
+	if guest.Spec.SchedulerName != "" && guest.Spec.NodeName == "" {
+		pod.Spec.SchedulerName = guest.Spec.SchedulerName
 	}
 }
 

--- a/internal/controller/swiftguest/pod_test.go
+++ b/internal/controller/swiftguest/pod_test.go
@@ -812,3 +812,68 @@ func TestBuildPod_NetworkInitHasIntentMount(t *testing.T) {
 		t.Errorf("pod missing volumes for network-init mounts: %v", vols)
 	}
 }
+
+// --- schedulerName (#418) ---
+//
+// The launcher already requests the guest's real cpu/memory, so the scheduler
+// can score on utilization; what an operator could not do before was choose a
+// profile that weights free capacity differently (NodeResourcesFit
+// LeastAllocated). These cover the three states that matter.
+
+func schedulerNameGuest(schedulerName, nodeName string) *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "sched", Namespace: "default"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			ImageRef:      &corev1.LocalObjectReference{Name: "img"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "class"},
+			SchedulerName: schedulerName,
+			NodeName:      nodeName,
+		},
+	}
+}
+
+func TestApplySchedulerName_SetsProfile(t *testing.T) {
+	pod := &corev1.Pod{}
+	applySchedulerName(pod, schedulerNameGuest("least-allocated", ""))
+	if pod.Spec.SchedulerName != "least-allocated" {
+		t.Fatalf("schedulerName = %q, want %q", pod.Spec.SchedulerName, "least-allocated")
+	}
+}
+
+func TestApplySchedulerName_EmptyLeavesClusterDefault(t *testing.T) {
+	pod := &corev1.Pod{}
+	applySchedulerName(pod, schedulerNameGuest("", ""))
+	if pod.Spec.SchedulerName != "" {
+		t.Fatalf("schedulerName = %q, want empty so the apiserver defaults it", pod.Spec.SchedulerName)
+	}
+}
+
+// NodeName bypasses the scheduler entirely, so a schedulerName alongside it
+// would be inert text in the pod spec that reads as if it took effect.
+func TestApplySchedulerName_NodeNameWins(t *testing.T) {
+	pod := &corev1.Pod{}
+	guest := schedulerNameGuest("least-allocated", "boba")
+	applyNodeName(pod, guest)
+	applySchedulerName(pod, guest)
+	if pod.Spec.NodeName != "boba" {
+		t.Fatalf("nodeName = %q, want boba", pod.Spec.NodeName)
+	}
+	if pod.Spec.SchedulerName != "" {
+		t.Fatalf("schedulerName = %q, want empty: direct binding skips the scheduler", pod.Spec.SchedulerName)
+	}
+}
+
+// The pool copies its template spec wholesale, so a schedulerName set once on
+// the template reaches every replica. This asserts the field survives the
+// round trip a replica actually takes.
+func TestBuildPod_SchedulerNameReachesLauncher(t *testing.T) {
+	rg := &resolved.ResolvedGuest{
+		Resources:     resolved.Resources{CPU: 2, Memory: 2048},
+		PreparedImage: resolved.PreparedImage{PVCName: "pvc"},
+		Network:       true,
+	}
+	pod := BuildPod(schedulerNameGuest("least-allocated", ""), rg, "", "test-intent", nil)
+	if pod.Spec.SchedulerName != "least-allocated" {
+		t.Fatalf("schedulerName = %q, want least-allocated", pod.Spec.SchedulerName)
+	}
+}


### PR DESCRIPTION
Closes #418.

## The gap

`spreadPolicy: Spread` counts pods. It will place the next replica on a node that is already nearly full, as long as that node holds no more pods of this pool than its neighbours — which is precisely the situation the issue describes, once every node already runs one.

Utilization was never invisible to the scheduler. The launcher pod requests the guest's real footprint:

```go
corev1.ResourceCPU:    cpu,                              // guest vCPU count
corev1.ResourceMemory:  mem + LauncherMemoryOverheadMiB, // guest RAM + overhead
```

with requests equal to limits, so `NodeResourcesFit` already scores nodes on the true cost of the VM. What an operator could not express is **how heavily free capacity should weigh** against the other scoring terms — the issue says this too.

## The change

`spec.schedulerName` on SwiftGuest sets `pod.spec.schedulerName` on the launcher. Point it at a profile configured with the `NodeResourcesFit` `LeastAllocated` scoring strategy and placement biases toward the emptier node:

```yaml
profiles:
  - schedulerName: default-scheduler
  - schedulerName: least-allocated
    pluginConfig:
      - name: NodeResourcesFit
        args:
          scoringStrategy:
            type: LeastAllocated
            resources: [{name: cpu, weight: 1}, {name: memory, weight: 1}]
```

```yaml
spec:
  spreadPolicy: Spread                 # still spreads across nodes
  template:
    spec:
      schedulerName: least-allocated   # ...and prefers the emptier ones
```

The two compose: spread keeps replicas off a single host, `LeastAllocated` breaks the tie.

## Design notes

**On SwiftGuestSpec, not on the pool.** The pool deep-copies `template.spec` wholesale (`controller.go:242`), so every replica inherits it with no pool-specific plumbing, and a standalone guest gets the same control.

**`nodeName` wins, and the pod says so.** Direct binding skips the scheduler entirely — including the target side of a live migration, which pins by design. `applySchedulerName` leaves the field unset in that case rather than writing configuration that never ran.

**An unknown profile name is a Pending-forever trap, and it is documented as one.** No scheduler claims a pod whose `schedulerName` matches no profile, so nothing writes an `Unschedulable` condition to explain it (`status.go` surfaces that reason when a scheduler *does* run). KubeSwift cannot validate the name — the set of scheduler profiles is not a Kubernetes API object. The guide states this plainly instead of implying the field is safe. It also notes that on a managed control plane you may not be able to add a profile at all, leaving topology spread as the available lever.

## Tests

Four unit tests: sets the profile; empty leaves the cluster default; `nodeName` wins; and the field survives the full `BuildPod` path a replica actually takes.

Negative control run: relaxing the `NodeName == ""` guard to a bare `SchedulerName != ""` — a compiling one-line behaviour change — fails `TestApplySchedulerName_NodeNameWins` and nothing else.

`gofmt -s`, `go vet`, `make generate` clean; all 46 repo packages pass.

## Not included

Cluster validation of the controller half needs a CI-built image; it will run against dev before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)