### PR TITLE
chart: give the UI its own empty ServiceAccount, assert gpu-discovery non-root

### DIFF
--- a/charts/kubeswift/templates/gpu-discovery/daemonset.yaml
+++ b/charts/kubeswift/templates/gpu-discovery/daemonset.yaml
@@ -21,6 +21,22 @@ spec:
       serviceAccountName: kubeswift-gpu-discovery
       hostPID: false
       hostNetwork: false
+      # Asserting a property the image already has, rather than changing
+      # behaviour: images/gpu-discovery/Containerfile ends in `USER 65534:65534`,
+      # and the pod on the dev GPU node (boba) reports uid=65534(nobody) while
+      # discovering the GTX 1080 correctly. runAsNonRoot makes the kubelet refuse
+      # to start it if that ever regresses to root.
+      #
+      # NOTE the contrast with the DRA driver, which looks identical to a linter
+      # (both were "missing runAsNonRoot") but must NOT get this: it runs as root
+      # by design for kubelet plugin sockets and /var/run/cdi — see the comment in
+      # dra-driver/daemonset.yaml. Adding runAsNonRoot there breaks plugin
+      # registration. Discovery only reads world-readable sysfs, writes nothing,
+      # and needs no /dev.
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       nodeSelector:
         kubeswift.io/gpu-node: "true"
       tolerations:

--- a/charts/kubeswift/templates/ui/deployment.yaml
+++ b/charts/kubeswift/templates/ui/deployment.yaml
@@ -28,6 +28,15 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      # The UI serves static assets; the BROWSER talks to the gateway, not this
+      # pod. It needs no Kubernetes API identity at all. Without these two lines
+      # it falls back to the namespace `default` ServiceAccount and mounts its
+      # token — verified on the dev cluster, where /var/run/secrets/kubernetes.io/
+      # serviceaccount/{token,ca.crt,namespace} were all present in the running
+      # pod. A dedicated empty SA plus automount:false removes a credential the
+      # workload has no use for.
+      serviceAccountName: kubeswift-ui
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/charts/kubeswift/templates/ui/serviceaccount.yaml
+++ b/charts/kubeswift/templates/ui/serviceaccount.yaml
@@ -1,0 +1,21 @@
+{{- if eq (include "kubeswift.uiEnabled" .) "true" }}
+# A dedicated, deliberately empty ServiceAccount for the UI.
+#
+# There is no Role or ClusterRole bound to it, and that is the point: the UI is
+# an nginx serving static assets, and every API call is made by the BROWSER
+# against the gateway. The pod itself never talks to the apiserver.
+#
+# Before this existed the UI ran under the namespace `default` SA and mounted
+# its token. automountServiceAccountToken is set false in both places — here so
+# the SA never projects a token by default, and on the pod so the setting holds
+# regardless of which SA is in play.
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: false
+metadata:
+  name: kubeswift-ui
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: ui
+{{- end }}


### PR DESCRIPTION
Step 3 of the Phase 4 design (#493) — **validated on the dev cluster rather than reasoned about**, which changed the outcome for two of the three items.

## gpu-discovery — safe, and not what I'd flagged

I had listed this as *unverified, needs a GPU node*. It turns out to be **already non-root**:

| | gpu-discovery | dra-driver |
|---|---|---|
| image `USER` | **`USER 65534:65534`** | none → root |
| **runtime uid on boba** | **65534 (nobody)** | **0 (root)** |
| state | `SwiftGPUNode boba` Ready, gpus=1, iommu=true | — |

So `runAsNonRoot: true` here **asserts a property the image already guarantees** — no behaviour change. It just makes the kubelet refuse to start the pod if that ever regresses.

**The contrast is the point, and is now recorded in the template.** gpu-discovery and the DRA driver look *identical* to a linter — both were "missing `runAsNonRoot`" — but the DRA driver must **not** get it. It runs as root by design for kubelet plugin sockets and `/var/run/cdi` (confirmed `uid=0` at runtime, matching its template comment), and adding `runAsNonRoot` there would break plugin registration. This is exactly why #493 insists the baseline encode *reasons* rather than suppressions.

## kubeswift-ui ServiceAccount — a real gap, confirmed

It had no `serviceAccountName`, so it fell back to the namespace `default` SA **and mounted its token**. Verified in the running pod:

```
$ ls /var/run/secrets/kubernetes.io/serviceaccount/
ca.crt    namespace    token
```

The UI serves static assets; the **browser** talks to the gateway. The pod needs no API identity at all. It now gets a dedicated ServiceAccount with **no Role bound to it**, and `automountServiceAccountToken: false` on both the SA and the pod.

Verified with a probe pod on dev: **HTTP 200** from nginx, serviceaccount directory **absent**, and `config.js` still generated correctly. Probe resources removed afterwards; the live deployment was never touched.

## Not done: `readOnlyRootFilesystem` on the UI — and it is not a chart change

A probe with a read-only root fails to start:

```
20-envsubst-on-templates.sh: can't create /etc/nginx/conf.d/default.conf: Read-only file system
```

`/tmp` and `/etc/nginx/conf.d` are both mountable. But `30-kubeswift-config-js.sh` writes `target="/usr/share/nginx/html/config.js"` — into the **web root**. An `emptyDir` there would mask the entire application.

Making the UI run read-only needs a change in the kubeswift-ui image so the runtime config lands somewhere mountable. Filed as kubeswift-io/kubeswift-ui#43. I'd rather leave the control off and say why than mount something that silently breaks the app.

## Verification

| check | result |
|---|---|
| `verify-render-coverage` | OK — 5 workloads |
| kubeconform `-strict` | 45 resources, **0 invalid**, 7 skipped |
| rendered `kubeswift-ui` | `SA=kubeswift-ui automount=False runAsNonRoot=True` |
| rendered `gpu-discovery` | `runAsNonRoot=True seccomp=RuntimeDefault` |
| rendered SA | `automountServiceAccountToken: false` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)