### PR TITLE
fix(status): surface a guest that never gets an IP (#527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to KubeSwift are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A guest that never gets an IP now says so** (#527). `NetworkReady=False` with
+  reason `DHCPTimeout` appears on the SwiftGuest once swiftletd's lease poller
+  gives up, instead of the guest sitting at `Running` / `GuestRunning=True` with
+  an empty `status.network.primaryIP` indefinitely.
+
+  Previously the timeout was a single `log::warn!("lease_poll_timeout")` in the
+  launcher and nothing else — nothing on the CR distinguished "never going to get
+  an IP" from "still booting", so diagnosing it meant reading launcher logs and
+  attaching to a serial console.
+
+  The condition message names the likely cause. The common one is knowable from
+  the spec: a **disk-boot guest with no `seedProfileRef` gets no NoCloud seed**,
+  so cloud-init finds no datasource, never writes netplan, and the interface is
+  never configured — the guest boots fine to `multi-user.target` and simply never
+  sends a DHCP request. That case now reads:
+
+  > no DHCP lease after 240s; the guest booted but never requested one. This
+  > guest is disk-boot with no seedProfileRef, so it gets no NoCloud seed:
+  > cloud-init finds no datasource, never writes netplan, and the interface is
+  > never configured. Set spec.seedProfileRef, or use an image that configures
+  > its own networking
+
+  The condition recovers to `True` if a lease arrives late, so it never latches
+  false. Deliberately **not** a webhook rejection of "disk-boot without a seed" —
+  an image that self-configures is a valid shape; the goal is visibility, not
+  prohibition. No CRD schema change (conditions are not schema).
+
 ### Changed
 
 - **swiftletd: kube-rs 0.92 → 4.2, k8s-openapi 0.22 → 0.28** (#499, #501). Four

--- a/api/swift/v1alpha1/swiftguest_types.go
+++ b/api/swift/v1alpha1/swiftguest_types.go
@@ -70,6 +70,15 @@ const ConditionServiceReady = "ServiceReady"
 // the pod-netns signal (the VM's forwarded traffic can bypass the eth0 hook).
 const ConditionEgressReady = "EgressReady"
 
+// ConditionNetworkReady reports whether the guest obtained an IP (#527).
+//
+// It exists because "Running with no IP" was previously indistinguishable from
+// "Running, still booting" — forever. The lease poller gave up after ~4 minutes
+// with only a launcher-log warning, so a guest whose NIC never came up looked
+// completely healthy on the CR. False here means the poller timed out with no
+// DHCP lease; the message carries the likely cause.
+const ConditionNetworkReady = "NetworkReady"
+
 // SwiftGuestPhase is the phase of a SwiftGuest.
 // +kubebuilder:validation:Enum=Pending;Scheduling;Running;Stopped;Failed
 type SwiftGuestPhase string

--- a/internal/controller/swiftguest/constants.go
+++ b/internal/controller/swiftguest/constants.go
@@ -22,6 +22,11 @@ const PodAnnotationGuestIP = "kubeswift.io/guest-ip"
 // PodAnnotationGuestInterfaces is the annotation key for guest network interfaces JSON (set by swiftletd lease poller).
 const PodAnnotationGuestInterfaces = "kubeswift.io/guest-interfaces"
 
+// PodAnnotationNetworkUnready is written by swiftletd when the lease poller
+// gives up without ever seeing a DHCP lease (#527). Value is
+// `{"reason":"DHCPTimeout","afterSeconds":N}`. Maps to NetworkReady=False.
+const PodAnnotationNetworkUnready = "kubeswift.io/guest-network-unready"
+
 // PodAnnotationGuestRuntimePID is the annotation key for the CH process PID (set by swiftletd on socket ready).
 const PodAnnotationGuestRuntimePID = "kubeswift.io/guest-runtime-pid"
 

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -594,6 +594,10 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Pod exists; update status from pod
 		podForMetrics = &existingPod
 		MapPodToStatus(&existingPod, status)
+		// AFTER MapPodToStatus, which is what populates status.Network: surface
+		// whether the guest ever acquired an IP, so "Running with no IP forever"
+		// stops being invisible on the CR (#527).
+		MapNetworkReadyCondition(&guest, &existingPod, status)
 		// In-guest identity agent (PR 4): for an agent-enabled cloneFromSnapshot
 		// clone, drive the one-shot identity-regen over vsock once it is Running.
 		// MUST run BEFORE the IP-not-discovered requeue below: a fresh clone has

--- a/internal/controller/swiftguest/status.go
+++ b/internal/controller/swiftguest/status.go
@@ -16,6 +16,67 @@ const (
 	ConditionPodScheduled = "PodScheduled"
 )
 
+// MapNetworkReadyCondition surfaces the guest's IP-acquisition outcome on the CR
+// (#527). Call AFTER MapPodToStatus, which is what populates status.Network.
+//
+// The bug this closes: a guest whose NIC never came up sat at Running with
+// GuestRunning=True and an empty IP indefinitely. swiftletd's lease poller gave
+// up after ~4 minutes into a `log::warn!` and told nobody, so nothing on the CR
+// distinguished "never going to get an IP" from "still booting". Diagnosing it
+// meant reading launcher logs and attaching to a serial console.
+//
+// Takes the guest, not just the pod, because the most common cause is knowable
+// from the spec: a disk-boot guest with no seedProfileRef gets no NoCloud seed,
+// so cloud-init finds no datasource, never writes netplan, and the interface is
+// never configured — no DHCP request is ever sent. Naming that in the message is
+// the difference between a dead end and a fix.
+//
+// Deliberately NOT a webhook rejection of "disk-boot without a seed": an image
+// that self-configures (baked-in static addressing, a different init) is a valid
+// configuration. Make the failure visible; do not forbid the shape.
+func MapNetworkReadyCondition(guest *swiftv1alpha1.SwiftGuest, pod *corev1.Pod, status *swiftv1alpha1.SwiftGuestStatus) {
+	if pod == nil || guest == nil {
+		return
+	}
+	hasIP := status.Network != nil && status.Network.PrimaryIP != ""
+	if hasIP {
+		// Covers a lease that landed after the poller had already reported a
+		// timeout (a late DHCP, or an operator fixing the guest in place): the
+		// condition must recover, not latch False forever.
+		setNetworkCondition(status, swiftv1alpha1.ConditionNetworkReady, true,
+			"IPAcquired", "guest acquired "+status.Network.PrimaryIP)
+		return
+	}
+	raw, reported := pod.Annotations[PodAnnotationNetworkUnready]
+	if !reported {
+		// No IP and no timeout report yet — still within the poll window. Not a
+		// failure, and asserting one here would make every booting guest look
+		// broken for its first minute.
+		return
+	}
+	setNetworkCondition(status, swiftv1alpha1.ConditionNetworkReady, false,
+		"DHCPTimeout", dhcpTimeoutMessage(guest, raw))
+}
+
+// dhcpTimeoutMessage composes the operator-facing explanation.
+func dhcpTimeoutMessage(guest *swiftv1alpha1.SwiftGuest, raw string) string {
+	msg := "no DHCP lease"
+	var report struct {
+		AfterSeconds int64 `json:"afterSeconds"`
+	}
+	if err := json.Unmarshal([]byte(raw), &report); err == nil && report.AfterSeconds > 0 {
+		msg += " after " + strconv.FormatInt(report.AfterSeconds, 10) + "s"
+	}
+	msg += "; the guest booted but never requested one"
+	if guest.Spec.ImageRef != nil && guest.Spec.SeedProfileRef == nil {
+		msg += ". This guest is disk-boot with no seedProfileRef, so it gets no " +
+			"NoCloud seed: cloud-init finds no datasource, never writes netplan, " +
+			"and the interface is never configured. Set spec.seedProfileRef, or " +
+			"use an image that configures its own networking"
+	}
+	return msg
+}
+
 // MapPodToStatus updates status from pod phase and conditions.
 func MapPodToStatus(pod *corev1.Pod, status *swiftv1alpha1.SwiftGuestStatus) {
 	if pod == nil {

--- a/internal/controller/swiftguest/status_test.go
+++ b/internal/controller/swiftguest/status_test.go
@@ -1,6 +1,7 @@
 package swiftguest
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -170,4 +171,116 @@ func hasCondition(status *swiftv1alpha1.SwiftGuestStatus, condType string, condS
 		}
 	}
 	return false
+}
+
+// #527: the whole point of this condition is that "Running with no IP forever"
+// used to be indistinguishable from "Running, still booting". These pin the
+// three states apart.
+
+func networkTestGuest(diskBoot, withSeed bool) *swiftv1alpha1.SwiftGuest {
+	g := &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "ns"},
+	}
+	if diskBoot {
+		g.Spec.ImageRef = &corev1.LocalObjectReference{Name: "img"}
+	} else {
+		g.Spec.KernelRef = &corev1.LocalObjectReference{Name: "k"}
+	}
+	if withSeed {
+		g.Spec.SeedProfileRef = &corev1.LocalObjectReference{Name: "seed"}
+	}
+	return g
+}
+
+func networkCond(status *swiftv1alpha1.SwiftGuestStatus) *metav1.Condition {
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == swiftv1alpha1.ConditionNetworkReady {
+			return &status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// A booting guest must NOT look broken. Without this guard the obvious
+// implementation ("no IP => NetworkReady=False") would mark every guest failed
+// for the first minute of its life.
+func TestMapNetworkReadyCondition_SilentWhileStillBooting(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "ns"}}
+	status := &swiftv1alpha1.SwiftGuestStatus{}
+	MapNetworkReadyCondition(networkTestGuest(true, true), pod, status)
+	if c := networkCond(status); c != nil {
+		t.Errorf("no IP and no timeout report yet is not a failure; got %s/%s", c.Status, c.Reason)
+	}
+}
+
+func TestMapNetworkReadyCondition_TrueOnceIPAcquired(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "ns"}}
+	status := &swiftv1alpha1.SwiftGuestStatus{
+		Network: &swiftv1alpha1.GuestNetworkStatus{PrimaryIP: "10.0.0.5"},
+	}
+	MapNetworkReadyCondition(networkTestGuest(true, true), pod, status)
+	c := networkCond(status)
+	if c == nil || c.Status != metav1.ConditionTrue || c.Reason != "IPAcquired" {
+		t.Fatalf("want NetworkReady=True/IPAcquired; got %+v", c)
+	}
+}
+
+// The condition must RECOVER. A lease can land after the poller already reported
+// a timeout (late DHCP, or an operator fixing the guest in place); latching
+// False forever would be a new silent lie in the opposite direction.
+func TestMapNetworkReadyCondition_RecoversWhenLeaseArrivesLate(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "g", Namespace: "ns",
+		Annotations: map[string]string{
+			PodAnnotationNetworkUnready: `{"reason":"DHCPTimeout","afterSeconds":240}`,
+		},
+	}}
+	status := &swiftv1alpha1.SwiftGuestStatus{
+		Network: &swiftv1alpha1.GuestNetworkStatus{PrimaryIP: "10.0.0.5"},
+	}
+	MapNetworkReadyCondition(networkTestGuest(true, true), pod, status)
+	c := networkCond(status)
+	if c == nil || c.Status != metav1.ConditionTrue {
+		t.Fatalf("an IP must win over a stale timeout report; got %+v", c)
+	}
+}
+
+// The message is the deliverable. A bare "no DHCP lease" sends the operator to
+// the launcher logs and a serial console — which is exactly the cost this change
+// exists to remove.
+func TestMapNetworkReadyCondition_NamesTheMissingSeed(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "g", Namespace: "ns",
+		Annotations: map[string]string{
+			PodAnnotationNetworkUnready: `{"reason":"DHCPTimeout","afterSeconds":240}`,
+		},
+	}}
+
+	// disk-boot, no seed: the cause is knowable from the spec, so say it.
+	status := &swiftv1alpha1.SwiftGuestStatus{}
+	MapNetworkReadyCondition(networkTestGuest(true, false), pod, status)
+	c := networkCond(status)
+	if c == nil || c.Status != metav1.ConditionFalse || c.Reason != "DHCPTimeout" {
+		t.Fatalf("want NetworkReady=False/DHCPTimeout; got %+v", c)
+	}
+	if !strings.Contains(c.Message, "240s") {
+		t.Errorf("message should carry how long it waited; got %q", c.Message)
+	}
+	if !strings.Contains(c.Message, "seedProfileRef") {
+		t.Errorf("disk-boot with no seed MUST name seedProfileRef — that is the fix; got %q", c.Message)
+	}
+
+	// disk-boot WITH a seed: the seed hint would be wrong, so it must not appear.
+	status = &swiftv1alpha1.SwiftGuestStatus{}
+	MapNetworkReadyCondition(networkTestGuest(true, true), pod, status)
+	if c := networkCond(status); c == nil || strings.Contains(c.Message, "seedProfileRef") {
+		t.Errorf("a guest that HAS a seed must not be told to set one; got %+v", c)
+	}
+
+	// kernel-boot: no cloud-init involved, so the seed hint is irrelevant.
+	status = &swiftv1alpha1.SwiftGuestStatus{}
+	MapNetworkReadyCondition(networkTestGuest(false, false), pod, status)
+	if c := networkCond(status); c == nil || strings.Contains(c.Message, "seedProfileRef") {
+		t.Errorf("kernel-boot has no cloud-init; the seed hint must not appear; got %+v", c)
+	}
 }

--- a/rust/swiftletd/src/lease.rs
+++ b/rust/swiftletd/src/lease.rs
@@ -9,6 +9,17 @@ use std::time::Duration;
 
 pub const ANNOTATION_GUEST_IP: &str = "kubeswift.io/guest-ip";
 pub const ANNOTATION_GUEST_INTERFACES: &str = "kubeswift.io/guest-interfaces";
+/// Written when the lease poller gives up without ever seeing a DHCP lease
+/// (#527). The controller maps it to a NetworkReady=False condition.
+///
+/// This exists because the timeout used to be a bare `log::warn!` and nothing
+/// else. The guest reached Running with GuestRunning=True and simply never
+/// reported an IP — no condition, no event, nothing on the CR. A real case cost
+/// hours: an Ubuntu disk-boot guest with no `seedProfileRef` gets no NoCloud
+/// seed, so cloud-init never writes netplan, the NIC is never configured, and no
+/// DHCP request is ever sent. Everything looked healthy. Design principle 6 says
+/// status fields reflect real state; a launcher-log warning is not status.
+pub const ANNOTATION_NETWORK_UNREADY: &str = "kubeswift.io/guest-network-unready";
 /// Egress reachability: "true"/"false" written by the launcher entrypoint's
 /// cluster-DNS-ClusterIP probe (service exposure §4 — egress observability).
 /// The controller maps it to status.network.egress + the EgressReady condition.
@@ -161,8 +172,61 @@ pub fn spawn_lease_poller(
             }
             // else: continue polling; transient error or RBAC gap.
         }
-        log::warn!("lease_poll_timeout");
+        let waited_secs = (max_attempts as u64).saturating_mul(INTERVAL.as_secs());
+        log::warn!("lease_poll_timeout after {}s", waited_secs);
+        report_network_unready(&namespace, &pod_name, waited_secs);
     });
+}
+
+/// Patches the network-unready annotation so the timeout reaches the CR (#527).
+///
+/// Retried, for the same reason spawn_lease_poller retries its IP patch (W4): a
+/// 403 during namespace RBAC setup or a momentarily unavailable apiserver must
+/// not swallow the report. Failing to report a silent failure silently would be
+/// the same bug one level up — so a give-up here logs at ERROR.
+///
+/// Bounded, unlike the IP poller: this runs once at the end of the poll window
+/// and there is nothing further to wait for.
+fn report_network_unready(namespace: &str, pod_name: &str, waited_secs: u64) {
+    const ATTEMPTS: u32 = 5;
+    const BACKOFF: Duration = Duration::from_secs(2);
+
+    let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    else {
+        log::error!("failed to create runtime for network-unready patch");
+        return;
+    };
+    for attempt in 0..ATTEMPTS {
+        if attempt > 0 {
+            thread::sleep(BACKOFF);
+        }
+        let ok = rt.block_on(async {
+            let client = match crate::kube_client::create_client().await {
+                Ok(c) => c,
+                Err(e) => {
+                    log::warn!("kube client unavailable for network-unready patch ({e})");
+                    return false;
+                }
+            };
+            match patch_network_unready(&client, namespace, pod_name, waited_secs).await {
+                Ok(()) => true,
+                Err(e) => {
+                    log::warn!("network_unready_patch_failed (will retry): {e}");
+                    false
+                }
+            }
+        });
+        if ok {
+            log::info!("pod_annotation_patched {ANNOTATION_NETWORK_UNREADY}=DHCPTimeout");
+            return;
+        }
+    }
+    log::error!(
+        "could not report the DHCP timeout to the pod after {ATTEMPTS} attempts; \
+         the guest will show as Running with no IP and no reason"
+    );
 }
 
 /// Build the interfaces JSON for pod annotation.
@@ -220,9 +284,60 @@ async fn patch_pod_annotation(
     Ok(())
 }
 
+/// Builds the network-unready annotation value.
+///
+/// JSON rather than a bare string so the controller can surface the wait
+/// duration in its condition message without the operator having to know what
+/// the poll window is. `serde_json::json!`, not `format!` — the repo convention
+/// for annotation payloads.
+fn network_unready_value(waited_secs: u64) -> String {
+    serde_json::to_string(&json!({
+        "reason": "DHCPTimeout",
+        "afterSeconds": waited_secs,
+    }))
+    .unwrap_or_else(|_| r#"{"reason":"DHCPTimeout"}"#.to_string())
+}
+
+async fn patch_network_unready(
+    client: &Client,
+    namespace: &str,
+    name: &str,
+    waited_secs: u64,
+) -> Result<(), kube::Error> {
+    let api: Api<k8s_openapi::api::core::v1::Pod> = Api::namespaced(client.clone(), namespace);
+    let patch = json!({
+        "metadata": {
+            "annotations": {
+                ANNOTATION_NETWORK_UNREADY: network_unready_value(waited_secs),
+            }
+        }
+    });
+    api.patch(name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The controller parses this payload to build its NetworkReady message
+    // (#527). A change here that the Go side does not expect silently degrades
+    // the message back to a bare "no DHCP lease" — which is the dead end this
+    // whole change exists to remove.
+    #[test]
+    fn network_unready_value_carries_reason_and_wait() {
+        let v = network_unready_value(240);
+        let parsed: serde_json::Value = serde_json::from_str(&v).expect("must be valid JSON");
+        assert_eq!(
+            parsed["reason"], "DHCPTimeout",
+            "controller matches on reason"
+        );
+        assert_eq!(
+            parsed["afterSeconds"], 240,
+            "the wait duration is what makes the message actionable"
+        );
+    }
 
     #[test]
     fn parse_first_lease_skips_blank_and_comment_lines() {


### PR DESCRIPTION
Fixes #527.

## The bug is the silence, not the seed

A guest whose NIC never comes up sits at `Running` / `GuestRunning=True` with an empty `status.network.primaryIP` **forever**. The lease poller gives up after ~4 minutes into:

```rust
log::warn!("lease_poll_timeout");   // and nothing else
```

Nothing on the CR distinguishes "never going to get an IP" from "still booting". Finding the cause meant reading launcher logs and attaching to a serial console. That is design principle 6 — a launcher-log warning is not status.

## What changed

- **swiftletd** patches `kubeswift.io/guest-network-unready` on timeout (`{"reason":"DHCPTimeout","afterSeconds":N}`) — the same annotation channel every other status already uses. Retried, for the same reason the IP patch is (the W4 finding): failing to report a silent failure silently would be the same bug one level up, so giving up logs at ERROR.
- **controller** maps it to `NetworkReady=False` / `DHCPTimeout`, and composes the message.

## The message is the deliverable

The common cause is knowable from the spec, so it gets named:

> no DHCP lease after 240s; the guest booted but never requested one. This guest is disk-boot with no seedProfileRef, so it gets no NoCloud seed: cloud-init finds no datasource, never writes netplan, and the interface is never configured. Set spec.seedProfileRef, or use an image that configures its own networking

That hint is suppressed when it would be wrong — a guest that already has a seed, or a kernel-boot guest where cloud-init is not involved. Tested.

## Root cause evidence

The guest boots **fine** — all the way to `multi-user.target` with a working serial getty. One unit fails:

```
[FAILED] Failed to start systemd-networkd-w… Wait for Network to be Configured.
```

The NIC is attached (`vm.info` shows virtio-net on `tap0` with a guest MAC), but the VM has exactly one disk — the root image, no seed. `internal/resolved/resolver.go:115` attaches a seed only `if guest.Spec.SeedProfileRef != nil`; there is no default.

Same image, same class, same build, one variable:

| guest | seedProfileRef | result |
|---|---|---|
| seeded | set | **IP in 135s** |
| unseeded | unset | no IP, ever |

## Design choices

**Not a webhook rejection** of disk-boot-without-a-seed. An image that self-configures — baked-in static addressing, a different init — is a valid shape. Make the failure visible; do not forbid the configuration. (Every shipped SwiftGuest sample already sets a seed; it was the hand-written guest that fell in the hole.)

**The condition recovers.** If a lease arrives after the timeout was reported, `NetworkReady` flips back to True. A latched False would be a new silent lie in the opposite direction.

**Silent while booting.** No IP and no timeout report yet sets no condition at all — otherwise every guest would look broken for its first minute.

## Verification

Both new guards were confirmed to go red when the behaviour is removed: dropping the seed hint reddens the message test, leaving it bare (`"no DHCP lease after 240s; the guest booted but never requested one"`).

Rust + Go build, fmt, and full test suites green. `make generate` produces no CRD diff — conditions are not schema.

Cluster validation pending — will boot an unseeded guest and confirm the condition and message appear, then a seeded one to confirm `NetworkReady=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
