### PR TITLE
ci(release): sign and verify every image the RC builds

### DIFF
--- a/.github/workflows/release-rc.yaml
+++ b/.github/workflows/release-rc.yaml
@@ -212,17 +212,65 @@ jobs:
       #   cosign verify <image>@<digest> \
       #     --certificate-identity-regexp 'https://github.com/kubeswift-io/kubeswift/\.github/workflows/release-(stable|rc)\.yaml@.*' \
       #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      # Every image this workflow builds, digest-pinned, shared by the sign and
+      # verify steps below so the two cannot drift.
+      #
+      # This replaces a hand-written sign list that had silently omitted
+      # sandbox-materialize: it was built and pushed on every RC and never
+      # signed, and nothing said so. That is the same defect #497 fixed in
+      # release-stable, where it had shipped an unsigned image for five
+      # releases. Deriving both steps from one list is what stops it recurring.
+      #
+      # NOTE this list is 8, not stable's 9 — release-rc does not build
+      # kubeswift-gateway at all. That difference predates this change and is
+      # left alone here; whether RC should build the gateway is #512.
+      - name: Collect image refs
+        id: refs
+        run: |
+          {
+            echo 'list<<EOF'
+            echo "${{ env.IMAGE_PREFIX }}/controller-manager@${{ steps.build-controller-manager.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/gpu-discovery@${{ steps.build-gpu-discovery.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/snapshot-s3@${{ steps.build-snapshot-s3.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/snapshot-oras@${{ steps.build-snapshot-oras.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/kubeswift-dra-driver@${{ steps.build-dra-driver.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/sandbox-materialize@${{ steps.build-sandbox-materialize.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/swiftletd@${{ steps.build-swiftletd.outputs.digest }}"
+            echo "${{ env.IMAGE_PREFIX }}/migration-stunnel@${{ steps.build-migration-stunnel.outputs.digest }}"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
       - name: Sign images (cosign keyless)
         env:
           COSIGN_YES: "true"
         run: |
-          cosign sign "${{ env.IMAGE_PREFIX }}/controller-manager@${{ steps.build-controller-manager.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/gpu-discovery@${{ steps.build-gpu-discovery.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/snapshot-s3@${{ steps.build-snapshot-s3.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/snapshot-oras@${{ steps.build-snapshot-oras.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/kubeswift-dra-driver@${{ steps.build-dra-driver.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/swiftletd@${{ steps.build-swiftletd.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}/migration-stunnel@${{ steps.build-migration-stunnel.outputs.digest }}"
+          set -euo pipefail
+          echo "${{ steps.refs.outputs.list }}" | while read -r ref; do
+            [ -n "$ref" ] || continue
+            echo "signing $ref"
+            cosign sign "$ref"
+          done
+
+      # An RC is what someone installs to test an upgrade before it ships. If
+      # `cosign verify` fails on one of its images, the tester cannot tell
+      # "we forgot to sign it" from "someone tampered with it" — which is the
+      # entire property the signature is meant to provide. So the RC checks its
+      # own work, exactly as release-stable does.
+      #
+      # Identity is pinned to THIS workflow file, not release-(stable|rc): an
+      # RC image must be signed by the RC workflow.
+      - name: Verify signatures (fail the RC if signing did not take)
+        run: |
+          set -euo pipefail
+          echo "${{ steps.refs.outputs.list }}" | while read -r ref; do
+            [ -n "$ref" ] || continue
+            echo "verifying $ref"
+            cosign verify "$ref" \
+              --certificate-identity-regexp '^https://github\.com/kubeswift-io/kubeswift/\.github/workflows/release-rc\.yaml@.*$' \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              > /dev/null
+          done
+          echo "all $(echo "${{ steps.refs.outputs.list }}" | grep -c .) images verified"
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
@@ -256,6 +304,11 @@ jobs:
           name: KubeSwift ${{ github.ref_name }}
           prerelease: true
           generate_release_notes: true
+          # MAINTAINERS: the image list in the body below is hand-maintained and
+          # must stay in step with the `refs` step above — it listed six of the
+          # eight built images until this change. Keep notes like this one HERE,
+          # in the workflow: everything under `body:` is published to the release
+          # page, where guidance aimed at us is just noise for readers.
           body: |
             Release candidate — see the matching CHANGELOG.md section for
             details and Known Limitations.
@@ -268,12 +321,17 @@ jobs:
 
             ## Images
 
+            All eight are signed, and verified by this workflow before the
+            pre-release is published.
+
             - `ghcr.io/kubeswift-io/kubeswift/controller-manager:${{ steps.version.outputs.tag }}`
             - `ghcr.io/kubeswift-io/kubeswift/swiftletd:${{ steps.version.outputs.tag }}`
             - `ghcr.io/kubeswift-io/kubeswift/gpu-discovery:${{ steps.version.outputs.tag }}`
             - `ghcr.io/kubeswift-io/kubeswift/snapshot-s3:${{ steps.version.outputs.tag }}`
             - `ghcr.io/kubeswift-io/kubeswift/snapshot-oras:${{ steps.version.outputs.tag }}`
             - `ghcr.io/kubeswift-io/kubeswift/migration-stunnel:${{ steps.version.outputs.tag }}`
+            - `ghcr.io/kubeswift-io/kubeswift/kubeswift-dra-driver:${{ steps.version.outputs.tag }}`
+            - `ghcr.io/kubeswift-io/kubeswift/sandbox-materialize:${{ steps.version.outputs.tag }}`
 
             ## Supply chain
 


### PR DESCRIPTION
Closes #512.

`release-rc` signed from a hand-written list of **seven** while building **eight**. `sandbox-materialize` was built, pushed, and never signed on every RC — and nothing reported it, because release-rc also had no step checking its own signatures.

That is the identical defect #497 fixed in `release-stable`, where the same omission shipped an unsigned image for five releases.

## What changed

Both halves of #497, ported:

- **`refs` step** — all eight images, digest-pinned, consumed by the sign loop. An image cannot be published without being signed.
- **verify step** — reads the *same* list, so a signing miss fails the RC run instead of shipping quietly. Identity is pinned to `release-rc.yaml`: an RC image must be signed by the RC workflow, not merely by something of ours.

The pre-release body had drifted the same way (six of eight listed); it now lists all eight, with the maintainer note as a **YAML comment** rather than inside `body:` — everything under `body:` publishes to the release page, which is the mistake #510 just cleaned up.

## Checks

```
refs list (8)   == build steps (8)     builds with no ref entry: NONE
every refs entry points at a real `id: build-*` step
body image list == refs list            MATCH: True
YAML parses
```

The last one matters: a typo in a build-step id expands to an empty digest and would produce `…/name@`, which `cosign sign` rejects — under `set -euo pipefail` that fails the run rather than skipping an image silently.

## Deliberately not changed

`release-rc` builds eight images where stable builds nine — it never builds `kubeswift-gateway`. That predates this change and is a scope question, not a signing bug, so it stays as-is; #512 records it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)