### PR TITLE
fix(security): move snapshot-oras to cosign 3.1.3, offline via signing-config (#486)

### DIFF
--- a/hack/cosign-interop.sh
+++ b/hack/cosign-interop.sh
@@ -10,28 +10,34 @@
 # Everything is torn down on exit. Nothing here touches a real registry, a real
 # cluster, or the operator's cosign install.
 #
+# The artifact it signs is a synthetic throwaway built fresh each run, and that
+# is deliberate rather than incidental: if the offline dialect is ever broken,
+# cosign uploads the signed digest to the PUBLIC Rekor — which is exactly the
+# failure this harness detects, and the reason it must never be pointed at a
+# real private artifact. Do not add a flag to sign an existing image with it.
+#
 # Usage:
 #   hack/cosign-interop.sh                            # baseline — must be green
 #   COSIGN_VERSIONS="v2.6.5 v3.1.3" hack/cosign-interop.sh   # evaluate a candidate
 #
 # Exit status is the test's: non-zero means a signature did not verify.
 #
-# KNOWN RESULT, recorded so nobody re-derives it: adding v3.1.3 fails, and it
-# fails at SIGN, not at verify. cosign 3.x rejects `--tlog-upload=false` at
-# runtime ("not supported with --signing-config"), so it cannot produce an
-# offline signature under our contract at all. Migrating to 3.x therefore means
-# adopting a signing-config file first — a contract change, not a version bump.
-# That is why the default matrix is the baseline alone: a script that is red out
-# of the box is a script nobody trusts.
+# Both majors are in the default matrix and both must pass. That was not always
+# true: cosign 3.x rejects `--tlog-upload=false`, so it could not sign under our
+# contract at all until SignArgs learned to pass a no-transparency-log
+# `--signing-config` instead. The trap it avoids is worth stating, because the
+# obvious shortcut is worse than the blocker — simply DROPPING the flag on 3.x
+# signs happily and uploads the artifact digest to the PUBLIC Rekor. The harness
+# checks for that directly (assertNoTransparencyLogEntry), so the shortcut fails
+# a test instead of silently disclosing private artifact digests.
 
 set -euo pipefail
 
-# The versions to cross-check. v2.6.5 is what we vendor and what every existing
-# signature in users' registries was made with, so it is always in the set: it
-# is the baseline every other implementation is judged against, and it generates
-# the keypair.
+# The versions to cross-check. v2.6.5 is what every existing signature in users'
+# registries was made with, so it is always in the set: it is the baseline every
+# other implementation is judged against, and it generates the keypair.
 BASELINE="v2.6.5"
-COSIGN_VERSIONS="${COSIGN_VERSIONS:-$BASELINE}"
+COSIGN_VERSIONS="${COSIGN_VERSIONS:-$BASELINE v3.1.3}"
 case " $COSIGN_VERSIONS " in
   *" $BASELINE "*) ;;
   *) COSIGN_VERSIONS="$BASELINE $COSIGN_VERSIONS" ;;
@@ -117,25 +123,38 @@ push_blob() {
   printf '%s' "$dgst"
 }
 
-REPO="interop/subject"
 CFG_DATA='{}'
 LAYER_DATA='kubeswift signature interop harness'
-CFG_DGST=$(push_blob "$REPO" "$CFG_DATA")
-LAYER_DGST=$(push_blob "$REPO" "$LAYER_DATA")
 
-MANIFEST=$(jq -nc \
-  --arg cd "$CFG_DGST" --argjson cs "${#CFG_DATA}" \
-  --arg ld "$LAYER_DGST" --argjson ls "${#LAYER_DATA}" '{
-    schemaVersion: 2,
-    mediaType: "application/vnd.oci.image.manifest.v1+json",
-    config: {mediaType: "application/vnd.oci.image.config.v1+json", digest: $cd, size: $cs},
-    layers: [{mediaType: "application/vnd.oci.image.layer.v1.tar", digest: $ld, size: $ls}]
-  }')
-DIGEST="sha256:$(printf '%s' "$MANIFEST" | sha256sum | awk '{print $1}')"
-printf '%s' "$MANIFEST" | "${CURL[@]}" -X PUT \
-  -H 'Content-Type: application/vnd.oci.image.manifest.v1+json' \
-  --data-binary @- -o /dev/null "https://$REG/v2/$REPO/manifests/v1"
-log "$REG/$REPO@$DIGEST"
+# The subject must exist in EVERY repository a signer will sign into, not just
+# one. Each signer gets its own repo so their signatures cannot be confused, and
+# cosign 3.x HEADs the subject manifest before signing — it refuses to sign a
+# digest the repository does not hold. cosign 2.x does not check, so an earlier
+# version of this script signed into empty repos and only looked correct.
+push_subject() {
+  local repo="$1" cfg layer manifest
+  cfg=$(push_blob "$repo" "$CFG_DATA")
+  layer=$(push_blob "$repo" "$LAYER_DATA")
+  manifest=$(jq -nc \
+    --arg cd "$cfg" --argjson cs "${#CFG_DATA}" \
+    --arg ld "$layer" --argjson ls "${#LAYER_DATA}" '{
+      schemaVersion: 2,
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      config: {mediaType: "application/vnd.oci.image.config.v1+json", digest: $cd, size: $cs},
+      layers: [{mediaType: "application/vnd.oci.image.layer.v1.tar", digest: $ld, size: $ls}]
+    }')
+  printf '%s' "$manifest" | "${CURL[@]}" -X PUT \
+    -H 'Content-Type: application/vnd.oci.image.manifest.v1+json' \
+    --data-binary @- -o /dev/null "https://$REG/v2/$repo/manifests/v1"
+  printf 'sha256:%s' "$(printf '%s' "$manifest" | sha256sum | awk '{print $1}')"
+}
+
+DIGEST=$(push_subject "interop/subject")
+# Mirror it into each signer's repo. Must match the naming in interop_test.go.
+for v in $COSIGN_VERSIONS; do
+  push_subject "interop-$(printf '%s' "$v" | tr '[:upper:]' '[:lower:]')/test" >/dev/null
+done
+log "$REG/interop/subject@$DIGEST (mirrored into each signer's repo)"
 
 step "signing key"
 # Generated by the baseline on purpose: the key format is part of what is under

--- a/images/snapshot-oras/Containerfile
+++ b/images/snapshot-oras/Containerfile
@@ -24,18 +24,26 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # Fetch a pinned cosign for provenance signing (P2). Verified against the
 # release checksums file so a tampered/corrupt binary fails the build.
 #
-# Stay on the 2.x line. cosign 3.x REJECTS `--tlog-upload=false` ("not supported
-# with --signing-config"), which internal/oci.SignArgs relies on to sign offline
-# with no Rekor entry. The flag still appears in `cosign 3 sign --help`, so this
-# only shows up at runtime. Moving to 3.x means reworking SignArgs onto a
-# signing-config file first.
+# 3.x, matching sandbox-materialize. This image SIGNS, which is why it stayed on
+# 2.x longer than the verifier did (#486):
 #
-# NOTE this image and sandbox-materialize now ship DIFFERENT cosign majors, and
-# that is intentional: sandbox-materialize only verifies, and 3.x verifies 2.x
-# signatures fine, so it took the 3.x CVE reduction. This image signs, so it
-# cannot. `hack/cosign-interop.sh` (#486) is what proves the two still
-# interoperate — run it before changing either pin.
-ARG COSIGN_VERSION=v2.6.5
+# cosign 3.x rejects `--tlog-upload=false`, the flag internal/oci.SignArgs used
+# to sign offline. The trap is that simply dropping the flag "works" — cosign
+# exits 0 — while uploading the artifact digest to the PUBLIC Rekor. Measured:
+# a signature made that way carries tlogEntries=1 with a real public logIndex.
+# For a private snapshot or an air-gapped golden image that is a disclosure, not
+# a convenience.
+#
+# SignArgs therefore passes `--signing-config` with a config declaring no
+# transparency-log service (embedded at internal/oci/signing-config.json,
+# verified to produce tlogEntries=0). It picks the dialect from the cosign major
+# it finds at run time, so `swiftctl image publish` still works against an
+# operator's own 2.x install, and REFUSES to sign on 3.x if it cannot supply the
+# config rather than quietly logging the digest.
+#
+# Signatures made either way verify with both majors — that is what
+# hack/cosign-interop.sh exists to prove, and it is the gate on changing this.
+ARG COSIGN_VERSION=v3.1.3
 RUN cd /tmp \
     && curl -sSfL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" -o cosign-linux-amd64 \
     && curl -sSfL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt" -o cosign_checksums.txt \

--- a/internal/oci/interop_test.go
+++ b/internal/oci/interop_test.go
@@ -14,12 +14,18 @@
 // signature produced by implementation A verify with implementation B? This
 // runs that matrix against a real registry.
 //
+// It also answers a second question the exit code cannot: was the signature
+// made OFFLINE? See assertNoTransparencyLogEntry — on cosign 3.x a signature
+// can succeed while publishing the artifact digest to the public Rekor, which
+// for a private snapshot is a disclosure. Every signer is checked for that.
+//
 // WHY IT LIVES HERE, not in hack/ as a shell script: it must exercise the argv
 // that `SignArgs`/`VerifyArgs` actually produce. A hand-written `cosign sign`
 // in a shell script would test cosign, not us — and the flags are the whole
-// point (`--tlog-upload=false` on sign, `--insecure-ignore-tlog` on verify).
-// Being in-package also lets it swap implementations by overriding the
-// `CosignRun` var, rather than manipulating PATH.
+// point (the no-transparency-log dialect on sign, which differs per major, and
+// `--insecure-ignore-tlog` on verify). Being in-package also lets it swap
+// implementations by overriding the `CosignRun`/`CosignVersionOutput` vars,
+// rather than manipulating PATH.
 //
 // NOT RUN BY DEFAULT. Build-tagged `interop`: it needs a live registry, a
 // keypair, and cosign binaries on disk. Drive it with hack/cosign-interop.sh,
@@ -28,7 +34,10 @@ package oci
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -58,6 +67,15 @@ func runWith(bin string) func(context.Context, []string) error {
 	}
 }
 
+// versionOf returns a CosignVersionOutput bound to a specific binary, so Sign
+// picks the offline dialect that binary actually accepts.
+func versionOf(bin string) func(context.Context) (string, error) {
+	return func(ctx context.Context) (string, error) {
+		out, err := exec.CommandContext(ctx, bin, "version").CombinedOutput()
+		return string(out), err
+	}
+}
+
 func envOrSkip(t *testing.T, key string) string {
 	t.Helper()
 	v := os.Getenv(key)
@@ -65,6 +83,82 @@ func envOrSkip(t *testing.T, key string) string {
 		t.Skipf("%s not set — run via hack/cosign-interop.sh", key)
 	}
 	return v
+}
+
+// assertNoTransparencyLogEntry is the leak guard, and it is the reason this
+// harness earns its keep beyond interop.
+//
+// "Signed offline" is not observable from cosign's exit code: on 3.x, an argv
+// missing the offline dialect signs successfully AND publishes the artifact
+// digest to the public Rekor. The only way to tell the two apart is to read the
+// signature back off the registry and look for transparency-log entries. For a
+// private VM snapshot or an air-gapped golden image, that upload is a
+// disclosure — so a signature carrying one fails the test.
+//
+// Only 3.x's Sigstore-bundle form can carry them; 2.x's legacy `.sig` tag has
+// nowhere to put one, so its absence there is structural rather than checked.
+func assertNoTransparencyLogEntry(t *testing.T, registry, repo, digest, impl string) {
+	t.Helper()
+	repoPath := strings.TrimPrefix(repo, registry+"/")
+	tag := "sha256-" + strings.TrimPrefix(digest, "sha256:")
+
+	get := func(ref, accept string) []byte {
+		req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/v2/%s/%s", registry, repoPath, ref), nil)
+		if err != nil {
+			return nil
+		}
+		req.Header.Set("Accept", accept)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return nil
+		}
+		b, _ := io.ReadAll(resp.Body)
+		return b
+	}
+
+	idx := get("manifests/"+tag, "application/vnd.oci.image.index.v1+json")
+	if idx == nil {
+		t.Logf("  %s: no bundle-form signature at %s (legacy .sig form cannot carry a tlog entry)", impl, tag)
+		return
+	}
+	var index struct {
+		Manifests []struct {
+			Digest string `json:"digest"`
+		} `json:"manifests"`
+	}
+	if err := json.Unmarshal(idx, &index); err != nil || len(index.Manifests) == 0 {
+		return
+	}
+	man := get("manifests/"+index.Manifests[0].Digest, "application/vnd.oci.image.manifest.v1+json")
+	var manifest struct {
+		Layers []struct {
+			Digest string `json:"digest"`
+		} `json:"layers"`
+	}
+	if err := json.Unmarshal(man, &manifest); err != nil || len(manifest.Layers) == 0 {
+		return
+	}
+	var bundle struct {
+		VerificationMaterial struct {
+			TlogEntries []struct {
+				LogIndex string `json:"logIndex"`
+			} `json:"tlogEntries"`
+		} `json:"verificationMaterial"`
+	}
+	if err := json.Unmarshal(get("blobs/"+manifest.Layers[0].Digest, "*/*"), &bundle); err != nil {
+		return
+	}
+	if n := len(bundle.VerificationMaterial.TlogEntries); n > 0 {
+		t.Errorf("LEAK: %s published this artifact to a transparency log — %d entr(y|ies), first logIndex=%s. "+
+			"Offline signing must produce none; a public Rekor entry discloses the digest of a private artifact.",
+			impl, n, bundle.VerificationMaterial.TlogEntries[0].LogIndex)
+		return
+	}
+	t.Logf("  %s: signed offline (tlogEntries=0)", impl)
 }
 
 // TestSignatureInterop signs one artifact with every implementation and then
@@ -98,8 +192,8 @@ func TestSignatureInterop(t *testing.T) {
 		t.Fatal("no implementations to test")
 	}
 
-	orig := CosignRun
-	t.Cleanup(func() { CosignRun = orig })
+	origRun, origVer := CosignRun, CosignVersionOutput
+	t.Cleanup(func() { CosignRun, CosignVersionOutput = origRun, origVer })
 
 	// Each signer gets its own repository so signatures cannot be confused with
 	// one another — cosign stores them at a digest-derived tag, so two signers
@@ -110,11 +204,13 @@ func TestSignatureInterop(t *testing.T) {
 		repo := fmt.Sprintf("%s/interop-%s/test", registry, strings.ToLower(s.name))
 		t.Run("sign/"+s.name, func(t *testing.T) {
 			CosignRun = runWith(s.path)
+			CosignVersionOutput = versionOf(s.path)
 			if err := Sign(context.Background(), repo, digest, keyPath, false); err != nil {
 				t.Errorf("%s could not sign: %v", s.name, err)
 				return
 			}
 			signed[s.name] = repo
+			assertNoTransparencyLogEntry(t, registry, repo, digest, s.name)
 		})
 	}
 

--- a/internal/oci/sign.go
+++ b/internal/oci/sign.go
@@ -2,9 +2,12 @@ package oci
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
+	"strconv"
 )
 
 // CosignRun executes the cosign CLI. A package var so tests can capture the args
@@ -19,21 +22,67 @@ var CosignRun = func(ctx context.Context, args []string) error {
 	return cmd.Run()
 }
 
-// SignArgs builds the argv for signing the artifact digest offline (no Rekor).
-// Uses cosign's DEFAULT tag-based attachment (a `sha256-<digest>.sig` tag), NOT
-// `--registry-referrers-mode=oci-1-1`: cluster validation showed `cosign verify`
-// has no referrer-discovery flag and cannot verify an oci-1-1-referrer
-// signature, whereas the tag-based signature verifies with a plain
-// `cosign verify --key`. The tag form is also the most registry-portable
-// (GHCR/ECR/Harbor all support it). insecure adds --allow-http-registry for a
-// plaintext registry (the sig still lands; cosign VERIFY over plaintext is
-// unsupported).
-func SignArgs(repository, digest, keyPath string, insecure bool) []string {
+// CosignVersionOutput returns `cosign version` output. A package var for the
+// same reason as CosignRun.
+var CosignVersionOutput = func(ctx context.Context) (string, error) {
+	out, err := exec.CommandContext(ctx, "cosign", "version").CombinedOutput()
+	return string(out), err
+}
+
+// offlineSigningConfig is a Sigstore signing-config declaring NO transparency-log
+// and NO timestamp-authority services. cosign 3.x needs it to sign offline.
+//
+// Embedded rather than shipped as a file in the image, because both signers must
+// have it: the in-cluster snapshot-oras Job AND `swiftctl image publish` running
+// on an operator's own machine, where there is nothing to install.
+//
+//go:embed signing-config.json
+var offlineSigningConfig []byte
+
+var cosignVersionRE = regexp.MustCompile(`GitVersion:\s*v?(\d+)\.`)
+
+// cosignMajor extracts the major version from `cosign version` output.
+func cosignMajor(out string) (int, error) {
+	m := cosignVersionRE.FindStringSubmatch(out)
+	if m == nil {
+		return 0, fmt.Errorf("could not parse a version from cosign output")
+	}
+	return strconv.Atoi(m[1])
+}
+
+// SignArgs builds the argv for signing the artifact digest OFFLINE — no Rekor
+// entry, so the artifact digest is never published to a transparency log.
+//
+// The two cosign majors express "offline" differently, and getting this wrong is
+// not a build error but a silent information leak, so both forms are spelled out:
+//
+//   - 2.x takes `--tlog-upload=false`.
+//   - 3.x REJECTS that flag at runtime and wants a signing-config with no
+//     transparency-log service. signingConfigPath supplies one.
+//
+// Passing neither is what happens if you simply drop the flag on 3.x, and cosign
+// then uploads to the PUBLIC Rekor while still exiting 0 — measured, see #486.
+// Sign() therefore refuses to call this without one of the two.
+//
+// Uses cosign's DEFAULT tag-based attachment, NOT `--registry-referrers-mode=
+// oci-1-1`: cluster validation showed `cosign verify` has no referrer-discovery
+// flag and cannot verify an oci-1-1-referrer signature. The two majors write
+// different tags (2.x `sha256-<digest>.sig`, 3.x `sha256-<digest>` holding a
+// Sigstore bundle), but both verifiers read both forms — proven by
+// hack/cosign-interop.sh, which is the gate on changing any of this.
+//
+// insecure adds --allow-http-registry for a plaintext registry (the sig still
+// lands; cosign VERIFY over plaintext is unsupported).
+func SignArgs(repository, digest, keyPath string, insecure bool, signingConfigPath string) []string {
 	args := []string{
 		"sign",
 		"--key", keyPath,
-		"--tlog-upload=false",
 		"--yes",
+	}
+	if signingConfigPath != "" {
+		args = append(args, "--signing-config", signingConfigPath)
+	} else {
+		args = append(args, "--tlog-upload=false")
 	}
 	if insecure {
 		args = append(args, "--allow-http-registry")
@@ -41,17 +90,67 @@ func SignArgs(repository, digest, keyPath string, insecure bool) []string {
 	return append(args, repository+"@"+digest)
 }
 
-// Sign cosign-signs Repository@Digest. Strict: any error is returned so the
-// caller fails loudly (the Job / publish command fails) — never an unsigned
-// artifact left marked signed.
+// Sign cosign-signs Repository@Digest offline. Strict: any error is returned so
+// the caller fails loudly (the Job / publish command fails) — never an unsigned
+// artifact left marked signed, and never a signature that quietly went to a
+// public transparency log.
 func Sign(ctx context.Context, repository, digest, keyPath string, insecure bool) error {
 	if _, err := os.Stat(keyPath); err != nil {
 		return fmt.Errorf("signing key %q not readable: %w", keyPath, err)
 	}
-	if err := CosignRun(ctx, SignArgs(repository, digest, keyPath, insecure)); err != nil {
+
+	// Which cosign is on PATH decides how "offline" has to be spelled. This is
+	// resolved at run time rather than pinned at build time because the signer
+	// is not always ours: `swiftctl image publish` uses whatever the operator
+	// has installed.
+	verOut, err := CosignVersionOutput(ctx)
+	if err != nil {
+		return fmt.Errorf("cosign version: %w (is cosign installed?)", err)
+	}
+	major, err := cosignMajor(verOut)
+	if err != nil {
+		return fmt.Errorf("cosign version: %w; got: %q", err, verOut)
+	}
+
+	signingConfig := ""
+	if major >= 3 {
+		path, cleanup, err := writeOfflineSigningConfig()
+		if err != nil {
+			// Refuse rather than fall back to no flag. On 3.x that fallback
+			// signs successfully AND publishes the digest to the public Rekor.
+			return fmt.Errorf(
+				"cosign %d.x needs an offline signing-config and one could not be written (%w); "+
+					"refusing to sign, because signing without it would publish %s@%s to the public transparency log",
+				major, err, repository, digest)
+		}
+		defer cleanup()
+		signingConfig = path
+	}
+
+	if err := CosignRun(ctx, SignArgs(repository, digest, keyPath, insecure, signingConfig)); err != nil {
 		return fmt.Errorf("cosign sign %s@%s: %w", repository, digest, err)
 	}
 	return nil
+}
+
+// writeOfflineSigningConfig materializes the embedded signing-config to a temp
+// file, since cosign takes a path. The caller must invoke cleanup.
+func writeOfflineSigningConfig() (string, func(), error) {
+	f, err := os.CreateTemp("", "kubeswift-signing-config-*.json")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() { _ = os.Remove(f.Name()) }
+	if _, err := f.Write(offlineSigningConfig); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, err
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return f.Name(), cleanup, nil
 }
 
 // VerifyArgs builds the argv for verifying a public-key signature against

--- a/internal/oci/sign_test.go
+++ b/internal/oci/sign_test.go
@@ -16,7 +16,7 @@ func TestSignArgs(t *testing.T) {
 		key    = "/oras-signing-key/cosign.key"
 	)
 
-	secure := SignArgs(repo, digest, key, false)
+	secure := SignArgs(repo, digest, key, false, "")
 	joined := strings.Join(secure, " ")
 	for _, want := range []string{
 		"sign",
@@ -42,12 +42,148 @@ func TestSignArgs(t *testing.T) {
 		t.Errorf("digest ref must be the final arg; got %q", secure[len(secure)-1])
 	}
 
-	insecure := SignArgs(repo, digest, key, true)
+	insecure := SignArgs(repo, digest, key, true, "")
 	if !strings.Contains(strings.Join(insecure, " "), "--allow-http-registry") {
 		t.Errorf("insecure args must carry --allow-http-registry; got: %v", insecure)
 	}
 	if insecure[len(insecure)-1] != repo+"@"+digest {
 		t.Errorf("digest ref must remain the final arg even with --allow-http-registry; got %q", insecure[len(insecure)-1])
+	}
+}
+
+// TestSignArgs_OfflineIsAlwaysExpressed is the leak guard. Every argv this
+// builds must say "do not use a transparency log" in the dialect of whichever
+// cosign will run it. An argv carrying NEITHER form still signs successfully on
+// 3.x — and publishes the artifact digest to the public Rekor (#486). That is
+// the failure this test exists to make impossible.
+func TestSignArgs_OfflineIsAlwaysExpressed(t *testing.T) {
+	const repo, digest, key = "ghcr.io/org/x", "sha256:abc", "/k/cosign.key"
+
+	for _, tc := range []struct {
+		name          string
+		signingConfig string
+		want, notWant string
+	}{
+		{"cosign 2.x: the flag", "", "--tlog-upload=false", "--signing-config"},
+		{"cosign 3.x: a no-tlog signing-config", "/tmp/sc.json", "--signing-config /tmp/sc.json", "--tlog-upload"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.Join(SignArgs(repo, digest, key, false, tc.signingConfig), " ")
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("missing %q; got: %s", tc.want, got)
+			}
+			if strings.Contains(got, tc.notWant) {
+				t.Errorf("must not mix dialects — found %q; got: %s", tc.notWant, got)
+			}
+		})
+	}
+}
+
+func TestCosignMajor(t *testing.T) {
+	for _, tc := range []struct {
+		out     string
+		want    int
+		wantErr bool
+	}{
+		{"GitVersion:    v2.6.5\n", 2, false},
+		{"GitVersion:    v3.1.3\n", 3, false},
+		{"GitVersion:    3.1.3\n", 3, false},
+		{"some banner with no version", 0, true},
+	} {
+		got, err := cosignMajor(tc.out)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("cosignMajor(%q) should have failed", tc.out)
+			}
+			continue
+		}
+		if err != nil || got != tc.want {
+			t.Errorf("cosignMajor(%q) = %d, %v; want %d", tc.out, got, err, tc.want)
+		}
+	}
+}
+
+// On cosign 3.x, Sign must pass a signing-config. If it ever calls cosign
+// without one, the signature silently lands in the public transparency log.
+func TestSign_Cosign3PassesSigningConfig(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "cosign.key")
+	if err := os.WriteFile(keyPath, []byte("k"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	origRun, origVer := CosignRun, CosignVersionOutput
+	defer func() { CosignRun, CosignVersionOutput = origRun, origVer }()
+	CosignVersionOutput = func(context.Context) (string, error) { return "GitVersion:    v3.1.3\n", nil }
+
+	var got []string
+	CosignRun = func(_ context.Context, args []string) error { got = args; return nil }
+
+	if err := Sign(context.Background(), "ghcr.io/org/x", "sha256:abc", keyPath, false); err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, "--signing-config") {
+		t.Errorf("cosign 3.x must be given --signing-config, else the digest goes to the public Rekor; got: %s", joined)
+	}
+	if strings.Contains(joined, "--tlog-upload") {
+		t.Errorf("cosign 3.x rejects --tlog-upload at runtime; got: %s", joined)
+	}
+
+	// And the file handed over must actually declare no transparency log.
+	idx := -1
+	for i, a := range got {
+		if a == "--signing-config" {
+			idx = i + 1
+		}
+	}
+	if idx < 0 || idx >= len(got) {
+		t.Fatal("--signing-config had no path argument")
+	}
+	// Sign removes the temp file on return, so assert on the embedded source.
+	if !strings.Contains(string(offlineSigningConfig), `"rekorTlogConfig": {}`) {
+		t.Errorf("embedded signing-config must declare NO tlog services; got: %s", offlineSigningConfig)
+	}
+}
+
+func TestSign_Cosign2UsesFlag(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "cosign.key")
+	if err := os.WriteFile(keyPath, []byte("k"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	origRun, origVer := CosignRun, CosignVersionOutput
+	defer func() { CosignRun, CosignVersionOutput = origRun, origVer }()
+	CosignVersionOutput = func(context.Context) (string, error) { return "GitVersion:    v2.6.5\n", nil }
+
+	var got []string
+	CosignRun = func(_ context.Context, args []string) error { got = args; return nil }
+	if err := Sign(context.Background(), "ghcr.io/org/x", "sha256:abc", keyPath, false); err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if !strings.Contains(strings.Join(got, " "), "--tlog-upload=false") {
+		t.Errorf("cosign 2.x must keep --tlog-upload=false; got: %v", got)
+	}
+}
+
+// An unreadable/unparseable cosign must fail the sign, not proceed blind.
+func TestSign_UnknownCosignVersionFails(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "cosign.key")
+	if err := os.WriteFile(keyPath, []byte("k"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	origRun, origVer := CosignRun, CosignVersionOutput
+	defer func() { CosignRun, CosignVersionOutput = origRun, origVer }()
+	CosignVersionOutput = func(context.Context) (string, error) { return "no version here", nil }
+
+	called := false
+	CosignRun = func(context.Context, []string) error { called = true; return nil }
+	if err := Sign(context.Background(), "ghcr.io/org/x", "sha256:abc", keyPath, false); err == nil {
+		t.Error("Sign must fail when the cosign version cannot be determined")
+	}
+	if called {
+		t.Error("cosign must not be invoked when its version is unknown")
 	}
 }
 
@@ -76,9 +212,12 @@ func TestSign_InvokesCosignWithDigest(t *testing.T) {
 	}
 
 	var gotArgs []string
-	orig := CosignRun
+	orig, origVer := CosignRun, CosignVersionOutput
 	CosignRun = func(_ context.Context, args []string) error { gotArgs = args; return nil }
-	defer func() { CosignRun = orig }()
+	// Stub the version probe too: Sign now asks cosign which major it is, and a
+	// unit test must not depend on a cosign existing on the machine running it.
+	CosignVersionOutput = func(context.Context) (string, error) { return "GitVersion:    v2.6.5\n", nil }
+	defer func() { CosignRun, CosignVersionOutput = orig, origVer }()
 
 	if err := Sign(context.Background(), "ghcr.io/org/s", "sha256:deadbeef", key, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/oci/signing-config.json
+++ b/internal/oci/signing-config.json
@@ -1,0 +1,5 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+  "rekorTlogConfig": {},
+  "tsaConfig": {}
+}


### PR DESCRIPTION
Completes the cosign migration. #518 moved the verifier; this is the signer, which was harder for a reason worth stating, because **the obvious shortcut is worse than the blocker it removes.**

Stacked on #521 (go 1.26.6) only because CI is red without it.

## Measured on the built image

| snapshot-oras | fixable | critical | high |
|---|---|---|---|
| cosign v2.6.5 (before) | 48 | 1 | 24 |
| cosign v3.1.3 (after) | **4** | **0** | **3** |

Same Containerfile, only `COSIGN_VERSION` differs. The remaining 4 are inside cosign's own build.

## The trap

cosign 3.x rejects `--tlog-upload=false`, the flag `SignArgs` used to sign offline. The tempting fix is to drop it — cosign then signs happily and exits 0.

It also uploads the artifact digest to the **public Rekor**. Measured, not assumed: a signature made that way carries `tlogEntries=1` with a real public `logIndex`. For a private VM snapshot or an air-gapped golden image that is a disclosure, and nothing in the exit code or the logs says so.

The real offline form on 3.x is a signing-config declaring no transparency-log service. It's **embedded** (`internal/oci/signing-config.json`) rather than shipped in the image, because both signers need it: the in-cluster `snapshot-oras` Job *and* `swiftctl image publish` on an operator's own machine, where there is nothing to install.

## Run-time dialect selection

`Sign()` picks the dialect from the cosign major it finds **at run time**, not build time — the signer isn't always ours, since `swiftctl` uses whatever the operator has. 2.x keeps the flag; 3.x gets the config.

On 3.x it **refuses to sign** if it cannot supply the config, rather than falling back to the silent-upload form. It also refuses when the cosign version can't be determined at all.

## Guards, because "signed offline" is invisible in an exit code

- **Unit** — every `SignArgs` output must express exactly one dialect and not mix them; `Sign` against a stubbed 3.x must pass `--signing-config`; an unparseable cosign version must fail *without* invoking cosign. All hermetic (verified by shadowing `cosign` with a failing stub).
- **Interop** — `assertNoTransparencyLogEntry` reads the signature back off the registry and fails on any tlog entry.

**Verified by regression-injection.** I re-applied the exact "just drop the flag" change and the harness caught it:

```
LEAK: v3.1.3 published this artifact to a transparency log — 1 entr(y|ies),
first logIndex=2465965347. Offline signing must produce none; a public Rekor
entry discloses the digest of a private artifact.
```

## Two harness bugs this surfaced

- It now **mirrors the subject into every signer's repository**. cosign 3.x HEADs the subject before signing and refuses a digest the repo doesn't hold; 2.x never checked — so the previous script was signing into empty repos and only *looked* correct.
- **Both majors are now in the default matrix**, all four cells green, both signers confirmed offline.

```
v2.6.5 signed -> v2.6.5 verifies : ok      v3.1.3 signed -> v2.6.5 verifies : ok
v2.6.5 signed -> v3.1.3 verifies : ok      v3.1.3 signed -> v3.1.3 verifies : ok
negative controls: both correctly reject a foreign key
```

Existing v2.6.5 signatures keep verifying — the original gate on all of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
