### PR TITLE
feat(rbac): scope sandbox and warm-pool launcher RBAC (#515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [Unreleased]
+
+### Security
+
+- **Per-launcher-pod scoped RBAC** (#515), behind `scopedLauncherRBAC.enabled`
+  (default `false`). Every launcher pod — SwiftGuest, migration target,
+  SwiftSandbox, and warm pool slot — now gets its own Role + RoleBinding
+  granting `pods: get,patch` on **exactly its own pod** (and, for a guest,
+  `swiftguests/status` on its own CR). Enabling the gate retires the shared
+  namespace-wide RoleBinding, leaving those per-pod grants as the only access.
+
+  This is **defence in depth, not the fix for #443**. RBAC is additive and the
+  launcher ServiceAccount is shared, so scoping alone cannot stop an attacker who
+  obtains the SA — the ValidatingAdmissionPolicy (`launcherSAGate`, v0.13.8) is
+  what does. This bounds what the token is worth if it leaks another way.
+
+  Scope was validated before the mechanism was built: a guest ran its full
+  lifecycle on a live cluster under a hand-made self-only Role — boot, IP
+  discovery, status reporting, stop — with zero RBAC denials, while
+  `patch pod/<other>` was denied.
+
+  A sandbox launcher is granted **no** `swiftguests/status`: it runs untrusted
+  code and has no SwiftGuest CR to report to, so granting it would let an escaped
+  sandbox forge guest status.
+
+  Warm pool slots take two phases, because a slot pod is created by the pool but
+  re-parented to a SwiftSandbox on checkout, so neither CR owns it for its whole
+  life. The pool creates the grant owned by itself (the pod does not exist yet,
+  and the grant must precede it), then hands ownership to the slot pod, which is
+  the only owner whose lifetime matches. A pool also converges grants for slots
+  it already has, so enabling the gate on a running pool does not cut off live
+  slots.
+
+  Object cost is two per launcher pod, garbage-collected with it. Failure to
+  retire the shared binding is logged at ERROR and never blocks a workload from
+  booting — the exposure in that case is exactly the pre-change posture.
+
+  Requires `roles` and `delete` on `rolebindings` in the controller ClusterRole;
+  `helm upgrade` covers this, but a controller image newer than its ClusterRole
+  will log the failure and keep running.
+
+---
+
 ## [v0.13.9] — 2026-08-14
 
 A supply-chain release. Both cosign-bearing images drop from **48 fixable CVEs

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -382,8 +382,12 @@ webhook:
 # attacker who obtains the SA. This limits what the token is worth if they get
 # it another way.
 #
-# Guest launchers only. Sandbox launchers have no per-pod grant yet, so their
-# shared binding is left alone; enabling this does not affect them.
+# Covers every launcher: guests, migration targets, sandboxes, and warm pool
+# slots. A pool converges grants for the slots it already has, so enabling this
+# on a running pool does not cut off live slots.
+#
+# Cost is two objects (a Role and a RoleBinding) per launcher pod, created and
+# garbage-collected with it.
 scopedLauncherRBAC:
   enabled: false
 

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -79,8 +79,9 @@ func main() {
 	migrationMTLSEnabled := flag.Bool("migration-mtls-enabled", false, "Enable the live-migration mTLS cert provisioner (Phase 3c; requires cert-manager)")
 	leaderElect := flag.Bool("leader-elect", false, "Enable leader election for controller manager")
 	scopedLauncherRBAC := flag.Bool("scoped-launcher-rbac", false,
-		"Retire the namespace-wide guest-launcher RoleBinding and rely solely on the per-pod scoped Roles (#515). "+
-			"Off by default: enabling it DELETES a live grant. Guest launchers only — sandboxes are not scoped yet.")
+		"Retire the namespace-wide launcher RoleBindings and rely solely on the per-pod scoped Roles (#515). "+
+			"Covers guests, migration targets, sandboxes and warm pool slots. "+
+			"Off by default: enabling it DELETES a live grant.")
 	webhookPort := flag.Int("webhook-port", defaultWebhookPort, "Port for webhook server")
 	webhookHost := flag.String("webhook-host", defaultWebhookHost, "Host for webhook server")
 	webhookCertDir := flag.String("webhook-cert-dir", defaultCertDir, "Directory containing webhook TLS certs (tls.crt, tls.key)")

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -578,17 +578,34 @@ Practically:
   access; namespace-admin there is cluster-significant.
 - Node isolation (taints/affinity) bounds *which* nodes are exposed, not whether.
 
-### What would actually close it
+### What closes it
 
-- **Admission control** — reject a pod referencing a launcher ServiceAccount
-  unless it is a genuine controller-created launcher. This closes it, at the cost
-  of a `pods` CREATE webhook the apiserver calls for every pod creation in the
-  cluster.
+- **Admission control — SHIPPED in v0.13.8.** `kubeswift-launcher-sa-gate`
+  rejects any Pod naming a launcher ServiceAccount unless the KubeSwift
+  controller created it (see above). This is what closes the escalation. The
+  paragraphs above describe the posture where it is disabled.
 - **Removing the grant** — move swiftletd's status reporting off pod annotations
-  onto a channel that needs no write access to its own pod. Closes it properly;
-  a rework of the status path in both the runtime and the controller.
+  onto a channel that needs no write access to its own pod. Would close it at the
+  source rather than by admission; a rework of the status path in both the
+  runtime and the controller. Not implemented.
 
-Neither is implemented. #443 tracks the decision.
+### Defence in depth: per-launcher-pod scoping (#515)
+
+From the `scopedLauncherRBAC` gate (default off), each launcher pod holds a Role
+scoped with `resourceNames` to exactly its own pod, and the shared namespace-wide
+RoleBinding is retired. Guests, migration targets, sandboxes and warm pool slots
+are all covered.
+
+Read this for what it is. It does **not** close the escalation — that is the VAP
+above, and the reason is unchanged: RBAC is additive on a shared ServiceAccount,
+so an attacker who obtains the SA still inherits the union of every launcher
+grant in the namespace. What it buys is that the token is worth one pod rather
+than the namespace when it leaks by some route other than SA-naming — a stolen
+projected token, a compromised node, a mounted secret.
+
+A sandbox launcher is granted no `swiftguests/status` at all: it runs untrusted
+code and has no SwiftGuest CR, so the grant would only let an escaped sandbox
+forge guest status on someone else's VM.
 
 ## Cross-Cutting Observations
 

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -131,31 +131,10 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	// The narrowing. Strictly AFTER the scoped grant above, so the launcher
-	// never has a window with neither. Off by default — see ScopedOnly.
-	//
-	// NOT fatal to the reconcile, deliberately, and this was learned on a
-	// cluster rather than reasoned out: returning the error here skips
-	// everything below it, including pod creation, so a controller that cannot
-	// delete the binding leaves every guest stuck in Scheduling with no pod. A
-	// defence-in-depth tidy-up must not stop VMs from booting.
-	//
-	// The exposure when it fails is exactly the pre-change posture — the shared
-	// namespace-wide binding, which is what ships by default anyway — so
-	// continuing is strictly no worse than not having enabled the gate. It is
-	// logged at ERROR on every reconcile so it cannot pass unnoticed.
-	//
-	// The realistic trigger is an upgrade-order mistake: a controller image new
-	// enough to have the gate, running against a ClusterRole too old to grant
-	// `delete` on rolebindings. That must degrade, not take the cluster down.
-	if ScopedOnly {
-		if err := RemoveSharedLauncherBinding(ctx, r.Client, guest.Namespace, GuestLauncher); err != nil {
-			logger.Error(err, "scoped-launcher-rbac is enabled but the shared launcher binding could NOT be removed; "+
-				"launchers keep namespace-wide pod access (the pre-change posture). "+
-				"Check that the controller ClusterRole grants delete on rolebindings.",
-				"namespace", guest.Namespace)
-		}
-	}
+	// The narrowing. Strictly AFTER the scoped grant above, so the launcher never
+	// has a window with neither. Off by default, and never fatal — see
+	// NarrowToScopedRBAC for why it cannot return an error.
+	NarrowToScopedRBAC(ctx, r.Client, guest.Namespace, GuestLauncher)
 
 	// cloneFromSnapshot (Snapshot Phase 4): a guest that boots as a clone of a
 	// SwiftSnapshot has no imageRef/kernelRef. Resolve the snapshot + the live

--- a/internal/controller/swiftguest/rbac.go
+++ b/internal/controller/swiftguest/rbac.go
@@ -168,17 +168,18 @@ func EnsureLauncherRBAC(ctx context.Context, c client.Client, namespace string, 
 		return err
 	}
 
-	// ScopedOnly (#515) retires the namespace-wide binding for GUEST launchers,
-	// whose per-pod grants the SwiftGuest and SwiftMigration controllers create.
-	// Without this skip the guest reconcile would recreate the binding that
-	// RemoveSharedLauncherBinding then deletes, every pass — a create/delete
-	// loop rather than a narrowing.
+	// ScopedOnly (#515) retires the namespace-wide binding entirely: every
+	// launcher pod now gets a per-pod grant from the controller that creates it —
+	// SwiftGuest and SwiftMigration for guests, SwiftSandbox and SwiftSandboxPool
+	// for sandboxes and warm slots. Without this skip the reconcile would recreate
+	// the binding that RemoveSharedLauncherBinding then deletes, every pass — a
+	// create/delete loop rather than a narrowing.
 	//
-	// Restricted to GuestLauncher on purpose: sandbox launchers have no per-pod
-	// grant yet, so retiring THEIR shared binding would leave them with nothing
-	// and break every sandbox. Widening this switch to sandboxes must wait until
-	// they are scoped too.
-	if ScopedOnly && class == GuestLauncher {
+	// Both classes are covered only as of the sandbox slice; while guests were
+	// scoped and sandboxes were not, this deliberately excluded SandboxLauncher,
+	// because retiring a shared binding for pods that have no per-pod grant leaves
+	// them with no access at all.
+	if ScopedOnly {
 		return nil
 	}
 	return ensureConvergedBinding(ctx, c, namespace, bindingName, clusterRole, saName)

--- a/internal/controller/swiftguest/rbac_scoped.go
+++ b/internal/controller/swiftguest/rbac_scoped.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Per-launcher-pod RBAC (#515) — defence in depth after #443.
@@ -35,6 +36,16 @@ import (
 // patch. Owning them by the pod would invert that: the pod must exist first,
 // reintroducing the race this design exists to avoid. Owning them by the CR also
 // gives exact garbage collection, since the pod never outlives its workload.
+//
+// WARM POOL SLOTS ARE THE EXCEPTION, and take two phases. A slot pod is created
+// by the POOL but re-parented to a SwiftSandbox on checkout (checkout.go), so
+// neither CR owns it for its whole life: pool-owned leaks a Role per churned
+// slot, sandbox-owned does not exist yet at create time. So the pool creates the
+// grant owned by ITSELF (ordering preserved, and a crash mid-sequence still
+// reaps with the pool), then re-parents it onto the slot pod once that exists.
+// Pod ownership is stable across the checkout re-parent and GCs exactly.
+// EnsureScopedLauncherRBAC converges the controller ownerReference, so phase two
+// is the same call with a different owner.
 //
 // SCOPE VALIDATED, MECHANISM NOT. A guest was booted on dev under a Role scoped
 // to exactly its own name and completed its full lifecycle — boot, IP discovery,
@@ -87,6 +98,39 @@ func RemoveSharedLauncherBinding(ctx context.Context, c client.Client, namespace
 		return fmt.Errorf("delete shared binding %s/%s: %w", namespace, bindingName, err)
 	}
 	return nil
+}
+
+// NarrowToScopedRBAC retires the shared namespace-wide binding for a launcher
+// class when the gate is on. A no-op when it is off.
+//
+// It returns NOTHING, and that is the point. This was learned on a cluster
+// rather than reasoned out: the first version returned an error, the guest
+// reconcile propagated it, and every guest stuck in Scheduling with no pod at
+// all — because the failing call sat above pod creation. A defence-in-depth
+// tidy-up must never stop VMs from booting, so the signature makes "fatal"
+// unspellable rather than leaving it to each caller to remember.
+//
+// The exposure when it fails is exactly the pre-change posture — the shared
+// namespace-wide binding, which is what ships by default — so continuing is
+// strictly no worse than never having enabled the gate. It is logged at ERROR
+// every reconcile so it cannot pass unnoticed.
+//
+// The realistic trigger is an upgrade-order mistake: a controller image new
+// enough to have the gate, running against a ClusterRole too old to grant
+// `delete` on rolebindings. That must degrade, not take the cluster down.
+//
+// MUST be called strictly AFTER the scoped grant for the pod about to be
+// created, so a launcher never has a window with neither.
+func NarrowToScopedRBAC(ctx context.Context, c client.Client, namespace string, class LauncherClass) {
+	if !ScopedOnly {
+		return
+	}
+	if err := RemoveSharedLauncherBinding(ctx, c, namespace, class); err != nil {
+		log.FromContext(ctx).Error(err, "scoped-launcher-rbac is enabled but the shared launcher binding could NOT be removed; "+
+			"launchers keep namespace-wide pod access (the pre-change posture). "+
+			"Check that the controller ClusterRole grants delete on rolebindings.",
+			"namespace", namespace)
+	}
 }
 
 // scopedRulesFor returns the rules a launcher of the given class may exercise,
@@ -190,14 +234,49 @@ func createOrUpdateRole(ctx context.Context, c client.Client, want *rbacv1.Role)
 	}
 	// No-op guard: without it every reconcile writes, the watch re-enqueues and
 	// the controller spins — the same trap ensureConvergedBinding documents.
-	if rulesEqual(existing.Rules, want.Rules) {
+	changed := false
+	if !rulesEqual(existing.Rules, want.Rules) {
+		existing.Rules = want.Rules
+		changed = true
+	}
+	if adoptControllerRef(&existing, want) {
+		changed = true
+	}
+	if !changed {
 		return nil
 	}
-	existing.Rules = want.Rules
 	if err := c.Update(ctx, &existing); err != nil {
 		return fmt.Errorf("update scoped role %s/%s: %w", want.Namespace, want.Name, err)
 	}
 	return nil
+}
+
+// adoptControllerRef moves the controller ownerReference of an existing object
+// onto want's owner, reporting whether anything changed.
+//
+// This is what makes the warm-slot handover work: the pool creates the grant
+// owned by itself, then the same Ensure call with the slot pod as owner takes
+// ownership over. SetControllerReference alone cannot do this — it refuses when
+// a DIFFERENT controller already owns the object (AlreadyOwnedError), which is
+// precisely the handover case.
+//
+// Non-controller ownerReferences are preserved: they are not ours to remove.
+func adoptControllerRef(existing, want metav1.Object) bool {
+	wantRef := metav1.GetControllerOf(want)
+	if wantRef == nil {
+		return false
+	}
+	if cur := metav1.GetControllerOf(existing); cur != nil && cur.UID == wantRef.UID {
+		return false
+	}
+	refs := []metav1.OwnerReference{*wantRef}
+	for _, ref := range existing.GetOwnerReferences() {
+		if ref.Controller == nil || !*ref.Controller {
+			refs = append(refs, ref)
+		}
+	}
+	existing.SetOwnerReferences(refs)
+	return true
 }
 
 func createOrUpdateBinding(ctx context.Context, c client.Client, want *rbacv1.RoleBinding) error {
@@ -212,12 +291,19 @@ func createOrUpdateBinding(ctx context.Context, c client.Client, want *rbacv1.Ro
 	if err != nil {
 		return fmt.Errorf("get scoped rolebinding %s/%s: %w", want.Namespace, want.Name, err)
 	}
-	if subjectsEqual(existing.Subjects, want.Subjects) {
+	changed := false
+	if !subjectsEqual(existing.Subjects, want.Subjects) {
+		// roleRef is immutable, so only subjects can be converged. A binding whose
+		// roleRef drifted must be deleted by an operator; we do not delete RBAC.
+		existing.Subjects = want.Subjects
+		changed = true
+	}
+	if adoptControllerRef(&existing, want) {
+		changed = true
+	}
+	if !changed {
 		return nil
 	}
-	// roleRef is immutable, so only subjects can be converged. A binding whose
-	// roleRef drifted must be deleted by an operator; we do not delete RBAC.
-	existing.Subjects = want.Subjects
 	if err := c.Update(ctx, &existing); err != nil {
 		return fmt.Errorf("update scoped rolebinding %s/%s: %w", want.Namespace, want.Name, err)
 	}

--- a/internal/controller/swiftguest/rbac_scoped.go
+++ b/internal/controller/swiftguest/rbac_scoped.go
@@ -163,10 +163,23 @@ func scopedRulesFor(class LauncherClass, podName string) []rbacv1.PolicyRule {
 // EnsureScopedLauncherRBAC creates (or converges) a Role + RoleBinding granting
 // the launcher SA access to exactly podName, owned by owner.
 //
-// MUST be called before the launcher pod is created. Callers must not proceed to
-// pod creation if it fails: without the grant the pod boots and looks healthy
-// while every status write 403s, which reaches the operator as a guest that
-// never reports an IP.
+// MUST be called before the launcher pod is created.
+//
+// It returns an error only when the grant is LOAD-BEARING — that is, when
+// ScopedOnly has retired the shared binding and this is the launcher's only
+// access. Then the caller must not create the pod: without the grant it boots and
+// looks healthy while every status write 403s, which reaches the operator as a
+// guest that never reports an IP.
+//
+// With the gate off the shared namespace-wide binding still covers the launcher,
+// so a failure here costs nothing at run time and is logged rather than
+// propagated. The case this exists for is an upgrade-order mistake — a controller
+// image new enough to mint these grants against a ClusterRole too old to allow
+// `roles` — which must not stop every guest and sandbox in the cluster from
+// booting over an object that is not doing any work yet.
+//
+// An empty pod name stays fatal in both modes: that is a programming error, and
+// the alternative is a grant scoped to nothing or to everything.
 func EnsureScopedLauncherRBAC(
 	ctx context.Context,
 	c client.Client,
@@ -178,6 +191,26 @@ func EnsureScopedLauncherRBAC(
 	if podName == "" {
 		return fmt.Errorf("scoped launcher RBAC: empty pod name")
 	}
+	err := ensureScopedLauncherRBAC(ctx, c, scheme, owner, podName, class)
+	if err == nil || ScopedOnly {
+		return err
+	}
+	log.FromContext(ctx).Error(err, "could not create the per-pod scoped launcher grant; "+
+		"continuing because scoped-launcher-rbac is OFF and the shared namespace-wide binding still covers this launcher. "+
+		"Enabling the gate in this state would break the workload. "+
+		"Check that the controller ClusterRole grants create/update on roles and rolebindings.",
+		"pod", podName, "namespace", owner.GetNamespace())
+	return nil
+}
+
+func ensureScopedLauncherRBAC(
+	ctx context.Context,
+	c client.Client,
+	scheme *runtime.Scheme,
+	owner client.Object,
+	podName string,
+	class LauncherClass,
+) error {
 	namespace := owner.GetNamespace()
 	saName, _, _ := launcherRBACNames(class)
 	name := ScopedRoleNameFor(podName)

--- a/internal/controller/swiftguest/rbac_scoped_test.go
+++ b/internal/controller/swiftguest/rbac_scoped_test.go
@@ -2,6 +2,7 @@ package swiftguest
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -10,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
@@ -265,6 +267,42 @@ func TestAdoptControllerRef_PreservesNonControllerRefs(t *testing.T) {
 	}
 	if adoptControllerRef(existing, want) {
 		t.Error("adopting an already-adopted ref must report no change")
+	}
+}
+
+// Upgrade-order safety. A controller new enough to mint these grants can be
+// running against a ClusterRole too old to allow `roles` — an ordinary upgrade
+// order, since helm applies both but not atomically. While the gate is OFF the
+// shared binding still covers every launcher, so that failure must not stop
+// guests and sandboxes from booting over an object doing no work yet. With the
+// gate ON the grant IS the access, and creating the pod without it would produce
+// a workload that boots and then silently 403s every status write.
+func TestEnsureScopedLauncherRBAC_FatalOnlyWhenLoadBearing(t *testing.T) {
+	sch := scheme.Scheme
+	guest := scopedTestGuest("g5")
+	denied := errors.New("roles.rbac.authorization.k8s.io is forbidden")
+	newClient := func() client.Client {
+		return fake.NewClientBuilder().WithScheme(sch).WithObjects(guest).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+					if _, ok := obj.(*rbacv1.Role); ok {
+						return denied
+					}
+					return nil
+				},
+			}).Build()
+	}
+
+	defer func(prev bool) { ScopedOnly = prev }(ScopedOnly)
+
+	ScopedOnly = false
+	if err := EnsureScopedLauncherRBAC(context.Background(), newClient(), sch, guest, "g5", GuestLauncher); err != nil {
+		t.Errorf("gate off: a failed grant must not block the workload, the shared binding still covers it; got %v", err)
+	}
+
+	ScopedOnly = true
+	if err := EnsureScopedLauncherRBAC(context.Background(), newClient(), sch, guest, "g5", GuestLauncher); err == nil {
+		t.Error("gate on: the grant is the only access — failing to create it MUST stop pod creation")
 	}
 }
 

--- a/internal/controller/swiftguest/rbac_scoped_test.go
+++ b/internal/controller/swiftguest/rbac_scoped_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/scheme"
 )
@@ -153,6 +155,116 @@ func TestEnsureScopedLauncherRBAC_ConvergesWidenedRules(t *testing.T) {
 	}
 	if len(reconverged.Rules[0].ResourceNames) != 1 || reconverged.Rules[0].ResourceNames[0] != "g3" {
 		t.Errorf("a widened Role must re-converge to [g3]; got %v", reconverged.Rules[0].ResourceNames)
+	}
+}
+
+// The warm-slot handover (#515). A pool slot's grant must be created BEFORE its
+// pod exists — so the pool owns it first — and then move onto the pod, which is
+// the only owner whose lifetime matches the slot's across a checkout re-parent.
+//
+// This fails against the obvious implementation. controllerutil.SetControllerReference
+// refuses to change an existing controller owner (AlreadyOwnedError), and
+// createOrUpdateRole only copies Rules, so without adoptControllerRef the Role
+// stays pool-owned forever: one leaked Role per churned slot, and a grant that
+// outlives the pod it was minted for.
+func TestEnsureScopedLauncherRBAC_HandsOwnershipToPod(t *testing.T) {
+	sch := scheme.Scheme
+	ctx := context.Background()
+	pool := &sandboxv1alpha1.SwiftSandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool", Namespace: "ns", UID: types.UID("uid-pool")},
+	}
+	slot := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-slot-abcde", Namespace: "ns", UID: types.UID("uid-slot")},
+	}
+	c := fake.NewClientBuilder().WithScheme(sch).WithObjects(pool, slot).Build()
+
+	// Phase one: pool-owned, pod does not exist yet.
+	if err := EnsureScopedLauncherRBAC(ctx, c, sch, pool, slot.Name, SandboxLauncher); err != nil {
+		t.Fatalf("phase one: %v", err)
+	}
+	key := types.NamespacedName{Namespace: "ns", Name: ScopedRoleNameFor(slot.Name)}
+	var role rbacv1.Role
+	if err := c.Get(ctx, key, &role); err != nil {
+		t.Fatal(err)
+	}
+	if ref := metav1.GetControllerOf(&role); ref == nil || ref.Kind != "SwiftSandboxPool" {
+		t.Fatalf("phase one must leave the pool as owner (the fail-safe); got %v", role.OwnerReferences)
+	}
+
+	// Phase two: the pod now exists and takes over.
+	if err := EnsureScopedLauncherRBAC(ctx, c, sch, slot, slot.Name, SandboxLauncher); err != nil {
+		t.Fatalf("phase two: %v", err)
+	}
+	for _, obj := range []client.Object{&rbacv1.Role{}, &rbacv1.RoleBinding{}} {
+		if err := c.Get(ctx, key, obj); err != nil {
+			t.Fatalf("%T: %v", obj, err)
+		}
+		ref := metav1.GetControllerOf(obj)
+		if ref == nil || ref.Kind != "Pod" || ref.UID != slot.UID {
+			t.Errorf("%T must be owned by the slot pod after handover; got %v", obj, obj.GetOwnerReferences())
+		}
+		if n := len(obj.GetOwnerReferences()); n != 1 {
+			t.Errorf("%T: handover must REPLACE the pool ref, not append; got %d refs", obj, n)
+		}
+	}
+}
+
+// Ownership convergence must not defeat the no-op guard: once the pod owns the
+// grant, re-ensuring with the same owner writes nothing.
+func TestEnsureScopedLauncherRBAC_HandoverIsIdempotent(t *testing.T) {
+	sch := scheme.Scheme
+	ctx := context.Background()
+	slot := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-slot-fghij", Namespace: "ns", UID: types.UID("uid-slot2")},
+	}
+	c := fake.NewClientBuilder().WithScheme(sch).WithObjects(slot).Build()
+	if err := EnsureScopedLauncherRBAC(ctx, c, sch, slot, slot.Name, SandboxLauncher); err != nil {
+		t.Fatal(err)
+	}
+	key := types.NamespacedName{Namespace: "ns", Name: ScopedRoleNameFor(slot.Name)}
+	var first rbacv1.Role
+	if err := c.Get(ctx, key, &first); err != nil {
+		t.Fatal(err)
+	}
+	// The pool census re-ensures every live slot on every reconcile.
+	for i := 0; i < 3; i++ {
+		if err := EnsureScopedLauncherRBAC(ctx, c, sch, slot, slot.Name, SandboxLauncher); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var after rbacv1.Role
+	if err := c.Get(ctx, key, &after); err != nil {
+		t.Fatal(err)
+	}
+	if first.ResourceVersion != after.ResourceVersion {
+		t.Errorf("census re-ensure rewrote the Role (rv %s -> %s) — the pool would spin",
+			first.ResourceVersion, after.ResourceVersion)
+	}
+}
+
+// An operator may add a non-controller ownerReference; the handover replaces the
+// CONTROLLER ref only.
+func TestAdoptControllerRef_PreservesNonControllerRefs(t *testing.T) {
+	yes, no := true, false
+	existing := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
+		{Kind: "SwiftSandboxPool", Name: "pool", UID: "uid-pool", Controller: &yes},
+		{Kind: "ConfigMap", Name: "keep-me", UID: "uid-cm", Controller: &no},
+	}}}
+	want := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
+		{Kind: "Pod", Name: "pool-slot-x", UID: "uid-slot", Controller: &yes},
+	}}}
+	if !adoptControllerRef(existing, want) {
+		t.Fatal("a differing controller ref must report a change")
+	}
+	refs := existing.GetOwnerReferences()
+	if len(refs) != 2 || refs[0].Kind != "Pod" {
+		t.Fatalf("want [Pod, ConfigMap]; got %v", refs)
+	}
+	if refs[1].Name != "keep-me" {
+		t.Errorf("a non-controller ownerReference is not ours to remove; got %v", refs[1])
+	}
+	if adoptControllerRef(existing, want) {
+		t.Error("adopting an already-adopted ref must report no change")
 	}
 }
 

--- a/internal/controller/swiftsandbox/controller.go
+++ b/internal/controller/swiftsandbox/controller.go
@@ -70,6 +70,23 @@ func (r *SwiftSandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	// Per-pod scoped grant (#515) for the COLD pod, which is named sb.Name.
+	//
+	// A pooled sandbox that claims a warm slot runs under the SLOT's pod, whose
+	// grant the pool created and which the slot pod owns — so no grant is minted
+	// here for it, and the checkout does not have to move one. Only a sandbox that
+	// will (or already did) boot cold needs this. createLaunch ensures it again
+	// unconditionally, which is what actually guarantees grant-before-pod on a
+	// first-reconcile cold-fallback; this call converges drift thereafter.
+	if sb.Spec.PoolRef == nil || sb.Status.PodRef == sb.Name {
+		if err := swiftguest.EnsureScopedLauncherRBAC(ctx, r.Client, r.Scheme, &sb, sb.Name, swiftguest.SandboxLauncher); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// The narrowing — strictly after the grants above, never fatal.
+	swiftguest.NarrowToScopedRBAC(ctx, r.Client, sb.Namespace, swiftguest.SandboxLauncher)
+
 	// Native SwiftGPU (spec.gpuProfileRef): allocate the device(s) at CONTROLLER
 	// time and stamp status.gpu BEFORE the pod is built (the pod pins to
 	// status.gpu.nodeName and gpu-init binds status.gpu.devices). A no-op for the
@@ -145,6 +162,14 @@ func (r *SwiftSandboxReconciler) createLaunch(ctx context.Context, sb *sandboxv1
 		return ctrl.Result{}, err
 	}
 	pod := buildPod(sb, kernelName)
+	// The scoped grant must exist before the pod does, or swiftletd's first
+	// annotation write 403s and the sandbox looks healthy while reporting nothing.
+	// Reconcile only mints it for a sandbox already known to be cold; a pool miss
+	// reaches here on the SAME reconcile that discovered it, so this is the call
+	// that actually orders the two for a cold-fallback.
+	if err := swiftguest.EnsureScopedLauncherRBAC(ctx, r.Client, r.Scheme, sb, pod.Name, swiftguest.SandboxLauncher); err != nil {
+		return ctrl.Result{}, err
+	}
 	if err := controllerutil.SetControllerReference(sb, pod, r.Scheme); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/swiftsandbox/pool_controller.go
+++ b/internal/controller/swiftsandbox/pool_controller.go
@@ -110,6 +110,15 @@ func (r *SwiftSandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if p.DeletionTimestamp != nil || p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
 			continue
 		}
+		// Converge the scoped grant (#515) for every LIVE slot, warm or claimed.
+		// createWarmSlot only covers slots this controller is creating now; slots
+		// that predate the gate have no grant at all, and retiring the shared
+		// binding under them would 403 every annotation write on a running slot.
+		// Also the self-heal for a create that crashed between the two phases —
+		// owner is the pod, so this adopts a still-pool-owned grant.
+		if err := swiftguest.EnsureScopedLauncherRBAC(ctx, r.Client, r.Scheme, p, p.Name, swiftguest.SandboxLauncher); err != nil {
+			return ctrl.Result{}, err
+		}
 		if p.Labels[SlotStateLabelKey] == slotStateWarm {
 			warmLive++
 			warmPods = append(warmPods, p)
@@ -120,6 +129,10 @@ func (r *SwiftSandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			claimed++ // claimed slots (Phase 3) are tracked but not replenished here
 		}
 	}
+
+	// The narrowing — only once every LIVE slot above holds its own grant, so no
+	// running slot loses access. Never fatal.
+	swiftguest.NarrowToScopedRBAC(ctx, r.Client, pool.Namespace, swiftguest.SandboxLauncher)
 
 	// Release the GPU of any slot whose pod is gone (drain / checkout completion /
 	// churn). Runs before warming so freed GPUs are available for new slots.
@@ -304,8 +317,26 @@ func (r *SwiftSandboxPoolReconciler) createWarmSlot(ctx context.Context, pool *s
 	if err := controllerutil.SetControllerReference(pool, pod, r.Scheme); err != nil {
 		return err
 	}
+
+	// Scoped grant (#515), phase one: owned by the POOL, because the pod it names
+	// does not exist yet and the grant must precede it. Phase two below re-parents
+	// it onto the pod. Pool ownership is the fail-safe: a crash between the two
+	// leaves a grant that still GCs with the pool, and the census in Reconcile
+	// re-parents it on the next pass.
+	if err := swiftguest.EnsureScopedLauncherRBAC(ctx, r.Client, r.Scheme, pool, pod.Name, swiftguest.SandboxLauncher); err != nil {
+		return err
+	}
 	if err := r.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
+	}
+	// Phase two. The slot pod outlives neither CR cleanly — checkout re-parents it
+	// from the pool to a SwiftSandbox — so the POD is the only owner whose lifetime
+	// matches the grant's in both states. Skipped on AlreadyExists (no UID to bind
+	// to); the census picks that up.
+	if pod.UID != "" {
+		if err := swiftguest.EnsureScopedLauncherRBAC(ctx, r.Client, r.Scheme, pod, pod.Name, swiftguest.SandboxLauncher); err != nil {
+			return err
+		}
 	}
 
 	if networked(slot) {

--- a/internal/controller/swiftsandbox/pool_controller_test.go
+++ b/internal/controller/swiftsandbox/pool_controller_test.go
@@ -1,6 +1,74 @@
 package swiftsandbox
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	sandboxv1alpha1 "github.com/kubeswift-io/kubeswift/api/sandbox/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/controller/swiftguest"
+	"github.com/kubeswift-io/kubeswift/internal/scheme"
+)
+
+// The upgrade case (#515). Slots warmed BEFORE the scoped-RBAC change have no
+// per-pod grant, and createWarmSlot never revisits them — it only runs for slots
+// it is creating now. If the pool did not converge grants for the slots it
+// already has, an operator enabling the gate would retire the shared binding out
+// from under running slots and every annotation write on them would 403: warm
+// slots stop reporting Ready, checkouts stop finding them, and the pool looks
+// empty for no visible reason.
+func TestPoolReconcile_GrantsExistingSlotsOnUpgrade(t *testing.T) {
+	s := scheme.Scheme
+	ctx := context.Background()
+	pool := &sandboxv1alpha1.SwiftSandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Spec:       sandboxv1alpha1.SwiftSandboxPoolSpec{Image: "busybox:1", MinWarm: 0},
+		// Non-empty digest so the reconcile skips the registry resolve.
+		Status: sandboxv1alpha1.SwiftSandboxPoolStatus{
+			Rootfs: &sandboxv1alpha1.SandboxRootfsStatus{Digest: "sha256:deadbeef"},
+		},
+	}
+	// A slot that predates the change: no scoped Role exists for it.
+	slot := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "p-slot-old01", Namespace: "ns", UID: types.UID("uid-old01"),
+		Labels: map[string]string{PoolLabelKey: "p", SlotStateLabelKey: slotStateWarm},
+	}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pool, slot).
+		WithStatusSubresource(pool).Build()
+	r := &SwiftSandboxPoolReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "p"},
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	key := types.NamespacedName{Namespace: "ns", Name: swiftguest.ScopedRoleNameFor(slot.Name)}
+	var role rbacv1.Role
+	if err := c.Get(ctx, key, &role); err != nil {
+		t.Fatalf("pre-existing slot got no scoped grant: %v", err)
+	}
+	if len(role.Rules) != 1 || len(role.Rules[0].ResourceNames) != 1 ||
+		role.Rules[0].ResourceNames[0] != slot.Name {
+		t.Errorf("grant must name exactly the slot pod; got %v", role.Rules)
+	}
+	// Owned by the POD, not the pool: the checkout re-parents the pod to a
+	// SwiftSandbox, and only pod ownership survives that with exact GC.
+	if ref := metav1.GetControllerOf(&role); ref == nil || ref.Kind != "Pod" || ref.UID != slot.UID {
+		t.Errorf("grant must be owned by the slot pod; got %v", role.OwnerReferences)
+	}
+	var rb rbacv1.RoleBinding
+	if err := c.Get(ctx, key, &rb); err != nil {
+		t.Fatalf("pre-existing slot got no scoped binding: %v", err)
+	}
+}
 
 func TestSlotsToCreate(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
Completes #515: every launcher pod now holds a grant scoped to exactly its own
pod. Guests and migration targets landed in #524 / 359c93e; this adds cold
SwiftSandbox pods and SwiftSandboxPool warm slots, and with both covered
`ScopedOnly` retires the shared namespace-wide RoleBinding for the sandbox class
too — which it previously had to skip, because retiring a shared binding for pods
that have no per-pod grant leaves them with no access at all.

Still **defence in depth**, not the fix for #443 — that is the ValidatingAdmissionPolicy
shipped in v0.13.8. RBAC is additive on a shared ServiceAccount, so scoping cannot
stop an attacker who obtains the SA. It bounds what the token is worth if it leaks
some other way.

## Warm slots need two phases

A slot pod is created by the pool but **re-parented to a SwiftSandbox on checkout**,
so neither CR owns it for its whole life:

| owner | problem |
|---|---|
| pool | leaks a Role per churned slot |
| sandbox | does not exist yet at create time |
| **pod** | correct — but the pod does not exist when the grant must |

So the pool creates the grant owned by itself (ordering preserved, and a crash
mid-sequence still reaps with the pool), then hands ownership to the slot pod.
`EnsureScopedLauncherRBAC` converges the controller ownerReference, so phase two
is the same call with a different owner — `SetControllerReference` alone cannot do
it, since it refuses when a different controller already owns the object.

The pool also converges grants for slots it **already has**. Without that,
enabling the gate on a running pool would retire the shared binding out from under
live slots and every annotation write on them would 403 — warm slots stop
reporting Ready and the pool silently looks empty.

## The narrowing cannot be fatal, by signature

`NarrowToScopedRBAC` returns nothing. The first version returned an error, the
guest reconcile propagated it, and every guest stuck in Scheduling with no pod —
because the failing call sat above pod creation (fixed in 359c93e). Making the
signature unable to express "fatal" is a stronger guarantee than asking three call
sites to remember.

## Both new guards were verified to go red

- reverting `adoptControllerRef` to a no-op reddens the handover test (Role stays
  pool-owned)
- dropping the pool census reddens the upgrade test (`roles.rbac.authorization.k8s.io
  "swiftletd-scoped-p-slot-old01" not found`)

## Also

Corrects the stale claim in `docs/security-audit.md` that neither closure for #443
is implemented — the VAP shipped in v0.13.8, and the doc contradicted itself two
paragraphs apart.

## Cluster validation

Pending — will validate on dev once the branch image is built: cold sandbox under
the gate, a warm pool through checkout, ownership handover, GC on slot churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)