### PR TITLE
release: v0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,36 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
-## [Unreleased]
+## [v0.13.6] — 2026-08-10
+
+A correctness release. Every item is a case where the system did the wrong thing
+quietly — a seed silently discarded, a safety interlock watching the wrong field,
+a controller idling while reporting healthy, an RBAC subject that outlived its
+reason to exist.
+
+### Upgrade
+
+**Upgrade the chart, not just the image tag.** v0.13.6's controller watches
+ServiceAccounts (the launcher-SA work), and that rule ships in this version's
+chart RBAC. A controller image newer than its chart's RBAC cannot sync its
+informer cache — and as of this release it now **exits non-zero** rather than
+running idle, so the mismatch presents as CrashLoopBackOff instead of a cluster
+where nothing reconciles. That is the intended behaviour, but it means an
+image-only bump fails loudly where it used to fail silently.
+
+```bash
+helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.6 \
+  -n kubeswift-system -f <(helm get values kubeswift -n kubeswift-system -o yaml)
+kubectl apply -f charts/kubeswift/crds/    # helm does not upgrade CRDs
+```
+
+Also note **`gateway.authMode: insecure` now refuses to render alongside any
+chart-managed exposure** — `gateway.ingress`, `ui.ingress`, or a
+LoadBalancer/NodePort Service for either. If you are running that combination
+today you are serving an unauthenticated control plane; switch to
+`authMode: oidc`, drop the exposure and use port-forward, or set
+`gateway.allowInsecureIngress=true` to accept the risk deliberately.
+
 
 ### Fixed
 
@@ -62,6 +91,42 @@ All notable changes to KubeSwift are documented here.
   construction — only the RBAC-denied case was invisible.
 
 ### Added
+
+- **Launcher pods run as dedicated ServiceAccounts** (#456). Until now they used
+  the workload namespace's `default`, and the reporter ClusterRole was bound to
+  it — so every Job, sidecar, CronJob and debug pod in that namespace silently
+  inherited `pods: patch` on a **privileged** launcher. Guests and sandboxes now
+  get separate SAs (`kubeswift-launcher`, `kubeswift-sandbox-launcher`), and a
+  sandbox launcher no longer receives `swiftguests/status` at all — it never
+  needed it, and granting it would let an escaped sandbox forge conditions on any
+  guest in the namespace.
+
+  The binding *converges* rather than being created once: the new SA is always
+  bound, and `default` stays bound only while a launcher pod is still running as
+  it, so an in-place upgrade does not break VMs that keep their original SA until
+  they next stop or migrate.
+
+  **If you attach `imagePullSecrets` to the namespace `default` ServiceAccount**
+  for a private registry, launchers no longer inherit them. Set
+  `swiftletd.imagePullSecrets` so the chart puts them on the pod, where they
+  apply regardless of SA — otherwise the first guest after upgrade is
+  `ImagePullBackOff`.
+
+  Read the scope honestly: Kubernetes has no RBAC gate on which ServiceAccount a
+  pod may reference, so this removes *incidental* inheritance and makes the grant
+  auditable — it does not stop someone who can create pods from naming the SA.
+  See `docs/security-audit.md` and #443.
+
+- **`swiftctl image publish` survives a registry rate limit** (#455). A 429 —
+  or a 403 whose body says rate limit, which is how GitHub signals its secondary
+  limit — aborted the whole publish and threw away every chunk already uploaded.
+  It now retries with jittered exponential backoff and scales chunk size with
+  artifact size. A plain 403 is still permission-denied and still fails fast;
+  retrying it would just be a slow way to reach the same error.
+
+- **Operator guide for apiserver audit logging** (#454) —
+  `docs/operator/audit-logging.md`, including why a VM platform needs it and the
+  k0s file-permission trap that makes the apiserver refuse to start.
 
 - **`spec.schedulerName` on SwiftGuest**, and therefore on every SwiftGuestPool
   replica (the pool copies its template spec wholesale). It sets

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.5 \
+  --version 0.13.6 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.5
-appVersion: "0.13.5"
+version: 0.13.6
+appVersion: "0.13.6"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.5 \
+  --set controllerManager.image.tag=v0.13.6 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.5
+  --set swiftletd.image.tag=v0.13.6
 ```
 
 ### Release workflow

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.5 -n kubeswift-system --create-namespace \
+  --version 0.13.6 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.5 \
+  --version 0.13.6 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.5 \
+  --version 0.13.6 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.5 \
+  --version 0.13.6 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.5 \
+  --set controllerManager.image.tag=v0.13.6 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.5
+  --set swiftletd.image.tag=v0.13.6
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.5 \
+  --version 0.13.6 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.5 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.5 \
-    --set swiftletd.image.tag=v0.13.5
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.6 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.6 \
+    --set swiftletd.image.tag=v0.13.6
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.5 \
+  --version 0.13.6 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.5 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.6 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows


### PR DESCRIPTION
Cuts **v0.13.6**. Chart `0.13.6` / appVersion `0.13.6`.

A correctness release — every item is a case where the system did the wrong thing *quietly*: a seed silently discarded, a safety interlock watching the wrong field, a controller idling while reporting healthy, an RBAC subject that outlived its reason to exist.

## Contents (9 entries, 8 commits since v0.13.5)

| PR | |
|---|---|
| #454 | audit-logging operator guide |
| #455 | `swiftctl image publish` retries registry rate limits |
| #456 | dedicated launcher ServiceAccounts, converging off `default` |
| #458 | `spec.schedulerName` — spread that can follow load |
| #461 | NoCloud `meta-data` defaulting |
| #462 | insecure-ingress guard triggers on reachability |
| #463 | unsynced cache is fatal, not silent |
| #464 | drained-namespace convergence + helper-Job tokens |

**Three of those shipped with no CHANGELOG entry at all** (#454, #455, #456) and are backfilled here. #456 matters most: it changes behaviour an operator can trip over — launchers no longer inherit `imagePullSecrets` patched onto the namespace `default` SA — and that belongs in release notes, not only a commit message. I verified `swiftletd.imagePullSecrets` is the correct value path before documenting it.

## Version sweep

Chart + every install reference: README, quickstart, deploy, releases, helm-oci, remote-cluster, dra-allocation, troubleshooting. Rendered chart confirms `controller-manager:v0.13.6`.

**Historical statements deliberately untouched** — "changed in v0.13.4", "hostPath opt-in (v0.13.4+)", "gateway records every RPC (v0.13.5+)" describe when something landed and are still true. A blanket find-and-replace would have falsified them.

Remaining `0.13.5` in the tree: the CHANGELOG's own history heading, and macOS-version strings inside gitignored buildroot artifacts.

## Upgrade section, and why it leads

The fleet check for #463 turned up a concrete hazard. This release's controller watches ServiceAccounts (#456), and that rule ships in **this version's chart RBAC**:

```
dev: serviceaccounts rules = 1     (applied during validation)
sov: serviceaccounts rules = 0
ntx: serviceaccounts rules = 0
```

So an **image-only bump** on sov or ntx would produce a controller that cannot sync its cache — and as of #463 that now exits non-zero rather than idling, i.e. CrashLoopBackOff instead of a cluster where nothing reconciles. Intended, but it turns a silent failure into a loud one at exactly the moment operators are upgrading. A proper `helm upgrade` applies the rule and is safe; the section says so first.

It also flags that `gateway.authMode: insecure` now refuses to render alongside any chart-managed exposure, since anyone running that today is serving an unauthenticated control plane.

All three clusters currently show **zero** `is forbidden` lines on v0.13.5, so nothing is in the stalled state right now.

## Verification

`make generate` clean (15 CRDs in sync), `gofmt -s`, `go vet`, 46 packages pass / 0 fail, `helm lint` + `helm template` clean.

#464 was cluster-validated on dev before merge: `default` correctly **retained** while a legacy launcher ran, **retired** after the namespace drained with no new guest; helper Job with no `kube-api-access` volume; launcher keeping its token; and a fresh guest reaching `Running` with a reported IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)