### PR TITLE
release: v0.13.8

### DIFF
--- a/.github/workflows/verify-release.yaml
+++ b/.github/workflows/verify-release.yaml
@@ -17,11 +17,15 @@ name: Verify release
 # A scheduled run would be red on every historical tag for a reason fixed in
 # v0.13.7, and a permanently red job is one nobody looks at.
 #
-# v0.13.7 is the first release with all nine signed. Move this onto a schedule
-# once that tag has shipped AND been verified by hand with this workflow; from
-# then on, red means something really changed rather than something never was.
-# Note a schedule also needs a default tag to verify — the tag input is
-# currently required, so resolving "the latest release" is part of that change.
+# v0.13.7 is the first release with all nine signed, and its precondition for a
+# schedule is now MET: v0.13.7 shipped and was verified 9/9 by probing the
+# registry directly (each image's sha256-<digest>.sig tag), independently of
+# this workflow's own report.
+#
+# What still blocks the schedule is mechanical, not evidential: the `tag` input
+# is required, so a scheduled run has nothing to verify. Resolving "the latest
+# release" — and deciding whether the schedule should check only the newest tag
+# or the last N — is its own change. Until then this stays dispatch-only.
 #
 # Usage: Actions -> Verify release -> Run workflow -> enter a tag, e.g. v0.13.7
 
@@ -32,7 +36,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to verify (e.g. v0.13.7)'
+        description: 'Release tag to verify (e.g. v0.13.8)'
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,105 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.13.8] — 2026-08-13
+
+Closes a privilege escalation. Anyone who could create an ordinary Pod in a
+namespace where a guest or sandbox ran could reach **node root** — no SwiftGuest
+required, no CRD access needed. If you run multi-tenant namespaces, this is the
+release to take.
+
+### Upgrade
+
+Drop-in from v0.13.7 — no CRD schema changes, no API changes, no values changes
+required.
+
+```bash
+helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.8 \
+  -n kubeswift-system -f <(helm get values kubeswift -n kubeswift-system -o yaml)
+kubectl apply -f charts/kubeswift/crds/    # helm does not upgrade CRDs
+```
+
+The new admission policy is **on by default** and cluster-scoped. It renders
+only where the cluster serves `admissionregistration.k8s.io/v1
+ValidatingAdmissionPolicy` (Kubernetes **1.30+**); on older clusters it is
+silently skipped and nothing changes. Disable with
+`launcherSAGate.enabled=false` if a policy engine of your own enforces the same
+rule — but read the trust-boundary note in `docs/security-audit.md` first,
+because turning it off restores the escalation.
+
+### Fixed
+
+- **A tenant who can create a Pod can no longer reach node root** (#443, #514).
+
+  Launcher pods run `privileged: true` and are a node-level trust boundary.
+  swiftletd needs `pods: patch` to report status, so the launcher
+  ServiceAccounts carry it — and **Kubernetes has no RBAC gate on which
+  ServiceAccount a pod may name**. So anyone able to create an ordinary Pod
+  could write `serviceAccountName: kubeswift-launcher`, receive that token,
+  patch the privileged launcher's `image`, and get node root. kubelet restarts a
+  container whose spec hash changed regardless of `restartPolicy: Never`.
+
+  v0.13.6's dedicated ServiceAccounts removed *incidental* inheritance and made
+  the grant auditable, but did not close this. Neither would `resourceNames`
+  scoping, which is what the issue originally proposed: RBAC is additive and the
+  ServiceAccount is shared, so an attacker still inherits the union of every
+  launcher pod name in the namespace. Both were tested on a live cluster before
+  being ruled out.
+
+  What closes it is a `ValidatingAdmissionPolicy` supplying the missing gate:
+  only the KubeSwift controller may create a Pod naming a launcher
+  ServiceAccount. A policy rather than a webhook deliberately — the rule matches
+  every Pod CREATE, and a webhook with `failurePolicy: Fail` would make all pod
+  creation in the cluster depend on our webhook server being up. Admission
+  policies are evaluated in-tree.
+
+  Validated on three clusters and two CNIs with the gate live: guest boot, GPU
+  guest, live migration (including the `<guest>-mig-<uid>` destination pod),
+  sandbox, and warm-pool slots (whose names are random) all admitted normally;
+  both launcher ServiceAccounts refused to an ordinary pod. Zero unintended
+  denials across the whole exercise.
+
+- **RC releases were publishing an unsigned image** (#512, #513). `release-rc`
+  still signed from a hand-written list of seven while building eight, so every
+  RC shipped `sandbox-materialize` unsigned — the identical defect #497 fixed in
+  `release-stable`, which had shipped it unsigned for five releases. RC now
+  derives its sign list from the same digest-pinned refs the build emits and
+  verifies its own signatures before publishing. Its pre-release body had
+  drifted the same way, listing six of eight.
+
+### Changed
+
+- **The manifest policy checks render through one script**
+  (`hack/render-lint-profile.sh`). `helm template` has no
+  ValidatingAdmissionPolicy in its default capability set, so a
+  capability-guarded template renders to nothing — CI would have linted the new
+  security control without being able to see it, while reporting green. Both the
+  coverage check and the workflow now share one render, and the coverage check
+  asserts the policy is present.
+
+- `sigstore/cosign-installer` v3 → v4 (#502). The explicit
+  `cosign-release: 'v2.6.5'` pin is retained deliberately: v4 defaults to cosign
+  3.0.5, which rejects `--tlog-upload=false` at runtime — the flag the offline
+  artifact-signing path needs.
+
+### Known issues
+
+- **45 fixable CVEs (1 critical, 23 high) remain in the vendored `cosign`
+  binary** shipped inside `snapshot-oras` and `sandbox-materialize` (#486).
+  They are **not** in KubeSwift code and not in the VM runtime: they are in a
+  signing helper's frozen dependency tree, which nothing in our tooling can
+  bump. v2.6.5 is the newest 2.x, and 3.x needs the offline signing contract
+  redesigned.
+
+  Measured: linking cosign as a Go library instead of vendoring the binary would
+  resolve **30 of the 45, including the only critical**, because Go's minimal
+  version selection would build those packages at the newer versions this
+  repository already carries. The remaining 15 are cosign's own sigstore
+  dependencies. That work is gated on proving signature interop with signatures
+  already in users' registries, so it is tracked rather than rushed.
+
+---
+
 ## [v0.13.7] — 2026-08-11
 
 A supply-chain release. Not one line of Go or Rust changed between v0.13.6 and

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.7 \
+  --version 0.13.8 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.7
-appVersion: "0.13.7"
+version: 0.13.8
+appVersion: "0.13.8"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/charts/kubeswift/README.md
+++ b/charts/kubeswift/README.md
@@ -20,6 +20,7 @@ them — re-apply `config/crd/bases/*.yaml` after a chart upgrade that changes a
 | `webhook.enabled`, `migration.mtls.enabled`, `ingress.tlsAuto` | cert-manager installed cluster-side |
 | `monitoring.enabled` | Prometheus Operator CRDs (e.g. kube-prometheus-stack); dashboards need a Grafana with the dashboard sidecar |
 | `gpuDiscovery.enabled` / `dra.enabled` | nodes labeled `kubeswift.io/gpu-node=true`; DRA also needs CDI enabled in the runtime + the `vfio-pci` module |
+| `launcherSAGate.enabled` (**on by default**) | Kubernetes ≥ 1.30 for `ValidatingAdmissionPolicy`. On older clusters it is silently skipped — see the note below |
 
 **Image tags** — the operator images default to `tag: latest`, which the chart
 rewrites to the chart's own `v<appVersion>` for a release (or `sha-<commit>` for a
@@ -177,6 +178,24 @@ point `ui.gateway.url` at an externally reachable gateway).
 | Parameter | Description | Default |
 |---|---|---|
 | `webhook.enabled` | Enable admission webhooks (runs the controller with `--webhook-enabled=true`). Requires cert-manager | `false` |
+| `launcherSAGate.enabled` | Refuse any Pod that names a launcher ServiceAccount unless the KubeSwift controller creates it. **Closes a privilege escalation — see below before disabling** | `true` |
+| `launcherSAGate.guestServiceAccountName` | Guest launcher SA the gate protects. Must match what the controller stamps | `kubeswift-launcher` |
+| `launcherSAGate.sandboxServiceAccountName` | Sandbox launcher SA the gate protects | `kubeswift-sandbox-launcher` |
+
+**Why `launcherSAGate` is on by default.** Launcher pods run privileged and are a
+node-level trust boundary. swiftletd needs `pods: patch` to report status, so the
+launcher ServiceAccounts carry it — and Kubernetes has **no RBAC gate on which
+ServiceAccount a pod may name**. Without this policy, anyone who can create a Pod
+in a namespace where a guest or sandbox runs can name that ServiceAccount, take
+its token, patch the privileged launcher's image, and reach node root. Scoping
+the RBAC with `resourceNames` does not close it (RBAC is additive and the
+ServiceAccount is shared).
+
+Turn it off only if a policy engine of your own enforces the same rule, or you
+already operate those namespaces as a trust boundary. Where it is off — including
+on clusters below Kubernetes 1.30, where it does not render — **treat anyone who
+can create a Pod in a KubeSwift workload namespace as a node administrator**. See
+`docs/security-audit.md`.
 
 ### Observability
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.7 \
+  --set controllerManager.image.tag=v0.13.8 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.7
+  --set swiftletd.image.tag=v0.13.8
 ```
 
 ### Release workflow

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.7 -n kubeswift-system --create-namespace \
+  --version 0.13.8 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.7 \
+  --version 0.13.8 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.7 \
+  --version 0.13.8 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.7 \
+  --version 0.13.8 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.7 \
+  --set controllerManager.image.tag=v0.13.8 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.7
+  --set swiftletd.image.tag=v0.13.8
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.7 \
+  --version 0.13.8 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.7 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.7 \
-    --set swiftletd.image.tag=v0.13.7
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.8 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.8 \
+    --set swiftletd.image.tag=v0.13.8
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.7 \
+  --version 0.13.8 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.7 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.8 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows


### PR DESCRIPTION
Cuts **v0.13.8**. The headline is a privilege escalation fix.

## What this release is

Anyone who could create an ordinary Pod in a namespace where a guest or sandbox ran could name a launcher ServiceAccount, take its token, patch the **privileged** launcher's image, and reach **node root** — without touching a SwiftGuest or holding any CRD permission. Closed by `kubeswift-launcher-sa-gate` (#514).

RC releases were also publishing `sandbox-materialize` unsigned (#513) — the same defect #497 fixed in `release-stable`, which had shipped it unsigned for five releases.

## Docs due diligence

**Swept** (install examples, 15 references): README, `docs/{releases,deploy,quickstart}`, `docs/gpu/dra-allocation`, `docs/install/{helm-oci,remote-cluster}`, `docs/operator/troubleshooting`, plus `Chart.yaml`.

**Deliberately not swept** — each still true:
- the CHANGELOG's own v0.13.7 entry and its upgrade command
- `docs/releases.md` "Coverage floor: **v0.13.7**" — a permanent fact about which release first signed all nine
- the v0.13.7 facts recorded in `release-stable.yaml`
- `config/samples/virtiofs` "v0.13.4+" hostPath opt-in note

**Newly documented**, because a default-on cluster-scoped admission policy belongs where operators look, not only in a changelog:
- chart README **requirements table** — `launcherSAGate.enabled` needs Kubernetes ≥ 1.30, and is silently skipped below that
- chart README **parameter table** — all three values, plus why it defaults on and what disabling it means ("treat anyone who can create a Pod in a KubeSwift workload namespace as a node administrator")
- `docs/security-audit.md` already carries the trust-boundary posture from #514

**`verify-release.yaml`** — its note said to move to a schedule once a fully-signed release had shipped *and* been hand-verified. Both are now true (v0.13.7 verified 9/9 by probing the registry directly), so the note records that, and says what actually blocks the schedule: the `tag` input is required, so a scheduled run has nothing to verify. That is its own change.

## Known issues, stated plainly

The CHANGELOG says #486 outright: **45 fixable CVEs (1 critical, 23 high) remain in the vendored cosign binary**, they are in a signing helper rather than the VM runtime, and linking cosign as a library would resolve **30 of them including the critical** — measured, not estimated. It is gated on proving signature interop with signatures already in users' registries.

I would rather ship that sentence than let a release with "supply chain" in its recent history imply the CVEs are handled.

## Pre-flight

```
gofmt -s               clean
go build / go vet      OK
go test (CI scope)     60 packages ok, 0 failed
make verify-crd-sync   OK (15 CRDs)
render-coverage        5 workloads + 2 capability-guarded objects
kubeconform -strict    40 valid, 0 invalid
kube-linter            no findings
helm lint              OK
```

Chart renders all images at `v0.13.8` with both admission-policy objects present.

## Cluster validation (already done, pre-tag)

The gate ran on **all three fleet clusters** and **two CNIs** before this PR: guest boot, GPU guest, live migration (including the `<guest>-mig-<uid>` destination pod), sandbox, and warm-pool slots (random names) all admitted; both launcher ServiceAccounts refused to an ordinary pod. **Zero unintended denials** in the apiserver audit log across the entire exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)