### PR TITLE
ci(security): filter the image-scan push trigger, not just the PR one

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -35,6 +35,20 @@ on:
       - '.github/workflows/image-scan.yaml'
   push:
     branches: [main]
+    # Same filter as the PR trigger, and for the same reason. Without it every
+    # merge to main — including a docs typo — rebuilds and rescans all nine
+    # images. A batch of 13 dependency merges queued 117 build jobs and starved
+    # the runners, which is how this was noticed.
+    #
+    # Nothing is lost: a merge that does not touch these paths cannot change the
+    # images, and the nightly run below re-scans the full matrix anyway, so
+    # main's current state is still established every day.
+    paths:
+      - 'images/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'rust/**'
+      - '.github/workflows/image-scan.yaml'
   schedule:
     # The important one. CVEs are disclosed against images we already shipped,
     # without anything in this repo changing.


### PR DESCRIPTION
A defect in #480, found by its own consequences.

#480 put a `paths:` filter on the `pull_request` trigger with the note that *"a docs PR should not pay for nine container builds"* — and then left `push: branches: [main]` unfiltered. So every merge paid for exactly that.

Merging the 13 green Dependabot PRs made it visible: **13 merges × 9 images = 117 build jobs**, plus CI and Release Dev per merge. The result was 26 runs queued behind 7 running, and PRs opened afterwards sitting pending for 20+ minutes.

## Why filtering loses nothing

- A merge that does not touch `images/**`, `go.mod`, `go.sum` or `rust/**` **cannot change what is in the images**.
- An image input that *does* change on main still triggers a scan immediately — the filter matches.
- The **nightly** run re-scans the full matrix regardless, so main's current state is still established every day. That run was always the one that mattered most, since CVEs get disclosed against images we already shipped without anything here changing.

So the coverage is the same and the cost drops to roughly the rate at which image inputs actually change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)