### PR TITLE
fix(chart): trigger the insecure-gateway guard on reachability, not on one field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ All notable changes to KubeSwift are documented here.
   is why clones worked and ordinary guests did not. An explicit value always
   wins; only NoCloud is affected.
 
+- **The chart's insecure-ingress interlock now triggers on actual reachability**
+  (#459). It only checked `gateway.ingress.enabled`, while the documented way to
+  publish the UI is `ui.ingress` — and the UI's nginx proxies the Connect RPCs to
+  the gateway at same origin, so it exposes the identical control plane. A hub
+  went out unauthenticated on a public address with the guard silent and
+  `allowInsecureIngress` still `false`. The check now covers `gateway.ingress`,
+  `ui.ingress`, and a `LoadBalancer`/`NodePort` Service for either — the last of
+  which needs no Ingress object at all. `authMode: insecure` remains usable with
+  no exposure (port-forward), and the override is unchanged.
+
 ### Added
 
 - **`spec.schedulerName` on SwiftGuest**, and therefore on every SwiftGuestPool

--- a/charts/kubeswift/templates/gateway/deployment.yaml
+++ b/charts/kubeswift/templates/gateway/deployment.yaml
@@ -46,9 +46,23 @@ spec:
               Refuse the combination rather than rely on the operator reading a
               comment. gateway.allowInsecureIngress is the explicit override for
               anyone who genuinely wants it (an isolated lab behind other controls).
+
+              REACHABILITY IS THE TRIGGER, NOT gateway.ingress (issue #459). The
+              first version of this guard checked only gateway.ingress.enabled and
+              so missed the way operators actually publish the UI: ui.ingress, plus
+              the tlsAuto ergonomics the chart itself recommends. The UI's nginx
+              proxies /kubeswift.v1.* to the gateway at same origin, so ui.ingress
+              exposes precisely the same control plane -- and a hub was published
+              unauthenticated on a public address with this guard sitting silent
+              and allowInsecureIngress still false. A LoadBalancer/NodePort UI
+              Service does it too, with no Ingress object at all.
             */ -}}
-            {{- if and (eq .Values.gateway.authMode "insecure") .Values.gateway.ingress.enabled (not .Values.gateway.allowInsecureIngress) }}
-              {{- fail "gateway.authMode=insecure with gateway.ingress.enabled exposes an UNAUTHENTICATED control plane (VM console, sandbox exec, RBAC editor). Set gateway.authMode=oidc (or token), or set gateway.allowInsecureIngress=true to accept the risk deliberately." }}
+            {{- $viaGatewayIngress := .Values.gateway.ingress.enabled -}}
+            {{- $viaUI := and .Values.ui.enabled (or .Values.ui.ingress.enabled (has .Values.ui.service.type (list "LoadBalancer" "NodePort"))) -}}
+            {{- $viaGatewayService := has .Values.gateway.service.type (list "LoadBalancer" "NodePort") -}}
+            {{- $reachable := or $viaGatewayIngress $viaUI $viaGatewayService -}}
+            {{- if and (eq .Values.gateway.authMode "insecure") $reachable (not .Values.gateway.allowInsecureIngress) }}
+              {{- fail "gateway.authMode=insecure with a reachable gateway (gateway.ingress, ui.ingress, or a LoadBalancer/NodePort Service for either) exposes an UNAUTHENTICATED control plane: every Connect RPC, the VM console and sandbox-exec WebSockets, and the RBAC editor, all running as the member cluster credential. The UI proxies these to the gateway at same origin, so publishing the UI publishes the gateway. Set gateway.authMode=oidc (or token), or keep authMode=insecure with NO ingress/LoadBalancer and reach it via kubectl port-forward. gateway.allowInsecureIngress=true accepts the risk deliberately." }}
             {{- end }}
             - --auth-mode={{ .Values.gateway.authMode }}
             - --cors-allow-origin={{ .Values.gateway.corsAllowOrigin }}


### PR DESCRIPTION
Closes #459.

## The hole

The guard is right about the risk and wrong about the trigger — it checks only `gateway.ingress.enabled`:

```gotemplate
{{- if and (eq .Values.gateway.authMode "insecure") .Values.gateway.ingress.enabled (not .Values.gateway.allowInsecureIngress) }}
```

The documented, chart-supported way to publish the UI is **`ui.ingress`** (plus the `tlsAuto` ergonomics this chart recommends), and the UI's nginx proxies `/kubeswift.v1.*` to the gateway at same origin. So this renders happily:

```yaml
gateway: {authMode: insecure}
ui:
  enabled: true
  ingress: {enabled: true, host: kubeswift.example.com, tlsAuto: {enabled: true, clusterIssuer: letsencrypt-prod}}
```

and publishes the identical unauthenticated control plane — every Connect RPC, the console and sandbox-exec WebSockets, the RBAC editor — with `allowInsecureIngress` still `false`, so nothing records that a risk was accepted.

This happened. A hub went out exactly like that on a public address with a real certificate. Under `insecure` every caller runs as the member cluster credential, so an anonymous request reached a federated member as whatever that kubeconfig held (cluster-admin, in a typical lab federation).

## The fix

Trigger on reachability rather than on one field:

```gotemplate
{{- $viaUI := and .Values.ui.enabled (or .Values.ui.ingress.enabled (has .Values.ui.service.type (list "LoadBalancer" "NodePort"))) -}}
{{- $reachable := or .Values.gateway.ingress.enabled $viaUI (has .Values.gateway.service.type (list "LoadBalancer" "NodePort")) -}}
```

The Service case earns its place independently: a `LoadBalancer`/`NodePort` UI or gateway Service exposes the plane with no Ingress object for the old check to inspect.

The message now names the UI ingress and offers the port-forward alternative, since an operator hitting this is most likely trying to publish the UI without realising that publishes the gateway.

## Tests

All eight combinations, checking both directions:

| config | expected | result |
|---|---|---|
| insecure + `ui.ingress` (**the incident**) | fail | fail |
| insecure + `gateway.ingress` (already caught) | fail | fail |
| insecure + ui `LoadBalancer` | fail | fail |
| insecure + gateway `NodePort` | fail | fail |
| insecure, no exposure (port-forward) | pass | pass |
| oidc + `ui.ingress` | pass | pass |
| insecure + `ui.ingress` + `allowInsecureIngress` | pass | pass |
| `ui.enabled=false`, insecure | pass | pass |

`helm lint` clean.

## Not included

Under `authMode: insecure` a self-registered hub also cannot read its own cluster — the impersonate grant is correctly withheld, but nothing replaces it as the read path, so the local cluster silently shows nothing while remote members work. That is a separate symptom of the same under-tested mode and is left to #459's follow-up rather than mixed in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)