### PR TITLE
fix(security): move sandbox-materialize to cosign 3.1.3 (#486)

### DIFF
--- a/images/sandbox-materialize/Containerfile
+++ b/images/sandbox-materialize/Containerfile
@@ -22,19 +22,29 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # Fetch a pinned cosign for the verify-before-boot path (spec.verifyKeySecretRef).
 # Verified against the release checksums so a tampered binary fails the build.
 #
-# Pinned to the 2.x line, but NOT for the reason previously recorded here. This
-# comment used to claim the two images must ship the same cosign so that a
-# signature made by one verifies with the other. hack/cosign-interop.sh was
-# built to test exactly that (#486) and it is not true: cosign v3.1.3 verifies a
-# v2.6.5-made signature under our own VerifyArgs, and correctly rejects a
-# foreign key, so its verification is real rather than a no-op.
+# DELIBERATELY 3.x HERE while images/snapshot-oras/Containerfile stays on 2.x.
+# The two images no longer match, so the reasoning is worth stating (#486):
 #
-# The 3.x blocker is signing only — `--tlog-upload=false` is rejected at runtime
-# — and this image never signs (cmd/sandbox-materialize calls oci.Verify alone).
-# So this pin is conservatism, not a constraint, and lifting it is tracked in
-# #486: v3.1.3 carries 4 fixable CVEs against v2.6.5's 48. Re-check with
-# `COSIGN_VERSIONS="v2.6.5 v3.1.3" hack/cosign-interop.sh` before moving it.
-ARG COSIGN_VERSION=v2.6.5
+#   - This image only ever VERIFIES — cmd/sandbox-materialize calls oci.Verify
+#     alone and has no signing path. The 3.x blocker is signing: it rejects
+#     `--tlog-upload=false` at runtime, which internal/oci.SignArgs needs.
+#     snapshot-oras signs, so it cannot move; this image is not affected.
+#
+#   - Verification stays compatible in the direction that matters. cosign 3.x
+#     verifies a v2.6.5-made signature under our own VerifyArgs, so signatures
+#     already sitting in users' registries keep verifying after an upgrade.
+#     hack/cosign-interop.sh exists to prove that and is the gate on changing
+#     this line — including the negative control that 3.x still REJECTS a
+#     foreign key, so the compatibility is real rather than permissive.
+#
+#   - The reason to move: v2.6.5 carries 48 fixable CVEs (1 critical, 24 high)
+#     in cosign's own frozen dependency tree, none of them reachable by our
+#     tooling. v3.1.3 carries 4 (0 critical, 3 high).
+#
+# Re-run `COSIGN_VERSIONS="v2.6.5 v3.1.3" hack/cosign-interop.sh` before moving
+# this again. It is EXPECTED to exit non-zero on the v3.1.3 sign row; what must
+# stay green is the "signed by v2.6.5 / verified by v3.1.3" cell.
+ARG COSIGN_VERSION=v3.1.3
 RUN cd /tmp \
     && curl -sSfL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" -o cosign-linux-amd64 \
     && curl -sSfL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt" -o cosign_checksums.txt \

--- a/images/snapshot-oras/Containerfile
+++ b/images/snapshot-oras/Containerfile
@@ -24,12 +24,17 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # Fetch a pinned cosign for provenance signing (P2). Verified against the
 # release checksums file so a tampered/corrupt binary fails the build.
 #
-# Stay on the 2.x line. cosign 3.x REMOVES support for `--tlog-upload=false`
-# ("not supported with --signing-config"), which internal/oci.SignArgs relies on
-# to sign offline with no Rekor entry. The flag still appears in `cosign 3 sign
-# --help`, so this only shows up at runtime — and no test covers the round-trip,
-# so a 3.x bump would break signing silently. Moving to 3.x means reworking
-# SignArgs onto a signing-config file first.
+# Stay on the 2.x line. cosign 3.x REJECTS `--tlog-upload=false` ("not supported
+# with --signing-config"), which internal/oci.SignArgs relies on to sign offline
+# with no Rekor entry. The flag still appears in `cosign 3 sign --help`, so this
+# only shows up at runtime. Moving to 3.x means reworking SignArgs onto a
+# signing-config file first.
+#
+# NOTE this image and sandbox-materialize now ship DIFFERENT cosign majors, and
+# that is intentional: sandbox-materialize only verifies, and 3.x verifies 2.x
+# signatures fine, so it took the 3.x CVE reduction. This image signs, so it
+# cannot. `hack/cosign-interop.sh` (#486) is what proves the two still
+# interoperate — run it before changing either pin.
 ARG COSIGN_VERSION=v2.6.5
 RUN cd /tmp \
     && curl -sSfL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" -o cosign-linux-amd64 \


### PR DESCRIPTION
Cuts the vendored-cosign CVEs on the verifier image, using the interop evidence from #517.

## Measured on the built image

| | fixable | critical | high |
|---|---|---|---|
| cosign v2.6.5 (before) | 48 | 1 | 24 |
| cosign v3.1.3 (after) | **4** | **0** | **3** |

Same Containerfile, only `COSIGN_VERSION` differs. The remaining 4 are inside cosign v3.1.3's own build (go stdlib 1.26.4, x/text, grpc) — a future cosign release fixes them, nothing here can.

## Why this is safe now

Both images were pinned to 2.x because 3.x rejects `--tlog-upload=false` at runtime. That blocker is real but it is a **signing** blocker, and this image never signs — `cmd/sandbox-materialize` calls `oci.Verify` alone.

What actually kept the pin was a second claim written into the Containerfile: that both images must ship the same cosign for a signature made by one to verify with the other. `hack/cosign-interop.sh` (#517) was built to test exactly that, and it is false.

Neither verify flag we pass (`--key`, `--insecure-ignore-tlog`) is deprecated in 3.x.

## Validation

Run against the **built image**, using the real `sandbox-materialize` binary with `-verify-key`, against a real TLS registry holding an `alpine:3.20` image **signed by cosign v2.6.5** — i.e. the exact upgrade case: an existing signature, read by the new verifier.

| case | expected | result |
|---|---|---|
| new image (3.1.3) verifies the v2.6.5 signature | succeed | **exit 0** — `The signatures were verified against the specified public key`, then `cosign-verified <repo>@<digest>` |
| new image, **wrong** public key | fail | **exit 1** — `no matching signatures: invalid signature` |
| old image (2.6.5), same signature | succeed | exit 0 |

The negative control is the one that matters: it proves 3.x's acceptance is real verification, not a permissive path that would wave anything through.

**Not yet exercised on a cluster.** CI builds PR images with `push: false`, so no branch image is published, and `release-dev` only publishes from `main`. The pod context does not change signature verification — same image, same binary, same flags — but that leg is outstanding and called out rather than glossed.

## Deliberate asymmetry

`snapshot-oras` stays on 2.x because it signs. The two images now ship different cosign majors on purpose, and both Containerfiles say why and point at the harness as the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
