### PR TITLE
fix(swiftletd): gate every SwiftGuest-CR write, not just the boot report (#519)

### DIFF
--- a/rust/swiftletd/src/action.rs
+++ b/rust/swiftletd/src/action.rs
@@ -1635,6 +1635,17 @@ async fn propagate_guest_ip_annotation(ip: &str) {
 /// affect the migration outcome — the controller's spec.timeout is
 /// the floor for stall detection.
 async fn report_guest_running_post_receive() {
+    // Same gate as the terminal/socket-ready reports in main.rs: when there is no
+    // SwiftGuest CR, do not patch one. This path cannot produce the sandbox 403 of
+    // #519 — it only runs on migration-receive, which sandboxes never take, and the
+    // guest-label lookup below would bail first — but every SwiftGuest-CR write
+    // should honour the same switch rather than each one guarding differently.
+    if !crate::report::report_guest_cr_enabled(
+        std::env::var("KUBESWIFT_REPORT_GUEST_CR").ok().as_deref(),
+    ) {
+        log::info!("w16_guest_running_skipped reason=guest_cr_reporting_disabled");
+        return;
+    }
     let (namespace, pod_name) = match (
         std::env::var("POD_NAMESPACE").ok(),
         std::env::var("POD_NAME").ok(),

--- a/rust/swiftletd/src/main.rs
+++ b/rust/swiftletd/src/main.rs
@@ -223,8 +223,22 @@ fn main() {
                 );
             }
 
+            // Gate the SwiftGuest CR status patch (default on). A SwiftSandbox launcher
+            // sets KUBESWIFT_REPORT_GUEST_CR=false — there is NO SwiftGuest CR for a
+            // sandbox, so patching one is guaranteed to 403. Computed here, above
+            // report_running, because BOTH the terminal reports below and the
+            // on_socket_ready report further down need it; when only the latter was
+            // gated, every sandbox ended its log with an ERROR-level 403 that read like
+            // an RBAC bug and invited widening the launcher SA's grants (#519).
+            let report_cr = report::report_guest_cr_enabled(
+                env::var("KUBESWIFT_REPORT_GUEST_CR").ok().as_deref(),
+            );
+            if !report_cr {
+                log::info!("guest-CR reporting disabled: no SwiftGuest CR to patch");
+            }
+
             let report_running = |running: bool, reason: Option<&str>| {
-                if is_primary_udn {
+                if is_primary_udn || !report_cr {
                     return;
                 }
                 let (Some(ns), Some(n)) = (&namespace, &name) else {
@@ -310,12 +324,8 @@ fn main() {
             // operators verify destination success via the
             // migration-status: ready annotation OR via vm_info
             // directly.
-            // Gate the SwiftGuest CR status patch (default on). A SwiftSandbox
-            // launcher sets KUBESWIFT_REPORT_GUEST_CR=false — there is no SwiftGuest
-            // CR to patch; the pod-annotation report + lease poller still run.
-            let report_cr = report::report_guest_cr_enabled(
-                env::var("KUBESWIFT_REPORT_GUEST_CR").ok().as_deref(),
-            );
+            // report_cr is computed once above, next to report_running — the pod-annotation
+            // report + lease poller still run when it is false.
             let on_socket_ready = if intent.is_migration_receiver() || is_primary_udn {
                 None
             } else {


### PR DESCRIPTION
Closes #519.

Every SwiftSandbox ended its launcher log with an ERROR-level 403 patching `swiftguests/status` — a CR that does not exist for a sandbox. Cosmetic (sandbox status comes from pod annotations and was always correct), but it names an RBAC denial on every run, which invites exactly the wrong fix: granting the privileged launcher ServiceAccount `swiftguests/status`, i.e. the ground #443 just closed.

## Cause

`KUBESWIFT_REPORT_GUEST_CR` already exists for this and the sandbox launcher already sets it. It was applied to one of the **three** places that write the CR:

| site | wrote the CR | gated before |
|---|---|---|
| `main.rs` `on_socket_ready` — boot `GuestRunning=true` | yes | **yes** |
| `main.rs` `report_running` — `lifecycle=stop`, `VmStopped`, `VmFailed` | yes | **no** |
| `action.rs` `report_guest_running_post_receive` | yes | **no** |

The second is the one that fires at VM exit, which is why the 403 landed right after `vm_stopped_gracefully`.

`report_cr` now lives once, above `report_running`, and both `main.rs` paths read it; the duplicate computation further down is removed.

## The third path

I found `action.rs` while checking whether I'd actually covered everything — it was not in the original issue. It **could not** have produced this 403: it runs only on migration-receive, which sandboxes never take, and its guest-label lookup would bail first. It is gated anyway, because a switch meaning "there is no SwiftGuest CR" should hold for every write to that CR. Each call site guarding on something different is what produced the bug in the first place.

## Not changed

No RBAC. The launcher ServiceAccount keeps having no `swiftguests/status` grant.

## Checks

`cargo build` clean, `cargo test` 120 passed, `cargo fmt --check` clean, clippy warnings pre-existing and in other crates.

Cluster validation folds into the next sandbox run: the pass condition is zero `report_failed` lines in a sandbox launcher log (currently exactly 1 on every sandbox, reproduced on v0.13.5 and sha-42a2f7c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)