### PR TITLE
fix(security): gate who may name a launcher ServiceAccount (#443)

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -73,10 +73,17 @@ jobs:
       - name: Verify render coverage
         run: ./hack/verify-render-coverage.sh
 
+      # Rendered through the shared script, NOT an inline `helm template` line.
+      # verify-render-coverage above uses the same script, so the set of objects
+      # asserted-present and the set actually scanned cannot drift apart. They
+      # previously could: capability-guarded templates (the #443 admission gate)
+      # render to nothing unless --api-versions is passed, so an inline command
+      # here that lacked the flag would scan a security control it could not see
+      # while every check stayed green.
       - name: Render the full lint profile
         run: |
           set -euo pipefail
-          helm template kubeswift charts/kubeswift -f hack/lint-values/full.yaml > /tmp/rendered.yaml
+          ./hack/render-lint-profile.sh > /tmp/rendered.yaml
           test -s /tmp/rendered.yaml
 
       # STEP 1. -strict is the flag that matters: it rejects unknown and

--- a/charts/kubeswift/templates/webhook/launcher-sa-policy.yaml
+++ b/charts/kubeswift/templates/webhook/launcher-sa-policy.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.launcherSAGate.enabled }}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy" }}
+# Closes the residual escalation in #443.
+#
+# THE PROBLEM. Launcher pods run `privileged: true` and are a NODE-level trust
+# boundary. swiftletd needs `pods: get,patch` to report status by annotation, so
+# the launcher ServiceAccounts carry that grant. Kubernetes has **no RBAC gate on
+# which ServiceAccount a pod may reference**, so anyone who can create an
+# ordinary Pod in a namespace where a guest runs can write
+# `serviceAccountName: kubeswift-launcher`, receive the token, patch the
+# privileged launcher's `image`, and get node root — kubelet restarts a container
+# whose spec hash changed regardless of `restartPolicy: Never`.
+#
+# WHY resourceNames ALONE IS NOT THE FIX. Scoping the reporter Role with
+# `resourceNames` to the launcher pod names does narrow the blast radius (a
+# bystander pod becomes unpatchable) but does NOT close this: RBAC is additive
+# and the ServiceAccount is SHARED, so the attacker still inherits the union of
+# every launcher pod name in the namespace — including the one they want. Tested
+# on a live cluster; see #443.
+#
+# WHAT THIS DOES. Supplies the missing gate: only the KubeSwift controller may
+# create a Pod that names a launcher ServiceAccount. The attacker's pod is
+# rejected at admission, so they never receive the token.
+#
+# WHY ValidatingAdmissionPolicy AND NOT A WEBHOOK. This rule has to match every
+# Pod CREATE in the cluster. A webhook with `failurePolicy: Fail` would couple
+# all pod creation to our webhook server being up — an unacceptable blast radius
+# for a VM platform, and the failure mode is a cluster that cannot schedule
+# anything. VAP is evaluated in-tree by the apiserver: there is no server to be
+# down. The `Has` guard above keeps the chart installable on clusters without it
+# (VAP is GA in k8s 1.30+); on those, set launcherSAGate.enabled=false and see
+# docs/security-audit.md for the trust-boundary posture that replaces it.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kubeswift-launcher-sa-gate
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: admission-policy
+spec:
+  # Fail is safe here in a way it would not be for a webhook: a VAP failure is a
+  # CEL evaluation error, not an unreachable network service. The expression
+  # below is total — it guards `has()` before dereferencing — so the only way to
+  # reach the failure path is a malformed policy, which should block rather than
+  # silently admit.
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        # CREATE only: `spec.serviceAccountName` is immutable on a Pod, so there
+        # is no UPDATE path that could introduce a launcher SA after admission.
+        operations: ["CREATE"]
+        resources: ["pods"]
+  variables:
+    - name: launcherSAs
+      expression: "['{{ .Values.launcherSAGate.guestServiceAccountName }}', '{{ .Values.launcherSAGate.sandboxServiceAccountName }}']"
+    - name: controllerUser
+      expression: "'system:serviceaccount:{{ .Values.namespace }}:controller-manager'"
+  validations:
+    - expression: >-
+        !(has(object.spec.serviceAccountName) &&
+          object.spec.serviceAccountName in variables.launcherSAs) ||
+        request.userInfo.username == variables.controllerUser
+      message: >-
+        this ServiceAccount is reserved for KubeSwift VM launcher pods, which run
+        privileged; only the KubeSwift controller may create pods that use it
+        (see kubeswift.io issue #443)
+      reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: kubeswift-launcher-sa-gate
+  labels:
+    app.kubernetes.io/name: kubeswift
+    app.kubernetes.io/component: admission-policy
+spec:
+  policyName: kubeswift-launcher-sa-gate
+  # Deny, not Warn/Audit: a pod naming a launcher SA is either the controller
+  # (exempted in the expression) or an escalation attempt. There is no benign
+  # third case to be lenient about.
+  validationActions: [Deny]
+  # Cluster-wide by design. Guests and sandboxes run in arbitrary user
+  # namespaces, so scoping this to a namespace list would leave exactly the
+  # namespaces an attacker would pick.
+{{- end }}
+{{- end }}

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -346,6 +346,35 @@ ui:
 webhook:
   enabled: false
 
+# Launcher-ServiceAccount admission gate (#443). ON by default — it closes a
+# privilege escalation, and a security control that ships off is a security
+# control nobody has.
+#
+# Launcher pods run privileged and are a NODE-level trust boundary. swiftletd
+# needs `pods: patch` to report status, so the launcher ServiceAccounts carry
+# it — and Kubernetes has no RBAC gate on *which* ServiceAccount a pod may
+# name. Without this, anyone who can create a Pod in a namespace where a guest
+# runs can name the launcher SA, get its token, patch the privileged launcher's
+# image, and reach node root. Scoping the RBAC with resourceNames does NOT close
+# that (RBAC is additive and the SA is shared) — this gate does.
+#
+# Implemented as a ValidatingAdmissionPolicy, evaluated in-tree by the
+# apiserver, so unlike a webhook there is no server whose outage would block
+# pod creation cluster-wide. Rendered only when the cluster serves
+# admissionregistration.k8s.io/v1 ValidatingAdmissionPolicy (GA in k8s 1.30+);
+# on older clusters it is silently skipped and the namespace is a trust
+# boundary instead — see docs/security-audit.md.
+#
+# Turn OFF only if you operate the workload namespaces as a trust boundary
+# already, or a policy engine of your own enforces the same rule.
+launcherSAGate:
+  enabled: true
+  # Must match the constants the controller stamps on launcher pods
+  # (internal/controller/swiftguest/rbac.go). Change both together or the gate
+  # protects a ServiceAccount nothing uses while the real one stays open.
+  guestServiceAccountName: kubeswift-launcher
+  sandboxServiceAccountName: kubeswift-sandbox-launcher
+
 # Observability (optional). Requires the Prometheus Operator CRDs
 # (monitoring.coreos.com — e.g. kube-prometheus-stack) when enabled; the
 # dashboards additionally need a Grafana with the dashboard sidecar (the

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -518,6 +518,29 @@ From v0.13.6 launchers run as dedicated ServiceAccounts rather than the namespac
 `default`, which removes *incidental* inheritance: ordinary Jobs, sidecars,
 CronJobs and debug pods in the namespace no longer hold `pods: patch` by accident.
 
+**From v0.13.8 a ValidatingAdmissionPolicy closes the residual** (#443). The
+dedicated ServiceAccount removed *incidental* inheritance but did not close the
+escalation, because Kubernetes has no RBAC gate on which ServiceAccount a pod may
+name: anyone able to create a Pod could write `serviceAccountName:
+kubeswift-launcher`, receive the token, patch the privileged launcher's image,
+and reach node root. Scoping the reporter Role with `resourceNames` does not fix
+that either — RBAC is additive and the ServiceAccount is shared, so the attacker
+inherits the union of every launcher pod name in the namespace. Verified on a
+live cluster.
+
+`kubeswift-launcher-sa-gate` supplies the missing gate: only the KubeSwift
+controller may create a Pod naming a launcher ServiceAccount. It is a
+ValidatingAdmissionPolicy rather than a webhook deliberately — the rule must
+match every Pod CREATE, and a webhook with `failurePolicy: Fail` would make all
+pod creation depend on our webhook server being up. VAP is evaluated in-tree.
+
+The policy is rendered only where the cluster serves
+`admissionregistration.k8s.io/v1 ValidatingAdmissionPolicy` (k8s 1.30+) and can
+be disabled with `launcherSAGate.enabled=false`. **Where it is off, the KubeSwift
+workload namespace is a trust boundary**: anyone who can create a Pod there can
+reach node root, and should be treated as equivalent to a node-level
+administrator. That is the same acceptance posture as SEC-01/02/03 above.
+
 **It does not close the escalation, and neither would `resourceNames` scoping.**
 Kubernetes has no RBAC gate on which ServiceAccount a pod may reference — there is
 no `serviceaccounts/use` subresource and no verb for it. A tenant who can create

--- a/hack/render-lint-profile.sh
+++ b/hack/render-lint-profile.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# render-lint-profile — the ONE canonical render of the chart for policy checks.
+#
+# Everything that scans rendered manifests (verify-render-coverage, kubeconform,
+# kube-linter) must render through here. The reason is drift: when two callers
+# each spell out their own `helm template` line, one can gain a flag the other
+# lacks and an object silently drops out of the scanned set while every check
+# still reports green. That is the same failure mode as a hand-maintained image
+# sign list (#497/#512) — the fix is to derive, not to repeat.
+#
+# --api-versions is why this exists. `helm template` does not talk to a cluster,
+# so `.Capabilities.APIVersions.Has` is evaluated against a built-in default set
+# that does NOT include ValidatingAdmissionPolicy. The launcher-SA admission gate
+# (#443) is guarded on that capability so the chart stays installable on clusters
+# older than k8s 1.30 — which means that without the flag below it renders to
+# nothing here, and CI would lint a security control it cannot see.
+#
+# Add an entry whenever a template becomes capability-guarded.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+API_VERSIONS=(
+  "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy"
+  "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicyBinding"
+)
+
+args=(template kubeswift "$ROOT/charts/kubeswift" -f "$ROOT/hack/lint-values/full.yaml")
+for v in "${API_VERSIONS[@]}"; do
+  args+=(--api-versions "$v")
+done
+
+helm "${args[@]}"

--- a/hack/verify-render-coverage.sh
+++ b/hack/verify-render-coverage.sh
@@ -31,7 +31,10 @@ Deployment/kubeswift-ui"
 
 command -v helm >/dev/null || { echo "verify-render-coverage: helm not found" >&2; exit 1; }
 
-rendered="$(helm template kubeswift "$CHART" -f "$VALUES")"
+# Render through the shared script, NOT a local `helm template` line: it carries
+# the --api-versions the capability-guarded templates need, and sharing it with
+# the workflow is what stops the two renders drifting apart.
+rendered="$("$ROOT/hack/render-lint-profile.sh")"
 
 # Pod-bearing kinds only — those are what the security policy checks apply to.
 actual="$(printf '%s' "$rendered" | awk '
@@ -53,4 +56,25 @@ if [[ "$actual" != "$EXPECTED" ]]; then
   exit 1
 fi
 
-echo "verify-render-coverage: OK — $(printf '%s\n' "$actual" | wc -l) workloads rendered and accounted for."
+# Capability-guarded objects render to NOTHING unless the shared render script
+# passes --api-versions for them, and a security control CI cannot see is worse
+# than one that does not exist — it reads as covered. Assert the launcher-SA
+# admission gate (#443) is actually in the scanned output.
+GUARDED="ValidatingAdmissionPolicy/kubeswift-launcher-sa-gate
+ValidatingAdmissionPolicyBinding/kubeswift-launcher-sa-gate"
+
+for want in $GUARDED; do
+  kind="${want%%/*}"; name="${want##*/}"
+  if ! printf '%s' "$rendered" | grep -q "^kind: ${kind}$"; then
+    echo "verify-render-coverage: ${kind} is missing from the render." >&2
+    echo "It is capability-guarded — check hack/render-lint-profile.sh passes" >&2
+    echo "--api-versions for it, or the policy check is scanning nothing." >&2
+    exit 1
+  fi
+  printf '%s' "$rendered" | grep -q "name: ${name}$" || {
+    echo "verify-render-coverage: ${kind} rendered but not named ${name}." >&2
+    exit 1
+  }
+done
+
+echo "verify-render-coverage: OK — $(printf '%s\n' "$actual" | wc -l) workloads + $(printf '%s\n' "$GUARDED" | wc -l) capability-guarded objects rendered and accounted for."


### PR DESCRIPTION
Closes the residual privilege escalation in #443.

## The fix #443 proposed does not work — proven, not argued

v0.13.6 gave launchers dedicated ServiceAccounts. #443 then proposed scoping the reporter Role with `resourceNames`. That scoping works:

```
Role: pods get,patch  resourceNames: [victim-launcher]
can-i patch pods/victim-launcher    -> yes
can-i patch pods/someone-elses-app  -> no
```

But it does not close the escalation, because **Kubernetes has no RBAC gate on which ServiceAccount a pod may name, and RBAC is additive on a shared subject**. An attacker names the SA and inherits the union of every launcher pod name in the namespace. On a live cluster:

```
$ kubectl apply -f attacker.yaml   # ordinary pod, serviceAccountName: <launcher SA>
pod/attacker created                # admitted, token mounted
```

That token carries `patch` on a **privileged** launcher whose `image` is mutable — kubelet restarts a container whose spec hash changed regardless of `restartPolicy: Never`. Node root.

## What this adds

A `ValidatingAdmissionPolicy` supplying the gate Kubernetes lacks: only the KubeSwift controller may create a Pod naming a launcher ServiceAccount. The attacker's pod is refused at admission and never receives a token.

**VAP, not a webhook — deliberately.** The rule must match every Pod CREATE. A webhook with `failurePolicy: Fail` would couple all pod creation in the cluster to our webhook server being up; the failure mode is a cluster that cannot schedule anything. VAP is evaluated in-tree, so there is no server to be down.

Capability-guarded (`admissionregistration.k8s.io/v1`, GA in k8s 1.30+) so the chart still installs on older clusters, and toggleable via `launcherSAGate.enabled`. Where it is off, the workload namespace **is** a trust boundary — now stated plainly in `docs/security-audit.md` beside SEC-01/02/03, rather than implied.

## A second bug the guard introduced, and the fix

`helm template` has no VAP in its default capability set, so the policy rendered to **nothing** — CI would have linted a security control it could not see, while reporting green. That is precisely the render-coverage trap Phase 4 (#493) exists to catch.

Both the coverage check and the manifests workflow now render through **one** script, `hack/render-lint-profile.sh`, which carries the `--api-versions`. Same lesson as the image sign lists in #497/#512: derive, don't repeat. The coverage check additionally asserts the policy is present — verified by deleting the flag:

```
verify-render-coverage: ValidatingAdmissionPolicy is missing from the render.
exit code: 1
```

## Cluster validation (dev, k0s v1.34.3, policy live)

| case | result |
|---|---|
| ordinary pod | created |
| pod naming `default` SA | created |
| **real SwiftGuest boot** | **Running, 192.168.99.20, launcher SA `kubeswift-launcher`** |
| pod naming `kubeswift-launcher` | **denied** |
| pod naming `kubeswift-sandbox-launcher` | **denied** |

The guest boot is the one that mattered: if the controller could not create launcher pods, every VM would stop working. Its launcher was admitted and the VM took a DHCP lease.

The sandbox case initially failed for the *wrong* reason — the apiserver's own SA-existence check fires first, and no sandbox had run in that namespace. Re-tested with the SA present; it is the policy that denies it.

Local gate: render-coverage (5 workloads + 2 guarded objects) · kubeconform `-strict` 40 valid / 0 invalid · kube-linter clean · `helm lint` OK.

## Still open on #443

`resourceNames` scoping remains worth doing as defence in depth — it removes the ability to patch *bystander* pods. It is deliberately not in this PR: warm-pool slots are named `<pool>-slot-<utilrand.String(5)>`, so the name set is random and must be reconciled before each pod is created, and a missed name is a silent 403. That is its own change with its own validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)