### PR TITLE
ci(release): keep the maintainer note out of the release body

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -418,6 +418,12 @@ jobs:
           name: KubeSwift ${{ github.ref_name }}
           generate_release_notes: true
           files: dist/*
+          # MAINTAINERS: the image list in the body below is hand-maintained and
+          # must stay in step with the `refs` step above. It listed four of nine
+          # until v0.13.7 — the same kind of hand-maintained list that let
+          # sandbox-materialize ship unsigned for five releases. Keep the note
+          # here, in the workflow: everything under `body:` is published to the
+          # release page, where guidance aimed at us is just noise for readers.
           body: |
             ## Install
 
@@ -427,10 +433,7 @@ jobs:
 
             ## Images
 
-            All nine are signed and verified by this workflow before the release
-            is published. Keep this list in step with the `refs` step above — it
-            listed four of nine until v0.13.7, which is precisely the kind of
-            hand-maintained list that let sandbox-materialize ship unsigned.
+            All nine are signed, and verified by the release workflow before publishing.
 
             - `ghcr.io/kubeswift-io/kubeswift/controller-manager:${{ needs.build-and-push.outputs.tag }}`
             - `ghcr.io/kubeswift-io/kubeswift/swiftletd:${{ needs.build-and-push.outputs.tag }}`


### PR DESCRIPTION
Everything under `body:` in the Create GitHub Release step is published to the release page. The note I added in #509 reminding maintainers to keep the image list in step with the `refs` step went in there rather than as a YAML comment, so it rendered publicly on v0.13.7:

> Keep this list in step with the `refs` step above — it listed four of nine until v0.13.7, which is precisely the kind of hand-maintained list that let sandbox-materialize ship unsigned.

Accurate, but it is guidance for whoever edits this workflow, not for someone reading a release page. Moved to a YAML comment above `body:`. The v0.13.7 release body has already been corrected by hand.

The reminder is worth keeping — the list being hand-maintained is precisely why `sandbox-materialize` shipped unsigned for five releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)