### PR TITLE
build: pin the Rust toolchain to 1.97.1

### DIFF
--- a/images/swiftletd/Containerfile
+++ b/images/swiftletd/Containerfile
@@ -4,7 +4,7 @@
 # us build both the Rust launcher (under rust/) and the small Go
 # snapshot-stager init-container helper (under cmd/snapshot-stager,
 # which depends on internal/snapshot/configjson) from the same image.
-FROM rust:1-bookworm AS builder
+FROM rust:1.97.1-bookworm AS builder
 WORKDIR /build
 
 ARG VERSION=dev

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,0 +1,28 @@
+# Pin the Rust toolchain.
+#
+# Before this file, nothing pinned the compiler. CI used
+# dtolnay/rust-toolchain@stable and images/swiftletd/Containerfile used
+# `FROM rust:1-bookworm` — both floating. Two consequences:
+#
+#   - Builds were not reproducible. The same commit compiled with a different
+#     compiler depending on when you built it.
+#   - A Rust stable release could change what we ship, or turn CI red one
+#     morning, with no pull request and nothing to review. Dependabot manages
+#     our crates (see .github/dependabot.yml), but the compiler itself was
+#     outside any of that.
+#
+# CI runs every cargo command from this directory, so rustup reads this file and
+# uses the pinned toolchain regardless of what the workflow's setup action
+# installed. This file is the single source of truth.
+#
+# Bumping it: images/swiftletd/Containerfile pins the SAME version, and that one
+# IS tracked by Dependabot (docker ecosystem, /images/swiftletd). So a Rust
+# release shows up as a Containerfile bump PR — treat that PR as the prompt to
+# move this file to match. The two must not drift: the container build and CI
+# would then be compiling with different compilers.
+[toolchain]
+channel = "1.97.1"
+# rustfmt only — CI runs `cargo fmt --check` but not clippy. Add clippy here if
+# it is ever added to the workflow, so the component is installed for the
+# pinned toolchain rather than resolved against whatever else is on the box.
+components = ["rustfmt"]


### PR DESCRIPTION
Nothing pinned the Rust compiler.

- CI: `dtolnay/rust-toolchain@<sha> # stable` — floats on latest stable at run time
- `images/swiftletd/Containerfile`: `FROM rust:1-bookworm` — floats on latest 1.x at build time
- No `rust-toolchain.toml`, no `rust-version` in `rust/Cargo.toml`

Two consequences:

- **Builds were not reproducible.** The same commit compiled with a different compiler depending on when you built it.
- **A Rust release could change what we ship, or turn CI red one morning, with no PR and nothing to review.**

That is the same class of exposure `.github/dependabot.yml` exists to close for crates — #482 bumped 8 of them — while the compiler that builds them sat outside all of it. There was literally no version to bump, which is exactly why this never surfaced as a stale pin: invisible drift does not look like anything.

`1.97.1` is the current stable, so this **freezes what we already effectively use** rather than changing behaviour.

## How it holds

CI runs every cargo command from `rust/`, so rustup reads `rust-toolchain.toml` and uses the pinned toolchain regardless of what the workflow's setup action installed. No workflow change needed, and the file is the single source of truth.

`images/swiftletd/Containerfile` pins the same version — and **that one is Dependabot-tracked** (docker ecosystem, `/images/swiftletd` is in the directories list). So a Rust release now arrives as a reviewable Containerfile bump PR, which is the prompt to move the toml to match. The header of the toml says so explicitly, because the two drifting apart would mean CI and the container build using different compilers.

`components = ["rustfmt"]` only — CI runs `cargo fmt --check` but not clippy. Noted in the file so clippy gets added there if it is ever added to the workflow.

## Verification

With the pin in place, locally:

```
rustup: 1.97.1-x86_64-unknown-linux-gnu (overridden by rust/rust-toolchain.toml)
cargo fmt --check   pass
cargo build         ok
cargo test          228 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)