### PR TITLE
fix(controller): refuse to run with an unsynced cache instead of idling silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ All notable changes to KubeSwift are documented here.
   which needs no Ingress object at all. `authMode: insecure` remains usable with
   no exposure (port-forward), and the override is unchanged.
 
+- **A cache that never syncs is now fatal instead of silent** (#460). When RBAC
+  denies a watched type, the reflector retries forever: the manager stays up, the
+  pod stays Ready, and *nothing* reconciles — no controller starts until every
+  informer syncs — so fresh resources sat with a completely empty `.status`, no
+  pod and no event. The manager now waits a bounded 3 minutes and exits non-zero
+  with the likely cause, turning an idle-but-healthy process into a
+  CrashLoopBackOff next to the reflector's own `is forbidden` lines. A cancelled
+  context (SIGTERM, lost leader election) is still a clean shutdown.
+
+  Note this differs from a *missing CRD*, which already failed at informer
+  construction — only the RBAC-denied case was invisible.
+
 ### Added
 
 - **`spec.schedulerName` on SwiftGuest**, and therefore on every SwiftGuestPool

--- a/cmd/controller-manager/cachesync_test.go
+++ b/cmd/controller-manager/cachesync_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The failure this guards against (#460) is invisible by construction: the
+// manager stays Ready and reconciles nothing. These pin the three outcomes.
+
+func TestCacheSyncOutcome_SyncedIsFine(t *testing.T) {
+	err := cacheSyncOutcome(context.Background(), time.Second, func(context.Context) bool { return true })
+	if err != nil {
+		t.Fatalf("err = %v, want nil when the cache syncs", err)
+	}
+}
+
+func TestCacheSyncOutcome_NeverSyncsIsAnError(t *testing.T) {
+	// Mirrors a forbidden LIST: the reflector retries until the deadline.
+	err := cacheSyncOutcome(context.Background(), 20*time.Millisecond, func(ctx context.Context) bool {
+		<-ctx.Done()
+		return false
+	})
+	if err == nil {
+		t.Fatal("err = nil; an unsynced cache must be fatal, not a silent idle process")
+	}
+	// The message is the whole point — it is the only thing the operator sees.
+	for _, want := range []string{"is forbidden", "list+watch", "newer than its chart"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message missing %q, got: %v", want, err)
+		}
+	}
+}
+
+// SIGTERM or a lost leader election during start-up cancels the parent context.
+// That is a shutdown, and reporting it as a cache fault would turn every clean
+// restart into a scary error.
+func TestCacheSyncOutcome_ShutdownIsNotAFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := cacheSyncOutcome(ctx, time.Minute, func(ctx context.Context) bool {
+		<-ctx.Done()
+		return false
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil: a cancelled parent context is a shutdown", err)
+	}
+}

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -14,6 +15,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	cacheopts "sigs.k8s.io/controller-runtime/pkg/cache"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -386,10 +388,76 @@ func main() {
 	}
 
 	klog.InfoS("starting manager", "version", version.Version, "git", version.GitCommit)
+	go watchdogCacheSync(ctx, mgr)
 	if err := mgr.Start(ctx); err != nil {
 		klog.ErrorS(err, "manager exited with error")
 		os.Exit(1)
 	}
+}
+
+// cacheSyncDeadline bounds how long the manager may run with an unsynced cache
+// before it gives up. Generous enough for a cold apiserver and a large fleet;
+// far short of "forever", which is the default and the bug (#460).
+var cacheSyncDeadline = 3 * time.Minute
+
+// watchdogCacheSync turns an un-syncable informer into a crash instead of a
+// silent, permanent no-op.
+//
+// controller-runtime's cached client starts an informer per watched type and
+// retries a failing LIST forever. The manager keeps running, the pod stays
+// Ready, and NOTHING reconciles — not just the affected type, all of it,
+// because no controller starts until the cache syncs. Observed for real when a
+// controller built after the launcher-ServiceAccount work ran against an older
+// chart's RBAC: `serviceaccounts is forbidden` every 15s, and freshly created
+// SwiftGuests sat with a completely empty .status, no pod, no event, no phase.
+// The operator has nothing to go on; `kubectl get deploy` says healthy.
+//
+// That is the most complete violation of "no silent failures" the system can
+// manage, so make it loud: wait a bounded time for the cache, and if it has not
+// synced, log the likely cause and exit non-zero. CrashLoopBackOff plus the
+// reflector's own "is forbidden" lines is a diagnosis; an idle Running pod is
+// not.
+//
+// The deadline is only armed while the process should be starting up — a normal
+// ctx cancellation (SIGTERM, lost leader election) exits quietly and is not a
+// sync failure.
+// A NOTE ON WHY THIS WAS NEEDED, given the comment above about VolumeSnapshot:
+// a MISSING CRD and a FORBIDDEN LIST fail differently. No such type at all fails
+// when the informer is constructed, and the manager does exit — which is what
+// that comment describes and why the CRD check exists. A type that exists but
+// which RBAC denies fails inside the reflector's retry loop instead, forever,
+// with the manager perfectly healthy. Only the second case is silent.
+func watchdogCacheSync(ctx context.Context, mgr manager.Manager) {
+	if err := cacheSyncOutcome(ctx, cacheSyncDeadline, mgr.GetCache().WaitForCacheSync); err != nil {
+		klog.ErrorS(err, "REFUSING TO RUN with an unsynced informer cache")
+		os.Exit(1)
+	}
+}
+
+// cacheSyncOutcome holds the decision, separate from the process exit, so the
+// three outcomes are testable without a real manager.
+//
+// Returns nil when the cache syncs, and nil when the parent context is already
+// done — a SIGTERM or a lost leader election during start-up is a shutdown, not
+// a fault, and must not be reported as one. Returns an error only when the
+// deadline passes with the process still expected to be running.
+func cacheSyncOutcome(ctx context.Context, deadline time.Duration, waitForCacheSync func(context.Context) bool) error {
+	deadlined, cancel := context.WithTimeout(ctx, deadline)
+	defer cancel()
+
+	if waitForCacheSync(deadlined) {
+		klog.InfoS("informer cache synced")
+		return nil
+	}
+	if ctx.Err() != nil {
+		return nil // shutting down, not a sync failure
+	}
+	return fmt.Errorf("informer cache did not sync within %s. No controller reconciles until "+
+		"EVERY watched type syncs, so this process would otherwise sit idle and Ready while doing "+
+		"nothing at all — no pods created, no status written, for any resource. The usual cause is "+
+		"missing RBAC on a watched type: look for \"is forbidden\" from the reflector above and grant "+
+		"the controller-manager ClusterRole list+watch on that resource. Running a controller image "+
+		"newer than its chart's RBAC produces exactly this", deadline)
 }
 
 // volumeSnapshotCRDsInstalled reports whether the CSI external-snapshotter


### PR DESCRIPTION
Closes #460.

## The failure

When RBAC denies a watched type, controller-runtime's reflector retries the LIST forever. The manager stays up, the pod stays Ready, and **nothing reconciles** — not just the affected type, everything, because no controller starts until every informer syncs.

Observed for real, running a `main`-built controller against the v0.13.5 chart's RBAC (which predates the launcher-ServiceAccount work, so grants no `serviceaccounts` rule):

```
E0810 10:24:30 "Failed to watch" error="failed to list *v1.ServiceAccount: serviceaccounts is forbidden:
  User \"system:serviceaccount:kubeswift-system:controller-manager\" cannot list resource \"serviceaccounts\"
  at the cluster scope" reflector="tools/cache/reflector.go:289"
```

every ~15s, while two freshly created SwiftGuests sat like this:

```
$ kubectl get swiftguest sched-a sched-b
NAME      PHASE   NODE   IP    AGE
sched-a                        4m18s
sched-b                        4m18s

$ kubectl get swiftguest sched-a -o jsonpath='{.status}'
        # empty
```

No pod, no event, no phase, no condition. `kubectl get deploy` reports healthy. There is nothing for an operator to go on.

## Why this is a bug, not just version skew

Skew is the trigger; the behaviour is the defect. It is the W7/W8 trap this codebase already knows about — a cached client needs `list`+`watch` on every GETable type or it blocks forever — and it violates Design Principle 6 about as completely as possible: 100% non-functional, reporting nothing.

It is also a realistic state. `helm upgrade` does not upgrade CRDs and operators routinely bump image tags separately from the chart, so "controller newer than its RBAC" happens.

## The fix

Wait a bounded three minutes for the cache; if it has not synced, log the likely cause and exit non-zero:

```
informer cache did not sync within 3m0s. No controller reconciles until EVERY watched type
syncs, so this process would otherwise sit idle and Ready while doing nothing at all — no pods
created, no status written, for any resource. The usual cause is missing RBAC on a watched type:
look for "is forbidden" from the reflector above and grant the controller-manager ClusterRole
list+watch on that resource. Running a controller image newer than its chart's RBAC produces
exactly this
```

The decision is split from the process exit (`cacheSyncOutcome`) so the outcomes are testable without a real manager.

**A cancelled parent context is not a failure.** SIGTERM or a lost leader election during start-up is a shutdown; reporting it as a cache fault would turn every clean restart into a scary error.

## A distinction worth recording

The comment above the manager setup says an unsyncable watch makes "the manager fatally exit", and that is why the VolumeSnapshot CRD discovery check exists. That is true for a **missing CRD** — no such type fails when the informer is constructed. A type that **exists but is RBAC-denied** fails inside the reflector's retry loop instead, with the manager perfectly healthy. Only the second case is silent, which is why this went unnoticed.

## Tests

Three outcomes: synced is fine; never-syncs is an error (and the message is asserted, since it is the only thing the operator sees); cancelled parent is a clean shutdown.

Negative control run: removing the shutdown guard — a compiling change — fails `TestCacheSyncOutcome_ShutdownIsNotAFailure` and nothing else.

## Related

Worth an upgrade note regardless: **v0.13.6's controller requires v0.13.6's chart RBAC**, and a mismatched pair stops all reconciliation. With this change it stops loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)