### PR TITLE
build: move the go directive to 1.26.5, matching the builder images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeswift-io/kubeswift
 
-go 1.25.12
+go 1.26.5
 
 require (
 	connectrpc.com/connect v1.20.0


### PR DESCRIPTION
Follow-on to the Dependabot batch just merged.

Dependabot moved 8 of the 9 image builders from `golang:1.25-bookworm` to `golang:1.26-bookworm` (#468, #469, #471, #474, #476, #478, #479, #481) and they all went green — so the binaries we ship now carry the **Go 1.26 standard library**. `go.mod` still said `1.25.12`.

That leaves our own vulnerability scanning auditing the wrong thing:

> `security.yaml` runs govulncheck with `go-version-file: go.mod` + `check-latest`, so it installs the newest **1.25.x** and reports against the 1.25 stdlib — while every image ships **1.26.x**.

Trivy would still catch a stdlib CVE in the built artifact, since it scans the binary — that is exactly the Phase 2 (#480) job. But govulncheck reporting on a standard library we do not ship is a silent gap in Phase 1, and it is invisible precisely *because both halves stay green*. Nothing fails; the coverage just quietly stops overlapping with reality.

`1.26.5` is the current release, and separately the one carrying the `os.Root` symlink-traversal fix (CVE-2026-39822).

## The ninth builder is intentionally untouched

`images/webhook-server/Containerfile` stays on 1.25. It builds `./cmd/webhook-server`, **which does not exist** — `cmd/` has no such directory. No workflow builds it, the chart does not reference it, and it is in neither the Dependabot directory list nor the image-scan matrix. That is why Dependabot never proposed a bump for it: nothing manages it.

It is dead config that would fail immediately if anyone built it, and it should be deleted rather than silently version-bumped. Tracked separately so this PR stays a one-line toolchain change.

## Verification

`go build` and `go test` over `./api/... ./internal/... ./cmd/...`: **46 ok, 0 FAIL** — unchanged from before the bump. Local Go is already 1.26.5, so the directive matches the toolchain exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)