### PR TITLE
build: go 1.26.5 -> 1.26.6 for 7 stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeswift-io/kubeswift
 
-go 1.26.5
+go 1.26.6
 
 require (
 	connectrpc.com/connect v1.20.0


### PR DESCRIPTION
Unblocks CI on `main` (and #520).

## Not a regression

`govulncheck` went red without any code changing. Commit `cedb83b` **passed** this job at 21:24 and **failed** it at 05:45 the next morning — same commit, different result. A vulnerability database update landed in between.

| run | commit | result |
|---|---|---|
| 2026-08-13 21:24 | `cedb83b` | success |
| 2026-08-14 05:45 | `cedb83b` | **failure** |
| 2026-08-14 06:38 | `42a2f7c` | **failure** |

## What it found

Seven advisories, all Go standard library, all reachable from our code, all fixed in **go1.26.6**: `net/url`, `html/template`, `crypto/tls`, `net/http`, `encoding/xml`, `encoding/asn1` — GO-2026-5026, -5972, -6088, -6089, -6090, -6091, -6218.

Reported call paths include `gateway.Start` → `ListenAndServe`, `gateway.httpClientWithCA` → `AppendCertsFromPEM` → `asn1.Unmarshal`, and `SwiftImageReconciler.Validate` → `rest.Request.Stream` → `url.URL.Parse`.

## Why one line is the whole fix

`go.mod` is the single source of truth: every workflow resolves the toolchain via `go-version-file`, and the image builders float on `golang:1.26-bookworm` so they already pick up 1.26.6.

## Verified

`govulncheck ./cmd/... ./internal/... ./api/...` → **0 vulnerabilities**, exit 0. Build and tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)