### PR TITLE
chore(deps): group kube and k8s-openapi so they cannot be bumped apart

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,26 @@ updates:
     schedule: {interval: weekly}
     open-pull-requests-limit: 5
     groups:
+      # kube and k8s-openapi are VERSION-LOCKED — kube declares an exact-minor
+      # requirement on k8s-openapi (kube 0.92 -> ^0.22, kube 4.2 -> ^0.28), so
+      # bumping either alone always breaks the build. Ungrouped, Dependabot
+      # opened them as two separate PRs (#484, #485) that could not pass
+      # individually AND did not combine into a working pair: #484 offered
+      # k8s-openapi 0.24 while #485's kube 4.2 needed 0.28. Both were closed.
+      #
+      # Listed FIRST because Dependabot assigns a dependency to the first group
+      # it matches, and rust-minor-patch below has no `patterns` so it would
+      # otherwise swallow the minor/patch updates of these two.
+      #
+      # update-types includes major so the pair also travels together across a
+      # major bump — the case that actually broke.
+      kube-rs:
+        patterns:
+          - "kube"
+          - "kube-*"
+          - "k8s-openapi"
+        update-types: [major, minor, patch]
+
       rust-minor-patch:
         update-types: [minor, patch]
 


### PR DESCRIPTION
Follow-up to closing #484 and #485.

`kube` declares an exact-minor requirement on `k8s-openapi` (per crates.io):

```
kube 0.92.1 → k8s-openapi ^0.22.0
kube 4.2.0  → k8s-openapi ^0.28.0
```

So **bumping either crate alone always breaks the Rust build**. Ungrouped, Dependabot opened them as two independent PRs — neither of which could pass on its own, and which did not combine into a working change either: #485's kube 4.2 needs k8s-openapi **0.28**, not the **0.24** #484 proposed.

Both were closed. Without this config change they simply reappear next week in the same shape.

## Details that matter

- The group is listed **first**. Dependabot assigns a dependency to the first group it matches, and `rust-minor-patch` has no `patterns`, so it would otherwise claim these two for minor/patch updates and re-split them.
- `update-types` includes **major** — the major bump is precisely the case that broke.

## Not included

The actual `kube 0.92 → 4.x` migration. That crosses four majors of kube-rs with real API changes in swiftletd, and belongs in a change with tests rather than an automated dependency PR. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)