### PR TITLE
fix(seed): default NoCloud meta-data, so a seed profile is not silently ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to KubeSwift are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A NoCloud seed with no `metaData` no longer discards the operator's
+  cloud-config** (#457). NoCloud is only recognised as a datasource when the
+  seed disk carries a `meta-data` file; the renderer omitted the key when the
+  field was empty, so cloud-init fell back to `DataSourceNone` and threw away
+  `userData` entirely — no user, no SSH key, no hostname — while the guest
+  booted, took a DHCP lease and reported Running/Ready. Nothing in `kubectl`
+  indicated anything had gone wrong.
+
+  The controller now synthesizes `instance-id: <namespace>-<guest>` +
+  `local-hostname: <guest>` when neither `metaData` nor `metaDataFrom` is set.
+  `instance-id` must be stable per guest because cloud-init keys "have I already
+  run for this instance?" off it. This is what the clone path already did, which
+  is why clones worked and ordinary guests did not. An explicit value always
+  wins; only NoCloud is affected.
+
 ### Added
 
 - **`spec.schedulerName` on SwiftGuest**, and therefore on every SwiftGuestPool

--- a/api/seed/v1alpha1/swiftseedprofile_types.go
+++ b/api/seed/v1alpha1/swiftseedprofile_types.go
@@ -27,10 +27,18 @@ type SeedDataValueFrom struct {
 
 // SwiftSeedProfileSpec defines the desired state of SwiftSeedProfile.
 type SwiftSeedProfileSpec struct {
-	Datasource      DatasourceType     `json:"datasource"`
-	UserData        string             `json:"userData"` // Inline; use UserDataFrom for ref
-	UserDataFrom    *SeedDataValueFrom `json:"userDataFrom,omitempty"`
-	MetaData        string             `json:"metaData,omitempty"` // Inline; use MetaDataFrom for ref
+	Datasource   DatasourceType     `json:"datasource"`
+	UserData     string             `json:"userData"` // Inline; use UserDataFrom for ref
+	UserDataFrom *SeedDataValueFrom `json:"userDataFrom,omitempty"`
+	// MetaData is inline NoCloud instance metadata (use MetaDataFrom for a ref).
+	//
+	// Optional because it is DEFAULTED, not because NoCloud works without it: a
+	// NoCloud seed disk with no meta-data file is not recognised as a datasource
+	// at all, and cloud-init then discards userData wholesale while the guest
+	// still boots and reports Ready (#457). When neither this nor MetaDataFrom is
+	// set, the controller synthesizes `instance-id: <namespace>-<guest>` +
+	// `local-hostname: <guest>`. Set it only to override that.
+	MetaData        string             `json:"metaData,omitempty"`
 	MetaDataFrom    *SeedDataValueFrom `json:"metaDataFrom,omitempty"`
 	NetworkData     string             `json:"networkData,omitempty"` // Inline; use NetworkDataFrom for ref
 	NetworkDataFrom *SeedDataValueFrom `json:"networkDataFrom,omitempty"`

--- a/charts/kubeswift/crds/seed.kubeswift.io_swiftseedprofiles.yaml
+++ b/charts/kubeswift/crds/seed.kubeswift.io_swiftseedprofiles.yaml
@@ -54,6 +54,15 @@ spec:
                 - NoCloud
                 type: string
               metaData:
+                description: |-
+                  MetaData is inline NoCloud instance metadata (use MetaDataFrom for a ref).
+
+                  Optional because it is DEFAULTED, not because NoCloud works without it: a
+                  NoCloud seed disk with no meta-data file is not recognised as a datasource
+                  at all, and cloud-init then discards userData wholesale while the guest
+                  still boots and reports Ready (#457). When neither this nor MetaDataFrom is
+                  set, the controller synthesizes `instance-id: <namespace>-<guest>` +
+                  `local-hostname: <guest>`. Set it only to override that.
                 type: string
               metaDataFrom:
                 description: SeedDataValueFrom holds a reference to Secret or ConfigMap.

--- a/config/crd/bases/seed.kubeswift.io_swiftseedprofiles.yaml
+++ b/config/crd/bases/seed.kubeswift.io_swiftseedprofiles.yaml
@@ -54,6 +54,15 @@ spec:
                 - NoCloud
                 type: string
               metaData:
+                description: |-
+                  MetaData is inline NoCloud instance metadata (use MetaDataFrom for a ref).
+
+                  Optional because it is DEFAULTED, not because NoCloud works without it: a
+                  NoCloud seed disk with no meta-data file is not recognised as a datasource
+                  at all, and cloud-init then discards userData wholesale while the guest
+                  still boots and reports Ready (#457). When neither this nor MetaDataFrom is
+                  set, the controller synthesizes `instance-id: <namespace>-<guest>` +
+                  `local-hostname: <guest>`. Set it only to override that.
                 type: string
               metaDataFrom:
                 description: SeedDataValueFrom holds a reference to Secret or ConfigMap.

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -213,7 +213,7 @@ cloud-init NoCloud datasource configuration. Rendered to a seed ISO and mounted 
 | `datasource` | enum | Yes | Only `NoCloud` is supported. |
 | `userData` | string | No | Inline cloud-config YAML. |
 | `userDataFrom` | SeedDataValueFrom | No | Reference to Secret or ConfigMap key. |
-| `metaData` | string | No | Inline instance metadata YAML. |
+| `metaData` | string | No | Inline instance metadata YAML. **Defaulted when omitted** (`instance-id: <namespace>-<guest>`, `local-hostname: <guest>`) — a NoCloud disk with no `meta-data` file is not recognised as a datasource, and cloud-init would silently discard `userData` while the guest still booted and reported Ready. Set it only to override. |
 | `metaDataFrom` | SeedDataValueFrom | No | Reference to Secret or ConfigMap key. |
 | `networkData` | string | No | Inline network configuration. |
 | `networkDataFrom` | SeedDataValueFrom | No | Reference to Secret or ConfigMap key. |

--- a/internal/resolved/merge.go
+++ b/internal/resolved/merge.go
@@ -52,7 +52,7 @@ func Merge(
 	rg.Networks = Networks{InterfaceModel: DefaultInterfaceModel}
 
 	// Seed: from SwiftSeedProfile when referenced
-	rg.Seed = mergeSeed(seedProfile)
+	rg.Seed = mergeSeed(seedProfile, guest)
 
 	// PreparedImage: from SwiftImage when Ready
 	rg.PreparedImage = mergePreparedImage(image)
@@ -172,7 +172,7 @@ func mergeRootDisk(guestClass *swiftv1alpha1.SwiftGuestClass) RootDisk {
 	return RootDisk{Size: size, Format: format}
 }
 
-func mergeSeed(seedProfile *seedv1alpha1.SwiftSeedProfile) *Seed {
+func mergeSeed(seedProfile *seedv1alpha1.SwiftSeedProfile, guest *swiftv1alpha1.SwiftGuest) *Seed {
 	if seedProfile == nil {
 		return nil
 	}
@@ -191,7 +191,45 @@ func mergeSeed(seedProfile *seedv1alpha1.SwiftSeedProfile) *Seed {
 	if seedProfile.Spec.NetworkDataFrom != nil {
 		s.NetworkDataFrom = seedProfile.Spec.NetworkDataFrom
 	}
+	defaultNoCloudMetaData(s, guest)
 	return s
+}
+
+// defaultNoCloudMetaData synthesizes meta-data for a NoCloud seed that does not
+// supply its own (issue #457).
+//
+// NoCloud is only RECOGNISED as a datasource if the seed disk carries a
+// meta-data file. The renderer omits the key when the field is empty, so a
+// profile that sets only userData produced a disk cloud-init could not identify:
+// it fell back to DataSourceNone and discarded the operator's entire user-data.
+// The guest still booted, still got a DHCP lease and still reported
+// Running/Ready, so nothing in kubectl indicated that no user, no SSH key and no
+// hostname had been applied. spec.metaData is marked +optional on the CRD, so an
+// operator following the CRD contract landed there.
+//
+// The values are not a guess. instance-id is what cloud-init keys "have I
+// already run for this instance?" off, so it must be stable per guest across
+// reboots — hence namespace-name rather than anything generated. This mirrors
+// what the clone path has always done (see swiftguest/clone.go), which is why
+// clones worked while ordinary guests did not.
+//
+// An explicit metaData (inline or metaDataFrom) always wins: this only fills a
+// gap, it never overrides an operator.
+func defaultNoCloudMetaData(s *Seed, guest *swiftv1alpha1.SwiftGuest) {
+	if s.Datasource != string(seedv1alpha1.DatasourceNoCloud) {
+		return
+	}
+	if s.MetaData != "" || s.MetaDataFrom != nil {
+		return
+	}
+	if guest == nil || guest.Name == "" {
+		return
+	}
+	instanceID := guest.Name
+	if guest.Namespace != "" {
+		instanceID = guest.Namespace + "-" + guest.Name
+	}
+	s.MetaData = "instance-id: " + instanceID + "\nlocal-hostname: " + guest.Name + "\n"
 }
 
 func mergePreparedImage(image *imagev1alpha1.SwiftImage) PreparedImage {

--- a/internal/resolved/merge_test.go
+++ b/internal/resolved/merge_test.go
@@ -119,3 +119,76 @@ func TestMerge_NoSeedWhenSwiftSeedProfileNotReferenced(t *testing.T) {
 		t.Errorf("Seed = %v, want nil", rg.Seed)
 	}
 }
+
+// --- NoCloud meta-data defaulting (#457) ---
+//
+// NoCloud is only recognised when the seed disk carries meta-data. Without it
+// cloud-init falls back to DataSourceNone and silently discards user-data, while
+// the guest still boots and reports Ready — so these cover the defaulting rather
+// than leaving the failure to a cluster to discover.
+
+func seedMergeFixture(t *testing.T, profile *seedv1alpha1.SwiftSeedProfile) *ResolvedGuest {
+	t.Helper()
+	guest := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-01", Namespace: "prod"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			SeedProfileRef: &corev1.LocalObjectReference{Name: "sp"},
+			ImageRef:       &corev1.LocalObjectReference{Name: "img"},
+			GuestClassRef:  corev1.LocalObjectReference{Name: "gc"},
+		},
+	}
+	guestClass := &swiftv1alpha1.SwiftGuestClass{Spec: swiftv1alpha1.SwiftGuestClassSpec{
+		CPU: resource.MustParse("2"), Memory: resource.MustParse("2Gi"),
+		RootDisk: swiftv1alpha1.RootDiskSpec{Size: resource.MustParse("10Gi"), Format: swiftv1alpha1.DiskFormatRaw},
+	}}
+	image := &imagev1alpha1.SwiftImage{Status: imagev1alpha1.SwiftImageStatus{
+		Phase: imagev1alpha1.SwiftImagePhaseReady, PreparedArtifact: &imagev1alpha1.PreparedArtifactRef{Format: imagev1alpha1.DiskFormatRaw},
+	}}
+	return Merge(guest, guestClass, image, profile)
+}
+
+func TestMerge_NoCloudWithoutMetaDataGetsADefault(t *testing.T) {
+	rg := seedMergeFixture(t, &seedv1alpha1.SwiftSeedProfile{Spec: seedv1alpha1.SwiftSeedProfileSpec{
+		Datasource: seedv1alpha1.DatasourceNoCloud,
+		UserData:   "#cloud-config\nusers: []",
+	}})
+	want := "instance-id: prod-web-01\nlocal-hostname: web-01\n"
+	if rg.Seed.MetaData != want {
+		t.Errorf("Seed.MetaData = %q, want %q — without it cloud-init ignores user-data entirely", rg.Seed.MetaData, want)
+	}
+}
+
+func TestMerge_ExplicitMetaDataIsNotOverridden(t *testing.T) {
+	rg := seedMergeFixture(t, &seedv1alpha1.SwiftSeedProfile{Spec: seedv1alpha1.SwiftSeedProfileSpec{
+		Datasource: seedv1alpha1.DatasourceNoCloud,
+		UserData:   "#cloud-config",
+		MetaData:   "instance-id: operator-chose-this\n",
+	}})
+	if rg.Seed.MetaData != "instance-id: operator-chose-this\n" {
+		t.Errorf("Seed.MetaData = %q; defaulting must fill a gap, never override", rg.Seed.MetaData)
+	}
+}
+
+// metaDataFrom is resolved later by the renderer, so an empty MetaData string
+// here does NOT mean the operator supplied nothing — defaulting would shadow the
+// Secret/ConfigMap they pointed at.
+func TestMerge_MetaDataFromSuppressesTheDefault(t *testing.T) {
+	rg := seedMergeFixture(t, &seedv1alpha1.SwiftSeedProfile{Spec: seedv1alpha1.SwiftSeedProfileSpec{
+		Datasource:   seedv1alpha1.DatasourceNoCloud,
+		UserData:     "#cloud-config",
+		MetaDataFrom: &seedv1alpha1.SeedDataValueFrom{},
+	}})
+	if rg.Seed.MetaData != "" {
+		t.Errorf("Seed.MetaData = %q, want empty: metaDataFrom supplies it at render time", rg.Seed.MetaData)
+	}
+}
+
+func TestMerge_NonNoCloudDatasourceIsUntouched(t *testing.T) {
+	rg := seedMergeFixture(t, &seedv1alpha1.SwiftSeedProfile{Spec: seedv1alpha1.SwiftSeedProfileSpec{
+		Datasource: "ConfigDrive",
+		UserData:   "#cloud-config",
+	}})
+	if rg.Seed.MetaData != "" {
+		t.Errorf("Seed.MetaData = %q, want empty: the meta-data requirement is NoCloud's", rg.Seed.MetaData)
+	}
+}


### PR DESCRIPTION
Closes #457.

## The failure

A `SwiftSeedProfile` with `datasource: NoCloud` and no `spec.metaData` renders a seed disk with `user-data` and `network-config` but **no `meta-data`**. NoCloud is only recognised as a datasource when that file is present, so cloud-init does not detect the seed at all:

```
cloud-init[1049]: Cloud-init v. 26.1 finished at ... Datasource DataSourceNone.  Up 20.86 seconds
cloud-init[1049]: cc_final_message.py[WARNING]: Used fallback datasource
Ubuntu 24.04.4 LTS ubuntu ttyS0          <- hostname `ubuntu`, not the one requested
```

Everything the operator asked for is discarded — no user, no SSH key, no hostname, no `runcmd` — while the guest boots, takes a DHCP lease and reports `Running`/`Ready` with an IP. `kubectl` shows a perfectly healthy VM. The only symptom is that SSH fails.

`spec.metaData` is `+optional` on the CRD, so this is where following the CRD contract lands you.

## The cause

`internal/seed/configmap.go` omits the key when the field is empty:

```go
if metaData != "" {
    data[KeyMetaData] = metaData
}
```

and nothing upstream supplies a default.

## The fix

`internal/resolved` synthesizes meta-data when the profile provides none:

```
instance-id: <namespace>-<guest>
local-hostname: <guest>
```

The values are not arbitrary. cloud-init keys *"have I already run for this instance?"* off `instance-id`, so it has to be stable per guest across reboots — a generated or random value would make cloud-init re-run every boot. This is exactly what the **clone path already does** (`swiftguest/clone.go:277`), which is why clones worked and ordinary guests did not; the normal path was the outlier.

Defaulting fills a gap and never overrides:

- explicit `metaData` wins;
- **`metaDataFrom` also suppresses it** — an empty `MetaData` string does not mean the operator supplied nothing, it means the renderer fetches it from a Secret/ConfigMap later, and defaulting would shadow what they pointed at;
- non-NoCloud datasources are untouched.

## Tests

Four cases: defaulted when absent, explicit not overridden, `metaDataFrom` suppresses, non-NoCloud untouched.

Negative control run: dropping the `MetaDataFrom` half of the guard — a compiling one-line change — fails `TestMerge_MetaDataFromSuppressesTheDefault` and nothing else.

## Docs

The CRD comment and `docs/crds.md` now say the field is optional **because it is defaulted**, rather than leaving "optional" to imply NoCloud works without it.

## Provenance

Found while rebuilding the dev hub: a guest that looked healthy in every way could not be logged into. The seed Secret contained the correct key the whole time — the fault was between the ISO and cloud-init, not in KubeSwift's seed rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)