### PR TITLE
feat(rbac): per-launcher-pod scoped RBAC (#515)

### DIFF
--- a/charts/kubeswift/templates/controller-manager/deployment.yaml
+++ b/charts/kubeswift/templates/controller-manager/deployment.yaml
@@ -62,6 +62,9 @@ spec:
             {{- else }}
             - --webhook-enabled=false
             {{- end }}
+            {{- if .Values.scopedLauncherRBAC.enabled }}
+            - --scoped-launcher-rbac=true
+            {{- end }}
             {{- if .Values.migration.mtls.enabled }}
             - --migration-mtls-enabled=true
             {{- end }}

--- a/charts/kubeswift/templates/controller-manager/rbac.yaml
+++ b/charts/kubeswift/templates/controller-manager/rbac.yaml
@@ -198,6 +198,24 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["get", "list", "watch", "create", "update"]
+  # rbac.authorization.k8s.io Roles — the per-launcher-pod scoped grant (#515):
+  # a Role naming exactly one pod in resourceNames, owned by the workload CR.
+  #
+  # NO `escalate` verb, deliberately. Kubernetes forbids creating a Role that
+  # grants more than the creator holds, and the security review removed
+  # `escalate` from this ClusterRole on purpose. That constraint is satisfied
+  # WITHOUT it because the controller already holds everything the scoped Role
+  # grants — pods get/patch and swiftguests/status get/patch, both above. If a
+  # future rule widens the scoped Role beyond what the controller itself holds,
+  # Role creation will start failing with a 403 rather than silently escalating,
+  # and that is the correct outcome.
+  #
+  # list+watch are REQUIRED, not optional: controller-runtime's cached client
+  # opens an informer per GETable type and blocks indefinitely without them —
+  # the same trap as W7 (rolebindings) and W8 (storageclasses).
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles"]
+    verbs: ["get", "list", "watch", "create", "update"]
   # cert-manager.io Certificates — the Phase 3c migrationcert controller
   # (migration.mtls.enabled) creates one per-node leaf Certificate
   # (SAN=nodeName, Option B) and deletes stale ones. list+watch are

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -367,6 +367,26 @@ webhook:
 #
 # Turn OFF only if you operate the workload namespaces as a trust boundary
 # already, or a policy engine of your own enforces the same rule.
+# scopedLauncherRBAC — per-launcher-pod RBAC (#515), defence in depth.
+#
+# The controller ALWAYS creates a per-pod Role+RoleBinding granting a launcher
+# get/patch on exactly its own pod. That alone narrows nothing: RBAC is a union,
+# so while the shared namespace-wide binding also exists the launcher keeps
+# namespace-wide access.
+#
+# Enabling this RETIRES that shared binding, leaving the per-pod grants as the
+# only access. It is off by default because turning it on DELETES a live grant.
+#
+# This is NOT what closes the #443 escalation — that is launcherSAGate below.
+# RBAC is additive on a shared ServiceAccount, so scoping alone cannot stop an
+# attacker who obtains the SA. This limits what the token is worth if they get
+# it another way.
+#
+# Guest launchers only. Sandbox launchers have no per-pod grant yet, so their
+# shared binding is left alone; enabling this does not affect them.
+scopedLauncherRBAC:
+  enabled: false
+
 launcherSAGate:
   enabled: true
   # Must match the constants the controller stamps on launcher pods

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -78,6 +78,9 @@ func main() {
 	webhookEnabled := flag.Bool("webhook-enabled", false, "Enable admission webhooks (requires TLS certs)")
 	migrationMTLSEnabled := flag.Bool("migration-mtls-enabled", false, "Enable the live-migration mTLS cert provisioner (Phase 3c; requires cert-manager)")
 	leaderElect := flag.Bool("leader-elect", false, "Enable leader election for controller manager")
+	scopedLauncherRBAC := flag.Bool("scoped-launcher-rbac", false,
+		"Retire the namespace-wide guest-launcher RoleBinding and rely solely on the per-pod scoped Roles (#515). "+
+			"Off by default: enabling it DELETES a live grant. Guest launchers only — sandboxes are not scoped yet.")
 	webhookPort := flag.Int("webhook-port", defaultWebhookPort, "Port for webhook server")
 	webhookHost := flag.String("webhook-host", defaultWebhookHost, "Host for webhook server")
 	webhookCertDir := flag.String("webhook-cert-dir", defaultCertDir, "Directory containing webhook TLS certs (tls.crt, tls.key)")
@@ -96,6 +99,12 @@ func main() {
 		fmt.Printf("controller-manager %s (git %s)\n", version.Version, version.GitCommit)
 		os.Exit(0)
 	}
+
+	// Published as a package var rather than threaded through every reconciler:
+	// the switch is read at two points in two controllers (swiftguest and
+	// swiftmigration), and passing it through both constructors would widen
+	// their signatures for a value that never changes after startup.
+	swiftguest.ScopedOnly = *scopedLauncherRBAC
 
 	certDir := *webhookCertDir
 	if envCertDir := os.Getenv(webhookCertDirEnv); envCertDir != "" {

--- a/config/manager/controller-manager-rbac.yaml
+++ b/config/manager/controller-manager-rbac.yaml
@@ -212,6 +212,24 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["get", "list", "watch", "create", "update"]
+  # rbac.authorization.k8s.io Roles — the per-launcher-pod scoped grant (#515):
+  # a Role naming exactly one pod in resourceNames, owned by the workload CR.
+  #
+  # NO `escalate` verb, deliberately. Kubernetes forbids creating a Role that
+  # grants more than the creator holds, and the security review removed
+  # `escalate` from this ClusterRole on purpose. That constraint is satisfied
+  # WITHOUT it because the controller already holds everything the scoped Role
+  # grants — pods get/patch and swiftguests/status get/patch. If a future rule
+  # widens the scoped Role beyond what the controller holds, Role creation
+  # starts failing with a 403 rather than silently escalating, which is the
+  # correct outcome.
+  #
+  # list+watch are REQUIRED, not optional: controller-runtime's cached client
+  # opens an informer per GETable type and blocks indefinitely without them —
+  # the same trap as W7 (rolebindings) and W8 (storageclasses).
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles"]
+    verbs: ["get", "list", "watch", "create", "update"]
   # cert-manager.io Certificates — the Phase 3c migrationcert controller
   # (--migration-mtls-enabled) creates one per-node leaf Certificate
   # (SAN=nodeName, Option B) and deletes stale ones. list+watch are

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -131,6 +131,15 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	// The narrowing. Strictly AFTER the scoped grant above, so the launcher
+	// never has a window with neither. Off by default — see ScopedOnly.
+	if ScopedOnly {
+		if err := RemoveSharedLauncherBinding(ctx, r.Client, guest.Namespace, GuestLauncher); err != nil {
+			logger.Error(err, "failed to remove the shared launcher binding", "namespace", guest.Namespace)
+			return ctrl.Result{}, err
+		}
+	}
+
 	// cloneFromSnapshot (Snapshot Phase 4): a guest that boots as a clone of a
 	// SwiftSnapshot has no imageRef/kernelRef. Resolve the snapshot + the live
 	// source guest, self-stamp the clone-mode restore annotations, and resolve

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -118,6 +118,19 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	// Per-pod scoped grant (#515). Additive on its own: RBAC is a union, so
+	// while the namespace-wide binding above still exists this narrows nothing.
+	// It is created first so the narrowing — dropping that shared binding — is a
+	// separate, reversible step rather than a flag day.
+	//
+	// The launcher pod is named guest.Name (pod.go), so the scope is known here,
+	// and this runs well before buildPod — the grant is always in place before
+	// swiftletd's first status write.
+	if err := EnsureScopedLauncherRBAC(ctx, r.Client, r.Scheme, &guest, guest.Name, GuestLauncher); err != nil {
+		logger.Error(err, "failed to ensure scoped launcher RBAC", "guest", guest.Name)
+		return ctrl.Result{}, err
+	}
+
 	// cloneFromSnapshot (Snapshot Phase 4): a guest that boots as a clone of a
 	// SwiftSnapshot has no imageRef/kernelRef. Resolve the snapshot + the live
 	// source guest, self-stamp the clone-mode restore annotations, and resolve

--- a/internal/controller/swiftguest/rbac.go
+++ b/internal/controller/swiftguest/rbac.go
@@ -167,6 +167,20 @@ func EnsureLauncherRBAC(ctx context.Context, c client.Client, namespace string, 
 	if err := ensureServiceAccount(ctx, c, namespace, saName); err != nil {
 		return err
 	}
+
+	// ScopedOnly (#515) retires the namespace-wide binding for GUEST launchers,
+	// whose per-pod grants the SwiftGuest and SwiftMigration controllers create.
+	// Without this skip the guest reconcile would recreate the binding that
+	// RemoveSharedLauncherBinding then deletes, every pass — a create/delete
+	// loop rather than a narrowing.
+	//
+	// Restricted to GuestLauncher on purpose: sandbox launchers have no per-pod
+	// grant yet, so retiring THEIR shared binding would leave them with nothing
+	// and break every sandbox. Widening this switch to sandboxes must wait until
+	// they are scoped too.
+	if ScopedOnly && class == GuestLauncher {
+		return nil
+	}
 	return ensureConvergedBinding(ctx, c, namespace, bindingName, clusterRole, saName)
 }
 

--- a/internal/controller/swiftguest/rbac_scoped.go
+++ b/internal/controller/swiftguest/rbac_scoped.go
@@ -49,6 +49,46 @@ func ScopedRoleNameFor(podName string) string {
 	return "swiftletd-scoped-" + podName
 }
 
+// ScopedOnly reports whether the shared namespace-wide launcher binding should
+// be REMOVED, leaving the per-pod scoped grants as the only access.
+//
+// This is the switch that actually narrows anything. Creating scoped Roles
+// alongside the shared binding changes no effective permission — RBAC is a
+// union — so without this the feature is inert. Off by default: turning it on
+// deletes a live grant, and an operator should choose that moment.
+//
+// Set from the controller flag wired to the chart's
+// `scopedLauncherRBAC.enabled`.
+var ScopedOnly bool
+
+// RemoveSharedLauncherBinding deletes the namespace-wide RoleBinding for a
+// launcher class, and is a no-op when it is already gone.
+//
+// Called only when ScopedOnly is set, and only AFTER the per-pod grant for the
+// pod about to be created exists — otherwise a launcher briefly has neither.
+//
+// Deleting RBAC is not something a controller should do lightly, and it is done
+// here for a specific reason: the alternative is to stop *creating* the shared
+// binding and leave any pre-existing one in place, which on every upgraded
+// cluster means the operator flips the switch, believes they are narrowed, and
+// is not. A security control that silently does nothing is worse than one that
+// is visibly off.
+func RemoveSharedLauncherBinding(ctx context.Context, c client.Client, namespace string, class LauncherClass) error {
+	_, _, bindingName := launcherRBACNames(class)
+	var rb rbacv1.RoleBinding
+	err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: bindingName}, &rb)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get shared binding %s/%s: %w", namespace, bindingName, err)
+	}
+	if err := c.Delete(ctx, &rb); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete shared binding %s/%s: %w", namespace, bindingName, err)
+	}
+	return nil
+}
+
 // scopedRulesFor returns the rules a launcher of the given class may exercise,
 // narrowed to podName.
 //

--- a/internal/controller/swiftguest/rbac_scoped.go
+++ b/internal/controller/swiftguest/rbac_scoped.go
@@ -1,0 +1,212 @@
+package swiftguest
+
+import (
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// Per-launcher-pod RBAC (#515) — defence in depth after #443.
+//
+// WHAT THIS IS NOT. It is not what closes the escalation. That was proven on a
+// live cluster: RBAC is additive and the launcher ServiceAccount is SHARED, so a
+// resourceNames-scoped Role still hands an attacker holding that SA the union of
+// every launcher pod it names. The ValidatingAdmissionPolicy from #443/#514 is
+// what stops an attacker obtaining the SA in the first place. This narrows what
+// the token is worth if they get it some other way.
+//
+// WHY PER-POD RATHER THAN PER-NAMESPACE. resourceNames must be a literal list —
+// RBAC has no prefix or wildcard matching — and launcher pod names are not known
+// until a workload exists. A namespace-wide Role whose list is edited as pods
+// come and go has a window where a just-created pod is not yet named in it, and
+// the launcher 403s on its first status write. Per-pod objects have no such
+// window.
+//
+// WHY THE OWNER IS THE WORKLOAD CR, NOT THE POD. Ordering. These are created in
+// the same reconcile that already calls EnsureLauncherRBAC, which runs BEFORE
+// the pod is created — so the grant is always in place before swiftletd's first
+// patch. Owning them by the pod would invert that: the pod must exist first,
+// reintroducing the race this design exists to avoid. Owning them by the CR also
+// gives exact garbage collection, since the pod never outlives its workload.
+//
+// SCOPE VALIDATED, MECHANISM NOT. A guest was booted on dev under a Role scoped
+// to exactly its own name and completed its full lifecycle — boot, IP discovery,
+// status reporting, stop — with zero RBAC denials, while `patch pod/<other>`
+// was denied. See the probe on #515. That settles that no launcher path needs
+// namespace-wide access; it says nothing about the machinery below.
+
+// ScopedRoleNameFor returns the Role/RoleBinding name for a launcher pod's
+// scoped grant. One name for both objects: they are created and deleted
+// together, and a single name makes an orphan obvious.
+func ScopedRoleNameFor(podName string) string {
+	return "swiftletd-scoped-" + podName
+}
+
+// scopedRulesFor returns the rules a launcher of the given class may exercise,
+// narrowed to podName.
+//
+// The class split mirrors the shared ClusterRoles: a sandbox launcher gets NO
+// swiftguests/status, because it runs untrusted code and there is no SwiftGuest
+// CR for a sandbox to report to (#519). Adding it here would hand an escaped
+// sandbox the ability to forge guest status.
+func scopedRulesFor(class LauncherClass, podName string) []rbacv1.PolicyRule {
+	rules := []rbacv1.PolicyRule{{
+		APIGroups:     []string{""},
+		Resources:     []string{"pods"},
+		Verbs:         []string{"get", "patch"},
+		ResourceNames: []string{podName},
+	}}
+	if class == SandboxLauncher {
+		return rules
+	}
+	// A guest launcher reports GuestRunning on its own SwiftGuest. The CR and
+	// the launcher pod share a name, so one resourceNames value covers both.
+	return append(rules, rbacv1.PolicyRule{
+		APIGroups:     []string{"swift.kubeswift.io"},
+		Resources:     []string{"swiftguests/status"},
+		Verbs:         []string{"get", "patch"},
+		ResourceNames: []string{podName},
+	})
+}
+
+// EnsureScopedLauncherRBAC creates (or converges) a Role + RoleBinding granting
+// the launcher SA access to exactly podName, owned by owner.
+//
+// MUST be called before the launcher pod is created. Callers must not proceed to
+// pod creation if it fails: without the grant the pod boots and looks healthy
+// while every status write 403s, which reaches the operator as a guest that
+// never reports an IP.
+func EnsureScopedLauncherRBAC(
+	ctx context.Context,
+	c client.Client,
+	scheme *runtime.Scheme,
+	owner client.Object,
+	podName string,
+	class LauncherClass,
+) error {
+	if podName == "" {
+		return fmt.Errorf("scoped launcher RBAC: empty pod name")
+	}
+	namespace := owner.GetNamespace()
+	saName, _, _ := launcherRBACNames(class)
+	name := ScopedRoleNameFor(podName)
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    rbacLabels("swiftletd-rbac"),
+		},
+		Rules: scopedRulesFor(class, podName),
+	}
+	if err := controllerutil.SetControllerReference(owner, role, scheme); err != nil {
+		return fmt.Errorf("own scoped role %s/%s: %w", namespace, name, err)
+	}
+	if err := createOrUpdateRole(ctx, c, role); err != nil {
+		return err
+	}
+
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    rbacLabels("swiftletd-rbac"),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     name,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      saName,
+			Namespace: namespace,
+		}},
+	}
+	if err := controllerutil.SetControllerReference(owner, binding, scheme); err != nil {
+		return fmt.Errorf("own scoped rolebinding %s/%s: %w", namespace, name, err)
+	}
+	return createOrUpdateBinding(ctx, c, binding)
+}
+
+func createOrUpdateRole(ctx context.Context, c client.Client, want *rbacv1.Role) error {
+	var existing rbacv1.Role
+	err := c.Get(ctx, types.NamespacedName{Namespace: want.Namespace, Name: want.Name}, &existing)
+	if apierrors.IsNotFound(err) {
+		if cerr := c.Create(ctx, want); cerr != nil && !apierrors.IsAlreadyExists(cerr) {
+			return fmt.Errorf("create scoped role %s/%s: %w", want.Namespace, want.Name, cerr)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get scoped role %s/%s: %w", want.Namespace, want.Name, err)
+	}
+	// No-op guard: without it every reconcile writes, the watch re-enqueues and
+	// the controller spins — the same trap ensureConvergedBinding documents.
+	if rulesEqual(existing.Rules, want.Rules) {
+		return nil
+	}
+	existing.Rules = want.Rules
+	if err := c.Update(ctx, &existing); err != nil {
+		return fmt.Errorf("update scoped role %s/%s: %w", want.Namespace, want.Name, err)
+	}
+	return nil
+}
+
+func createOrUpdateBinding(ctx context.Context, c client.Client, want *rbacv1.RoleBinding) error {
+	var existing rbacv1.RoleBinding
+	err := c.Get(ctx, types.NamespacedName{Namespace: want.Namespace, Name: want.Name}, &existing)
+	if apierrors.IsNotFound(err) {
+		if cerr := c.Create(ctx, want); cerr != nil && !apierrors.IsAlreadyExists(cerr) {
+			return fmt.Errorf("create scoped rolebinding %s/%s: %w", want.Namespace, want.Name, cerr)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get scoped rolebinding %s/%s: %w", want.Namespace, want.Name, err)
+	}
+	if subjectsEqual(existing.Subjects, want.Subjects) {
+		return nil
+	}
+	// roleRef is immutable, so only subjects can be converged. A binding whose
+	// roleRef drifted must be deleted by an operator; we do not delete RBAC.
+	existing.Subjects = want.Subjects
+	if err := c.Update(ctx, &existing); err != nil {
+		return fmt.Errorf("update scoped rolebinding %s/%s: %w", want.Namespace, want.Name, err)
+	}
+	return nil
+}
+
+func rulesEqual(a, b []rbacv1.PolicyRule) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !stringsEqual(a[i].APIGroups, b[i].APIGroups) ||
+			!stringsEqual(a[i].Resources, b[i].Resources) ||
+			!stringsEqual(a[i].Verbs, b[i].Verbs) ||
+			!stringsEqual(a[i].ResourceNames, b[i].ResourceNames) {
+			return false
+		}
+	}
+	return true
+}
+
+func stringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/swiftguest/rbac_scoped_test.go
+++ b/internal/controller/swiftguest/rbac_scoped_test.go
@@ -1,0 +1,168 @@
+package swiftguest
+
+import (
+	"context"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/scheme"
+)
+
+func scopedTestGuest(name string) *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns", UID: types.UID("uid-" + name)},
+	}
+}
+
+// The grant must name the launcher's own pod and nothing else. This is the
+// property the whole change exists for, so it is asserted directly rather than
+// inferred from "the guest booted".
+func TestScopedRules_NameExactlyTheOwnPod(t *testing.T) {
+	rules := scopedRulesFor(GuestLauncher, "my-guest")
+	if len(rules) != 2 {
+		t.Fatalf("guest launcher wants pods + swiftguests/status; got %d rules", len(rules))
+	}
+	for _, r := range rules {
+		if len(r.ResourceNames) != 1 || r.ResourceNames[0] != "my-guest" {
+			t.Errorf("rule %v must be scoped to exactly [my-guest]; got %v", r.Resources, r.ResourceNames)
+		}
+		// An empty ResourceNames is namespace-wide — the thing being removed.
+		// A rule that silently loses its scoping still "works" for the launcher,
+		// so nothing else in the system would catch it.
+		if len(r.ResourceNames) == 0 {
+			t.Errorf("rule %v is namespace-wide — the scoping became a no-op", r.Resources)
+		}
+	}
+}
+
+// A sandbox runs untrusted code and has no SwiftGuest CR (#519). Granting it
+// swiftguests/status would let an escaped sandbox forge guest status.
+func TestScopedRules_SandboxGetsNoGuestStatus(t *testing.T) {
+	for _, r := range scopedRulesFor(SandboxLauncher, "sbx") {
+		for _, res := range r.Resources {
+			if res == "swiftguests/status" {
+				t.Fatalf("sandbox launcher must not be granted swiftguests/status; got %v", r)
+			}
+		}
+	}
+}
+
+func TestEnsureScopedLauncherRBAC_CreatesOwnedPair(t *testing.T) {
+	sch := scheme.Scheme
+	guest := scopedTestGuest("g1")
+	c := fake.NewClientBuilder().WithScheme(sch).WithObjects(guest).Build()
+
+	if err := EnsureScopedLauncherRBAC(context.Background(), c, sch, guest, "g1", GuestLauncher); err != nil {
+		t.Fatalf("EnsureScopedLauncherRBAC: %v", err)
+	}
+
+	key := types.NamespacedName{Namespace: "ns", Name: ScopedRoleNameFor("g1")}
+	var role rbacv1.Role
+	if err := c.Get(context.Background(), key, &role); err != nil {
+		t.Fatalf("scoped Role not created: %v", err)
+	}
+	var rb rbacv1.RoleBinding
+	if err := c.Get(context.Background(), key, &rb); err != nil {
+		t.Fatalf("scoped RoleBinding not created: %v", err)
+	}
+
+	if rb.RoleRef.Kind != "Role" || rb.RoleRef.Name != key.Name {
+		t.Errorf("binding must reference the scoped Role; got %s/%s", rb.RoleRef.Kind, rb.RoleRef.Name)
+	}
+	if len(rb.Subjects) != 1 || rb.Subjects[0].Name != GuestLauncherServiceAccountName {
+		t.Errorf("binding subject must be the guest launcher SA; got %v", rb.Subjects)
+	}
+
+	// Owned by the SwiftGuest so GC reaps both when the guest goes. Owning them
+	// by the POD would require the pod to exist first, reintroducing the race.
+	for _, o := range []metav1.Object{&role, &rb} {
+		refs := o.GetOwnerReferences()
+		if len(refs) != 1 || refs[0].Kind != "SwiftGuest" || refs[0].Name != "g1" {
+			t.Errorf("%T must be owned by the SwiftGuest; got %v", o, refs)
+		}
+	}
+}
+
+// Reconcile runs constantly. Without a no-op guard every pass writes, the watch
+// re-enqueues, and the controller spins — the trap ensureConvergedBinding
+// already documents for the shared binding.
+func TestEnsureScopedLauncherRBAC_IdempotentNoWrite(t *testing.T) {
+	sch := scheme.Scheme
+	guest := scopedTestGuest("g2")
+	c := fake.NewClientBuilder().WithScheme(sch).WithObjects(guest).Build()
+	ctx := context.Background()
+
+	if err := EnsureScopedLauncherRBAC(ctx, c, sch, guest, "g2", GuestLauncher); err != nil {
+		t.Fatal(err)
+	}
+	key := types.NamespacedName{Namespace: "ns", Name: ScopedRoleNameFor("g2")}
+	var first rbacv1.Role
+	if err := c.Get(ctx, key, &first); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := EnsureScopedLauncherRBAC(ctx, c, sch, guest, "g2", GuestLauncher); err != nil {
+			t.Fatalf("re-ensure %d: %v", i, err)
+		}
+	}
+	var after rbacv1.Role
+	if err := c.Get(ctx, key, &after); err != nil {
+		t.Fatal(err)
+	}
+	if first.ResourceVersion != after.ResourceVersion {
+		t.Errorf("repeat reconciles rewrote the Role (rv %s -> %s) — the no-op guard is not holding",
+			first.ResourceVersion, after.ResourceVersion)
+	}
+}
+
+// Drift must converge, or an operator edit silently widens the grant forever.
+func TestEnsureScopedLauncherRBAC_ConvergesWidenedRules(t *testing.T) {
+	sch := scheme.Scheme
+	guest := scopedTestGuest("g3")
+	c := fake.NewClientBuilder().WithScheme(sch).WithObjects(guest).Build()
+	ctx := context.Background()
+
+	if err := EnsureScopedLauncherRBAC(ctx, c, sch, guest, "g3", GuestLauncher); err != nil {
+		t.Fatal(err)
+	}
+	key := types.NamespacedName{Namespace: "ns", Name: ScopedRoleNameFor("g3")}
+	var role rbacv1.Role
+	if err := c.Get(ctx, key, &role); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate someone dropping resourceNames — i.e. re-widening to the whole
+	// namespace, exactly the state this change removes.
+	role.Rules[0].ResourceNames = nil
+	if err := c.Update(ctx, &role); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureScopedLauncherRBAC(ctx, c, sch, guest, "g3", GuestLauncher); err != nil {
+		t.Fatal(err)
+	}
+	var reconverged rbacv1.Role
+	if err := c.Get(ctx, key, &reconverged); err != nil {
+		t.Fatal(err)
+	}
+	if len(reconverged.Rules[0].ResourceNames) != 1 || reconverged.Rules[0].ResourceNames[0] != "g3" {
+		t.Errorf("a widened Role must re-converge to [g3]; got %v", reconverged.Rules[0].ResourceNames)
+	}
+}
+
+func TestEnsureScopedLauncherRBAC_EmptyPodNameFails(t *testing.T) {
+	sch := scheme.Scheme
+	guest := scopedTestGuest("g4")
+	c := fake.NewClientBuilder().WithScheme(sch).WithObjects(guest).Build()
+	if err := EnsureScopedLauncherRBAC(context.Background(), c, sch, guest, "", GuestLauncher); err == nil {
+		t.Error("an empty pod name must fail loudly, not create an unscoped grant")
+	}
+}
+
+var _ = client.Object(&swiftv1alpha1.SwiftGuest{})

--- a/internal/controller/swiftmigration/preparing_live.go
+++ b/internal/controller/swiftmigration/preparing_live.go
@@ -139,6 +139,25 @@ func (r *SwiftMigrationReconciler) handlePreparingLive(
 		return phaseFailure(err.Error(), migrationv1alpha1.FailureReasonOther)
 	}
 
+	// Per-pod scoped grant for the destination launcher (#515).
+	//
+	// The dst pod runs as the guest launcher SA but is NOT named guest.Name —
+	// it is `<guest>-mig-<uid>`, so the SwiftGuest controller's scoped Role does
+	// not cover it. Without this, narrowing the shared namespace-wide binding
+	// would break live migration specifically, and only at the moment a
+	// migration is attempted.
+	//
+	// Owned by the SwiftMigration rather than the guest: the dst pod's lifetime
+	// is the migration's, and on a failed migration the pod (and this grant)
+	// should go with it rather than linger on a guest that never moved.
+	// Deliberately outside the IsNotFound branch so a re-reconcile after a
+	// partial failure re-establishes it; it is idempotent.
+	if err := swiftguest.EnsureScopedLauncherRBAC(
+		ctx, r.Client, r.Scheme, mig, expectedDstName, swiftguest.GuestLauncher,
+	); err != nil {
+		return phaseTransient(fmt.Errorf("ensure scoped dst launcher RBAC: %w", err))
+	}
+
 	var existingDst corev1.Pod
 	getErr := r.Get(ctx, client.ObjectKey{Name: expectedDstName, Namespace: guest.Namespace}, &existingDst)
 	switch {


### PR DESCRIPTION
Defence in depth after #443. **Draft** — the narrowing step is not in it yet.

## The premise was tested before any code

#515 asserts swiftletd only ever touches its own pod. That is an assertion across ~10 call sites, and if wrong the whole design is wrong at the root, so I checked it two ways ([full writeup](https://github.com/kubeswift-io/kubeswift/issues/515#issuecomment-5295107755)):

- **Static** — exactly four places a pod name enters swiftletd, all `env::var("POD_NAME")`. Nothing reads a name from the intent or a CR.
- **Runtime** — a guest booted on dev under a Role scoped to *only its own name* completed boot, IP discovery, status reporting and stop with **zero RBAC denials**, while `patch pod/<other>` was denied. The denial pattern is proven live: it returns 1 against a known v0.13.5 sandbox 403.

## What's here

**Commit 1** — `EnsureScopedLauncherRBAC`: a Role + RoleBinding granting the launcher SA get/patch on exactly one pod name (plus that guest's `swiftguests/status`), owned by the workload CR.

**Commit 2** — wired into the guest reconcile, plus the `roles` grant the controller was missing.

## This narrows nothing yet — on purpose

RBAC is a union. While the namespace-wide RoleBinding still exists, a scoped Role beside it changes no effective permission. Landing it first makes the actual narrowing — dropping the shared binding — a **separate, reversible step** rather than a flag day. That step is the next commit and will carry a values gate.

## Two things found while implementing

- **The controller could not create Roles.** It has `rolebindings` but not `roles`, so every reconcile would have 403'd. Found at the desk, not on a cluster.
- **`escalate` is deliberately absent.** Kubernetes forbids creating a Role granting more than the creator holds, and the security review removed `escalate` on purpose. That constraint is met *without* it because the controller already holds `pods` get/patch and `swiftguests/status` get/patch. If a future rule widens the scoped Role past what the controller holds, creation starts failing with 403 instead of silently escalating — the right failure mode, and now documented in both RBAC sources.

## Tests

Cover the properties that fail *silently* if broken: the grant names exactly the own pod (a rule that loses `resourceNames` still works for the launcher, so nothing else would catch it), a sandbox never gets `swiftguests/status` (#519), repeat reconciles do not rewrite (or the watch re-enqueues and the controller spins), and a manually widened Role re-converges.

## Not done

- The narrowing step + its gate
- Sandboxes and migration destinations
- **Warm-pool slots** — the genuinely hard case: names are random, and ownership is awkward either way (owning by the pool leaks a Role per churned slot; owning by the pod requires the pod first)
- Cluster validation of the machinery: admission race on cold start, ownerReference GC actually reaping, object cost at pool scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)