### PR TITLE
ci(security): gate the chart on kube-linter, with the baseline on the objects

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -104,3 +104,46 @@ jobs:
             -kubernetes-version 1.34.0 \
             -ignore-missing-schemas \
             /tmp/rendered.yaml
+
+      - name: Install kube-linter
+        env:
+          KUBE_LINTER_VERSION: '0.8.3'
+        run: |
+          set -euo pipefail
+          curl -sSfL -o /tmp/kube-linter.tar.gz \
+            "https://github.com/stackrox/kube-linter/releases/download/v${KUBE_LINTER_VERSION}/kube-linter-linux.tar.gz"
+          tar -xzf /tmp/kube-linter.tar.gz -C /tmp kube-linter
+          /tmp/kube-linter version
+
+      # STEPS 4-5 of #493, landed together rather than report-only-then-gate.
+      #
+      # The report-only cycle in that plan was a proxy for "we do not know the
+      # finding volume". We do now: the default check set finds FIVE issues on
+      # the full render, every one of them understood, and the baseline below
+      # accounts for all five. There is no unknown noise to discover, so an
+      # intermediate cycle would only delay the gate. Contrast Phase 3 (#487),
+      # which stayed report-only because gosec found 86.
+      #
+      # THE BASELINE LIVES ON THE OBJECTS, NOT HERE. Each excused finding is an
+      # `ignore-check.kube-linter.io/<check>` annotation on the specific workload,
+      # carrying the reason:
+      #
+      #   dra-driver     run-as-non-root        root by design (kubelet plugin
+      #                                         sockets, /var/run/cdi)
+      #   dra-driver     sensitive-host-mounts  /sys for GPU/PCI topology
+      #   gpu-discovery  sensitive-host-mounts  /sys, read-only, uid 65534
+      #   kubeswift-ui   latest-tag             UI released from its own repo
+      #   kubeswift-ui   no-read-only-root-fs   TEMPORARY, kubeswift-ui#43
+      #
+      # That is the whole point of the design: a config-level `exclude:` would
+      # switch a check off everywhere, so a NEW privileged container or host
+      # mount would sail through. Verified it does not — with the baseline in
+      # place the chart reports 0 findings, but injecting privileged + root +
+      # hostPath:/etc into controller-manager produces 4 findings and exit 1,
+      # including the two checks the DaemonSets are excused from.
+      #
+      # gpu-discovery is excused ONLY for the host mount; it keeps run-as-non-root
+      # because it genuinely runs as uid 65534. dra-driver looks identical to a
+      # linter but must keep its exemption — see #495.
+      - name: kube-linter
+        run: /tmp/kube-linter lint /tmp/rendered.yaml

--- a/charts/kubeswift/templates/dra-driver/daemonset.yaml
+++ b/charts/kubeswift/templates/dra-driver/daemonset.yaml
@@ -14,6 +14,20 @@ kind: DaemonSet
 metadata:
   name: kubeswift-dra-driver
   namespace: {{ .Values.namespace }}
+  annotations:
+    # Policy baseline (#493). Scoped to THIS object and carrying the reason, so
+    # the checks stay live for every other workload — a new root container or a
+    # new host mount anywhere else still fails the build.
+    ignore-check.kube-linter.io/run-as-non-root: >-
+      Runs as root by design: the kubelet plugin socket under
+      /var/lib/kubelet/plugins and /var/run/cdi are root-owned host paths.
+      Confirmed uid=0 at runtime on the dev cluster. NOT privileged, and all
+      capabilities are dropped. Contrast gpu-discovery, which looks identical to
+      a linter but is genuinely non-root (uid 65534) — adding runAsNonRoot HERE
+      breaks kubelet plugin registration.
+    ignore-check.kube-linter.io/sensitive-host-mounts: >-
+      /sys is read for GPU and PCI topology. Inherent to a node-inspecting
+      DaemonSet; the mount is read-only and the container drops ALL capabilities.
   labels:
     app.kubernetes.io/name: kubeswift
     app.kubernetes.io/component: dra-driver

--- a/charts/kubeswift/templates/gpu-discovery/daemonset.yaml
+++ b/charts/kubeswift/templates/gpu-discovery/daemonset.yaml
@@ -4,6 +4,13 @@ kind: DaemonSet
 metadata:
   name: gpu-discovery
   namespace: {{ .Values.namespace }}
+  annotations:
+    # Policy baseline (#493). Only the host mount is excused here — this
+    # DaemonSet IS non-root (uid 65534) and keeps the run-as-non-root check.
+    ignore-check.kube-linter.io/sensitive-host-mounts: >-
+      /sys is read for GPU, PCI, NUMA, IOMMU and hugepage topology. Inherent to
+      a node-inspecting DaemonSet: it reads world-readable sysfs only, writes
+      nothing, needs no /dev, runs as uid 65534 and drops ALL capabilities.
   labels:
     app.kubernetes.io/name: kubeswift
     app.kubernetes.io/component: gpu-discovery

--- a/charts/kubeswift/templates/ui/deployment.yaml
+++ b/charts/kubeswift/templates/ui/deployment.yaml
@@ -9,6 +9,20 @@ kind: Deployment
 metadata:
   name: kubeswift-ui
   namespace: {{ .Values.namespace }}
+  annotations:
+    # Policy baseline (#493).
+    ignore-check.kube-linter.io/latest-tag: >-
+      ui.image.tag defaults to "latest" deliberately: kubeswift-ui is released
+      from its own repo on its own cadence, so the chart cannot know a current
+      version. values.yaml documents pinning sha-<short> or vX.Y.Z for
+      production, and the fleet does pin it. Revisit if the two repos ever
+      release together.
+    ignore-check.kube-linter.io/no-read-only-root-fs: >-
+      TEMPORARY — remove this when kubeswift-io/kubeswift-ui#43 lands. The
+      entrypoint writes /usr/share/nginx/html/config.js (the web root) for the
+      runtime gateway URL, so no volume can be mounted there without masking the
+      application; /tmp and /etc/nginx/conf.d alone are not enough. Needs an
+      image change to emit the runtime config somewhere mountable.
   labels:
     app.kubernetes.io/name: kubeswift
     app.kubernetes.io/component: ui


### PR DESCRIPTION
Phase 4 of #466 — **steps 4 and 5** of the design in #493, landed together rather than report-only-then-gate.

## Why both steps at once

That plan's report-only cycle was a proxy for *"we do not know the finding volume."* We do now — kube-linter's default check set finds **five** issues on the full render, and all five were already understood from the step-3 cluster work in #495:

| workload | check | why it is excused |
|---|---|---|
| `dra-driver` | `run-as-non-root` | root **by design** — kubelet plugin sockets, `/var/run/cdi`. Confirmed `uid=0` |
| `dra-driver` | `sensitive-host-mounts` | `/sys` for GPU/PCI topology |
| `gpu-discovery` | `sensitive-host-mounts` | `/sys`, read-only, runs as uid 65534 |
| `kubeswift-ui` | `latest-tag` | UI released from its own repo on its own cadence; `values.yaml` documents pinning for production |
| `kubeswift-ui` | `no-read-only-root-fs` | **temporary** — blocked on kubeswift-io/kubeswift-ui#43 |

There is no unknown noise left to discover, so an intermediate cycle would only delay the gate. Contrast Phase 3 (#487), which **stays** report-only precisely because gosec finds 86.

## The baseline lives on the objects, not in a config file

Each excused finding is an `ignore-check.kube-linter.io/<check>` annotation on the specific workload, carrying its reason inline.

A config-level `exclude:` would switch the check off **everywhere** — so a new privileged container or host mount would sail straight through, and the gate would report green while permitting exactly what it exists to catch. That would be worse than no gate at all.

**Verified it does not do that:**

| scenario | result |
|---|---|
| chart with the baseline | **0 findings, exit 0** |
| controller-manager injected with `privileged` + `runAsNonRoot: false` + `hostPath: /etc` | **4 findings, exit 1** |

The four include `run-as-non-root` and `sensitive-host-mounts` — *the two checks the DaemonSets are excused from* — firing on a different object. The exemptions are per-object.

## The distinction that motivated all of this

`gpu-discovery` is excused **only** for the host mount and keeps `run-as-non-root`, because it genuinely runs as uid 65534. `dra-driver` looks identical to a linter but must keep both, because adding `runAsNonRoot` there breaks kubelet plugin registration. Encoding that difference — rather than blanket-suppressing a rule both would trip — is the entire point of #493's baseline.

The UI's `no-read-only-root-fs` entry is marked **TEMPORARY** and names the upstream issue, so it gets removed rather than forgotten once the image can run read-only.

## Verification

Every step run locally with the exact CI invocations:

- `verify-render-coverage` — 5/5 workloads
- kubeconform `-strict` — 45 resources, **0 invalid**
- kube-linter — **exit 0**
- `helm lint` — clean (the annotations are valid in-template)
- control — regression injection **exits 1**

With this, Phase 4 is complete: schema validation, render-coverage assertion, and policy — all gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)