### PR TITLE
release: v0.13.7

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -281,8 +281,11 @@ jobs:
       # Producing signatures and never checking them means an image that misses
       # signing is indistinguishable from one that got it. That is not
       # hypothetical: sandbox-materialize was absent from the sign list above and
-      # shipped UNSIGNED in v0.13.6, while the other eight verified fine and the
-      # release job reported success. Nothing anywhere flagged it.
+      # shipped UNSIGNED in EVERY release up to and including v0.13.6 — probed at
+      # v0.12.0, v0.13.0, v0.13.2, v0.13.4 and v0.13.6, no signature at any of
+      # them, while every other image at those same tags verifies. For all of
+      # those releases the job reported success and nothing flagged it. v0.13.7
+      # is the first release in which all nine are signed.
       #
       # Because the list is now derived from the same `refs` output the signing
       # loop uses, an image cannot be built-and-published without also being

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -427,10 +427,20 @@ jobs:
 
             ## Images
 
+            All nine are signed and verified by this workflow before the release
+            is published. Keep this list in step with the `refs` step above — it
+            listed four of nine until v0.13.7, which is precisely the kind of
+            hand-maintained list that let sandbox-materialize ship unsigned.
+
             - `ghcr.io/kubeswift-io/kubeswift/controller-manager:${{ needs.build-and-push.outputs.tag }}`
             - `ghcr.io/kubeswift-io/kubeswift/swiftletd:${{ needs.build-and-push.outputs.tag }}`
             - `ghcr.io/kubeswift-io/kubeswift/gpu-discovery:${{ needs.build-and-push.outputs.tag }}`
             - `ghcr.io/kubeswift-io/kubeswift/migration-stunnel:${{ needs.build-and-push.outputs.tag }}`
+            - `ghcr.io/kubeswift-io/kubeswift/kubeswift-gateway:${{ needs.build-and-push.outputs.tag }}`
+            - `ghcr.io/kubeswift-io/kubeswift/kubeswift-dra-driver:${{ needs.build-and-push.outputs.tag }}`
+            - `ghcr.io/kubeswift-io/kubeswift/sandbox-materialize:${{ needs.build-and-push.outputs.tag }}`
+            - `ghcr.io/kubeswift-io/kubeswift/snapshot-s3:${{ needs.build-and-push.outputs.tag }}`
+            - `ghcr.io/kubeswift-io/kubeswift/snapshot-oras:${{ needs.build-and-push.outputs.tag }}`
 
             ## swiftctl
 

--- a/.github/workflows/verify-release.yaml
+++ b/.github/workflows/verify-release.yaml
@@ -10,15 +10,18 @@ name: Verify release
 #
 # WHY workflow_dispatch AND NOT A SCHEDULE, for now:
 #
-# v0.13.6 verifies for eight of nine images; sandbox-materialize was missing
-# from release-stable's sign list and shipped unsigned. A scheduled run today
-# would therefore be red on the newest release for a reason already fixed but
-# not yet re-released — and a permanently red job is one nobody looks at.
+# Every release up to and including v0.13.6 verifies for eight of nine images:
+# sandbox-materialize was missing from release-stable's sign list and shipped
+# unsigned. Probed at v0.12.0, v0.13.0, v0.13.2, v0.13.4 and v0.13.6 — no
+# signature at any of them, while every other image at those same tags verifies.
+# A scheduled run would be red on every historical tag for a reason fixed in
+# v0.13.7, and a permanently red job is one nobody looks at.
 #
-# Move this onto a schedule once a release cut WITH that fix has shipped; at
-# that point red means something really changed. Verified by hand at the time
-# of writing: all nine v0.13.6 images except sandbox-materialize pass the exact
-# cosign verify below.
+# v0.13.7 is the first release with all nine signed. Move this onto a schedule
+# once that tag has shipped AND been verified by hand with this workflow; from
+# then on, red means something really changed rather than something never was.
+# Note a schedule also needs a default tag to verify — the tag input is
+# currently required, so resolving "the latest release" is part of that change.
 #
 # Usage: Actions -> Verify release -> Run workflow -> enter a tag, e.g. v0.13.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,129 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.13.7] — 2026-08-11
+
+A supply-chain release. Nothing in the runtime changed; what changed is how much
+of the release you have to take on trust. Every prior version asked you to
+believe that the images in the registry are what this repository built. This one
+proves it in the same job that publishes them — and building that proof
+immediately turned up an image that had never been signed at all.
+
+### Upgrade
+
+**`ui.image.tag` must be `v0.12.3` or newer**, and the chart now ships pinned to
+it rather than tracking `latest`. The UI Deployment sets
+`readOnlyRootFilesystem: true`, which earlier UI images cannot survive: they
+generate their runtime config inside the web root, a directory no volume can make
+writable without hiding the application. An older tag fails closed and loudly:
+
+```
+30-kubeswift-config-js.sh: can't create /usr/share/nginx/html/config.js: Read-only file system
+```
+
+If you override `ui.image.tag`, raise it in the same step as the chart upgrade.
+The tag is still not chart-derived — kubeswift-ui releases on its own cadence, so
+a chart upgrade will not move it for you.
+
+```bash
+helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.7 \
+  -n kubeswift-system -f <(helm get values kubeswift -n kubeswift-system -o yaml) \
+  --set ui.image.tag=v0.12.3
+kubectl apply -f charts/kubeswift/crds/    # helm does not upgrade CRDs
+```
+
+Otherwise this is a drop-in upgrade from v0.13.6. No CRD schema changes, no API
+changes, no controller behaviour changes.
+
+### Fixed
+
+- **`sandbox-materialize` was shipping unsigned, and had been since it entered
+  the release set** (#497). The sign list in `release-stable.yaml` was written by
+  hand and covered eight of the nine published images. Probing the registry
+  directly at v0.12.0, v0.13.0, v0.13.2, v0.13.4 and v0.13.6 finds no signature
+  at any of them, while every other image at those same tags verifies — so
+  anyone running `cosign verify` across the full set has been getting a failure
+  on that one image for five releases, and every release job reported success.
+
+  The sign list is now derived from the same digest-pinned refs the build step
+  emits, so an image cannot be published without also being signed; and the
+  release **verifies its own signatures and attestations before finishing**, so a
+  signing failure now fails the release instead of producing a quietly unsigned
+  artifact. v0.13.7 is the first release in which all nine images are signed.
+
+  Re-verify any deployment that pinned digests on the assumption the whole set
+  was signed. The images themselves were never in question — only the signatures.
+
+- **The image scan queued 117 jobs on a single push** (#489). `paths:` filtering
+  was applied to the `pull_request` trigger but not to `push`, so every merge to
+  `main` re-scanned all nine images regardless of whether anything in them
+  changed. Both triggers now carry the same filter.
+
+### Added
+
+- **The CI security programme (#466) is complete — five phases, four of them
+  gating.** Each answers a different question, and they are deliberately gated
+  differently, because a scanner that cries wolf gets deleted rather than tuned:
+
+  | Phase | Asks | Gate |
+  |---|---|---|
+  | 1 — dependencies + secrets (#467) | is something we depend on known-vulnerable? is a credential committed? | fails the build |
+  | 2 — images (#480) | is something *in the published image* vulnerable? | fails on **fixable** findings only |
+  | 3 — SAST (#487) | did we write a bug? | **report-only** |
+  | 4 — manifests + chart (#494, #495, #496) | would this chart render something we would reject in review? | fails the build |
+  | 5 — signing + attestation (#497) | is what we published what we built? | fails the release |
+
+  Phase 3 is report-only on purpose: gosec reports 86 findings on the current
+  tree, all triaged and recorded as a baseline in the workflow header. Turning
+  that red on day one would mean 86 things to clear before anyone could merge.
+
+  Phase 4's policy baseline lives as per-object
+  `ignore-check.kube-linter.io/<check>` annotations rather than a config-level
+  `exclude:`, so a suppression is visible next to the object it excuses and
+  applies only there. Each was verified by removing it and confirming the check
+  actually fires. It also asserts what it renders: a default `helm template`
+  covers one of five workloads, so a coverage check fails if a new workload is
+  added without being linted.
+
+- **`Verify release` workflow** — re-verify any published tag's signatures and
+  attestations on demand (Actions → Verify release). Deliberately not on a
+  schedule yet; see the header for why, and for what has to be true first.
+
+- **Toolchains are pinned** — Go `1.26.5` (#488) and Rust `1.97.1` (#490),
+  matching the builder images. A floating toolchain changes scanner output
+  without anyone touching the repository, which makes a recorded baseline
+  meaningless.
+
+### Changed
+
+- **The web console runs with a read-only root filesystem** (#507), with
+  `emptyDir` volumes at `/tmp` and `/etc/nginx/conf.d` — the only two paths the
+  image writes. See Upgrade above for the tag floor this requires.
+
+- **The web console has its own empty ServiceAccount**, with
+  `automountServiceAccountToken: false` (#495). It serves static assets; the
+  browser talks to the gateway, not this pod, so it needs no Kubernetes identity
+  at all. Previously it fell back to the namespace `default` ServiceAccount and
+  mounted that token — verified present in the running pod before the fix.
+
+- **`gpu-discovery` asserts `runAsNonRoot` + `RuntimeDefault` seccomp** (#495).
+  The image already ran as uid 65534; the pod spec now states it, so a future
+  base-image change cannot silently regress it.
+
+- **kube and k8s-openapi are grouped for Dependabot** (#498). They are
+  version-locked (kube 0.92 → k8s-openapi ^0.22, kube 4.2 → ^0.28), so ungrouped
+  updates arrived as two PRs that could not build individually *and* did not
+  combine into a working pair. Both were closed; the pair now travels together,
+  including across a major bump.
+
+- **The orphaned `webhook-server` image was removed** (#492). Admission webhooks
+  are served by the controller-manager; nothing referenced it.
+
+- Roughly twenty dependency updates across base images, GitHub Actions, Go and
+  Rust — the routine half of Phase 1 doing its job.
+
+---
+
 ## [v0.13.6] — 2026-08-10
 
 A correctness release. Every item is a case where the system did the wrong thing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable changes to KubeSwift are documented here.
 
 ## [v0.13.7] — 2026-08-11
 
-A supply-chain release. Nothing in the runtime changed; what changed is how much
-of the release you have to take on trust. Every prior version asked you to
-believe that the images in the registry are what this repository built. This one
-proves it in the same job that publishes them — and building that proof
-immediately turned up an image that had never been signed at all.
+A supply-chain release. Not one line of Go or Rust changed between v0.13.6 and
+v0.13.7 — the diff is workflows, the chart, docs and dependency lockfiles. What
+changed is how much of the release you have to take on trust: every prior
+version asked you to believe that the images in the registry are what this
+repository built, and this one proves it in the same job that publishes them.
+Building that proof immediately turned up an image that had never been signed
+at all.
 
 ### Upgrade
 
@@ -35,8 +37,10 @@ helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.1
 kubectl apply -f charts/kubeswift/crds/    # helm does not upgrade CRDs
 ```
 
-Otherwise this is a drop-in upgrade from v0.13.6. No CRD schema changes, no API
-changes, no controller behaviour changes.
+Otherwise this is a drop-in upgrade from v0.13.6: no CRD schema changes, no API
+changes, and no KubeSwift source changes at all. The binaries are rebuilt, so
+they do carry the dependency updates and toolchain pins below, but no KubeSwift
+logic differs from v0.13.6.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.6 \
+  --version 0.13.7 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.6
-appVersion: "0.13.6"
+version: 0.13.7
+appVersion: "0.13.7"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.6 \
+  --set controllerManager.image.tag=v0.13.7 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.6
+  --set swiftletd.image.tag=v0.13.7
 ```
 
 ### Release workflow

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.6 -n kubeswift-system --create-namespace \
+  --version 0.13.7 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.6 \
+  --version 0.13.7 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.6 \
+  --version 0.13.7 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.6 \
+  --version 0.13.7 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.6 \
+  --set controllerManager.image.tag=v0.13.7 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.6
+  --set swiftletd.image.tag=v0.13.7
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.6 \
+  --version 0.13.7 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.6 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.6 \
-    --set swiftletd.image.tag=v0.13.6
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.7 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.7 \
+    --set swiftletd.image.tag=v0.13.7
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.6 \
+  --version 0.13.7 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.6 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.7 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -112,6 +112,20 @@ Release artifacts (rc and stable) are signed and attested:
   (`SHA256SUMS.sig` + `SHA256SUMS.pem` release assets); the checksums then
   cover each binary.
 
+**Coverage floor: v0.13.7.** All nine images are signed from v0.13.7 onward. In
+earlier releases the sign list was maintained by hand and covered eight of nine —
+`sandbox-materialize` was omitted and shipped **unsigned in every release up to
+and including v0.13.6** (checked at v0.12.0, v0.13.0, v0.13.2, v0.13.4 and
+v0.13.6; every other image at those tags verifies). Verifying the full set
+against an older tag will fail on that one image, and that failure is expected
+rather than a sign of tampering. From v0.13.7 the list is derived from the same
+digest-pinned refs the build emits, and the release verifies its own signatures
+before publishing, so a miss fails the release instead of shipping quietly.
+
+To re-check a published tag at any time, run the **Verify release** workflow
+(Actions → Verify release) with that tag; it verifies signatures and attestation
+presence for all nine images.
+
 Verify an image signature and inspect its provenance/SBOM:
 
 ```bash


### PR DESCRIPTION
Cuts **v0.13.7**. Chart + appVersion to `0.13.7`, install examples swept across README and docs, CHANGELOG entry, and two workflow comments corrected.

## What this release is

A supply-chain release. Nothing in the runtime changed — no CRD schema changes, no API changes, no controller behaviour changes. What changed is how much of the release you have to take on trust.

## The finding

Building Phase 5's self-verification turned up that **`sandbox-materialize` has never been signed**. The sign list in `release-stable.yaml` was hand-written and covered eight of nine images.

Probed against the registry directly:

| tag | sandbox-materialize | control (other images at the same tag) |
|---|---|---|
| v0.12.0 | UNSIGNED | controller-manager SIGNED |
| v0.13.0 | UNSIGNED | |
| v0.13.2 | UNSIGNED | |
| v0.13.4 | UNSIGNED | |
| v0.13.6 | UNSIGNED | controller-manager, swiftletd, snapshot-oras all SIGNED |

So anyone verifying the full set has been getting a failure on that one image for five releases, while every release job reported success. The comments in `release-stable.yaml` and `verify-release.yaml` both said "v0.13.6" — they understated it, and are corrected here.

v0.13.7 is the first release where all nine are signed **and** where the release verifies its own signatures and attestations before finishing.

## PR triage before the cut

Merged into this release: #500, #503, #504, #505 (all green), plus #508 which supersedes the broken #506.

Deferred to **v0.13.8**, with reasons on each PR:
- **#502** cosign-installer v3→v4 — appears only in release workflows, which don't run on PRs, so its green checks exercise nothing; the first real run would be this release. v4 also defaults to cosign 3.0.5, and we pin 2.x deliberately (3.x rejects `--tlog-upload=false` at runtime).
- **#501** kube-rs 0.92→4.2 — the major migration tracked in #499, not a routine bump. Its three red checks are the real API breakage.

## Verification

- `go build` / `go vet` / `go test ./api/... ./internal/... ./cmd/...` — pass (scoped as CI does; a bare `./...` also walks the gitignored buildroot tree, which contains GCC's own Go testsuite and does not compile)
- `gofmt -s` clean · `make verify-crd-sync` OK (15 CRDs)
- `helm lint` · render-coverage (5 workloads) · `kubeconform -strict` 38 valid / 0 invalid · `kube-linter` no findings
- Rendered chart resolves images to `v0.13.7` from appVersion

Historical version references are deliberately untouched — "Until v0.13.6" in the launcher-SA code, "From v0.13.6" in the chart and security audit, and the v0.13.6 CHANGELOG entry's own upgrade command all remain true as written.

## Release notes

Written separately for the GitHub Release, and they **also carry v0.13.6's notes**, which shipped with only the boilerplate install/images template and no description of what changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)