### PR TITLE
ci(security): sign all nine images, and verify what we signed

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -228,6 +228,15 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        with:
+          # PIN the cosign BINARY, not just the installer action. Unpinned, the
+          # action installs the newest cosign, and cosign 3.x moved where a
+          # signature lands: 2.x writes a `sha256-<digest>.sig` tag, 3.x writes
+          # `sha256-<digest>` with no suffix. Anything that looks for a signature
+          # by tag name silently stops finding one across that boundary.
+          # 2.6.5 also matches the cosign vendored into snapshot-oras and
+          # sandbox-materialize, so the project speaks one cosign version.
+          cosign-release: 'v2.6.5'
 
       # Keyless signing: the signing identity is THIS workflow run's GitHub
       # OIDC identity (repo + workflow path + tag ref); the signature and
@@ -236,18 +245,82 @@ jobs:
       #   cosign verify <image>@<digest> \
       #     --certificate-identity-regexp 'https://github.com/kubeswift-io/kubeswift/\.github/workflows/release-(stable|rc)\.yaml@.*' \
       #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      # The nine refs, digest-pinned, shared by the sign and verify steps below
+      # so the two can never drift. sandbox-materialize used to be missing from
+      # the sign list — eight of nine were signed and nothing said so.
+      - name: Collect image refs
+        id: refs
+        run: |
+          {
+            echo 'list<<EOF'
+            echo "${{ env.IMAGE_PREFIX }}/controller-manager@${{ steps.build-controller-manager.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/gpu-discovery@${{ steps.build-gpu-discovery.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/snapshot-s3@${{ steps.build-snapshot-s3.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/snapshot-oras@${{ steps.build-snapshot-oras.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/kubeswift-dra-driver@${{ steps.build-dra-driver.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/sandbox-materialize@${{ steps.build-sandbox-materialize.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/swiftletd@${{ steps.build-swiftletd.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/migration-stunnel@${{ steps.build-migration-stunnel.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/kubeswift-gateway@${{ steps.build-gateway.outputs.digest }}"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
       - name: Sign images (cosign keyless)
         env:
           COSIGN_YES: "true"
         run: |
-          cosign sign "${{ env.IMAGE_PREFIX }}/controller-manager@${{ steps.build-controller-manager.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/gpu-discovery@${{ steps.build-gpu-discovery.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/snapshot-s3@${{ steps.build-snapshot-s3.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/snapshot-oras@${{ steps.build-snapshot-oras.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/kubeswift-dra-driver@${{ steps.build-dra-driver.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/swiftletd@${{ steps.build-swiftletd.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/migration-stunnel@${{ steps.build-migration-stunnel.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/kubeswift-gateway@${{ steps.build-gateway.outputs.digest }}"
+          set -euo pipefail
+          echo "${{ steps.refs.outputs.list }}" | while read -r ref; do
+            [ -n "$ref" ] || continue
+            echo "signing $ref"
+            cosign sign "$ref"
+          done
+
+      # VERIFY WHAT WE JUST SIGNED — the point of Phase 5 (#466).
+      #
+      # Producing signatures and never checking them means an image that misses
+      # signing is indistinguishable from one that got it. That is not
+      # hypothetical: sandbox-materialize was absent from the sign list above and
+      # shipped UNSIGNED in v0.13.6, while the other eight verified fine and the
+      # release job reported success. Nothing anywhere flagged it.
+      #
+      # Because the list is now derived from the same `refs` output the signing
+      # loop uses, an image cannot be built-and-published without also being
+      # signed and verified — the three steps cannot drift apart.
+      #
+      # The identity is this workflow's own OIDC identity, so it is pinned to
+      # the exact workflow file and repo rather than "anything Sigstore signed".
+      - name: Verify signatures (fail the release if signing did not take)
+        run: |
+          set -euo pipefail
+          echo "${{ steps.refs.outputs.list }}" | while read -r ref; do
+            [ -n "$ref" ] || continue
+            echo "verifying $ref"
+            cosign verify "$ref" \
+              --certificate-identity-regexp '^https://github\.com/kubeswift-io/kubeswift/\.github/workflows/release-stable\.yaml@.*$' \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              > /dev/null
+          done
+          echo "all $(echo "${{ steps.refs.outputs.list }}" | grep -c .) images verified"
+
+      # The SBOM and SLSA provenance are attached by BuildKit (provenance:
+      # mode=max, sbom: true on every build above) as an attestation manifest
+      # inside the image INDEX — not as a cosign attestation, so `cosign
+      # verify-attestation` does not see them. This is a presence check on the
+      # index, which is what BuildKit's output actually supports.
+      - name: Verify SBOM + provenance are attached
+        run: |
+          set -euo pipefail
+          echo "${{ steps.refs.outputs.list }}" | while read -r ref; do
+            [ -n "$ref" ] || continue
+            n=$(docker buildx imagetools inspect --raw "$ref" \
+                 | grep -c 'attestation-manifest' || true)
+            if [ "$n" -eq 0 ]; then
+              echo "::error::$ref has no attestation manifest (provenance/SBOM missing)"
+              exit 1
+            fi
+            echo "$ref: $n attestation manifest(s)"
+          done
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
@@ -314,6 +387,15 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        with:
+          # PIN the cosign BINARY, not just the installer action. Unpinned, the
+          # action installs the newest cosign, and cosign 3.x moved where a
+          # signature lands: 2.x writes a `sha256-<digest>.sig` tag, 3.x writes
+          # `sha256-<digest>` with no suffix. Anything that looks for a signature
+          # by tag name silently stops finding one across that boundary.
+          # 2.6.5 also matches the cosign vendored into snapshot-oras and
+          # sandbox-materialize, so the project speaks one cosign version.
+          cosign-release: 'v2.6.5'
 
       # Keyless blob signing of the checksums file. Verifying SHA256SUMS via
       # the .sig/.pem pair transitively authenticates every binary it lists.

--- a/.github/workflows/verify-release.yaml
+++ b/.github/workflows/verify-release.yaml
@@ -1,0 +1,86 @@
+name: Verify release
+
+# Phase 5 of #466 — re-verify a PUBLISHED release's images on demand.
+#
+# release-stable.yaml already verifies what it just signed, which is the
+# important half: a silent signing failure now fails the release. This workflow
+# is the other half — checking that an ALREADY-published release still verifies,
+# which catches things that happen after the release run finishes (a signature
+# deleted, a tag re-pointed, a package made private).
+#
+# WHY workflow_dispatch AND NOT A SCHEDULE, for now:
+#
+# v0.13.6 verifies for eight of nine images; sandbox-materialize was missing
+# from release-stable's sign list and shipped unsigned. A scheduled run today
+# would therefore be red on the newest release for a reason already fixed but
+# not yet re-released — and a permanently red job is one nobody looks at.
+#
+# Move this onto a schedule once a release cut WITH that fix has shipped; at
+# that point red means something really changed. Verified by hand at the time
+# of writing: all nine v0.13.6 images except sandbox-materialize pass the exact
+# cosign verify below.
+#
+# Usage: Actions -> Verify release -> Run workflow -> enter a tag, e.g. v0.13.7
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to verify (e.g. v0.13.7)'
+        required: true
+        type: string
+
+env:
+  IMAGE_PREFIX: ghcr.io/kubeswift-io/kubeswift
+
+jobs:
+  verify:
+    name: Verify ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        with:
+          # Same pin as release-stable. cosign 2.x and 3.x disagree about where
+          # a signature lives, so verifier and signer must not drift.
+          cosign-release: 'v2.6.5'
+
+      - name: Verify signatures + attestations
+        run: |
+          set -euo pipefail
+          IMAGES="controller-manager gpu-discovery snapshot-s3 snapshot-oras
+                  kubeswift-dra-driver sandbox-materialize swiftletd
+                  migration-stunnel kubeswift-gateway"
+          fail=0
+          for img in $IMAGES; do
+            ref="${IMAGE_PREFIX}/${img}:${{ inputs.tag }}"
+
+            # Verify against the release workflow's own OIDC identity, not
+            # "anything Sigstore ever signed". release-(stable|rc) because both
+            # publish images under this prefix.
+            if cosign verify "$ref" \
+                 --certificate-identity-regexp '^https://github\.com/kubeswift-io/kubeswift/\.github/workflows/release-(stable|rc)\.yaml@.*$' \
+                 --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+                 > /dev/null 2>&1; then
+              sig=ok
+            else
+              sig=MISSING; fail=1
+            fi
+
+            # SBOM/provenance are BuildKit attestation manifests in the image
+            # index, not cosign attestations — a presence check is what that
+            # output supports.
+            if docker buildx imagetools inspect --raw "$ref" 2>/dev/null \
+                 | grep -q 'attestation-manifest'; then
+              att=ok
+            else
+              att=MISSING; fail=1
+            fi
+
+            printf '  %-24s signature=%-8s attestation=%s\n' "$img" "$sig" "$att"
+          done
+          [ "$fail" -eq 0 ] || { echo "::error::${{ inputs.tag }} did not fully verify"; exit 1; }
+          echo "all 9 images verified for ${{ inputs.tag }}"


### PR DESCRIPTION
Phase 5 of #466. The plan said *"extend attestation to all images if it does not already cover them, and verify it in CI"*. Checking first changed **both** halves.

## Attestation already covers everything

All nine builds carry `provenance: mode=max` + `sbom: true`, and the published `v0.13.6` index confirms an `attestation-manifest` sitting alongside the image. **Nothing to extend.**

## The real gap was signing — and it is narrow

`sandbox-materialize` was absent from `release-stable`'s sign list. Eight of nine images were signed, and nothing said so.

Confirmed against the actual published release:

```
controller-manager       SIGNED      snapshot-oras          SIGNED
gpu-discovery            SIGNED      kubeswift-dra-driver   SIGNED
snapshot-s3              SIGNED      swiftletd              SIGNED
migration-stunnel        SIGNED      kubeswift-gateway      SIGNED
sandbox-materialize      ** UNSIGNED **
```

> **A correction worth stating plainly:** while investigating I first concluded that *no* stable image was signed, and said so. That was wrong. My registry probe omitted an `Accept` header, and GHCR returns 404 when the requested media type does not match a manifest — which I read as "no signature exists". `cosign verify` shows eight of nine verify cleanly against the release-stable OIDC identity. The workflow-source finding (eight in the sign list) was correct and independent; the two just coincided misleadingly.

## The fix makes drift structurally impossible

The nine refs now come from a single `refs` step output that **both** the sign loop and the verify loop consume. An image cannot be built and published without also being signed and verified — the lists cannot drift apart the way they just did.

## Verification is the point of the phase

Producing signatures and never checking them makes a missed image indistinguishable from a signed one. Two checks now run immediately after signing:

- **`cosign verify`** against this workflow's own OIDC identity — pinned to the exact workflow path and repo, not "anything Sigstore ever signed".
- **A presence check for the BuildKit attestation manifest** in the image index. SBOM/provenance are *not* cosign attestations, so `cosign verify-attestation` does not see them; a presence check is what that output actually supports, and saying so beats implying a cryptographic check we are not doing.

## Pinning the cosign binary, not just the action

Unpinned, `cosign-installer` installs the newest cosign — and **2.x and 3.x disagree about where a signature lands**:

```
cosign 2.6.5 → sha256-<digest>.sig
cosign 3.1.3 → sha256-<digest>      (no suffix)
```

Verified locally against a throwaway registry. Anything checking for a signature by tag name silently stops finding one across that boundary. `v2.6.5` also matches the cosign vendored into `snapshot-oras` and `sandbox-materialize` (#480), so the project speaks one cosign version end to end.

## verify-release.yaml

Re-verifies an already-published tag on demand — covering what can happen *after* a release run ends: a signature deleted, a tag re-pointed, a package made private.

`workflow_dispatch`-only for now, because it would be red on v0.13.6's `sandbox-materialize` for a reason this PR fixes but which is not yet re-released. Move it to a schedule once a release carrying this fix has shipped.

## What CI cannot prove here

`release-stable` only runs on a tag, so **the sign/verify path is unexercised until the next release** — same situation as the `login-action` bump earlier. The verify step is written so that if signing does not take, the release fails loudly instead of publishing quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)