### PR TITLE
fix(rbac): retire `default` in drained namespaces, drop tokens from helper Jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to KubeSwift are documented here.
 
 ### Fixed
 
+- **A drained namespace now retires the legacy `default` launcher subject**
+  (#443). Subject convergence only ran from a SwiftGuest or SwiftSandbox
+  reconcile, so once the last guest in a namespace was deleted nothing
+  reconciled there again and `default` stayed bound to the reporter ClusterRole
+  forever — the namespace-wide `pods: patch` grant left behind in a namespace
+  with no launcher to justify it, which is when it is least defensible. A small
+  reconciler now watches the launcher RoleBindings themselves, so the object
+  carrying the stale subject drives its own cleanup after every CR is gone.
+
+- **Helper Jobs no longer mount a ServiceAccount token** (#443). Thirteen
+  pod specs across image import/validate, kernel pull, root/data disk
+  provisioning, snapshot s3/oci/cold-migration and clone download now set
+  `automountServiceAccountToken: false`. None of them talks to the API server.
+  Launcher pods are deliberately untouched — swiftletd needs its token to
+  report status.
+
 - **A NoCloud seed with no `metaData` no longer discards the operator's
   cloud-config** (#457). NoCloud is only recognised as a datasource when the
   seed disk carries a `meta-data` file; the renderer omitted the key when the

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -200,6 +200,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Retires the legacy `default` subject from launcher RoleBindings once a
+	// namespace stops running legacy launchers. Convergence otherwise only runs
+	// from a guest/sandbox reconcile, so a fully drained namespace would keep
+	// the namespace-wide pods:patch grant forever (#443).
+	if err = (&swiftguest.LauncherRBACReconciler{Client: mgr.GetClient()}).SetupWithManager(mgr); err != nil {
+		klog.ErrorS(err, "unable to create launcher-rbac controller")
+		os.Exit(1)
+	}
+
 	if err = (&swiftkernel.SwiftKernelReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -503,6 +503,70 @@ The OVMF_VARS.fd file is copied with the default permissions of the source file.
 
 ---
 
+## Accepted risk: `create pods` in a VM namespace is node-admin
+
+**Status: accepted and documented (#443). Not a defect report — a threat-model boundary.**
+
+A launcher pod is privileged by design (see SEC-01/02/03 above). swiftletd reports
+status by patching annotations onto its own pod, so the launcher ServiceAccount
+holds `pods: get,patch` in the workload namespace. Because
+`spec.containers[*].image` is mutable and kubelet restarts a container whose spec
+hash changed — regardless of `restartPolicy: Never` — anyone who can obtain that
+grant can repoint the privileged launcher's image and get node root.
+
+From v0.13.6 launchers run as dedicated ServiceAccounts rather than the namespace
+`default`, which removes *incidental* inheritance: ordinary Jobs, sidecars,
+CronJobs and debug pods in the namespace no longer hold `pods: patch` by accident.
+
+**It does not close the escalation, and neither would `resourceNames` scoping.**
+Kubernetes has no RBAC gate on which ServiceAccount a pod may reference — there is
+no `serviceaccounts/use` subresource and no verb for it. A tenant who can create
+pods simply names the launcher SA on a pod of their own and receives its token.
+Verified on a live cluster:
+
+```
+$ kubectl auth can-i patch pods -n <ns> --as=system:serviceaccount:<ns>:tenant
+no
+
+$ # ...as that same tenant, create a pod with `serviceAccountName: <launcher-sa>`
+pod/attacker created
+$ kubectl -n <ns> get pod attacker -o jsonpath='{.spec.serviceAccountName} {.spec.volumes[0].name}'
+<launcher-sa> kube-api-access-7qq6x
+```
+
+The token is mounted, so the tenant now holds whatever the launcher SA holds.
+Scoping the grant with `resourceNames` narrows *which* launcher pods are
+reachable; it does not stop the tenant reaching them.
+
+This matters most where Pod Security Admission stops a tenant from creating a
+privileged pod directly — they cannot make their own, but they can repoint the
+one already running.
+
+### The boundary
+
+**Treat `create pods` in a namespace that runs SwiftGuests or SwiftSandboxes as
+equivalent to node-admin on the nodes those workloads land on.** Grant it only to
+principals you would trust with node root.
+
+Practically:
+
+- Run tenant workloads in namespaces that do **not** run KubeSwift launchers.
+- Do not grant `create pods` in VM namespaces to anyone who should not have node
+  access; namespace-admin there is cluster-significant.
+- Node isolation (taints/affinity) bounds *which* nodes are exposed, not whether.
+
+### What would actually close it
+
+- **Admission control** — reject a pod referencing a launcher ServiceAccount
+  unless it is a genuine controller-created launcher. This closes it, at the cost
+  of a `pods` CREATE webhook the apiserver calls for every pod creation in the
+  cluster.
+- **Removing the grant** — move swiftletd's status reporting off pod annotations
+  onto a channel that needs no write access to its own pod. Closes it properly;
+  a rework of the status path in both the runtime and the controller.
+
+Neither is implemented. #443 tracks the decision.
+
 ## Cross-Cutting Observations
 
 ### Trust Boundary Summary

--- a/internal/controller/swiftguest/coldmig_import.go
+++ b/internal/controller/swiftguest/coldmig_import.go
@@ -213,10 +213,11 @@ func buildDiskFromOCIJob(guest *swiftv1alpha1.SwiftGuest, snap *snapshotv1alpha1
 			BackoffLimit: ptr.To(int32(4)),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					NodeName:      node,
-					RestartPolicy: corev1.RestartPolicyOnFailure,
-					Containers:    []corev1.Container{container},
-					Volumes:       volumes,
+					NodeName:                     node,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					AutomountServiceAccountToken: ptr.To(false),
+					Containers:                   []corev1.Container{container},
+					Volumes:                      volumes,
 				},
 			},
 		},

--- a/internal/controller/swiftguest/datadisk.go
+++ b/internal/controller/swiftguest/datadisk.go
@@ -175,7 +175,8 @@ echo "Fill complete: $(stat -c %%s /dst/image.raw) bytes"`, d.Name, bytes, bytes
 			BackoffLimit: ptr.To(int32(3)),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
+					RestartPolicy:                corev1.RestartPolicyNever,
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{{
 						Name:         "fill",
 						Image:        CloneJobImage,

--- a/internal/controller/swiftguest/rbac_converge_controller.go
+++ b/internal/controller/swiftguest/rbac_converge_controller.go
@@ -1,0 +1,100 @@
+package swiftguest
+
+import (
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// LauncherRBACReconciler retires the legacy `default` subject from launcher
+// RoleBindings in namespaces that no longer run any legacy launcher.
+//
+// # The gap this closes
+//
+// EnsureLauncherRBAC converges the subject set, but it only runs from a
+// SwiftGuest or SwiftSandbox reconcile. Once the last guest in a namespace is
+// deleted nothing reconciles there again, so a namespace that has been fully
+// drained keeps `default` bound to the reporter ClusterRole forever — the exact
+// namespace-wide `pods: patch` grant #443 exists to remove, left behind in a
+// namespace that no longer has any launcher to justify it.
+//
+// Draining is also the moment the grant is least defensible: with no VM left,
+// the only thing the binding can still do is hand `pods: patch` to whatever
+// else lives in that namespace.
+//
+// # Why a RoleBinding watch rather than a timer
+//
+// Reconciling the binding itself makes the object that carries the stale
+// subject the thing that drives its own cleanup, so convergence keeps running
+// after every CR is gone. The manager's 30s SyncPeriod resyncs watched objects,
+// which gives a drained namespace a bounded retirement window without a bespoke
+// ticker.
+//
+// It is deliberately NOT owned by any CR: these objects are shared by every
+// launcher in the namespace and must outlive any individual guest.
+type LauncherRBACReconciler struct {
+	client.Client
+}
+
+// Reconcile re-runs subject convergence for the namespace of the RoleBinding
+// that triggered it.
+//
+// Convergence is idempotent and has a no-op guard, so a resync that finds
+// nothing to do writes nothing and does not re-enqueue itself.
+func (r *LauncherRBACReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var rb rbacv1.RoleBinding
+	if err := r.Get(ctx, req.NamespacedName, &rb); err != nil {
+		// Deleted, or not ours. Nothing to converge; the next launcher created
+		// in this namespace recreates the binding from scratch.
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	class, ok := launcherClassForBinding(req.Name)
+	if !ok {
+		return ctrl.Result{}, nil
+	}
+	if err := EnsureLauncherRBAC(ctx, r.Client, req.Namespace, class); err != nil {
+		// A namespace being torn down races this: the binding exists when the
+		// watch fires and the namespace is gone by the time we write. That is
+		// ordinary, not an error worth backing off on.
+		if apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("converge launcher rbac in %s: %w", req.Namespace, err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// launcherClassForBinding maps a RoleBinding name back to the launcher class it
+// serves. Anything else in the cluster is ignored.
+func launcherClassForBinding(name string) (LauncherClass, bool) {
+	switch name {
+	case SwiftletdReporterRoleBindingName:
+		return GuestLauncher, true
+	case SandboxReporterRoleBindingName:
+		return SandboxLauncher, true
+	default:
+		// NB: LauncherClass is an int and GuestLauncher is its zero value, so
+		// there is no "invalid" sentinel to return. The bool is the only
+		// trustworthy signal — callers must check it, not the class.
+		return GuestLauncher, false
+	}
+}
+
+// SetupWithManager registers the reconciler on RoleBindings, filtered by name
+// so the controller does not wake for unrelated bindings in the cluster.
+func (r *LauncherRBACReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("launcher-rbac").
+		For(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
+			_, ok := launcherClassForBinding(o.GetName())
+			return ok
+		}))).
+		Complete(r)
+}

--- a/internal/controller/swiftguest/rbac_converge_controller_test.go
+++ b/internal/controller/swiftguest/rbac_converge_controller_test.go
@@ -1,0 +1,47 @@
+package swiftguest
+
+import "testing"
+
+// launcherClassForBinding drives whether a RoleBinding is converged at all, and
+// LauncherClass is an int whose zero value is a REAL class (GuestLauncher). A
+// caller that trusts the class without the bool would converge every RoleBinding
+// in the cluster as if it were a guest launcher.
+
+func TestLauncherClassForBinding(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		binding   string
+		wantClass LauncherClass
+		wantOK    bool
+	}{
+		{"guest launcher", SwiftletdReporterRoleBindingName, GuestLauncher, true},
+		{"sandbox launcher", SandboxReporterRoleBindingName, SandboxLauncher, true},
+		{"unrelated binding", "some-operator-binding", GuestLauncher, false},
+		{"empty", "", GuestLauncher, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := launcherClassForBinding(tc.binding)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && got != tc.wantClass {
+				t.Errorf("class = %v, want %v", got, tc.wantClass)
+			}
+		})
+	}
+}
+
+// The zero value of LauncherClass is GuestLauncher, so "not ours" cannot be
+// signalled through the class. This pins that the bool is the only usable
+// signal — if someone later switches the sentinel to a class comparison, an
+// unrelated RoleBinding would look exactly like a guest launcher.
+func TestLauncherClassForBinding_ZeroValueIsNotASentinel(t *testing.T) {
+	class, ok := launcherClassForBinding("not-a-launcher-binding")
+	if ok {
+		t.Fatal("unrelated binding reported as a launcher binding")
+	}
+	if class != GuestLauncher {
+		t.Fatalf("class = %v; the point of this test is that it EQUALS GuestLauncher, "+
+			"so the class alone cannot distinguish 'not ours'", class)
+	}
+}

--- a/internal/controller/swiftguest/rootdisk.go
+++ b/internal/controller/swiftguest/rootdisk.go
@@ -517,7 +517,8 @@ echo "Clone complete: $(stat -c %%s /dst/image.raw) bytes"`,
 			BackoffLimit: ptr.To(int32(3)),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
+					RestartPolicy:                corev1.RestartPolicyNever,
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{{
 						Name:          "clone",
 						Image:         CloneJobImage,

--- a/internal/controller/swiftimage/import.go
+++ b/internal/controller/swiftimage/import.go
@@ -198,7 +198,8 @@ func (r *SwiftImageReconciler) importHTTP(ctx context.Context, img *imagev1alpha
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyOnFailure,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					AutomountServiceAccountToken: ptr.To(false),
 					SecurityContext: &corev1.PodSecurityContext{
 						// Root is needed for apt-get (and, on Linux, the loop-mount).
 						RunAsUser: ptr.To(int64(0)),
@@ -349,7 +350,8 @@ func (r *SwiftImageReconciler) importOCI(ctx context.Context, img *imagev1alpha1
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyOnFailure,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					AutomountServiceAccountToken: ptr.To(false),
 					SecurityContext: &corev1.PodSecurityContext{
 						// Root: the init container writes into the (root-owned) PVC
 						// mount; the main container runs apt-get (+ Linux loop-mount).

--- a/internal/controller/swiftimage/validate.go
+++ b/internal/controller/swiftimage/validate.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"k8s.io/utils/ptr"
 	"strconv"
 	"strings"
 
@@ -53,7 +54,8 @@ func (r *SwiftImageReconciler) Validate(ctx context.Context, img *imagev1alpha1.
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
-							RestartPolicy: corev1.RestartPolicyNever,
+							RestartPolicy:                corev1.RestartPolicyNever,
+							AutomountServiceAccountToken: ptr.To(false),
 							Containers: []corev1.Container{{
 								Name:    "measure",
 								Image:   "ubuntu:22.04",

--- a/internal/controller/swiftkernel/pull.go
+++ b/internal/controller/swiftkernel/pull.go
@@ -72,7 +72,8 @@ func (r *SwiftKernelReconciler) StartPullOnNode(ctx context.Context, sk *kernelv
 			"kubeswift.io/kernel-node": "true",
 			"kubernetes.io/hostname":   nodeName,
 		},
-		RestartPolicy: corev1.RestartPolicyNever,
+		RestartPolicy:                corev1.RestartPolicyNever,
+		AutomountServiceAccountToken: ptr.To(false),
 		SecurityContext: &corev1.PodSecurityContext{
 			RunAsUser: ptr.To(int64(0)),
 		},

--- a/internal/controller/swiftsnapshot/coldmig.go
+++ b/internal/controller/swiftsnapshot/coldmig.go
@@ -363,10 +363,11 @@ func buildChunkJob(snap *snapshotv1alpha1.SwiftSnapshot, image, captureNode, job
 			BackoffLimit: ptr.To(ociPushBackoffLimit),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					NodeName:      captureNode,
-					RestartPolicy: corev1.RestartPolicyOnFailure,
-					Containers:    []corev1.Container{container},
-					Volumes:       volumes,
+					NodeName:                     captureNode,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					AutomountServiceAccountToken: ptr.To(false),
+					Containers:                   []corev1.Container{container},
+					Volumes:                      volumes,
 				},
 			},
 		},

--- a/internal/controller/swiftsnapshot/oci.go
+++ b/internal/controller/swiftsnapshot/oci.go
@@ -279,8 +279,9 @@ func buildOCIPushJob(snap *snapshotv1alpha1.SwiftSnapshot, image, captureNode st
 			BackoffLimit: ptr.To(ociPushBackoffLimit),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					NodeName:      captureNode,
-					RestartPolicy: corev1.RestartPolicyOnFailure,
+					NodeName:                     captureNode,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{{
 						Name:         "push",
 						Image:        image,

--- a/internal/controller/swiftsnapshot/s3.go
+++ b/internal/controller/swiftsnapshot/s3.go
@@ -232,7 +232,8 @@ func buildDeleteJob(snap *snapshotv1alpha1.SwiftSnapshot, image string) *batchv1
 			BackoffLimit: ptr.To(s3UploadBackoffLimit),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyOnFailure,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{{
 						Name:  "delete",
 						Image: image,
@@ -321,8 +322,9 @@ func buildUploadJob(snap *snapshotv1alpha1.SwiftSnapshot, image, captureNode str
 			BackoffLimit: ptr.To(s3UploadBackoffLimit),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					NodeName:      captureNode,
-					RestartPolicy: corev1.RestartPolicyOnFailure,
+					NodeName:                     captureNode,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{{
 						Name:  "upload",
 						Image: image,

--- a/internal/snapshot/clonecommon/download.go
+++ b/internal/snapshot/clonecommon/download.go
@@ -106,8 +106,9 @@ func BuildDownloadJob(p DownloadJobParams) *batchv1.Job {
 			BackoffLimit: ptr.To(DownloadBackoffLimit),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					NodeName:      p.Node,
-					RestartPolicy: corev1.RestartPolicyOnFailure,
+					NodeName:                     p.Node,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{{
 						Name:  "download",
 						Image: p.Image,
@@ -228,8 +229,9 @@ func BuildOCIDownloadJob(p OCIDownloadJobParams) *batchv1.Job {
 			BackoffLimit: ptr.To(DownloadBackoffLimit),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					NodeName:      p.Node,
-					RestartPolicy: corev1.RestartPolicyOnFailure,
+					NodeName:                     p.Node,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{{
 						Name:         "download",
 						Image:        p.Image,


### PR DESCRIPTION
Part of #443, under the **accept and document** decision.

## 1. Convergence survives a drained namespace

`EnsureLauncherRBAC` converges the subject set, but only runs from a SwiftGuest or SwiftSandbox reconcile. Delete the last guest in a namespace and nothing reconciles there again — so `default` stays bound to the reporter ClusterRole forever.

That is the namespace-wide `pods: patch` grant #443 exists to remove, left behind in a namespace with no launcher to justify it. It is also when the grant is *least* defensible: with no VM left, the only thing the binding can still do is hand `pods: patch` to whatever else lives there.

A small reconciler now watches the launcher RoleBindings themselves, so the object carrying the stale subject drives its own cleanup after every CR is gone. Watching the binding rather than running a ticker also means the manager's existing 30s `SyncPeriod` gives a drained namespace a bounded retirement window with no bespoke timer.

Namespace teardown races the watch (binding exists when it fires, namespace gone when we write), so `NotFound`/`Forbidden` are treated as ordinary rather than backed off on.

## 2. Helper Jobs stop mounting a ServiceAccount token

Thirteen pod specs — image import/validate, kernel pull, root/data disk provisioning, snapshot s3/oci/cold-migration, clone download — now set `automountServiceAccountToken: false`. None talks to the API server and none names a ServiceAccount, so this is pure removal.

**Launcher pods are deliberately untouched**; swiftletd needs its token to report status. I checked that explicitly rather than relying on the sweep missing them:

```
$ grep -c AutomountServiceAccountToken internal/controller/swiftguest/pod.go internal/controller/swiftsandbox/pod.go
0
0
```

## 3. The threat-model boundary, written down

`docs/security-audit.md` gains a section stating that **`create pods` in a namespace running SwiftGuests or SwiftSandboxes is equivalent to node-admin**, with the cluster evidence and the guidance that follows (run tenant workloads in namespaces without launchers; treat namespace-admin there as cluster-significant).

## What is NOT here, and why

The issue's plan says `resourceNames`-scoped `pods: get,patch` is "the fix that does close it". **It is not**, so it is not shipped dressed as one.

Kubernetes has no RBAC gate on which ServiceAccount a pod may reference — no `serviceaccounts/use` subresource, no verb. Confirmed on the dev cluster: a principal that could **not** patch pods created a pod naming the launcher SA and received its token:

```
$ kubectl auth can-i patch pods -n sa-probe --as=system:serviceaccount:sa-probe:tenant
no
pod/attacker created
$ kubectl -n sa-probe get pod attacker -o jsonpath='{.spec.serviceAccountName} {.spec.volumes[0].name}'
fake-launcher kube-api-access-7qq6x
```

Scoping narrows *which* launcher pods are reachable; it does not stop them being reached, with either a shared SA or per-guest SAs. Shipping it as the closer would be exactly the overclaim `rbac.go`'s own header warns against ("A change that only renames the SA must not claim the escalation is closed").

The two things that would close it — a `pods` CREATE admission guard, or removing the pod-patch grant from the status path — are recorded in the doc as unimplemented, with their real costs, rather than half-built.

## Tests

`launcherClassForBinding` gated both ways, including a test pinning that `LauncherClass`'s zero value **is** `GuestLauncher` — so the bool is the only usable "not ours" signal. Swap that for a class comparison later and every unrelated RoleBinding in the cluster looks like a guest launcher.

`gofmt -s`, `go vet` clean; 46 packages pass, 0 failures.

## Not yet done

Cluster validation of the drained-namespace retirement needs a CI-built image; the mechanism is unit-covered but the convergence timing is cluster-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)