### PR TITLE
chore: anchor the snapshot-oras gitignore pattern to the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ vendor/
 /webhook-server
 /snapshot-stager
 /snapshot-s3
+/snapshot-oras
 
 .claude/
 .cursor/
@@ -34,4 +35,3 @@ docs/design/*spike*.md
 /docs/design/
 /docs/reports/
 /bin/
-snapshot-oras


### PR DESCRIPTION
`.gitignore` had `snapshot-oras` unanchored as a trailing entry. **A bare gitignore pattern matches at any depth**, so as well as ignoring the built binary at the repo root, it also matched the `images/snapshot-oras/` *source* directory.

Found while committing the cosign bump in #480: `git add images/snapshot-oras/Containerfile` failed with *"paths are ignored by one of your .gitignore files"* and needed `-f`. The existing Containerfile is only tracked because it predates the rule.

The real risk is the next file, not that one: **any new file added under `images/snapshot-oras/`** — an entrypoint script, a config — **would have been silently ignored and never committed.** Silent is the problem; a hard failure would have been fine.

The other eight build-output entries are all correctly anchored (`/swiftctl`, `/controller-manager`, `/snapshot-s3`, …). This one was appended later at the bottom of the file and missed the leading slash. It now sits with its siblings.

## Audit

Checked every remaining unanchored pattern against real directory names under `images/`, `cmd/` and `rust/`. **No other bare entry shadows a directory.** The ones that remain unanchored — `CLAUDE.md`, `vendor/`, `.claude/`, `.cursor/`, `**/target/` — are meant to match at any depth.

## Verification

Both directions, because the fix had to preserve the original purpose as well as remove the shadowing:

| check | result |
|---|---|
| root binary `snapshot-oras` still ignored | yes — `.gitignore:22:/snapshot-oras` |
| `images/snapshot-oras/probe.tmp` ignored? | no (correct) |
| `git add` a new file there without `-f` | succeeds |

🤖 Generated with [Claude Code](https://claude.com/claude-code)