### PR TITLE
release: v0.13.9

### DIFF
--- a/.github/workflows/verify-release.yaml
+++ b/.github/workflows/verify-release.yaml
@@ -36,7 +36,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to verify (e.g. v0.13.8)'
+        description: 'Release tag to verify (e.g. v0.13.9)'
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,67 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.13.9] — 2026-08-14
+
+A supply-chain release. Both cosign-bearing images drop from **48 fixable CVEs
+(1 critical, 24 high) to 4 (0 critical, 3 high)**, the Go toolchain picks up 7
+standard-library fixes, and a signing behaviour that could have leaked private
+artifact digests is now caught by a test rather than shipped quietly.
+
+No CRD schema changes, no API changes, no values changes.
+
+### Upgrade
+
+```bash
+helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.9 \
+  -n kubeswift-system -f <(helm get values kubeswift -n kubeswift-system -o yaml)
+kubectl apply -f charts/kubeswift/crds/    # helm does not upgrade CRDs
+```
+
+### Security
+
+- **cosign 2.6.5 → 3.1.3 in `sandbox-materialize` and `snapshot-oras`** (#486).
+  48 fixable CVEs → 4 on each image, measured on the built images; the critical
+  is gone. The four that remain are inside cosign's own build.
+
+  Both images were pinned to 2.x because 3.x rejects `--tlog-upload=false`, the
+  flag used to sign offline. **Dropping that flag is not the fix**: cosign 3.x
+  then signs successfully, exits 0, and uploads the artifact digest to the
+  **public Rekor**. For a private VM snapshot or an air-gapped golden image that
+  is a disclosure. The signer now passes a signing-config declaring no
+  transparency-log service, selects the dialect from the cosign major found at
+  run time (so `swiftctl image publish` still works against an operator's own
+  2.x install), and **refuses to sign** rather than falling back to the
+  silent-upload form.
+
+  Existing v2.6.5 signatures keep verifying. `hack/cosign-interop.sh` proves it
+  across both majors in both directions, with negative controls, and fails on
+  any transparency-log entry.
+
+- **go 1.26.5 → 1.26.6** — 7 standard-library advisories reachable from our code
+  (`net/url`, `html/template`, `crypto/tls`, `net/http`, `encoding/xml`,
+  `encoding/asn1`). Not a regression from any change here: the same commit
+  passed `govulncheck` and then failed it hours later on a database update.
+
+### Fixed
+
+- **swiftletd no longer logs a 403 at every sandbox exit** (#519). It was trying
+  to patch a `SwiftGuest` CR that does not exist for a sandbox. Cosmetic —
+  sandbox status was always reported correctly — but it named an RBAC denial on
+  every run, which invites granting the privileged launcher ServiceAccount
+  `swiftguests/status`. The existing `KUBESWIFT_REPORT_GUEST_CR` switch was
+  applied to one of the three places that write the CR; it now covers all three.
+  No RBAC change.
+
+### Documentation
+
+- The manual golden-image verify command was **wrong** and would have looked like
+  an invalid signature: it omitted `--insecure-ignore-tlog=true`, which offline
+  signatures require. Corrected, with an explanation of why the flag is not a
+  weakening here.
+
+---
+
 ## [v0.13.8] — 2026-08-13
 
 Closes a privilege escalation. Anyone who could create an ordinary Pod in a

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.8 \
+  --version 0.13.9 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.8
-appVersion: "0.13.8"
+version: 0.13.9
+appVersion: "0.13.9"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.8 \
+  --set controllerManager.image.tag=v0.13.9 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.8
+  --set swiftletd.image.tag=v0.13.9
 ```
 
 ### Release workflow

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.8 -n kubeswift-system --create-namespace \
+  --version 0.13.9 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.8 \
+  --version 0.13.9 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.8 \
+  --version 0.13.9 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.8 \
+  --version 0.13.9 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.8 \
+  --set controllerManager.image.tag=v0.13.9 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.8
+  --set swiftletd.image.tag=v0.13.9
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.8 \
+  --version 0.13.9 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.8 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.8 \
-    --set swiftletd.image.tag=v0.13.8
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.9 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.9 \
+    --set swiftletd.image.tag=v0.13.9
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.8 \
+  --version 0.13.9 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/registry/golden-images.md
+++ b/docs/registry/golden-images.md
@@ -121,18 +121,29 @@ swiftctl image publish golden.raw \
   --to ghcr.io/acme/vm-images --tag base --sign-key cosign.key
 ```
 
-This attaches a cosign signature (default tag-based `sha256-<digest>.sig`) to the
-pushed manifest. Verify it manually today:
+This attaches a cosign signature to the pushed manifest. Verify it manually:
 
 ```bash
-cosign verify --key cosign.pub ghcr.io/acme/vm-images@sha256:1a2b...
+cosign verify --key cosign.pub --insecure-ignore-tlog=true \
+  ghcr.io/acme/vm-images@sha256:1a2b...
 ```
+
+> **`--insecure-ignore-tlog=true` is required, and is not a weakening here.**
+> KubeSwift signs **offline** — no entry is written to a transparency log,
+> deliberately, so publishing a private VM image does not disclose its digest to
+> a public log. `cosign verify` demands a log entry by default and exits non-zero
+> without this flag, which looks like an invalid signature but is not one. The
+> key check — that the signature was made by the key you pass — is unaffected.
 
 > **TLS is required for verification.** `cosign verify` speaks HTTPS only — it
 > does **not** honor `--insecure`/`--allow-http-registry` on the registry ping.
 > A signature *pushed* over a plaintext (`--insecure`) registry lands, but cannot
 > be verified until the registry is fronted with TLS. Use a TLS registry on the
 > production path.
+
+> **Signature format.** cosign 2.x writes a `sha256-<digest>.sig` tag; 3.x writes
+> a `sha256-<digest>` index holding a Sigstore bundle. Both cosign majors read
+> both forms, so which one you have does not affect the command above.
 
 ### Verify-on-pull
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.8 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.9 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows


### PR DESCRIPTION
Supply-chain release. Chart + appVersion 0.13.8 → 0.13.9.

## What's in it

| PR | |
|---|---|
| #517 | cosign signature-interop harness |
| #518 | `sandbox-materialize` → cosign 3.1.3 |
| #521 | go 1.26.5 → 1.26.6 (7 reachable stdlib advisories) |
| #520 | gate every SwiftGuest-CR write (#519) |
| #522 | `snapshot-oras` → cosign 3.1.3, offline via signing-config |

**Both cosign-bearing images: 48 fixable CVEs (1 critical, 24 high) → 4 (0 critical, 3 high)**, measured on the built images.

No CRD schema changes, no API changes, no values changes.

## Docs sweep

Install/upgrade commands moved to 0.13.9 across README, quickstart, deploy, helm-oci, remote-cluster, troubleshooting, dra-allocation, releases.

**Two version references deliberately left alone**, because they state *when* something shipped and rewriting them would falsify history:
- `docs/security-audit.md` — "From v0.13.8 a ValidatingAdmissionPolicy closes the residual"
- the v0.13.8 CHANGELOG entry's own upgrade command

## A documentation bug found while checking the docs still hold

`docs/registry/golden-images.md` told operators to verify a published golden image with:

```
cosign verify --key cosign.pub <ref>
```

That **fails** — exit 12 — against our signatures, because we sign offline and `cosign verify` demands a transparency-log entry by default. An operator following the doc would conclude their signature was invalid. Tested against a real TLS registry before and after; the corrected command adds `--insecure-ignore-tlog=true`, with an explanation of why that is not a weakening (the key check is unaffected; the flag only stops cosign demanding a public log entry we deliberately never create).

Also documented that the two cosign majors write different signature formats and that both verifiers read both, so operators aren't surprised by the tag shape changing.

## Pre-flight

`gofmt` clean · `go build`/`go vet` green · `cargo build --release` + `cargo fmt --check` green · `make generate` produced no diff (CRDs in sync) · `helm lint` 0 failed · `verify-render-coverage` OK (5 workloads + 2 capability-guarded objects) · `verify-crd-sync` OK (15 CRDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)