### PR TITLE
ci(security): move all three codeql-action pins together

### DIFF
--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -90,8 +90,18 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
+      # The three codeql-action/* pins below (init, analyze, upload-sarif) MUST
+      # move together. init writes a config file stamped with its own version and
+      # analyze refuses to read one written by a different version:
+      #
+      #   Loaded a configuration file for version '4.31.0', but running version '4.37.6'
+      #
+      # Dependabot treats each sub-action as its own dependency, so it opens a PR
+      # bumping only the one whose path changed (#506 bumped analyze alone and the
+      # job failed on exactly that error). When a bump lands, check all three SHAs
+      # match before merging.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: go
           # The DEFAULT query suite, not security-extended. #466 chose this for
@@ -111,7 +121,7 @@ jobs:
         run: go build ./api/... ./internal/... ./cmd/...
 
       - name: Analyze
-        uses: github/codeql-action/analyze@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: codeql-go
 
@@ -150,7 +160,7 @@ jobs:
           test -s gosec.sarif
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         if: always()
         with:
           sarif_file: gosec.sarif


### PR DESCRIPTION
Supersedes #506 (which I'll close).

Dependabot bumped `github/codeql-action/analyze` to 4.37.6 and left `init` and `upload-sarif` at 4.31.0 — it treats each sub-action as a separate dependency. CodeQL then failed:

```
Loaded a configuration file for version '4.31.0', but running version '4.37.6'
```

`init` writes a config file stamped with its own version and `analyze` refuses to read one written by a different version, so a partial bump is **always** broken — #506 could never have gone green.

This moves all three pins to 4.37.6 (verified: both the `v4` and `v4.37.6` tags resolve to `5595ccaf912efad79be6eef63a5619ff05969be3`, which is the SHA Dependabot proposed) and records the constraint next to the pins, so the next partial bump gets recognised instead of rediscovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)