### PR TITLE
chart: run the UI read-only-root, now that it can

### DIFF
--- a/charts/kubeswift/README.md
+++ b/charts/kubeswift/README.md
@@ -24,7 +24,9 @@ them — re-apply `config/crd/bases/*.yaml` after a chart upgrade that changes a
 **Image tags** — the operator images default to `tag: latest`, which the chart
 rewrites to the chart's own `v<appVersion>` for a release (or `sha-<commit>` for a
 dev build). Only override for locally-built images. The `kubeswift-ui` image is
-released from a separate repo and is **not** chart-derived — pin `ui.image.tag`.
+released from a separate repo and is **not** chart-derived: `ui.image.tag` ships
+pinned, and a chart upgrade does not move it — raise it when you want a newer
+console. `v0.12.3` is the floor (the UI Deployment runs read-only-root).
 See [`docs/install/helm-oci.md`](../../docs/install/helm-oci.md).
 
 ## Common configurations
@@ -152,7 +154,7 @@ point `ui.gateway.url` at an externally reachable gateway).
 |---|---|---|
 | `ui.enabled` | Deploy the web console (auto-on for `role=hub`) | `false` |
 | `ui.image.repository` | UI image repo (a top-level package, not chart-derived) | `ghcr.io/kubeswift-io/kubeswift-ui` |
-| `ui.image.tag` | Published UI tag — **pin a version for production** | `latest` |
+| `ui.image.tag` | Published UI tag (not chart-derived; `v0.12.3` is the floor for read-only-root) | `v0.12.3` |
 | `ui.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `ui.imagePullSecrets` | Pull Secret(s) if the UI package is private | `[]` |
 | `ui.replicas` | UI replicas | `1` |

--- a/charts/kubeswift/templates/ui/deployment.yaml
+++ b/charts/kubeswift/templates/ui/deployment.yaml
@@ -9,20 +9,6 @@ kind: Deployment
 metadata:
   name: kubeswift-ui
   namespace: {{ .Values.namespace }}
-  annotations:
-    # Policy baseline (#493).
-    ignore-check.kube-linter.io/latest-tag: >-
-      ui.image.tag defaults to "latest" deliberately: kubeswift-ui is released
-      from its own repo on its own cadence, so the chart cannot know a current
-      version. values.yaml documents pinning sha-<short> or vX.Y.Z for
-      production, and the fleet does pin it. Revisit if the two repos ever
-      release together.
-    ignore-check.kube-linter.io/no-read-only-root-fs: >-
-      TEMPORARY — remove this when kubeswift-io/kubeswift-ui#43 lands. The
-      entrypoint writes /usr/share/nginx/html/config.js (the web root) for the
-      runtime gateway URL, so no volume can be mounted there without masking the
-      application; /tmp and /etc/nginx/conf.d alone are not enough. Needs an
-      image change to emit the runtime config somewhere mountable.
   labels:
     app.kubernetes.io/name: kubeswift
     app.kubernetes.io/component: ui
@@ -100,12 +86,38 @@ spec:
             periodSeconds: 10
           securityContext:
             allowPrivilegeEscalation: false
-            # nginx regenerates /usr/share/nginx/html/config.js and writes temp
-            # files at startup, so the root filesystem stays writable (the image
-            # runs unprivileged, non-root, with all capabilities dropped).
+            # Read-only root as of kubeswift-ui v0.12.3. Before that the
+            # entrypoint wrote the runtime config to
+            # /usr/share/nginx/html/config.js — inside the directory the SPA is
+            # baked into, which cannot be made writable by mounting over it
+            # without hiding the application. kubeswift-io/kubeswift-ui#43 moved
+            # it to /tmp/kubeswift-ui/config.js, served by an nginx alias.
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
+          volumeMounts:
+            # The two paths this image still has to write, and the ONLY two.
+            #
+            # /tmp                  nginx's pid plus all five *_temp_path dirs,
+            #                       and now the generated config.js.
+            # /etc/nginx/conf.d     20-envsubst-on-templates.sh renders
+            #                       default.conf here from the template at
+            #                       startup. The directory holds nothing else in
+            #                       the image, so an emptyDir masks nothing.
+            #
+            # Both must be writable by uid 101. An emptyDir is created 0777, so
+            # it is; a docker --tmpfs defaults to root-owned 0775 and is NOT,
+            # which is worth knowing if you reproduce this outside Kubernetes.
+            - name: tmp
+              mountPath: /tmp
+            - name: nginx-conf-d
+              mountPath: /etc/nginx/conf.d
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-conf-d
+          emptyDir: {}
 {{- end }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -273,9 +273,18 @@ ui:
     # Full image repository (kubeswift-ui is a top-level package, not under the
     # ghcr.io/kubeswift-io/kubeswift/ prefix the operator images use).
     repository: ghcr.io/kubeswift-io/kubeswift-ui
-    # Pin a published tag (sha-<short> or vX.Y.Z). "latest" tracks the
-    # kubeswift-ui main branch; fine for dev, pin a version for production.
-    tag: latest
+    # A published kubeswift-ui tag (vX.Y.Z, or sha-<short> for a dev build).
+    #
+    # Pinned, not "latest". The Deployment sets readOnlyRootFilesystem: true,
+    # and v0.12.3 is the FLOOR for that — earlier images write their runtime
+    # config into the web root, which no volume can make writable without
+    # hiding the SPA, so nginx never starts (kubeswift-io/kubeswift-ui#43).
+    # A floating tag would let that regress silently on a redeploy.
+    #
+    # kubeswift-ui releases on its own cadence from its own repo, so this is
+    # NOT chart-derived and a chart bump does not move it: check the UI repo's
+    # releases and raise this when you want a newer console.
+    tag: v0.12.3
     pullPolicy: IfNotPresent
   # New ghcr packages default PRIVATE; until the kubeswift-ui package is made
   # public (one-time, web UI), reference a docker-registry pull Secret here,


### PR DESCRIPTION
Closes the `TEMPORARY` kube-linter suppression that #496 left on the UI Deployment.

## Why it was suppressed

The entrypoint generated the runtime config at `/usr/share/nginx/html/config.js` — inside the directory the SPA is baked into. No volume can make that path writable without hiding the application, so under `readOnlyRootFilesystem` the write failed and nginx never started. `/tmp` and `/etc/nginx/conf.d` alone were not enough. It needed an image change.

## What changed

kubeswift-io/kubeswift-ui#44 (released as **v0.12.3**) moves the file to `/tmp/kubeswift-ui/config.js`, served by an explicit nginx `alias` so the URL the SPA fetches is unchanged. That leaves exactly two paths the image must write, and both are mountable:

| path | why |
|---|---|
| `/tmp` | nginx's pid + all five `*_temp_path` dirs, plus the generated shim |
| `/etc/nginx/conf.d` | where the stock envsubst entrypoint renders `default.conf` |

Both get an `emptyDir`; the container gets `readOnlyRootFilesystem: true`; the suppression is **deleted**, not reworded.

## `ui.image.tag` now ships pinned

`v0.12.3` is the floor for that securityContext, so the tag stops floating on `latest`. A mutable tag would let the pairing regress silently on a redeploy, and an image that cannot start is a worse failure than a stale console.

It is still **not** chart-derived — kubeswift-ui releases on its own cadence and a chart upgrade does not move this. That also retires the *second* suppression on this object, `latest-tag`, whose justification ("defaults to `latest` deliberately") had become false. The UI Deployment now carries **no kube-linter suppressions at all**.

## Verification

Locally, with CI's exact flags:

- `verify-render-coverage.sh` — OK, 5 workloads
- `kubeconform -strict -kubernetes-version 1.34.0 -ignore-missing-schemas` — 38 valid, 0 invalid
- `kube-linter` — **no lint errors found**, with the suppression removed rather than in spite of it
- `helm lint` — OK

The two suppressions were each tested by removing them and re-running kube-linter, rather than assumed obsolete.

Dev-cluster verification (`helm upgrade` + probe that the root FS is genuinely read-only and `config.js` still serves) follows on merge.

## For the next release cut

This is user-visible and wants a CHANGELOG line: the chart now pins a UI tag by default, and operators pinning `ui.image.tag` to anything **older than v0.12.3** will get a CrashLoopBackOff rather than a working console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)