### PR TITLE
test(oci): cosign signature-interop harness (#486)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,11 @@ verify-crd-sync:
 verify-render-coverage:
 	./hack/verify-render-coverage.sh
 
+verify-cosign-interop: ## Cross-check that our cosign signatures verify (#486). Needs docker.
+	@# Not in any CI gate: it pulls release binaries and runs a local registry.
+	@# Run it before changing how anything is signed or verified.
+	./hack/cosign-interop.sh
+
 .PHONY: proto proto-lint
 proto: ## Regenerate Go (messages + connect handlers) from proto/ into gen/.
 	GOBIN=$(LOCALBIN) go install google.golang.org/protobuf/cmd/protoc-gen-go@$(PROTOC_GEN_GO_VERSION)

--- a/hack/cosign-interop.sh
+++ b/hack/cosign-interop.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Drive the signature-interop harness in internal/oci/interop_test.go (#486).
+#
+# Provisions everything that test needs and then runs it:
+#   - the cosign binaries under comparison, checksum-verified against upstream
+#   - a TLS registry (cosign verify will not speak plain HTTP, so a plaintext
+#     registry cannot test the verify half at all)
+#   - a signing keypair and a small artifact to sign
+#
+# Everything is torn down on exit. Nothing here touches a real registry, a real
+# cluster, or the operator's cosign install.
+#
+# Usage:
+#   hack/cosign-interop.sh                            # baseline — must be green
+#   COSIGN_VERSIONS="v2.6.5 v3.1.3" hack/cosign-interop.sh   # evaluate a candidate
+#
+# Exit status is the test's: non-zero means a signature did not verify.
+#
+# KNOWN RESULT, recorded so nobody re-derives it: adding v3.1.3 fails, and it
+# fails at SIGN, not at verify. cosign 3.x rejects `--tlog-upload=false` at
+# runtime ("not supported with --signing-config"), so it cannot produce an
+# offline signature under our contract at all. Migrating to 3.x therefore means
+# adopting a signing-config file first — a contract change, not a version bump.
+# That is why the default matrix is the baseline alone: a script that is red out
+# of the box is a script nobody trusts.
+
+set -euo pipefail
+
+# The versions to cross-check. v2.6.5 is what we vendor and what every existing
+# signature in users' registries was made with, so it is always in the set: it
+# is the baseline every other implementation is judged against, and it generates
+# the keypair.
+BASELINE="v2.6.5"
+COSIGN_VERSIONS="${COSIGN_VERSIONS:-$BASELINE}"
+case " $COSIGN_VERSIONS " in
+  *" $BASELINE "*) ;;
+  *) COSIGN_VERSIONS="$BASELINE $COSIGN_VERSIONS" ;;
+esac
+REGISTRY_PORT="${REGISTRY_PORT:-5443}"
+WORKDIR="${WORKDIR:-$(mktemp -d -t cosign-interop-XXXXXX)}"
+BIN_CACHE="${BIN_CACHE:-${TMPDIR:-/tmp}/kubeswift-cosign-bins}"
+REGISTRY_NAME="kubeswift-interop-registry"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+log()  { printf '  %s\n' "$*"; }
+step() { printf '\n== %s\n' "$*"; }
+
+cleanup() {
+  docker rm -f "$REGISTRY_NAME" >/dev/null 2>&1 || true
+  [ -n "${KEEP_WORKDIR:-}" ] || rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+for tool in docker openssl curl go jq; do
+  command -v "$tool" >/dev/null || { echo "missing required tool: $tool" >&2; exit 1; }
+done
+
+step "cosign binaries"
+mkdir -p "$BIN_CACHE"
+IMPLS=""
+for v in $COSIGN_VERSIONS; do
+  bin="$BIN_CACHE/cosign-$v"
+  if [ ! -x "$bin" ]; then
+    log "downloading cosign $v"
+    curl -sSfL "https://github.com/sigstore/cosign/releases/download/${v}/cosign-linux-amd64" -o "$bin"
+    chmod +x "$bin"
+  fi
+  # These binaries sign artifacts, so verify them rather than trusting the
+  # download. A tampered signer would make the whole matrix meaningless.
+  sums="$BIN_CACHE/sums-$v.txt"
+  [ -f "$sums" ] || curl -sSfL "https://github.com/sigstore/cosign/releases/download/${v}/cosign_checksums.txt" -o "$sums"
+  want=$(awk '/ cosign-linux-amd64$/ {print $1}' "$sums")
+  got=$(sha256sum "$bin" | awk '{print $1}')
+  [ "$want" = "$got" ] || { echo "checksum mismatch for cosign $v" >&2; exit 1; }
+  log "$v  checksum ok  ($($bin version 2>/dev/null | awk '/GitVersion/{print $2}'))"
+  IMPLS="${IMPLS:+$IMPLS,}$v=$bin"
+done
+
+step "TLS registry on 127.0.0.1:$REGISTRY_PORT"
+certs="$WORKDIR/certs"; mkdir -p "$certs"
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -subj "/CN=127.0.0.1" -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" \
+  -keyout "$certs/registry.key" -out "$certs/registry.crt" >/dev/null 2>&1
+docker rm -f "$REGISTRY_NAME" >/dev/null 2>&1 || true
+docker run -d --name "$REGISTRY_NAME" -p "$REGISTRY_PORT:5000" \
+  -v "$certs:/certs:ro" \
+  -e REGISTRY_HTTP_ADDR=0.0.0.0:5000 \
+  -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/registry.crt \
+  -e REGISTRY_HTTP_TLS_KEY=/certs/registry.key \
+  registry:2 >/dev/null
+
+REG="127.0.0.1:$REGISTRY_PORT"
+CURL=(curl -sS --cacert "$certs/registry.crt")
+for _ in $(seq 30); do
+  [ "$("${CURL[@]}" -o /dev/null -w '%{http_code}' "https://$REG/v2/" 2>/dev/null)" = "200" ] && break
+  sleep 1
+done
+[ "$("${CURL[@]}" -o /dev/null -w '%{http_code}' "https://$REG/v2/")" = "200" ] || {
+  echo "registry did not come up" >&2; docker logs "$REGISTRY_NAME" 2>&1 | tail -20 >&2; exit 1; }
+log "up (self-signed CA, trusted via SSL_CERT_FILE)"
+
+step "test artifact"
+# Pushed with the registry API directly rather than `docker push`: that would
+# need the CA installed into the docker daemon's trust store, which needs root
+# and a daemon restart. The artifact content is irrelevant — cosign signs a
+# digest — so a minimal OCI image is enough.
+push_blob() {
+  local repo="$1" data="$2" dgst
+  dgst="sha256:$(printf '%s' "$data" | sha256sum | awk '{print $1}')"
+  local loc
+  loc=$("${CURL[@]}" -X POST -D- -o /dev/null "https://$REG/v2/$repo/blobs/uploads/" \
+        | awk 'tolower($1)=="location:"{print $2}' | tr -d '\r')
+  case "$loc" in /*) loc="https://$REG$loc" ;; esac
+  local sep='?'; case "$loc" in *\?*) sep='&' ;; esac
+  printf '%s' "$data" | "${CURL[@]}" -X PUT -H 'Content-Type: application/octet-stream' \
+    --data-binary @- -o /dev/null "${loc}${sep}digest=$dgst"
+  printf '%s' "$dgst"
+}
+
+REPO="interop/subject"
+CFG_DATA='{}'
+LAYER_DATA='kubeswift signature interop harness'
+CFG_DGST=$(push_blob "$REPO" "$CFG_DATA")
+LAYER_DGST=$(push_blob "$REPO" "$LAYER_DATA")
+
+MANIFEST=$(jq -nc \
+  --arg cd "$CFG_DGST" --argjson cs "${#CFG_DATA}" \
+  --arg ld "$LAYER_DGST" --argjson ls "${#LAYER_DATA}" '{
+    schemaVersion: 2,
+    mediaType: "application/vnd.oci.image.manifest.v1+json",
+    config: {mediaType: "application/vnd.oci.image.config.v1+json", digest: $cd, size: $cs},
+    layers: [{mediaType: "application/vnd.oci.image.layer.v1.tar", digest: $ld, size: $ls}]
+  }')
+DIGEST="sha256:$(printf '%s' "$MANIFEST" | sha256sum | awk '{print $1}')"
+printf '%s' "$MANIFEST" | "${CURL[@]}" -X PUT \
+  -H 'Content-Type: application/vnd.oci.image.manifest.v1+json' \
+  --data-binary @- -o /dev/null "https://$REG/v2/$REPO/manifests/v1"
+log "$REG/$REPO@$DIGEST"
+
+step "signing key"
+# Generated by the baseline on purpose: the key format is part of what is under
+# test, and every existing signature was made with a key this version produced.
+export COSIGN_PASSWORD=""
+( cd "$WORKDIR" && "$BIN_CACHE/cosign-$BASELINE" generate-key-pair >/dev/null )
+log "$WORKDIR/cosign.key (+ cosign.pub), generated by $BASELINE"
+
+# A second, unrelated keypair for the test's negative control — verification
+# against it must fail, which is what proves the matrix means anything.
+mkdir -p "$WORKDIR/wrong"
+( cd "$WORKDIR/wrong" && "$BIN_CACHE/cosign-$BASELINE" generate-key-pair >/dev/null )
+log "$WORKDIR/wrong/cosign.pub (negative control)"
+
+step "interop matrix"
+# SSL_CERT_FILE is how cosign is told to trust the throwaway CA. It is set here
+# rather than passed as a flag on purpose: the test must run the argv that
+# SignArgs/VerifyArgs produce in production, unmodified.
+export SSL_CERT_FILE="$certs/registry.crt"
+export KUBESWIFT_INTEROP_REGISTRY="$REG"
+export KUBESWIFT_INTEROP_DIGEST="$DIGEST"
+export KUBESWIFT_INTEROP_KEY="$WORKDIR/cosign.key"
+export KUBESWIFT_INTEROP_PUBKEY="$WORKDIR/cosign.pub"
+export KUBESWIFT_INTEROP_WRONG_PUBKEY="$WORKDIR/wrong/cosign.pub"
+export KUBESWIFT_INTEROP_COSIGNS="$IMPLS"
+
+cd "$REPO_ROOT"
+go test -tags=interop -count=1 -v -timeout 15m ./internal/oci/ -run TestSignatureInterop

--- a/images/sandbox-materialize/Containerfile
+++ b/images/sandbox-materialize/Containerfile
@@ -22,10 +22,18 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # Fetch a pinned cosign for the verify-before-boot path (spec.verifyKeySecretRef).
 # Verified against the release checksums so a tampered binary fails the build.
 #
-# Stay on the 2.x line — see the note in images/snapshot-oras/Containerfile:
-# cosign 3.x rejects `--tlog-upload=false` at runtime, which internal/oci.SignArgs
-# needs, and the two images must ship the same cosign so a signature produced by
-# one verifies with the other.
+# Pinned to the 2.x line, but NOT for the reason previously recorded here. This
+# comment used to claim the two images must ship the same cosign so that a
+# signature made by one verifies with the other. hack/cosign-interop.sh was
+# built to test exactly that (#486) and it is not true: cosign v3.1.3 verifies a
+# v2.6.5-made signature under our own VerifyArgs, and correctly rejects a
+# foreign key, so its verification is real rather than a no-op.
+#
+# The 3.x blocker is signing only — `--tlog-upload=false` is rejected at runtime
+# — and this image never signs (cmd/sandbox-materialize calls oci.Verify alone).
+# So this pin is conservatism, not a constraint, and lifting it is tracked in
+# #486: v3.1.3 carries 4 fixable CVEs against v2.6.5's 48. Re-check with
+# `COSIGN_VERSIONS="v2.6.5 v3.1.3" hack/cosign-interop.sh` before moving it.
 ARG COSIGN_VERSION=v2.6.5
 RUN cd /tmp \
     && curl -sSfL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" -o cosign-linux-amd64 \

--- a/internal/oci/interop_test.go
+++ b/internal/oci/interop_test.go
@@ -1,0 +1,183 @@
+//go:build interop
+
+// Signature-interoperability harness for #486.
+//
+// WHAT THIS GATES. `snapshot-oras` signs artifacts and `sandbox-materialize`
+// verifies them, each with a vendored cosign binary. Changing how we sign — a
+// cosign major bump, or replacing the binary with the sigstore Go library —
+// risks a signature that the other side cannot read. That failure is silent in
+// the worst way: a golden image that stops verifying at boot, or a
+// SwiftSnapshot that verifies today and not after an upgrade. Signatures made
+// by v2.6.5 already exist in users' registries and must keep verifying.
+//
+// So before any of that work lands, we need to be able to answer: does a
+// signature produced by implementation A verify with implementation B? This
+// runs that matrix against a real registry.
+//
+// WHY IT LIVES HERE, not in hack/ as a shell script: it must exercise the argv
+// that `SignArgs`/`VerifyArgs` actually produce. A hand-written `cosign sign`
+// in a shell script would test cosign, not us — and the flags are the whole
+// point (`--tlog-upload=false` on sign, `--insecure-ignore-tlog` on verify).
+// Being in-package also lets it swap implementations by overriding the
+// `CosignRun` var, rather than manipulating PATH.
+//
+// NOT RUN BY DEFAULT. Build-tagged `interop`: it needs a live registry, a
+// keypair, and cosign binaries on disk. Drive it with hack/cosign-interop.sh,
+// which provisions all three.
+package oci
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// implementation is one signer/verifier under test — today a cosign binary,
+// later a library-backed in-process implementation. The matrix does not care
+// which, as long as it can sign and verify given our argv.
+type implementation struct {
+	name string
+	path string // cosign binary; empty means "in-process" (not yet used)
+}
+
+// runWith returns a CosignRun that shells out to a specific binary. Everything
+// else — the arguments, the environment contract, the error handling — is the
+// production path untouched.
+func runWith(bin string) func(context.Context, []string) error {
+	return func(ctx context.Context, args []string) error {
+		cmd := exec.CommandContext(ctx, bin, args...)
+		cmd.Env = os.Environ()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("%s %s: %w\n%s", bin, strings.Join(args, " "), err, out)
+		}
+		return nil
+	}
+}
+
+func envOrSkip(t *testing.T, key string) string {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		t.Skipf("%s not set — run via hack/cosign-interop.sh", key)
+	}
+	return v
+}
+
+// TestSignatureInterop signs one artifact with every implementation and then
+// verifies each signature with every implementation, printing the full matrix.
+//
+// A cell can fail for two very different reasons and the distinction matters:
+// the signer could not produce a signature at all (its own diagonal cell fails
+// too), or it produced one this verifier cannot read (only the off-diagonal
+// fails). The diagonal is therefore the control: an implementation that cannot
+// verify its OWN signature means the harness or the environment is broken, not
+// the interop.
+func TestSignatureInterop(t *testing.T) {
+	registry := envOrSkip(t, "KUBESWIFT_INTEROP_REGISTRY") // host:port
+	digest := envOrSkip(t, "KUBESWIFT_INTEROP_DIGEST")     // sha256:... of a pushed artifact
+	keyPath := envOrSkip(t, "KUBESWIFT_INTEROP_KEY")       // private key, for signing
+	pubPath := envOrSkip(t, "KUBESWIFT_INTEROP_PUBKEY")    // public key, for verifying
+	binList := envOrSkip(t, "KUBESWIFT_INTEROP_COSIGNS")   // name=path,name=path
+
+	var impls []implementation
+	for _, spec := range strings.Split(binList, ",") {
+		name, path, ok := strings.Cut(strings.TrimSpace(spec), "=")
+		if !ok {
+			t.Fatalf("KUBESWIFT_INTEROP_COSIGNS entry %q is not name=path", spec)
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("implementation %q: %v", name, err)
+		}
+		impls = append(impls, implementation{name: name, path: path})
+	}
+	if len(impls) < 1 {
+		t.Fatal("no implementations to test")
+	}
+
+	orig := CosignRun
+	t.Cleanup(func() { CosignRun = orig })
+
+	// Each signer gets its own repository so signatures cannot be confused with
+	// one another — cosign stores them at a digest-derived tag, so two signers
+	// signing the same digest in one repo would both write the same tag and the
+	// second would merely append.
+	signed := map[string]string{} // impl name -> repository it signed into
+	for _, s := range impls {
+		repo := fmt.Sprintf("%s/interop-%s/test", registry, strings.ToLower(s.name))
+		t.Run("sign/"+s.name, func(t *testing.T) {
+			CosignRun = runWith(s.path)
+			if err := Sign(context.Background(), repo, digest, keyPath, false); err != nil {
+				t.Errorf("%s could not sign: %v", s.name, err)
+				return
+			}
+			signed[s.name] = repo
+		})
+	}
+
+	type cell struct{ signer, verifier, result string }
+	var results []cell
+
+	for _, s := range impls {
+		repo, ok := signed[s.name]
+		if !ok {
+			for _, v := range impls {
+				results = append(results, cell{s.name, v.name, "SIGN-FAILED"})
+			}
+			continue
+		}
+		for _, v := range impls {
+			name := fmt.Sprintf("verify/%s-signed/%s-verifies", s.name, v.name)
+			res := "ok"
+			t.Run(name, func(t *testing.T) {
+				CosignRun = runWith(v.path)
+				if err := Verify(context.Background(), repo, digest, pubPath); err != nil {
+					res = "FAIL"
+					// Every cell must pass for a migration to be safe: existing
+					// signatures must verify with the new implementation, and a
+					// fleet mid-upgrade has old verifiers reading new signatures.
+					// So both cases fail — the message says which kind it is.
+					if s.name == v.name {
+						t.Errorf("%s cannot verify its OWN signature — harness or environment is broken, not interop: %v", s.name, err)
+					} else {
+						t.Errorf("INTEROP GAP: %s-signed does not verify with %s: %v", s.name, v.name, err)
+					}
+				}
+			})
+			results = append(results, cell{s.name, v.name, res})
+		}
+	}
+
+	t.Log("signature interop matrix (rows = signer, columns = verifier):")
+	for _, c := range results {
+		t.Logf("  %-10s signed  ->  %-10s verifies  :  %s", c.signer, c.verifier, c.result)
+	}
+
+	// NEGATIVE CONTROL. Everything above is a green light, and a green light
+	// that cannot turn red is not evidence. Verifying the same artifact with an
+	// unrelated public key MUST fail; if it passes, this harness would have
+	// certified an interop that was never actually checked — which is a worse
+	// failure than any gap it might report.
+	wrongPub := os.Getenv("KUBESWIFT_INTEROP_WRONG_PUBKEY")
+	if wrongPub == "" {
+		t.Error("negative control not configured (KUBESWIFT_INTEROP_WRONG_PUBKEY) — the matrix above is unproven")
+		return
+	}
+	for _, v := range impls {
+		repo, ok := signed[impls[0].name]
+		if !ok {
+			continue
+		}
+		t.Run("negative-control/"+v.name, func(t *testing.T) {
+			CosignRun = runWith(v.path)
+			if err := Verify(context.Background(), repo, digest, wrongPub); err == nil {
+				t.Errorf("%s verified a signature against the WRONG public key — the harness is not checking anything", v.name)
+			} else {
+				t.Logf("  %-10s correctly rejects a foreign key", v.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Builds the thing that gates the rest of #486, and the first run already changed what that work should be.

## Why

Cutting the CVEs in the vendored `cosign` means changing how we sign or verify. The risk is a signature one side can no longer read — a golden image that stops verifying at boot, a snapshot that verified before an upgrade and not after. Signatures made by v2.6.5 are already sitting in users' registries.

We had no way to test that. Now we do.

## What

`hack/cosign-interop.sh` provisions a TLS registry, a keypair and the cosign binaries under comparison, then runs `internal/oci/interop_test.go` — sign with every implementation, verify each signature with every other, print the matrix.

The test is **in-package** deliberately: it must exercise the argv `SignArgs`/`VerifyArgs` actually produce, because the offline flags are the whole point. A hand-rolled `cosign sign` in a shell script would test cosign, not us. Being in-package also lets it swap implementations by overriding the `CosignRun` var instead of manipulating `PATH`.

Two controls keep it honest:

- **The diagonal.** An implementation that cannot verify its *own* signature means the harness or environment is broken, not the interop. This caught a real bug in the harness on its first run.
- **A negative control.** Verification against an unrelated public key must fail. A green matrix that cannot turn red is not evidence.

TLS rather than plaintext because `cosign verify` will not speak HTTP — a plaintext registry cannot test the verify half at all. cosign trusts the throwaway CA via `SSL_CERT_FILE`, so no flag is added to the production argv.

## Findings

| | verified by v2.6.5 | verified by v3.1.3 |
|---|---|---|
| **signed by v2.6.5** | ok | **ok** |
| **signed by v3.1.3** | cannot sign | cannot sign |

**v3.1.3 cannot sign under our contract.** It rejects `--tlog-upload=false` at runtime and wants a `--signing-config` file with no transparency-log service. Moving the signer to 3.x is a contract change, not a version bump.

**v3.1.3 verifies v2.6.5's signatures** — and rejects a foreign key, so that verification is real rather than permissive. This **refutes the assumption recorded in `images/sandbox-materialize/Containerfile`**, which claimed both images must ship the same cosign for signatures to cross. That comment is corrected here; it was exactly the kind of untested claim this harness exists to check.

## What that changes

`sandbox-materialize` only ever verifies — `cmd/sandbox-materialize` calls `oci.Verify` alone. So its v2.6.5 pin is conservatism, not a constraint. Measured with Trivy against the binaries themselves:

| | fixable | critical | high |
|---|---|---|---|
| cosign v2.6.5 | 48 | 1 | 24 |
| cosign v3.1.3 | 4 | 0 | 3 |

That is a larger and cheaper reduction than the library migration this issue originally proposed (measured at 30 of 45), and it applies to one of the two images today. **Left to a change of its own** — this PR only establishes the evidence.

The signer (`snapshot-oras`, `swiftctl image publish`) stays blocked on the signing-config redesign.

## Notes

Not wired into any CI gate: it pulls release binaries and runs a local registry. `make verify-cosign-interop` runs the baseline; `COSIGN_VERSIONS="v2.6.5 v3.1.3" hack/cosign-interop.sh` evaluates a candidate. The default matrix is the baseline alone so the script is green out of the box — a script that is red by default is one nobody trusts.

Build-tagged `interop`, so `go test ./...` does not pick it up (verified: zero matches without the tag). `go build`/`go vet`/`go test` over the package tree are green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)