### PR TITLE
chore: replace lab infrastructure names with generic placeholders

### DIFF
--- a/api/fleet/v1alpha1/cluster_types_test.go
+++ b/api/fleet/v1alpha1/cluster_types_test.go
@@ -32,12 +32,12 @@ func TestClusterConditionConstants(t *testing.T) {
 func TestClusterDeepCopy(t *testing.T) {
 	count := int32(3)
 	orig := &Cluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "boba", Namespace: "kubeswift-system"},
+		ObjectMeta: metav1.ObjectMeta{Name: "edge-1", Namespace: "kubeswift-system"},
 		Spec: ClusterSpec{
 			Server:              "https://10.0.0.1:6443",
-			CredentialSecretRef: &corev1.LocalObjectReference{Name: "boba-kubeconfig"},
-			PrometheusEndpoint:  "http://prometheus.boba:9090",
-			DisplayName:         "Boba (lab)",
+			CredentialSecretRef: &corev1.LocalObjectReference{Name: "edge-1-kubeconfig"},
+			PrometheusEndpoint:  "http://prometheus.edge-1:9090",
+			DisplayName:         "Edge 1 (lab)",
 		},
 		Status: ClusterStatus{
 			KubernetesVersion: "v1.34.3",

--- a/charts/kubeswift/templates/gpu-discovery/daemonset.yaml
+++ b/charts/kubeswift/templates/gpu-discovery/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       hostNetwork: false
       # Asserting a property the image already has, rather than changing
       # behaviour: images/gpu-discovery/Containerfile ends in `USER 65534:65534`,
-      # and the pod on the dev GPU node (boba) reports uid=65534(nobody) while
+      # and the pod on the dev GPU node (worker-1) reports uid=65534(nobody) while
       # discovering the GTX 1080 correctly. runAsNonRoot makes the kubelet refuse
       # to start it if that ever regresses to root.
       #

--- a/cmd/kubeswift-dra-driver/driver_test.go
+++ b/cmd/kubeswift-dra-driver/driver_test.go
@@ -116,7 +116,7 @@ func TestPrepareClaim(t *testing.T) {
 			Allocation: &resourceapi.AllocationResult{
 				Devices: resourceapi.DeviceAllocationResult{
 					Results: []resourceapi.DeviceRequestAllocationResult{
-						{Request: "gpu", Driver: driverName, Pool: "boba",
+						{Request: "gpu", Driver: driverName, Pool: "worker-1",
 							Device: gpualloc.EncodeDeviceName("0000:01:00.0")},
 						{Request: "x", Driver: "other.example.com", Pool: "p", Device: "d"},
 					},
@@ -124,7 +124,7 @@ func TestPrepareClaim(t *testing.T) {
 			},
 		},
 	}
-	d := &draDriver{nodeName: "boba", cdiDir: dir, kube: fake.NewSimpleClientset(claim)}
+	d := &draDriver{nodeName: "worker-1", cdiDir: dir, kube: fake.NewSimpleClientset(claim)}
 
 	res := d.prepareClaim(context.Background(), claim)
 	if res.Err != nil {
@@ -135,7 +135,7 @@ func TestPrepareClaim(t *testing.T) {
 		t.Fatalf("devices = %+v, want exactly ours", res.Devices)
 	}
 	dev := res.Devices[0]
-	if dev.DeviceName != gpualloc.EncodeDeviceName("0000:01:00.0") || dev.PoolName != "boba" {
+	if dev.DeviceName != gpualloc.EncodeDeviceName("0000:01:00.0") || dev.PoolName != "worker-1" {
 		t.Errorf("device = %+v", dev)
 	}
 	if len(dev.CDIDeviceIDs) != 1 || dev.CDIDeviceIDs[0] != "kubeswift.io/gpu=claim-uid-9" {

--- a/cmd/swiftctl/guest_coldmig.go
+++ b/cmd/swiftctl/guest_coldmig.go
@@ -81,7 +81,7 @@ The referenced SwiftSnapshot must be Ready in this namespace. --guest-class is
 required (a clone needs a guestClassRef even though CPU/memory come from the
 snapshot); --target-node pins where the clone runs (and where its disk is
 downloaded).`,
-	Example: `  swiftctl guest import db2 --from-snapshot db-export --target-node boba --guest-class ft-small --wait`,
+	Example: `  swiftctl guest import db2 --from-snapshot db-export --target-node worker-1 --guest-class ft-small --wait`,
 	Args:    cobra.ExactArgs(1),
 	RunE:    runGuestImport,
 }

--- a/cmd/swiftctl/guest_coldmig_test.go
+++ b/cmd/swiftctl/guest_coldmig_test.go
@@ -50,15 +50,15 @@ func TestBuildExportSnapshot_InsecureCredsSignTag(t *testing.T) {
 }
 
 func TestBuildImportGuest_CloneFromSnapshot(t *testing.T) {
-	g := buildImportGuest("db2", "team-a", "db-export", "boba", "ft-small")
+	g := buildImportGuest("db2", "team-a", "db-export", "worker-1", "ft-small")
 	if g.Spec.CloneFromSnapshot == nil {
 		t.Fatal("import guest must set cloneFromSnapshot")
 	}
 	if g.Spec.CloneFromSnapshot.SnapshotRef.Name != "db-export" {
 		t.Errorf("snapshotRef = %q, want db-export", g.Spec.CloneFromSnapshot.SnapshotRef.Name)
 	}
-	if g.Spec.CloneFromSnapshot.TargetNode != "boba" {
-		t.Errorf("targetNode = %q, want boba", g.Spec.CloneFromSnapshot.TargetNode)
+	if g.Spec.CloneFromSnapshot.TargetNode != "worker-1" {
+		t.Errorf("targetNode = %q, want worker-1", g.Spec.CloneFromSnapshot.TargetNode)
 	}
 	// guestClassRef is required by the CRD/webhook even for a clone.
 	if g.Spec.GuestClassRef.Name != "ft-small" {

--- a/cmd/swiftctl/migration_check_test.go
+++ b/cmd/swiftctl/migration_check_test.go
@@ -28,7 +28,7 @@ func readyNode(name string) *corev1.Node {
 }
 
 func TestMigratePreflight_PrimaryOnNAD_NoBlockers(t *testing.T) {
-	migrateTargetNode = "miles"
+	migrateTargetNode = "worker-2"
 	migrateAllowIPChange = false
 	defer func() { migrateTargetNode = ""; migrateAllowIPChange = false }()
 
@@ -40,14 +40,14 @@ func TestMigratePreflight_PrimaryOnNAD_NoBlockers(t *testing.T) {
 				{Name: "app", Primary: true, NetworkRef: &swiftv1alpha1.NetworkReference{Name: "ovn-l2"}},
 			},
 		},
-		Status: swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning, NodeName: "boba"},
+		Status: swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning, NodeName: "worker-1"},
 	}
 	class := &swiftv1alpha1.SwiftGuestClass{
 		ObjectMeta: metav1.ObjectMeta{Name: "cls"},
 		Spec:       swiftv1alpha1.SwiftGuestClassSpec{CPU: resource.MustParse("2"), Memory: resource.MustParse("4Gi")},
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
-		WithObjects(guest, class, readyNode("miles"), readyNode("boba")).Build()
+		WithObjects(guest, class, readyNode("worker-2"), readyNode("worker-1")).Build()
 
 	cmd := &cobra.Command{}
 	var buf bytes.Buffer
@@ -65,7 +65,7 @@ func TestMigratePreflight_PrimaryOnNAD_NoBlockers(t *testing.T) {
 }
 
 func TestMigratePreflight_LiveWithSRIOV_IsBlocker(t *testing.T) {
-	migrateTargetNode = "miles"
+	migrateTargetNode = "worker-2"
 	defer func() { migrateTargetNode = "" }()
 
 	guest := &swiftv1alpha1.SwiftGuest{
@@ -74,14 +74,14 @@ func TestMigratePreflight_LiveWithSRIOV_IsBlocker(t *testing.T) {
 			GuestClassRef: corev1.LocalObjectReference{Name: "cls"},
 			Interfaces:    []swiftv1alpha1.GuestInterface{{Name: "rdma", Type: swiftv1alpha1.InterfaceTypeSRIOV}},
 		},
-		Status: swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning, NodeName: "boba"},
+		Status: swiftv1alpha1.SwiftGuestStatus{Phase: swiftv1alpha1.SwiftGuestPhaseRunning, NodeName: "worker-1"},
 	}
 	class := &swiftv1alpha1.SwiftGuestClass{
 		ObjectMeta: metav1.ObjectMeta{Name: "cls"},
 		Spec:       swiftv1alpha1.SwiftGuestClassSpec{CPU: resource.MustParse("2"), Memory: resource.MustParse("4Gi")},
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
-		WithObjects(guest, class, readyNode("miles"), readyNode("boba")).Build()
+		WithObjects(guest, class, readyNode("worker-2"), readyNode("worker-1")).Build()
 
 	cmd := &cobra.Command{}
 	var buf bytes.Buffer
@@ -96,7 +96,7 @@ func TestMigratePreflight_LiveWithSRIOV_IsBlocker(t *testing.T) {
 }
 
 func TestMigratePreflight_GuestNotFound(t *testing.T) {
-	migrateTargetNode = "miles"
+	migrateTargetNode = "worker-2"
 	defer func() { migrateTargetNode = "" }()
 	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
 	cmd := &cobra.Command{}

--- a/cmd/swiftctl/migration_test.go
+++ b/cmd/swiftctl/migration_test.go
@@ -58,7 +58,7 @@ func TestRenderMigrationDescribe_CompletedLive(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
 		Spec: migrationv1alpha1.SwiftMigrationSpec{
 			GuestRef: migrationv1alpha1.SwiftMigrationGuestRef{Name: "g"},
-			Target:   migrationv1alpha1.SwiftMigrationTarget{NodeName: "boba"},
+			Target:   migrationv1alpha1.SwiftMigrationTarget{NodeName: "worker-1"},
 			Mode:     migrationv1alpha1.SwiftMigrationModeLive,
 		},
 		Status: migrationv1alpha1.SwiftMigrationStatus{

--- a/config/samples/dra-gpu/README.md
+++ b/config/samples/dra-gpu/README.md
@@ -54,13 +54,13 @@ dra-gpu-vm-gpu-vkt4l   allocated,reserved   1m
 
 $ kubectl get swiftguest dra-gpu-vm
 NAME         PHASE     NODE   IP              AGE
-dra-gpu-vm   Running   boba   192.168.99.13   2m
+dra-gpu-vm   Running   worker-1   192.168.99.13   2m
 
 $ kubectl get swiftguest dra-gpu-vm -o jsonpath='{.status.gpu}'
-{"devices":["0000:01:00.0"],"hypervisor":"cloud-hypervisor","nodeName":"boba","partitionId":-1}
+{"devices":["0000:01:00.0"],"hypervisor":"cloud-hypervisor","nodeName":"worker-1","partitionId":-1}
 ```
 
-- Condition `GPUAllocated=True` (`allocated 1 GPU(s) on node boba`); while the
+- Condition `GPUAllocated=True` (`allocated 1 GPU(s) on node worker-1`); while the
   scheduler is still deciding, the guest shows `GPUClaimPending` instead.
 - Inside the guest: `lspci | grep -i nvidia` shows the GPU.
 

--- a/config/samples/gateway/cluster.yaml
+++ b/config/samples/gateway/cluster.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: boba-kubeconfig
+  name: edge-1-kubeconfig
   namespace: kubeswift-system
 type: Opaque
 stringData:
@@ -16,31 +16,31 @@ stringData:
     apiVersion: v1
     kind: Config
     clusters:
-      - name: boba
+      - name: edge-1
         cluster:
-          server: https://boba.example.com:6443
+          server: https://edge-1.example.com:6443
           # certificate-authority-data: <base64 CA>
     users:
       - name: kubeswift-gateway
         user:
           token: <member service-account token>
     contexts:
-      - name: boba
+      - name: edge-1
         context:
-          cluster: boba
+          cluster: edge-1
           user: kubeswift-gateway
-    current-context: boba
+    current-context: edge-1
 ---
 apiVersion: fleet.kubeswift.io/v1alpha1
 kind: Cluster
 metadata:
-  name: boba
+  name: edge-1
   namespace: kubeswift-system
 spec:
   # Optional when the kubeconfig already names the server.
-  server: https://boba.example.com:6443
+  server: https://edge-1.example.com:6443
   credentialSecretRef:
-    name: boba-kubeconfig
+    name: edge-1-kubeconfig
   # Optional: per-member Prometheus for VM telemetry (P1).
   # prometheusEndpoint: http://prometheus.monitoring.svc:9090
-  displayName: Boba (lab)
+  displayName: Edge 1 (lab)

--- a/config/samples/gpu-pcie/swiftguest-gpu-gtx1080.yaml
+++ b/config/samples/gpu-pcie/swiftguest-gpu-gtx1080.yaml
@@ -1,11 +1,11 @@
-# SwiftGuest with GTX 1080 GPU passthrough on node boba.
+# SwiftGuest with GTX 1080 GPU passthrough on node worker-1.
 # Uses Cloud Hypervisor (Tier 1 PCIe) — boots Ubuntu Noble with CLOUDHV.fd.
 # gpu-init binds the GPU + IOMMU group peers (audio controller) to vfio-pci.
 #
 # Prerequisites:
 #   1. SwiftImage ubuntu-noble in Ready state
 #   2. SwiftGPUProfile gtx1080-single created
-#   3. SwiftGPUNode for boba populated by discovery DaemonSet
+#   3. SwiftGPUNode for worker-1 populated by discovery DaemonSet
 #   4. SwiftGuestClass default and SwiftSeedProfile minimal created
 #
 # Apply order:
@@ -16,13 +16,13 @@
 #   5. kubectl apply -f swiftguest-gpu-gtx1080.yaml
 #
 # Verify:
-#   kubectl get swiftguest gpu-test-boba -w
-#   kubectl logs gpu-test-boba -c gpu-init
-#   swiftctl ssh gpu-test-boba -- lspci | grep -i nvidia
+#   kubectl get swiftguest gpu-test-worker-1 -w
+#   kubectl logs gpu-test-worker-1 -c gpu-init
+#   swiftctl ssh gpu-test-worker-1 -- lspci | grep -i nvidia
 apiVersion: swift.kubeswift.io/v1alpha1
 kind: SwiftGuest
 metadata:
-  name: gpu-test-boba
+  name: gpu-test-worker-1
   namespace: default
 spec:
   imageRef:

--- a/config/samples/migratable-guests/lab-live-migration-set.yaml
+++ b/config/samples/migratable-guests/lab-live-migration-set.yaml
@@ -4,7 +4,7 @@
 #   - disk-boot guests use the live-migratable class (RWX + Block storage)
 #   - kernel-boot has no PVC, so it's live-migratable on default storage
 #
-# Spread across the two worker nodes (frida is tainted control-plane).
+# Spread across the two worker nodes (cp-1 is tainted control-plane).
 # Migrate one with:  swiftctl migrate <name> --to <worker> --allow-ip-change
 # (default node-local networking changes the IP cross-node).
 ---

--- a/config/samples/migration/phase-4/swiftguest-drainpolicy-block.yaml
+++ b/config/samples/migration/phase-4/swiftguest-drainpolicy-block.yaml
@@ -19,7 +19,7 @@ spec:
     name: default
   kernelCmdline: "console=ttyS0 root=/dev/ram0 rdinit=/init"
   runPolicy: Running
-  nodeName: miles
+  nodeName: worker-2
   migration:
     enabled: true
     drainPolicy: Block

--- a/config/samples/migration/phase-4/swiftguest-drainpolicy-migrate.yaml
+++ b/config/samples/migration/phase-4/swiftguest-drainpolicy-migrate.yaml
@@ -20,7 +20,7 @@ spec:
     name: default
   kernelCmdline: "console=ttyS0 root=/dev/ram0 rdinit=/init"
   runPolicy: Running
-  nodeName: miles          # start on miles so `kubectl drain miles` moves it
+  nodeName: worker-2          # start on worker-2 so `kubectl drain worker-2` moves it
   migration:
     enabled: true
     drainPolicy: Migrate    # Migrate | LiveMigrate | Block

--- a/config/samples/oci-snapshots/04-restore-clone.yaml
+++ b/config/samples/oci-snapshots/04-restore-clone.yaml
@@ -1,7 +1,7 @@
 # Cross-node clone restore from the oci-backend snapshot.
 #
 # Because the artifact lives in the registry, this restore can land on ANY node
-# — set spec.targetNode to the node you want the clone to run on (here "boba";
+# — set spec.targetNode to the node you want the clone to run on (here "worker-1";
 # change to a node in your cluster). A node-pinned Job pulls the OCI artifact
 # (pinned by the digest in status.oci.manifestDigest) into that node's local
 # cache, then the standard restore path boots the clone.
@@ -23,7 +23,7 @@ spec:
     name: snapshot-oci-mem
   targetGuest:
     name: snapshot-oci-clone            # different from source => clone
-  targetNode: boba                      # pin the restore to this node
+  targetNode: worker-1                      # pin the restore to this node
   resumeAfterRestore: true
   identity:
     regenerate:

--- a/config/samples/s3-snapshots/04-restore-clone.yaml
+++ b/config/samples/s3-snapshots/04-restore-clone.yaml
@@ -2,7 +2,7 @@
 #
 # Because the artifacts live in object storage, this restore can land on ANY
 # node — set spec.targetNode to the node you want the clone to run on (here
-# "boba"; change to a node in your cluster). A node-pinned download Job pulls
+# "worker-1"; change to a node in your cluster). A node-pinned download Job pulls
 # the artifacts from S3 into that node's local cache, then the standard restore
 # path boots the clone. Phases: Pending -> Downloading -> Restoring ->
 # Resuming -> Ready.
@@ -25,7 +25,7 @@ spec:
     name: snapshot-s3-mem
   targetGuest:
     name: snapshot-s3-clone            # different from source => clone
-  targetNode: boba                     # pin the restore to this node (s3 only)
+  targetNode: worker-1                     # pin the restore to this node (s3 only)
   resumeAfterRestore: true
   identity:
     regenerate:

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -126,7 +126,7 @@ sysfs (no NVIDIA userspace needed), and publishes one `ResourceSlice` per node:
 ```
 $ kubectl get resourceslice
 NAME                          NODE   DRIVER             POOL   AGE
-boba-gpu.kubeswift.io-mg7pp   boba   gpu.kubeswift.io   boba   18m
+worker-1-gpu.kubeswift.io-mg7pp   worker-1   gpu.kubeswift.io   worker-1   18m
 ```
 
 Each device carries the attributes `pciAddress`, `vendorDevice` (PCI
@@ -191,10 +191,10 @@ dra-gpu-vm-gpu-vkt4l   allocated,reserved   1m
 
 $ kubectl get swiftguest dra-gpu-vm
 NAME         PHASE     NODE   IP              AGE
-dra-gpu-vm   Running   boba   192.168.99.13   2m
+dra-gpu-vm   Running   worker-1   192.168.99.13   2m
 
 $ kubectl get swiftguest dra-gpu-vm -o jsonpath='{.status.gpu}'
-{"devices":["0000:01:00.0"],"hypervisor":"cloud-hypervisor","nodeName":"boba","partitionId":-1}
+{"devices":["0000:01:00.0"],"hypervisor":"cloud-hypervisor","nodeName":"worker-1","partitionId":-1}
 
 $ swiftctl ssh dra-gpu-vm -- lspci | grep -i nvidia
 01:00.0 VGA compatible controller: NVIDIA Corporation GP104 [GeForce GTX 1080]
@@ -259,7 +259,7 @@ mutually exclusive with `gpuProfileRef`, `kernelRef`, `cloneFromSnapshot`, and
 - **`GPUClaimPending=True`** — the guest is DRA-backed and the scheduler has
   not allocated yet (or the controller hasn't observed it). The launcher pod
   exists and is what the scheduler is placing. Cleared once resolved.
-- **`GPUAllocated=True`** (`allocated 1 GPU(s) on node boba`) — the allocation
+- **`GPUAllocated=True`** (`allocated 1 GPU(s) on node worker-1`) — the allocation
   was read back from the claim into `status.gpu`
   (`devices`, `nodeName`, `hypervisor`, `partitionId: -1`).
 - `kubectl get resourceclaim` shows the authoritative allocation state

--- a/docs/migration/observability.md
+++ b/docs/migration/observability.md
@@ -10,7 +10,7 @@ A live migration's pre-copy progress is surfaced on the SwiftMigration:
 ```bash
 kubectl get swiftmigration
 # NAME        GUEST  FROM   TO    MODE  PHASE        PROGRESS  DOWNTIME  TRANSFER  AGE
-# web-1-mig   web-1  miles  boba  live  StopAndCopy  52        <none>    <none>    14s
+# web-1-mig   web-1  worker-2  worker-1  live  StopAndCopy  52        <none>    <none>    14s
 ```
 
 `status.transferProgress` (the **Progress** column) is an integer percentage,

--- a/docs/migration/phase-2.md
+++ b/docs/migration/phase-2.md
@@ -47,7 +47,7 @@ Operators on production clusters should not use this workflow. The unsafe-plaint
 
 ## Prerequisites
 
-- Two-node cluster with both nodes labelled `kubeswift.io/launcher-node=true`. The smoke-test miles + boba pair is the validated configuration.
+- Two-node cluster with both nodes labelled `kubeswift.io/launcher-node=true`. The smoke-test worker-2 + worker-1 pair is the validated configuration.
 - The same swiftletd image deployed cluster-wide. Phase 2 mandates exact-image-tag match across source and destination CH (Phase 2 Decision 3 — `spec.allowVersionSkew` lands in Phase 3).
 - A running SwiftGuest on the source node with a known sentinel marker file the operator can verify post-migration.
 - Operator-level RBAC on the namespace (pods/get, pods/patch, pods/exec, pods/log, swiftguests/get).

--- a/docs/migration/phase-3a.md
+++ b/docs/migration/phase-3a.md
@@ -71,13 +71,13 @@ Apply a SwiftMigration manifest:
 apiVersion: migration.kubeswift.io/v1alpha1
 kind: SwiftMigration
 metadata:
-  name: my-guest-to-boba
+  name: my-guest-to-worker-1
   namespace: workloads
 spec:
   guestRef:
     name: my-guest
   target:
-    nodeName: boba
+    nodeName: worker-1
   mode: live
   timeout: 5m   # default; raise for very large guests
 ```
@@ -85,7 +85,7 @@ spec:
 Or via swiftctl (after PR 2 ships):
 
 ```sh
-swiftctl migrate my-guest --to boba --mode live
+swiftctl migrate my-guest --to worker-1 --mode live
 ```
 
 `mode: auto` (the default) resolves to `live` for non-VFIO
@@ -178,7 +178,7 @@ will land in "few seconds" range.
 To cancel:
 
 ```sh
-kubectl patch smig my-guest-to-boba \
+kubectl patch smig my-guest-to-worker-1 \
   --type merge -p '{"spec":{"cancelRequested":true}}'
 ```
 
@@ -279,11 +279,11 @@ Common debug commands:
 
 ```sh
 # Inspect the migration:
-kubectl describe smig my-guest-to-boba -n workloads
+kubectl describe smig my-guest-to-worker-1 -n workloads
 
 # Inspect the pods:
 kubectl get pod -l swift.kubeswift.io/guest=my-guest -n workloads
-kubectl get pod -l kubeswift.io/migration=my-guest-to-boba -n workloads
+kubectl get pod -l kubeswift.io/migration=my-guest-to-worker-1 -n workloads
 
 # Source/destination launcher logs:
 kubectl logs <src-pod> -c launcher -n workloads --tail=200

--- a/docs/migration/phase-3c.md
+++ b/docs/migration/phase-3c.md
@@ -127,7 +127,7 @@ TLSv1.3 ciphersuite: TLS_AES_256_GCM_SHA384 (256-bit encryption)
 
 ## 5. Validated baseline (PR 5 cluster walkthrough)
 
-Kernel-boot guest (4 Gi class), default node-local networking, `miles→boba`:
+Kernel-boot guest (4 Gi class), default node-local networking, `worker-2→worker-1`:
 
 | Metric | mTLS | Plaintext (Phase 3b) |
 |---|---|---|

--- a/docs/migration/phase-4.md
+++ b/docs/migration/phase-4.md
@@ -113,34 +113,34 @@ guest's eviction is blocked by the PDB with no auto-evacuation.
 
 ```bash
 # 1. Drain a worker; SwiftGuest VMs evacuate automatically.
-kubectl drain miles --ignore-daemonsets --delete-emptydir-data
+kubectl drain worker-2 --ignore-daemonsets --delete-emptydir-data
 #   evicting pod default/web-1
 #   error when evicting pod "web-1" (will retry after 5s): admission webhook
 #     "veviction.kubeswift.io" denied the request: SwiftGuest "web-1" on node
-#     "miles" is being migrated off before eviction; retry
-#   ... (the guest live-migrates to boba) ...
+#     "worker-2" is being migrated off before eviction; retry
+#   ... (the guest live-migrates to worker-1) ...
 #   pod/web-1 evicted
-#   node/miles drained
+#   node/worker-2 drained
 
 # 2. Watch the auto-created migration.
 kubectl get swiftmigration -w        # <guest>-drain-<hash>, reason=node-drain
 
 # 3. Confirm the guest landed on the other node.
-kubectl get swiftguest web-1 -o jsonpath='{.status.nodeName}{"\n"}'   # boba
+kubectl get swiftguest web-1 -o jsonpath='{.status.nodeName}{"\n"}'   # worker-1
 
 # 4. Done; uncordon.
-kubectl uncordon miles
+kubectl uncordon worker-2
 ```
 
-## Empirical results (dev cluster, miles/boba, CH v51.1, image sha-04c054d)
+## Empirical results (dev cluster, worker-2/worker-1, CH v51.1, image sha-04c054d)
 
 PR 5 cluster walkthrough (2026-06-02), kernel-boot guest, default node-local
 networking, live-migration mTLS enabled:
 
 | Scenario | Result |
 |---|---|
-| **Drain → auto-migrate** (`drainPolicy: Migrate`) | `kubectl drain miles` → eviction denied 429 (~6 retries at 5s) → drain controller created `phase4-migrate-drain-96888133` (`reason=node-drain`, resolved **mode=live**, target=boba, `allowIPChange=true`) → guest live-migrated to boba, marker cleared → **`node/miles drained`** (exit 0). **observedDowntime 2.30s**, observedTransferDuration 38.48s. |
-| **Block** (`drainPolicy: Block`) | eviction denied `... drainPolicy=Block ... handle this guest manually`; **no marker, no migration**; guest stayed Running on miles; drain stalls (operator `--force`s or moves manually). |
+| **Drain → auto-migrate** (`drainPolicy: Migrate`) | `kubectl drain worker-2` → eviction denied 429 (~6 retries at 5s) → drain controller created `phase4-migrate-drain-96888133` (`reason=node-drain`, resolved **mode=live**, target=worker-1, `allowIPChange=true`) → guest live-migrated to worker-1, marker cleared → **`node/worker-2 drained`** (exit 0). **observedDowntime 2.30s**, observedTransferDuration 38.48s. |
+| **Block** (`drainPolicy: Block`) | eviction denied `... drainPolicy=Block ... handle this guest manually`; **no marker, no migration**; guest stayed Running on worker-2; drain stalls (operator `--force`s or moves manually). |
 | **Webhook down** (controller scaled to 0) | webhook skipped (`failurePolicy: Ignore`) → the `maxUnavailable:0` PDB denied the eviction (`Cannot evict pod as it would violate the pod's disruption budget`) → drain stalls **safely**, VM protected. |
 | **Per-guest PDB** | every guest got a `maxUnavailable:0` PDB (ALLOWED DISRUPTIONS 0), owned by the SwiftGuest, selecting its launcher pod; GC'd with the guest. |
 

--- a/docs/snapshots/clone-from-snapshot.md
+++ b/docs/snapshots/clone-from-snapshot.md
@@ -28,7 +28,7 @@ spec:
   cloneFromSnapshot:
     snapshotRef:
       name: my-snapshot        # a Ready SwiftSnapshot in the same namespace
-    targetNode: boba           # REQUIRED for a Tier C (s3) snapshot; ignored for Tier B
+    targetNode: worker-1           # REQUIRED for a Tier C (s3) snapshot; ignored for Tier B
     regenerate:                # identity reset on the clone (default: all four)
       - macAddresses
       - hostname
@@ -165,8 +165,8 @@ kubectl get swiftguest -l swift.kubeswift.io/pool-name=clone-pool -o wide -w
 
 ## Cluster walkthrough
 
-Validated on the dev cluster (k0s 1.34, CH v51.1, in-cluster MinIO, miles+boba).
-A `clone-source` (rocky9) on boba got a sentinel + a Tier C `clone-snap`
+Validated on the dev cluster (k0s 1.34, CH v51.1, in-cluster MinIO, worker-2+worker-1).
+A `clone-source` (rocky9) on worker-1 got a sentinel + a Tier C `clone-snap`
 (Ready); a 2-replica `clone-pool` then cloned it. The walkthrough caught **two
 real bugs** unit tests structurally cannot (the recurring **W5 pattern** —
 fake-client tests verify control flow, not on-cluster runtime behavior); both
@@ -189,8 +189,8 @@ Results after the fixes:
 
 | | clone-pool-0 | clone-pool-1 |
 |---|---|---|
-| Assigned node | **boba** | **miles** (cross-node) |
-| Tier C download Job | on boba ✓ | on miles ✓ |
+| Assigned node | **worker-1** | **worker-2** (cross-node) |
+| Tier C download Job | on worker-1 ✓ | on worker-2 ✓ |
 | Phase | Running | Running |
 | Hypervisor MAC | `52:54:00:7e:0c:47` | `52:54:00:fd:c6:1a` (distinct) |
 | Sentinel `CLONE-POOL-…` | survived ✓ | survived ✓ |

--- a/docs/snapshots/cold-migration.md
+++ b/docs/snapshots/cold-migration.md
@@ -86,8 +86,8 @@ swiftctl guest export db --to ghcr.io/acme/vm-snapshots --credentials-secret reg
 #   disk:   ghcr.io/acme/vm-snapshots:default-db-export-disk (sha256:...)
 
 # Resume it as a new guest on another node.
-swiftctl guest import db2 --from-snapshot db-export --target-node boba --guest-class ft-small --wait
-# ... Running on boba (IP 192.168.99.x)
+swiftctl guest import db2 --from-snapshot db-export --target-node worker-1 --guest-class ft-small --wait
+# ... Running on worker-1 (IP 192.168.99.x)
 ```
 
 `--sign-key <secret>` on export cosign-signs the artifacts (supply-chain
@@ -116,7 +116,7 @@ spec:
       # signingKeySecretRef: {name: cosign-key}
 ```
 
-`swiftctl guest import db2 --from-snapshot db-export --target-node boba
+`swiftctl guest import db2 --from-snapshot db-export --target-node worker-1
 --guest-class ft-small` creates:
 
 ```yaml
@@ -127,7 +127,7 @@ metadata:
 spec:
   cloneFromSnapshot:
     snapshotRef: {name: db-export}
-    targetNode: boba           # required for an oci snapshot
+    targetNode: worker-1           # required for an oci snapshot
   guestClassRef: {name: ft-small}  # required even for a clone (resources come
   runPolicy: Running               # from the snapshot, but a class ref is mandatory)
 ```

--- a/docs/snapshots/operator-walkthrough.md
+++ b/docs/snapshots/operator-walkthrough.md
@@ -28,8 +28,8 @@ The accompanying sample manifests live in
 
 ## Cluster used for this walkthrough
 
-The output captured below comes from a 3-node k0s cluster (`boba`,
-`frida`, `miles`) running Longhorn as the default StorageClass with
+The output captured below comes from a 3-node k0s cluster (`worker-1`,
+`cp-1`, `worker-2`) running Longhorn as the default StorageClass with
 two `VolumeSnapshotClass`es: `longhorn-snapshot` (Retain) and
 `longhorn-snapshot-delete` (Delete). KubeSwift controller-manager is
 built from `main`.

--- a/docs/snapshots/s3-snapshots.md
+++ b/docs/snapshots/s3-snapshots.md
@@ -159,7 +159,7 @@ reboot via the seed profile's bootcmd. See
 ## Cluster walkthrough
 
 Validated on the dev cluster (k0s 1.34, CH v51.1, in-cluster MinIO) with a 2Gi
-rocky9 memory snapshot. Source guest on **boba**, restore target **miles**
+rocky9 memory snapshot. Source guest on **worker-1**, restore target **worker-2**
 (cross-node). The walkthrough caught **two real bugs** that unit tests
 structurally cannot (the recurring "W5 pattern" — fake-client tests verify
 control flow, not on-cluster kubelet/filesystem/network behavior); both are
@@ -197,16 +197,16 @@ was driven entirely by the controllers (no manual Jobs):
 
 | Step | Result |
 |---|---|
-| Sentinel written into source (boba) | `S3-RT-FULL-1780557632`, md5 `2b945b3e57ba25efd687bb370953eff0` |
+| Sentinel written into source (worker-1) | `S3-RT-FULL-1780557632`, md5 `2b945b3e57ba25efd687bb370953eff0` |
 | SwiftSnapshot (s3) | `Pending → Capturing → Uploading → Ready` (~20s); `status.s3.location = s3://kubeswift-snapshots/demo/default/s3-clean/` |
 | MinIO objects | `config.json` + `state.json` + 2GiB `memory-ranges` + `manifest.json`, per-artifact sha256 |
-| SwiftRestore (`targetNode: miles`, clone) | `Pending → Downloading → Restoring → Resuming → Ready` |
-| Download → miles (cross-node) | all 3 artifacts **sha256-verified** against the manifest |
-| Clone guest | **Running on miles** (cross-node from boba), `GuestRunning=True` |
+| SwiftRestore (`targetNode: worker-2`, clone) | `Pending → Downloading → Restoring → Resuming → Ready` |
+| Download → worker-2 (cross-node) | all 3 artifacts **sha256-verified** against the manifest |
+| Clone guest | **Running on worker-2** (cross-node from worker-1), `GuestRunning=True` |
 | **Sentinel on the clone** | `S3-RT-FULL-1780557632`, md5 `2b945b3e57ba25efd687bb370953eff0` — **byte-identical** ✅ |
 
 Guest state survived the full Tier C round-trip **across nodes via object
-storage**: capture on boba → upload to MinIO → cross-node download on miles →
+storage**: capture on worker-1 → upload to MinIO → cross-node download on worker-2 →
 `CH --restore` → resume, with the in-guest sentinel preserved exactly.
 
 ### Tracked follow-up

--- a/docs/ui/gateway.md
+++ b/docs/ui/gateway.md
@@ -68,7 +68,7 @@ and a `Cluster` object. The simplest credential is a kubeconfig:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: boba-kubeconfig
+  name: edge-1-kubeconfig
   namespace: kubeswift-system
 type: Opaque
 stringData:
@@ -78,14 +78,14 @@ stringData:
 apiVersion: fleet.kubeswift.io/v1alpha1
 kind: Cluster
 metadata:
-  name: boba
+  name: edge-1
   namespace: kubeswift-system
 spec:
-  server: https://boba.example.com:6443       # optional if the kubeconfig has it
+  server: https://edge-1.example.com:6443       # optional if the kubeconfig has it
   credentialSecretRef:
-    name: boba-kubeconfig
+    name: edge-1-kubeconfig
   prometheusEndpoint: http://prometheus.monitoring.svc:9090   # optional (see below)
-  displayName: Boba (lab)
+  displayName: Edge 1 (lab)
 ```
 
 Alternatively the Secret may carry a `token` (+ optional `ca.crt`) instead of a
@@ -113,7 +113,7 @@ The gateway picks the member up immediately, probes it, and writes status:
 ```bash
 kubectl -n kubeswift-system get clusters
 # NAME   SERVER                          READY   K8S       GUESTS   AGE
-# boba   https://boba.example.com:6443   True    v1.34.3   7        1m
+# edge-1   https://edge-1.example.com:6443   True    v1.34.3   7        1m
 ```
 
 ## Authentication (decision D1)

--- a/docs/validation-guest-networking-status.md
+++ b/docs/validation-guest-networking-status.md
@@ -15,7 +15,7 @@ This document summarizes the root causes, fixes, and validation steps for the sm
 
 ### 2. Kube API client (Connect error)
 
-**Cause:** swiftletd used `kube::Client::try_default()` which uses `KUBERNETES_SERVICE_HOST` + `KUBERNETES_SERVICE_PORT`. In clusters with an external API server (e.g. `https://frida.labk8s.io:6443`), the cluster IP may be unreachable from pods. The patch to SwiftGuest status fails with `ServiceError: client error (Connect)`.
+**Cause:** swiftletd used `kube::Client::try_default()` which uses `KUBERNETES_SERVICE_HOST` + `KUBERNETES_SERVICE_PORT`. In clusters with an external API server (e.g. `https://k8s-api.example.com:6443`), the cluster IP may be unreachable from pods. The patch to SwiftGuest status fails with `ServiceError: client error (Connect)`.
 
 **Target:** `api.patch_status()` in `report.rs` → `PATCH /apis/swift.kubeswift.io/v1alpha1/namespaces/{ns}/swiftguests/{name}/status` → Kubernetes API server at `https://{KUBERNETES_SERVICE_HOST}:{PORT}` or `https://kubernetes.default.svc`.
 

--- a/docs/validation/discovery-daemonset-validation.md
+++ b/docs/validation/discovery-daemonset-validation.md
@@ -6,13 +6,13 @@
 ## Cluster Info
 
 - **Cluster version:** k0s v1.34.3
-- **Nodes:** frida (control-plane), miles (worker)
+- **Nodes:** cp-1 (control-plane), worker-2 (worker)
 - **OS:** Ubuntu 24.04.4 LTS
-- **Kernel:** 6.8.0-101-generic (miles)
+- **Kernel:** 6.8.0-101-generic (worker-2)
 - **Container runtime:** containerd 1.7.30
 - **GPU hardware:** None (validation covers host topology discovery without GPUs)
 - **Image used:** `ghcr.io/kubeswift-io/kubeswift/gpu-discovery:sha-111f3d2`
-- **Node under test:** miles
+- **Node under test:** worker-2
 
 ## Validation Checks
 
@@ -20,7 +20,7 @@
 
 | Check | Expected | Actual | Status |
 |-------|----------|--------|--------|
-| Pod scheduled on labeled node | Running, 0 restarts | Running, 0 restarts on miles | PASS |
+| Pod scheduled on labeled node | Running, 0 restarts | Running, 0 restarts on worker-2 | PASS |
 | Pod image pulled | gpu-discovery image | sha-111f3d2 pulled successfully | PASS |
 
 Note: The DaemonSet manifest uses `:latest` but that tag does not exist in ghcr.io.
@@ -29,7 +29,7 @@ be updated to use a CI-managed tag or the Helm chart's image tag override.
 
 ### 1b. SwiftGPUNode Creation
 
-SwiftGPUNode `miles` created within first discovery cycle (~60s).
+SwiftGPUNode `worker-2` created within first discovery cycle (~60s).
 
 | Field | Expected | Actual | Status |
 |-------|----------|--------|--------|
@@ -64,18 +64,18 @@ SwiftGPUNode `miles` created within first discovery cycle (~60s).
 | Check | Expected | Actual | Status |
 |-------|----------|--------|--------|
 | Pod terminates after label removal | Terminating/gone | Pod gone ("No resources found") | PASS |
-| SwiftGPUNode resource persists | Still exists | `miles` still present with Phase=Ready | PASS |
+| SwiftGPUNode resource persists | Still exists | `worker-2` still present with Phase=Ready | PASS |
 
 ## Pod Logs (excerpt)
 
 ```
-I0403 12:11:28.713366  1 main.go:40] "gpu-discovery starting" node="miles" interval="1m0s"
-I0403 12:11:28.713414  1 main.go:59] "starting discovery cycle" node="miles"
+I0403 12:11:28.713366  1 main.go:40] "gpu-discovery starting" node="worker-2" interval="1m0s"
+I0403 12:11:28.713414  1 main.go:59] "starting discovery cycle" node="worker-2"
 I0403 12:11:29.614646  1 main.go:254] "Fabric Manager discovery skipped" reason="fmpm not in PATH"
-I0403 12:11:29.861800  1 main.go:110] "discovery cycle complete" node="miles" gpuCount=0 freeGPUs=0 phase="Ready"
-I0403 12:12:28.742032  1 main.go:59] "starting discovery cycle" node="miles"
+I0403 12:11:29.861800  1 main.go:110] "discovery cycle complete" node="worker-2" gpuCount=0 freeGPUs=0 phase="Ready"
+I0403 12:12:28.742032  1 main.go:59] "starting discovery cycle" node="worker-2"
 I0403 12:12:29.448111  1 main.go:254] "Fabric Manager discovery skipped" reason="fmpm not in PATH"
-I0403 12:12:29.540906  1 main.go:110] "discovery cycle complete" node="miles" gpuCount=0 freeGPUs=0 phase="Ready"
+I0403 12:12:29.540906  1 main.go:110] "discovery cycle complete" node="worker-2" gpuCount=0 freeGPUs=0 phase="Ready"
 ```
 
 ## Issues Found

--- a/docs/validation/qemu-boot-validation.md
+++ b/docs/validation/qemu-boot-validation.md
@@ -11,9 +11,9 @@
 |----------|-------|
 | Date | 2026-04-03 |
 | Kubernetes | v1.34.3+k0s |
-| Nodes | frida (control-plane+worker), miles (worker) |
+| Nodes | cp-1 (control-plane+worker), worker-2 (worker) |
 | Node OS | Ubuntu 24.04.4 LTS |
-| Node kernels | 6.8.0-106-generic (frida), 6.8.0-101-generic (miles) |
+| Node kernels | 6.8.0-106-generic (cp-1), 6.8.0-101-generic (worker-2) |
 | Container runtime | containerd 1.7.30 |
 | Controller image | `ghcr.io/kubeswift-io/kubeswift/controller-manager:sha-3c5c476` |
 | Swiftletd image | `ghcr.io/kubeswift-io/kubeswift/swiftletd:sha-3c5c476` |

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -138,7 +138,7 @@ func TestMigrate_CreatesSwiftMigration(t *testing.T) {
 	created, err := Migrate(context.Background(), dyn, MigrateParams{
 		Namespace:     "default",
 		GuestName:     "vm-a",
-		TargetNode:    "miles",
+		TargetNode:    "worker-2",
 		Mode:          "offline",
 		AllowIPChange: true,
 		Reason:        "test",
@@ -167,7 +167,7 @@ func TestMigrate_CreatesSwiftMigration(t *testing.T) {
 	reason, _, _ := unstructured.NestedString(m.Object, "spec", "reason")
 	timeout, _, _ := unstructured.NestedString(m.Object, "spec", "timeout")
 	ttl, _, _ := unstructured.NestedString(m.Object, "spec", "ttl")
-	if guestName != "vm-a" || node != "miles" || mode != "offline" || !allowIP || reason != "test" {
+	if guestName != "vm-a" || node != "worker-2" || mode != "offline" || !allowIP || reason != "test" {
 		t.Errorf("spec wrong: guest=%q node=%q mode=%q allowIP=%v reason=%q", guestName, node, mode, allowIP, reason)
 	}
 	if timeout != "10m0s" || ttl != "1h0m0s" {
@@ -183,7 +183,7 @@ func TestMigrate_DefaultsModeAndName(t *testing.T) {
 	if _, err := Migrate(context.Background(), dyn, MigrateParams{
 		Namespace:  "default",
 		GuestName:  "vm-a",
-		TargetNode: "miles",
+		TargetNode: "worker-2",
 	}); err != nil {
 		t.Fatalf("Migrate: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestMigrate_ExplicitName(t *testing.T) {
 	created, err := Migrate(context.Background(), dyn, MigrateParams{
 		Namespace:  "default",
 		GuestName:  "vm-a",
-		TargetNode: "miles",
+		TargetNode: "worker-2",
 		Name:       "vm-a-rebalance",
 	})
 	if err != nil {

--- a/internal/controller/migrationcert/controller_test.go
+++ b/internal/controller/migrationcert/controller_test.go
@@ -48,14 +48,14 @@ func getCert(ctx context.Context, c client.Client, ns, name string) (*unstructur
 }
 
 func TestMigrationNodeNames(t *testing.T) {
-	if got := MigrationNodeCertName("miles"); got != "kubeswift-migration-node-miles" {
+	if got := MigrationNodeCertName("worker-2"); got != "kubeswift-migration-node-worker-2" {
 		t.Errorf("MigrationNodeCertName = %q", got)
 	}
-	if got := MigrationNodeSecretName("miles"); got != "kubeswift-migration-node-miles" {
+	if got := MigrationNodeSecretName("worker-2"); got != "kubeswift-migration-node-worker-2" {
 		t.Errorf("MigrationNodeSecretName = %q", got)
 	}
 	// SAN/checkHost pin value MUST be exactly the node name (Option B).
-	if got := MigrationNodeCertSAN("miles"); got != "miles" {
+	if got := MigrationNodeCertSAN("worker-2"); got != "worker-2" {
 		t.Errorf("MigrationNodeCertSAN = %q, want node name verbatim", got)
 	}
 }
@@ -65,12 +65,12 @@ func TestMigrationNodeNames(t *testing.T) {
 // is dst-server in one migration and src-client in another), and the CA
 // Issuer reference. A regression here silently breaks SAN pinning.
 func TestNewNodeCertificate_Fields(t *testing.T) {
-	u := newNodeCertificate(testSystemNS, "boba")
+	u := newNodeCertificate(testSystemNS, "worker-1")
 
 	if u.GetNamespace() != testSystemNS {
 		t.Errorf("namespace = %q, want %q", u.GetNamespace(), testSystemNS)
 	}
-	if u.GetName() != "kubeswift-migration-node-boba" {
+	if u.GetName() != "kubeswift-migration-node-worker-1" {
 		t.Errorf("name = %q", u.GetName())
 	}
 	if u.GetAPIVersion() != "cert-manager.io/v1" || u.GetKind() != "Certificate" {
@@ -78,16 +78,16 @@ func TestNewNodeCertificate_Fields(t *testing.T) {
 	}
 
 	secretName, _, _ := unstructured.NestedString(u.Object, "spec", "secretName")
-	if secretName != "kubeswift-migration-node-boba" {
+	if secretName != "kubeswift-migration-node-worker-1" {
 		t.Errorf("spec.secretName = %q", secretName)
 	}
 	cn, _, _ := unstructured.NestedString(u.Object, "spec", "commonName")
-	if cn != "boba" {
-		t.Errorf("spec.commonName = %q, want boba", cn)
+	if cn != "worker-1" {
+		t.Errorf("spec.commonName = %q, want worker-1", cn)
 	}
 	dnsNames, _, _ := unstructured.NestedStringSlice(u.Object, "spec", "dnsNames")
-	if len(dnsNames) != 1 || dnsNames[0] != "boba" {
-		t.Errorf("spec.dnsNames = %v, want [boba]", dnsNames)
+	if len(dnsNames) != 1 || dnsNames[0] != "worker-1" {
+		t.Errorf("spec.dnsNames = %v, want [worker-1]", dnsNames)
 	}
 	usages, _, _ := unstructured.NestedStringSlice(u.Object, "spec", "usages")
 	if len(usages) != 2 || usages[0] != "server auth" || usages[1] != "client auth" {
@@ -158,57 +158,57 @@ func TestEnsureNodeCertificate_CreatesWhenAbsent(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	ctx := context.Background()
 
-	if err := ensureNodeCertificate(ctx, c, testSystemNS, "miles"); err != nil {
+	if err := ensureNodeCertificate(ctx, c, testSystemNS, "worker-2"); err != nil {
 		t.Fatalf("ensureNodeCertificate: %v", err)
 	}
-	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-miles"); err != nil {
+	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-worker-2"); err != nil {
 		t.Fatalf("expected certificate to exist: %v", err)
 	}
 }
 
 func TestEnsureNodeCertificate_IdempotentWhenPresent(t *testing.T) {
 	scheme := certScheme(t)
-	pre := newNodeCertificate(testSystemNS, "miles")
+	pre := newNodeCertificate(testSystemNS, "worker-2")
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pre).Build()
 	ctx := context.Background()
 
-	if err := ensureNodeCertificate(ctx, c, testSystemNS, "miles"); err != nil {
+	if err := ensureNodeCertificate(ctx, c, testSystemNS, "worker-2"); err != nil {
 		t.Fatalf("ensureNodeCertificate (idempotent): %v", err)
 	}
-	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-miles"); err != nil {
+	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-worker-2"); err != nil {
 		t.Fatalf("certificate should still exist: %v", err)
 	}
 }
 
 func TestDeleteNodeCertificate(t *testing.T) {
 	scheme := certScheme(t)
-	pre := newNodeCertificate(testSystemNS, "miles")
+	pre := newNodeCertificate(testSystemNS, "worker-2")
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pre).Build()
 	ctx := context.Background()
 
-	if err := deleteNodeCertificate(ctx, c, testSystemNS, "miles"); err != nil {
+	if err := deleteNodeCertificate(ctx, c, testSystemNS, "worker-2"); err != nil {
 		t.Fatalf("deleteNodeCertificate: %v", err)
 	}
-	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-miles"); !apierrors.IsNotFound(err) {
+	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-worker-2"); !apierrors.IsNotFound(err) {
 		t.Fatalf("expected NotFound after delete, got %v", err)
 	}
 	// Idempotent: deleting again tolerates NotFound.
-	if err := deleteNodeCertificate(ctx, c, testSystemNS, "miles"); err != nil {
+	if err := deleteNodeCertificate(ctx, c, testSystemNS, "worker-2"); err != nil {
 		t.Fatalf("deleteNodeCertificate (NotFound) must be tolerated: %v", err)
 	}
 }
 
 func TestReconcile_WorkerNode_CreatesCert(t *testing.T) {
 	scheme := certScheme(t)
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-2"}}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
 	r := &MigrationCertReconciler{Client: c, SystemNamespace: testSystemNS}
 	ctx := context.Background()
 
-	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "miles"}}); err != nil {
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "worker-2"}}); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
-	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-miles"); err != nil {
+	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-worker-2"); err != nil {
 		t.Fatalf("worker node should get a certificate: %v", err)
 	}
 }
@@ -216,19 +216,19 @@ func TestReconcile_WorkerNode_CreatesCert(t *testing.T) {
 func TestReconcile_ControlPlaneNode_DeletesStaleCert(t *testing.T) {
 	scheme := certScheme(t)
 	// A node that was a worker (has a cert) and is now control-plane.
-	staleCert := newNodeCertificate(testSystemNS, "frida")
+	staleCert := newNodeCertificate(testSystemNS, "cp-1")
 	cpNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
-		Name:   "frida",
+		Name:   "cp-1",
 		Labels: map[string]string{controlPlaneRoleLabel: ""},
 	}}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cpNode, staleCert).Build()
 	r := &MigrationCertReconciler{Client: c, SystemNamespace: testSystemNS}
 	ctx := context.Background()
 
-	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "frida"}}); err != nil {
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "cp-1"}}); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
-	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-frida"); !apierrors.IsNotFound(err) {
+	if _, err := getCert(ctx, c, testSystemNS, "kubeswift-migration-node-cp-1"); !apierrors.IsNotFound(err) {
 		t.Fatalf("control-plane node's stale cert should be deleted, got %v", err)
 	}
 }

--- a/internal/controller/migrationcert/secret_test.go
+++ b/internal/controller/migrationcert/secret_test.go
@@ -46,7 +46,7 @@ func TestEnsureMigrationIdentitySecret_SameNamespaceNoop(t *testing.T) {
 
 	// No source secret present; same-namespace must still be a no-op
 	// (it returns before any Get).
-	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, testSystemNS, "miles"); err != nil {
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, testSystemNS, "worker-2"); err != nil {
 		t.Fatalf("same-namespace must be a no-op, got: %v", err)
 	}
 }
@@ -61,23 +61,23 @@ func TestEnsureMigrationIdentitySecret_SourceMissingErrors(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	ctx := context.Background()
 
-	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "miles"); err == nil {
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "worker-2"); err == nil {
 		t.Fatal("expected error when source secret missing (precondition not ready)")
 	}
 }
 
 func TestEnsureMigrationIdentitySecret_CopiesToTarget(t *testing.T) {
 	scheme := secretScheme(t)
-	src := sourceSecret(testSystemNS, "miles", tlsData)
+	src := sourceSecret(testSystemNS, "worker-2", tlsData)
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(src).Build()
 	ctx := context.Background()
 
-	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "miles"); err != nil {
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "worker-2"); err != nil {
 		t.Fatalf("EnsureMigrationIdentitySecret: %v", err)
 	}
 
 	var copied corev1.Secret
-	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "kubeswift-migration-node-miles"}, &copied); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "kubeswift-migration-node-worker-2"}, &copied); err != nil {
 		t.Fatalf("expected copied secret in team-a: %v", err)
 	}
 	if copied.Type != corev1.SecretTypeTLS {
@@ -103,9 +103,9 @@ func TestEnsureMigrationIdentitySecret_CopiesToTarget(t *testing.T) {
 // copy rather than leaving a stale cert in the guest namespace.
 func TestEnsureMigrationIdentitySecret_UpdatesOnRotation(t *testing.T) {
 	scheme := secretScheme(t)
-	src := sourceSecret(testSystemNS, "miles", tlsData)
+	src := sourceSecret(testSystemNS, "worker-2", tlsData)
 	staleCopy := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "kubeswift-migration-node-miles", Namespace: "team-a"},
+		ObjectMeta: metav1.ObjectMeta{Name: "kubeswift-migration-node-worker-2", Namespace: "team-a"},
 		Type:       corev1.SecretTypeTLS,
 		Data: map[string][]byte{
 			migrationSecretTLSCert: []byte("OLD-CERT"),
@@ -116,12 +116,12 @@ func TestEnsureMigrationIdentitySecret_UpdatesOnRotation(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(src, staleCopy).Build()
 	ctx := context.Background()
 
-	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "miles"); err != nil {
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "worker-2"); err != nil {
 		t.Fatalf("EnsureMigrationIdentitySecret (rotation): %v", err)
 	}
 
 	var refreshed corev1.Secret
-	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "kubeswift-migration-node-miles"}, &refreshed); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "kubeswift-migration-node-worker-2"}, &refreshed); err != nil {
 		t.Fatalf("get refreshed: %v", err)
 	}
 	if string(refreshed.Data[migrationSecretTLSCert]) != "CERT" {
@@ -133,18 +133,18 @@ func TestEnsureMigrationIdentitySecret_UpdatesOnRotation(t *testing.T) {
 // second call with matching data performs no update (no churn).
 func TestEnsureMigrationIdentitySecret_IdempotentWhenCurrent(t *testing.T) {
 	scheme := secretScheme(t)
-	src := sourceSecret(testSystemNS, "miles", tlsData)
+	src := sourceSecret(testSystemNS, "worker-2", tlsData)
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(src).Build()
 	ctx := context.Background()
 
-	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "miles"); err != nil {
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "worker-2"); err != nil {
 		t.Fatalf("first copy: %v", err)
 	}
-	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "miles"); err != nil {
+	if err := EnsureMigrationIdentitySecret(ctx, c, testSystemNS, "team-a", "worker-2"); err != nil {
 		t.Fatalf("second copy (idempotent): %v", err)
 	}
 	var copied corev1.Secret
-	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "kubeswift-migration-node-miles"}, &copied); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "kubeswift-migration-node-worker-2"}, &copied); err != nil {
 		t.Fatalf("get: %v", err)
 	}
 	if string(copied.Data[migrationSecretTLSCert]) != "CERT" {

--- a/internal/controller/swiftdrain/controller_test.go
+++ b/internal/controller/swiftdrain/controller_test.go
@@ -132,7 +132,7 @@ func getGuest(t *testing.T, c client.Client, name string) *swiftv1alpha1.SwiftGu
 // --- tests ---
 
 func TestReconcile_NoMarker_NoOp(t *testing.T) {
-	r, c := newR(guest("g"), node("miles"), node("boba"), smallClass())
+	r, c := newR(guest("g"), node("worker-2"), node("worker-1"), smallClass())
 	reconcileGuest(t, r, "g")
 	if migs := listMigs(t, c); len(migs) != 0 {
 		t.Errorf("no marker → no migration; got %d", len(migs))
@@ -140,7 +140,7 @@ func TestReconcile_NoMarker_NoOp(t *testing.T) {
 }
 
 func TestReconcile_GuestMovedOff_ClearsMarker(t *testing.T) {
-	r, c := newR(guest("g", drain("miles"), statusNode("boba")), node("miles"), node("boba"), smallClass())
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-1")), node("worker-2"), node("worker-1"), smallClass())
 	reconcileGuest(t, r, "g")
 	g := getGuest(t, c, "g")
 	if _, ok := g.Annotations[swiftv1alpha1.AnnotationDrainRequested]; ok {
@@ -166,10 +166,10 @@ func swiftGPUNode(name string, vfioReady bool, free int) *gpuv1alpha1.SwiftGPUNo
 }
 
 func TestReconcile_GPUGuest_NoGPUTarget_NoMigration(t *testing.T) {
-	// GPU guest, profile exists, but boba is not a GPU node (no SwiftGPUNode)
+	// GPU guest, profile exists, but worker1 is not a GPU node (no SwiftGPUNode)
 	// → no schedulable GPU target → no migration; marker stays.
-	r, c := newR(guest("g", drain("miles"), statusNode("miles"), vfio()),
-		node("miles"), node("boba"), smallClass(), gpuProfileFixture())
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-2"), vfio()),
+		node("worker-2"), node("worker-1"), smallClass(), gpuProfileFixture())
 	res := reconcileGuest(t, r, "g")
 	if migs := listMigs(t, c); len(migs) != 0 {
 		t.Errorf("no GPU target → no migration; got %d", len(migs))
@@ -177,24 +177,24 @@ func TestReconcile_GPUGuest_NoGPUTarget_NoMigration(t *testing.T) {
 	if res.RequeueAfter == 0 {
 		t.Errorf("no GPU target should requeue")
 	}
-	if getGuest(t, c, "g").Annotations[swiftv1alpha1.AnnotationDrainRequested] != "miles" {
+	if getGuest(t, c, "g").Annotations[swiftv1alpha1.AnnotationDrainRequested] != "worker-2" {
 		t.Errorf("marker must stay when there is no GPU target")
 	}
 }
 
 func TestReconcile_GPUGuest_CreatesOfflineMigration(t *testing.T) {
-	// GPU guest with a vfio-ready GPU target (boba) → creates an offline
+	// GPU guest with a vfio-ready GPU target (worker1) → creates an offline
 	// (auto→offline) migration via release-and-reallocate.
-	r, c := newR(guest("g", drain("miles"), statusNode("miles"), vfio()),
-		node("miles"), node("boba"), smallClass(), gpuProfileFixture(),
-		swiftGPUNode("boba", true, 1))
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-2"), vfio()),
+		node("worker-2"), node("worker-1"), smallClass(), gpuProfileFixture(),
+		swiftGPUNode("worker-1", true, 1))
 	reconcileGuest(t, r, "g")
 	migs := listMigs(t, c)
 	if len(migs) != 1 {
 		t.Fatalf("GPU guest with a vfio-ready GPU target should create 1 migration; got %d", len(migs))
 	}
-	if migs[0].Spec.Target.NodeName != "boba" {
-		t.Errorf("target = %q, want boba (the vfio-ready GPU node)", migs[0].Spec.Target.NodeName)
+	if migs[0].Spec.Target.NodeName != "worker-1" {
+		t.Errorf("target = %q, want worker-1 (the vfio-ready GPU node)", migs[0].Spec.Target.NodeName)
 	}
 	if migs[0].Spec.Mode != migrationv1alpha1.SwiftMigrationModeAuto {
 		t.Errorf("mode = %q, want auto (resolves to offline for VFIO)", migs[0].Spec.Mode)
@@ -202,11 +202,11 @@ func TestReconcile_GPUGuest_CreatesOfflineMigration(t *testing.T) {
 }
 
 func TestReconcile_GPUGuest_NonVfioReadyTarget_NoMigration(t *testing.T) {
-	// boba is a GPU node but NOT vfio-ready → GPUNodeHasCapacity rejects it →
+	// worker1 is a GPU node but NOT vfio-ready → GPUNodeHasCapacity rejects it →
 	// no GPU target → no migration.
-	r, c := newR(guest("g", drain("miles"), statusNode("miles"), vfio()),
-		node("miles"), node("boba"), smallClass(), gpuProfileFixture(),
-		swiftGPUNode("boba", false, 1))
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-2"), vfio()),
+		node("worker-2"), node("worker-1"), smallClass(), gpuProfileFixture(),
+		swiftGPUNode("worker-1", false, 1))
 	reconcileGuest(t, r, "g")
 	if migs := listMigs(t, c); len(migs) != 0 {
 		t.Errorf("a non-vfio-ready GPU node is not a valid target; got %d migrations", len(migs))
@@ -214,7 +214,7 @@ func TestReconcile_GPUGuest_NonVfioReadyTarget_NoMigration(t *testing.T) {
 }
 
 func TestReconcile_CreatesMigration(t *testing.T) {
-	r, c := newR(guest("g", drain("miles"), statusNode("miles")), node("miles"), node("boba"), smallClass())
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-2")), node("worker-2"), node("worker-1"), smallClass())
 	reconcileGuest(t, r, "g")
 
 	migs := listMigs(t, c)
@@ -222,14 +222,14 @@ func TestReconcile_CreatesMigration(t *testing.T) {
 		t.Fatalf("expected 1 migration created; got %d", len(migs))
 	}
 	m := migs[0]
-	if want := drainMigrationName("g", "miles"); m.Name != want {
+	if want := drainMigrationName("g", "worker-2"); m.Name != want {
 		t.Errorf("migration name = %q, want %q", m.Name, want)
 	}
 	if m.Spec.GuestRef.Name != "g" {
 		t.Errorf("guestRef = %q, want g", m.Spec.GuestRef.Name)
 	}
-	if m.Spec.Target.NodeName != "boba" {
-		t.Errorf("target = %q, want boba (the non-draining peer)", m.Spec.Target.NodeName)
+	if m.Spec.Target.NodeName != "worker-1" {
+		t.Errorf("target = %q, want worker-1 (the non-draining peer)", m.Spec.Target.NodeName)
 	}
 	if m.Spec.Mode != migrationv1alpha1.SwiftMigrationModeAuto {
 		t.Errorf("mode = %q, want auto (default Migrate policy)", m.Spec.Mode)
@@ -249,8 +249,8 @@ func TestReconcile_CreatesMigration(t *testing.T) {
 }
 
 func TestReconcile_LiveMigratePolicy_LiveMode(t *testing.T) {
-	r, c := newR(guest("g", drain("miles"), statusNode("miles"), policy(swiftv1alpha1.DrainPolicyLiveMigrate)),
-		node("miles"), node("boba"), smallClass())
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-2"), policy(swiftv1alpha1.DrainPolicyLiveMigrate)),
+		node("worker-2"), node("worker-1"), smallClass())
 	reconcileGuest(t, r, "g")
 	migs := listMigs(t, c)
 	if len(migs) != 1 {
@@ -262,8 +262,8 @@ func TestReconcile_LiveMigratePolicy_LiveMode(t *testing.T) {
 }
 
 func TestReconcile_MigrationInFlight_NoDuplicate(t *testing.T) {
-	existing := drainMig(drainMigrationName("g", "miles"), migrationv1alpha1.SwiftMigrationPhaseValidating)
-	r, c := newR(guest("g", drain("miles"), statusNode("miles")), existing, node("miles"), node("boba"), smallClass())
+	existing := drainMig(drainMigrationName("g", "worker-2"), migrationv1alpha1.SwiftMigrationPhaseValidating)
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-2")), existing, node("worker-2"), node("worker-1"), smallClass())
 	reconcileGuest(t, r, "g")
 	if migs := listMigs(t, c); len(migs) != 1 {
 		t.Errorf("in-flight migration must not be duplicated; got %d", len(migs))
@@ -271,22 +271,22 @@ func TestReconcile_MigrationInFlight_NoDuplicate(t *testing.T) {
 }
 
 func TestReconcile_MigrationFailed_MarkerStays_NoNew(t *testing.T) {
-	failed := drainMig(drainMigrationName("g", "miles"), migrationv1alpha1.SwiftMigrationPhaseFailed)
+	failed := drainMig(drainMigrationName("g", "worker-2"), migrationv1alpha1.SwiftMigrationPhaseFailed)
 	failed.Status.FailureMessage = "boom"
-	r, c := newR(guest("g", drain("miles"), statusNode("miles")), failed, node("miles"), node("boba"), smallClass())
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-2")), failed, node("worker-2"), node("worker-1"), smallClass())
 	reconcileGuest(t, r, "g")
 	if migs := listMigs(t, c); len(migs) != 1 {
 		t.Errorf("failed migration must not trigger a new one (no retry storm); got %d", len(migs))
 	}
 	g := getGuest(t, c, "g")
-	if g.Annotations[swiftv1alpha1.AnnotationDrainRequested] != "miles" {
+	if g.Annotations[swiftv1alpha1.AnnotationDrainRequested] != "worker-2" {
 		t.Errorf("marker must stay after a failed migration (VM stays protected)")
 	}
 }
 
 func TestReconcile_NoTarget_Requeue(t *testing.T) {
 	// Only the draining node exists → no schedulable peer.
-	r, c := newR(guest("g", drain("miles"), statusNode("miles")), node("miles"), smallClass())
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-2")), node("worker-2"), smallClass())
 	res := reconcileGuest(t, r, "g")
 	if migs := listMigs(t, c); len(migs) != 0 {
 		t.Errorf("no target → no migration; got %d", len(migs))
@@ -297,7 +297,7 @@ func TestReconcile_NoTarget_Requeue(t *testing.T) {
 }
 
 func TestReconcile_CordonedPeer_NoTarget(t *testing.T) {
-	r, c := newR(guest("g", drain("miles"), statusNode("miles")), node("miles"), node("boba", cordoned), smallClass())
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-2")), node("worker-2"), node("worker-1", cordoned), smallClass())
 	reconcileGuest(t, r, "g")
 	if migs := listMigs(t, c); len(migs) != 0 {
 		t.Errorf("cordoned peer is not a valid target; got %d migrations", len(migs))
@@ -305,7 +305,7 @@ func TestReconcile_CordonedPeer_NoTarget(t *testing.T) {
 }
 
 func TestReconcile_NotReadyPeer_NoTarget(t *testing.T) {
-	r, c := newR(guest("g", drain("miles"), statusNode("miles")), node("miles"), node("boba", notReady), smallClass())
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-2")), node("worker-2"), node("worker-1", notReady), smallClass())
 	reconcileGuest(t, r, "g")
 	if migs := listMigs(t, c); len(migs) != 0 {
 		t.Errorf("not-Ready peer is not a valid target; got %d migrations", len(migs))
@@ -313,8 +313,8 @@ func TestReconcile_NotReadyPeer_NoTarget(t *testing.T) {
 }
 
 func TestReconcile_OtherMigrationInProgress_Defers(t *testing.T) {
-	r, c := newR(guest("g", drain("miles"), statusNode("miles"), inProgress("some-other-mig")),
-		node("miles"), node("boba"), smallClass())
+	r, c := newR(guest("g", drain("worker-2"), statusNode("worker-2"), inProgress("some-other-mig")),
+		node("worker-2"), node("worker-1"), smallClass())
 	res := reconcileGuest(t, r, "g")
 	if migs := listMigs(t, c); len(migs) != 0 {
 		t.Errorf("must not create a second migration while one is in flight; got %d", len(migs))
@@ -325,18 +325,18 @@ func TestReconcile_OtherMigrationInProgress_Defers(t *testing.T) {
 }
 
 func TestDrainMigrationName_DeterministicAndBounded(t *testing.T) {
-	a := drainMigrationName("guest", "miles")
-	if a != drainMigrationName("guest", "miles") {
+	a := drainMigrationName("guest", "worker-2")
+	if a != drainMigrationName("guest", "worker-2") {
 		t.Errorf("name must be deterministic for the same (guest, node)")
 	}
-	if a == drainMigrationName("guest", "boba") {
+	if a == drainMigrationName("guest", "worker-1") {
 		t.Errorf("name must differ across draining nodes")
 	}
 	long := ""
 	for i := 0; i < 80; i++ {
 		long += "x"
 	}
-	n := drainMigrationName(long, "miles")
+	n := drainMigrationName(long, "worker-2")
 	if len(n) > maxMigrationNameLen {
 		t.Errorf("name %q (len %d) exceeds the %d-char label-value bound", n, len(n), maxMigrationNameLen)
 	}
@@ -357,9 +357,9 @@ func TestDrainMode(t *testing.T) {
 // guard: a SwiftMigration get error other than NotFound is surfaced.
 func TestObserveMigration_InProgress_NoOp(t *testing.T) {
 	r, _ := newR()
-	g := guest("g", drain("miles"))
+	g := guest("g", drain("worker-2"))
 	m := drainMig("x", migrationv1alpha1.SwiftMigrationPhasePreparing)
-	res, err := r.observeMigration(context.Background(), g, m, "miles")
+	res, err := r.observeMigration(context.Background(), g, m, "worker-2")
 	if err != nil {
 		t.Fatalf("observeMigration: %v", err)
 	}

--- a/internal/controller/swiftdrain/metrics_test.go
+++ b/internal/controller/swiftdrain/metrics_test.go
@@ -13,7 +13,7 @@ import (
 // drainPolicy. The in-flight duplicate guard means a second reconcile must
 // not re-count.
 func TestReconcile_CreatesMigration_CountsDrainMetric(t *testing.T) {
-	r, c := newR(guest("mg", drain("miles"), statusNode("miles")), node("miles"), node("boba"), smallClass())
+	r, c := newR(guest("mg", drain("worker-2"), statusNode("worker-2")), node("worker-2"), node("worker-1"), smallClass())
 
 	before := testutil.ToFloat64(metrics.DrainMigrationsTotal.WithLabelValues("Migrate", "created"))
 	reconcileGuest(t, r, "mg")

--- a/internal/controller/swiftgpu/allocate_wgpu1_test.go
+++ b/internal/controller/swiftgpu/allocate_wgpu1_test.go
@@ -42,64 +42,64 @@ func wgpu1Guest(statusNode string) *swiftv1alpha1.SwiftGuest {
 
 // TestFindAndAllocate_PrefersStatusGPUNode is the W-GPU-1 regression: during a
 // VFIO migration's reserve-before-stop double-hold the guest is allocated on
-// BOTH "boba" (first in the list) and "miles". findAndAllocate must return the
+// BOTH "worker-1" (first in the list) and "worker-2". findAndAllocate must return the
 // node status.GPU references, NOT the first-found node — otherwise the SwiftGPU
 // controller re-stamps status.GPU and races the migration controller.
 func TestFindAndAllocate_PrefersStatusGPUNode(t *testing.T) {
-	boba := nodeAllocatedTo("boba", "0000:01:00.0", "default/g")
-	miles := nodeAllocatedTo("miles", "0000:ff:00.0", "default/g")
+	worker1 := nodeAllocatedTo("worker-1", "0000:01:00.0", "default/g")
+	worker2 := nodeAllocatedTo("worker-2", "0000:ff:00.0", "default/g")
 	profile := wgpu1Profile()
 
-	t.Run("status.GPU=miles returns miles (not first-found boba)", func(t *testing.T) {
-		r := newReconciler(boba, miles, wgpu1Guest("miles"))
-		node, _, _, _, err := r.findAndAllocate(context.Background(), wgpu1Guest("miles"), profile)
+	t.Run("status.GPU=worker-2 returns worker-2 (not first-found worker-1)", func(t *testing.T) {
+		r := newReconciler(worker1, worker2, wgpu1Guest("worker-2"))
+		node, _, _, _, err := r.findAndAllocate(context.Background(), wgpu1Guest("worker-2"), profile)
 		if err != nil {
 			t.Fatalf("findAndAllocate: %v", err)
 		}
-		if node == nil || node.Name != "miles" {
-			t.Fatalf("must prefer the status.GPU node (miles); got %v", node)
+		if node == nil || node.Name != "worker-2" {
+			t.Fatalf("must prefer the status.GPU node (worker-2); got %v", node)
 		}
 	})
 
-	t.Run("status.GPU=boba returns boba", func(t *testing.T) {
-		r := newReconciler(boba, miles, wgpu1Guest("boba"))
-		node, _, _, _, err := r.findAndAllocate(context.Background(), wgpu1Guest("boba"), profile)
+	t.Run("status.GPU=worker-1 returns worker-1", func(t *testing.T) {
+		r := newReconciler(worker1, worker2, wgpu1Guest("worker-1"))
+		node, _, _, _, err := r.findAndAllocate(context.Background(), wgpu1Guest("worker-1"), profile)
 		if err != nil {
 			t.Fatalf("findAndAllocate: %v", err)
 		}
-		if node == nil || node.Name != "boba" {
-			t.Fatalf("must prefer the status.GPU node (boba); got %v", node)
+		if node == nil || node.Name != "worker-1" {
+			t.Fatalf("must prefer the status.GPU node (worker-1); got %v", node)
 		}
 	})
 
 	t.Run("no status.GPU falls back to first-found", func(t *testing.T) {
 		// Single allocation (no double-hold), no status.GPU → returns it.
-		r := newReconciler(boba, wgpu1Guest(""))
+		r := newReconciler(worker1, wgpu1Guest(""))
 		node, _, _, _, err := r.findAndAllocate(context.Background(), wgpu1Guest(""), profile)
 		if err != nil {
 			t.Fatalf("findAndAllocate: %v", err)
 		}
-		if node == nil || node.Name != "boba" {
+		if node == nil || node.Name != "worker-1" {
 			t.Fatalf("with no status.GPU and one allocation, returns that node; got %v", node)
 		}
 	})
 }
 
 // TestDeallocateGPUs_FreesAllNodes is the §10.1 regression: a guest allocated on
-// BOTH the source ("miles", = status.GPU.NodeName) and the target ("boba", a
+// BOTH the source ("worker-2", = status.GPU.NodeName) and the target ("worker-1", a
 // held reservation) — the reserve-before-stop double-hold — must have BOTH
 // freed when the guest is deleted. Releasing only status.GPU.NodeName would
 // strand the target reservation forever (AllocatedTo a now-deleted guest).
 func TestDeallocateGPUs_FreesAllNodes(t *testing.T) {
-	source := nodeAllocatedTo("miles", "0000:01:00.0", "default/g")
-	target := nodeAllocatedTo("boba", "0000:ff:00.0", "default/g")
-	guest := wgpu1Guest("miles") // status.GPU.NodeName = miles (source)
+	source := nodeAllocatedTo("worker-2", "0000:01:00.0", "default/g")
+	target := nodeAllocatedTo("worker-1", "0000:ff:00.0", "default/g")
+	guest := wgpu1Guest("worker-2") // status.GPU.NodeName = worker2 (source)
 	r := newReconciler(source, target, guest)
 
 	if err := r.deallocateGPUs(context.Background(), guest); err != nil {
 		t.Fatalf("deallocateGPUs: %v", err)
 	}
-	for _, name := range []string{"miles", "boba"} {
+	for _, name := range []string{"worker-2", "worker-1"} {
 		n := getNode(t, r.Client, name)
 		if got := n.Status.GPUs[0].AllocatedTo; got != "" {
 			t.Errorf("node %q GPU still AllocatedTo %q after dealloc; reservation/allocation leaked", name, got)

--- a/internal/controller/swiftgpu/metrics_test.go
+++ b/internal/controller/swiftgpu/metrics_test.go
@@ -17,14 +17,14 @@ import (
 // ReleaseFromNode for EVERY SwiftGPUNode on every finalizer reconcile).
 func TestReleaseFromNode_CountsOnlyChangedReleases(t *testing.T) {
 	g := gpuGuest("metrics-g")
-	c := newClient(gpuNodeWithDevices("boba", true, dev(0, "0000:01:00.0", 0)), g)
+	c := newClient(gpuNodeWithDevices("worker-1", true, dev(0, "0000:01:00.0", 0)), g)
 
-	if _, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "boba"); err != nil {
+	if _, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "worker-1"); err != nil {
 		t.Fatalf("reserve: %v", err)
 	}
 
 	before := testutil.ToFloat64(metrics.GPUReleasesTotal)
-	if err := ReleaseFromNode(context.Background(), c, g, "boba"); err != nil {
+	if err := ReleaseFromNode(context.Background(), c, g, "worker-1"); err != nil {
 		t.Fatalf("release: %v", err)
 	}
 	if got := testutil.ToFloat64(metrics.GPUReleasesTotal); got != before+1 {
@@ -32,7 +32,7 @@ func TestReleaseFromNode_CountsOnlyChangedReleases(t *testing.T) {
 	}
 
 	// Idempotent re-release: nothing left to free, counter must not move.
-	if err := ReleaseFromNode(context.Background(), c, g, "boba"); err != nil {
+	if err := ReleaseFromNode(context.Background(), c, g, "worker-1"); err != nil {
 		t.Fatalf("no-op release: %v", err)
 	}
 	if got := testutil.ToFloat64(metrics.GPUReleasesTotal); got != before+1 {

--- a/internal/controller/swiftgpu/preflight_test.go
+++ b/internal/controller/swiftgpu/preflight_test.go
@@ -44,37 +44,37 @@ func TestGPUNodeHasCapacity(t *testing.T) {
 		},
 		{
 			name:    "not vfio-ready",
-			node:    gpuNode("boba", false, 1, "GeForce GTX 1080"),
+			node:    gpuNode("worker-1", false, 1, "GeForce GTX 1080"),
 			profile: profile(1, "", "isolated"),
 			wantErr: true,
 		},
 		{
 			name:    "insufficient free GPUs",
-			node:    gpuNode("boba", true, 0, "GeForce GTX 1080"),
+			node:    gpuNode("worker-1", true, 0, "GeForce GTX 1080"),
 			profile: profile(1, "", "isolated"),
 			wantErr: true,
 		},
 		{
 			name:    "model mismatch",
-			node:    gpuNode("boba", true, 1, "GeForce GTX 1080"),
+			node:    gpuNode("worker-1", true, 1, "GeForce GTX 1080"),
 			profile: profile(1, "H200", "isolated"),
 			wantErr: true,
 		},
 		{
 			name:    "fits (empty model matches any)",
-			node:    gpuNode("boba", true, 1, "GeForce GTX 1080"),
+			node:    gpuNode("worker-1", true, 1, "GeForce GTX 1080"),
 			profile: profile(1, "", "isolated"),
 			wantErr: false,
 		},
 		{
 			name:    "fits (model substring match)",
-			node:    gpuNode("boba", true, 2, "NVIDIA Corporation GP104 [GeForce GTX 1080]"),
+			node:    gpuNode("worker-1", true, 2, "NVIDIA Corporation GP104 [GeForce GTX 1080]"),
 			profile: profile(2, "GTX 1080", "isolated"),
 			wantErr: false,
 		},
 		{
 			name:    "shared mode without FM partition",
-			node:    gpuNode("boba", true, 4, "H200 SXM"),
+			node:    gpuNode("worker-1", true, 4, "H200 SXM"),
 			profile: profile(2, "", "shared"),
 			wantErr: true,
 		},
@@ -88,7 +88,7 @@ func TestGPUNodeHasCapacity(t *testing.T) {
 			}
 			c := b.Build()
 
-			err := GPUNodeHasCapacity(context.Background(), c, "boba", tc.profile)
+			err := GPUNodeHasCapacity(context.Background(), c, "worker-1", tc.profile)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("GPUNodeHasCapacity err = %v, wantErr = %v", err, tc.wantErr)
 			}

--- a/internal/controller/swiftgpu/primitives_test.go
+++ b/internal/controller/swiftgpu/primitives_test.go
@@ -61,10 +61,10 @@ func allocatedTo(n *gpuv1alpha1.SwiftGPUNode, pci string) string {
 
 func TestReserveOnNode_MarksWithoutTouchingStatus(t *testing.T) {
 	g := gpuGuest("g")
-	n := gpuNodeWithDevices("boba", true, dev(0, "0000:01:00.0", 0))
+	n := gpuNodeWithDevices("worker-1", true, dev(0, "0000:01:00.0", 0))
 	c := newClient(n, g)
 
-	devs, _, partID, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "boba")
+	devs, _, partID, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "worker-1")
 	if err != nil {
 		t.Fatalf("ReserveOnNode: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestReserveOnNode_MarksWithoutTouchingStatus(t *testing.T) {
 		t.Errorf("partitionID = %d, want -1 (isolated)", partID)
 	}
 
-	got := getNode(t, c, "boba")
+	got := getNode(t, c, "worker-1")
 	if allocatedTo(got, "0000:01:00.0") != "default/g" {
 		t.Errorf("GPU must be AllocatedTo default/g; got %q", allocatedTo(got, "0000:01:00.0"))
 	}
@@ -92,34 +92,34 @@ func TestReserveOnNode_MarksWithoutTouchingStatus(t *testing.T) {
 
 func TestReserveOnNode_Idempotent(t *testing.T) {
 	g := gpuGuest("g")
-	n := gpuNodeWithDevices("boba", true, dev(0, "0000:01:00.0", 0))
+	n := gpuNodeWithDevices("worker-1", true, dev(0, "0000:01:00.0", 0))
 	c := newClient(n, g)
 
-	if _, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "boba"); err != nil {
+	if _, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "worker-1"); err != nil {
 		t.Fatalf("first reserve: %v", err)
 	}
-	devs, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "boba")
+	devs, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "worker-1")
 	if err != nil {
 		t.Fatalf("re-reserve must be idempotent, not error: %v", err)
 	}
 	if len(devs) != 1 {
 		t.Errorf("re-reserve returned %d devices, want the existing 1", len(devs))
 	}
-	if got := getNode(t, c, "boba"); got.Status.FreeGPUs != 0 {
+	if got := getNode(t, c, "worker-1"); got.Status.FreeGPUs != 0 {
 		t.Errorf("FreeGPUs = %d, want 0 (no double-allocation on re-reserve)", got.Status.FreeGPUs)
 	}
 }
 
 func TestReserveOnNode_NotVfioReady(t *testing.T) {
-	c := newClient(gpuNodeWithDevices("boba", false, dev(0, "0000:01:00.0", 0)), gpuGuest("g"))
-	if _, _, _, err := ReserveOnNode(context.Background(), c, gpuGuest("g"), profile(1, "", "isolated"), "boba"); err == nil {
+	c := newClient(gpuNodeWithDevices("worker-1", false, dev(0, "0000:01:00.0", 0)), gpuGuest("g"))
+	if _, _, _, err := ReserveOnNode(context.Background(), c, gpuGuest("g"), profile(1, "", "isolated"), "worker-1"); err == nil {
 		t.Errorf("expected error reserving on a non-vfio-ready node")
 	}
 }
 
 func TestReserveOnNode_Insufficient(t *testing.T) {
-	c := newClient(gpuNodeWithDevices("boba", true), gpuGuest("g")) // no GPUs
-	if _, _, _, err := ReserveOnNode(context.Background(), c, gpuGuest("g"), profile(1, "", "isolated"), "boba"); err == nil {
+	c := newClient(gpuNodeWithDevices("worker-1", true), gpuGuest("g")) // no GPUs
+	if _, _, _, err := ReserveOnNode(context.Background(), c, gpuGuest("g"), profile(1, "", "isolated"), "worker-1"); err == nil {
 		t.Errorf("expected error reserving when no GPUs are free")
 	}
 }
@@ -128,27 +128,27 @@ func TestReserveOnNode_Insufficient(t *testing.T) {
 // guest A reserves the only GPU, guest B cannot reserve on the same node.
 func TestReserveOnNode_HoldsAgainstOtherGuests(t *testing.T) {
 	gA, gB := gpuGuest("a"), gpuGuest("b")
-	c := newClient(gpuNodeWithDevices("boba", true, dev(0, "0000:01:00.0", 0)), gA, gB)
+	c := newClient(gpuNodeWithDevices("worker-1", true, dev(0, "0000:01:00.0", 0)), gA, gB)
 
-	if _, _, _, err := ReserveOnNode(context.Background(), c, gA, profile(1, "", "isolated"), "boba"); err != nil {
+	if _, _, _, err := ReserveOnNode(context.Background(), c, gA, profile(1, "", "isolated"), "worker-1"); err != nil {
 		t.Fatalf("guest A reserve: %v", err)
 	}
-	if _, _, _, err := ReserveOnNode(context.Background(), c, gB, profile(1, "", "isolated"), "boba"); err == nil {
+	if _, _, _, err := ReserveOnNode(context.Background(), c, gB, profile(1, "", "isolated"), "worker-1"); err == nil {
 		t.Errorf("guest B must NOT be able to reserve the GPU A holds")
 	}
 }
 
 func TestReleaseFromNode(t *testing.T) {
 	g := gpuGuest("g")
-	c := newClient(gpuNodeWithDevices("boba", true, dev(0, "0000:01:00.0", 0)), g)
+	c := newClient(gpuNodeWithDevices("worker-1", true, dev(0, "0000:01:00.0", 0)), g)
 
-	if _, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "boba"); err != nil {
+	if _, _, _, err := ReserveOnNode(context.Background(), c, g, profile(1, "", "isolated"), "worker-1"); err != nil {
 		t.Fatalf("reserve: %v", err)
 	}
-	if err := ReleaseFromNode(context.Background(), c, g, "boba"); err != nil {
+	if err := ReleaseFromNode(context.Background(), c, g, "worker-1"); err != nil {
 		t.Fatalf("release: %v", err)
 	}
-	got := getNode(t, c, "boba")
+	got := getNode(t, c, "worker-1")
 	if allocatedTo(got, "0000:01:00.0") != "" {
 		t.Errorf("GPU must be freed; AllocatedTo = %q", allocatedTo(got, "0000:01:00.0"))
 	}

--- a/internal/controller/swiftgpu/tier3_reject_test.go
+++ b/internal/controller/swiftgpu/tier3_reject_test.go
@@ -27,7 +27,7 @@ func gpuAllocatedReason(guest *swiftv1alpha1.SwiftGuest) string {
 // silent failure. LOAD-BEARING: if a future change wires NVSwitches and lifts this
 // rejection, it must be hardware-validated first.
 func TestReconcile_HGXFull_RejectedNotSilentlyBooted(t *testing.T) {
-	node := testGPUNode("boba", eightGPUs(), &gpuv1alpha1.FabricManagerStatus{
+	node := testGPUNode("worker-1", eightGPUs(), &gpuv1alpha1.FabricManagerStatus{
 		Installed: true, Running: true, Version: "550.90.07",
 		Partitions: []gpuv1alpha1.FMPartitionStatus{{ID: 0, GPUIndices: []int{0, 1, 2, 3, 4, 5, 6, 7}, Active: true}},
 	})
@@ -53,7 +53,7 @@ func TestReconcile_HGXFull_RejectedNotSilentlyBooted(t *testing.T) {
 		t.Errorf("GPUAllocated reason = %q, want UnsupportedTier", reason)
 	}
 	// No GPUs may have been allocated on the node (the tier check precedes allocation).
-	n, _ := getGPUNode(r, "boba")
+	n, _ := getGPUNode(r, "worker-1")
 	if n.Status.FreeGPUs != 8 {
 		t.Errorf("Tier 3 rejection must not allocate GPUs: node free = %d, want 8", n.Status.FreeGPUs)
 	}
@@ -66,7 +66,7 @@ func TestReconcile_HGXFull_RejectedNotSilentlyBooted(t *testing.T) {
 // Tier 2 (hgx-shared) is NOT rejected by the tier gate — it uses the host Fabric
 // Manager and passes no NVSwitches into the guest, so it stays allocatable.
 func TestReconcile_HGXShared_NotRejectedByTierGate(t *testing.T) {
-	node := testGPUNode("boba", eightGPUs(), &gpuv1alpha1.FabricManagerStatus{
+	node := testGPUNode("worker-1", eightGPUs(), &gpuv1alpha1.FabricManagerStatus{
 		Installed: true, Running: true, Version: "550.90.07",
 		Partitions: []gpuv1alpha1.FMPartitionStatus{{ID: 0, GPUIndices: []int{0, 1, 2, 3, 4, 5, 6, 7}, Active: true}},
 	})

--- a/internal/controller/swiftguest/clone_test.go
+++ b/internal/controller/swiftguest/clone_test.go
@@ -70,7 +70,7 @@ func localSnap(phase snapshotv1alpha1.SwiftSnapshotPhase) *snapshotv1alpha1.Swif
 				Local: &snapshotv1alpha1.LocalBackend{HostPath: "/var/lib/kubeswift/snapshots/ns-snap"},
 			},
 		},
-		Status: snapshotv1alpha1.SwiftSnapshotStatus{Phase: phase, NodeName: "boba"},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{Phase: phase, NodeName: "worker-1"},
 	}
 }
 
@@ -101,7 +101,7 @@ func TestPrepareCloneFromSnapshot_TierB(t *testing.T) {
 	}
 	if got.Annotations[AnnotationActiveRestore] != "snap" ||
 		got.Annotations[AnnotationRestoreMode] != RestoreModeClone ||
-		got.Annotations[AnnotationRestoreNodeName] != "boba" ||
+		got.Annotations[AnnotationRestoreNodeName] != "worker-1" ||
 		got.Annotations[AnnotationRestoreSnapshotPath] != "/var/lib/kubeswift/snapshots/ns-snap" ||
 		got.Annotations[AnnotationRestoreMACRewrites] == "" ||
 		got.Annotations[AnnotationRestoreNullifyHostMAC] != "true" {
@@ -150,7 +150,7 @@ func TestPrepareCloneFromSnapshot_TierC_RequiresTargetNode(t *testing.T) {
 
 func TestPrepareCloneFromSnapshot_TierC_DownloadsThenProceeds(t *testing.T) {
 	g := cloneGuest()
-	g.Spec.CloneFromSnapshot.TargetNode = "miles"
+	g.Spec.CloneFromSnapshot.TargetNode = "worker-2"
 	r, c := newCloneReconciler(t, g, sourceGuest(), s3CloneSnap())
 	r.SnapshotS3Image = "img"
 
@@ -160,12 +160,12 @@ func TestPrepareCloneFromSnapshot_TierC_DownloadsThenProceeds(t *testing.T) {
 		t.Fatalf("first pass should create the download Job + requeue; fail=%q requeue=%v err=%v", fail, requeue, err)
 	}
 	var job batchv1.Job
-	wantJob := cloneDownloadJobName(s3CloneSnap(), "miles")
+	wantJob := cloneDownloadJobName(s3CloneSnap(), "worker-2")
 	if err := c.Get(context.Background(), client.ObjectKey{Name: wantJob, Namespace: "ns"}, &job); err != nil {
 		t.Fatalf("download Job not created: %v", err)
 	}
-	if job.Spec.Template.Spec.NodeName != "miles" {
-		t.Errorf("download Job must pin to targetNode miles; got %q", job.Spec.Template.Spec.NodeName)
+	if job.Spec.Template.Spec.NodeName != "worker-2" {
+		t.Errorf("download Job must pin to targetNode worker-2; got %q", job.Spec.Template.Spec.NodeName)
 	}
 	// The shared Job is owned by the clone guest that created it.
 	if oc := metav1.GetControllerOf(&job); oc == nil || oc.Kind != "SwiftGuest" || oc.Name != "clone-a" {
@@ -181,7 +181,7 @@ func TestPrepareCloneFromSnapshot_TierC_DownloadsThenProceeds(t *testing.T) {
 	if err != nil || fail != "" || requeue || eff == nil {
 		t.Fatalf("after download completes, should proceed; fail=%q requeue=%v err=%v", fail, requeue, err)
 	}
-	if g.Annotations[AnnotationRestoreNodeName] != "miles" ||
+	if g.Annotations[AnnotationRestoreNodeName] != "worker-2" ||
 		g.Annotations[AnnotationRestoreSnapshotPath] != "/var/lib/kubeswift/snapshots/ns-snap" {
 		t.Errorf("Tier C restore annotations wrong: %+v", g.Annotations)
 	}
@@ -222,7 +222,7 @@ func TestPrepareCloneFromSnapshot_OCI_RequiresTargetNode(t *testing.T) {
 
 func TestPrepareCloneFromSnapshot_OCI_DownloadsThenProceeds(t *testing.T) {
 	g := cloneGuest()
-	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	g.Spec.CloneFromSnapshot.TargetNode = "worker-1"
 	r, c := newCloneReconciler(t, g, sourceGuest(), ociCloneSnap())
 	r.SnapshotORASImage = "img"
 
@@ -232,7 +232,7 @@ func TestPrepareCloneFromSnapshot_OCI_DownloadsThenProceeds(t *testing.T) {
 		t.Fatalf("first pass should create the oci download Job + requeue; fail=%q requeue=%v err=%v", fail, requeue, err)
 	}
 	var job batchv1.Job
-	wantJob := cloneDownloadJobName(ociCloneSnap(), "boba")
+	wantJob := cloneDownloadJobName(ociCloneSnap(), "worker-1")
 	if err := c.Get(context.Background(), client.ObjectKey{Name: wantJob, Namespace: "ns"}, &job); err != nil {
 		t.Fatalf("oci download Job not created: %v", err)
 	}
@@ -240,8 +240,8 @@ func TestPrepareCloneFromSnapshot_OCI_DownloadsThenProceeds(t *testing.T) {
 	if !strings.Contains(args, "--mode=download") || !strings.Contains(args, "--repository=zot.svc:5000/vmsnap") || !strings.Contains(args, "--digest=sha256:abc") {
 		t.Errorf("download Job is not an oci pull-by-digest: %q", args)
 	}
-	if job.Spec.Template.Spec.NodeName != "boba" {
-		t.Errorf("oci download Job must pin to targetNode boba; got %q", job.Spec.Template.Spec.NodeName)
+	if job.Spec.Template.Spec.NodeName != "worker-1" {
+		t.Errorf("oci download Job must pin to targetNode worker-1; got %q", job.Spec.Template.Spec.NodeName)
 	}
 
 	// Mark the Job complete; second pass should proceed (effective + stamped).
@@ -258,20 +258,20 @@ func TestPrepareCloneFromSnapshot_OCI_DownloadsThenProceeds(t *testing.T) {
 func TestCloneDownloadJobName_PerNodeSnapshot(t *testing.T) {
 	snap := s3CloneSnap()
 	// Deterministic + DNS-1123 valid + guest-independent.
-	if a, b := cloneDownloadJobName(snap, "miles"), cloneDownloadJobName(snap, "miles"); a != b {
+	if a, b := cloneDownloadJobName(snap, "worker-2"), cloneDownloadJobName(snap, "worker-2"); a != b {
 		t.Errorf("name must be deterministic; got %q vs %q", a, b)
 	}
-	if !strings.HasPrefix(cloneDownloadJobName(snap, "miles"), "clone-dl-") {
-		t.Errorf("name must carry the clone-dl- prefix; got %q", cloneDownloadJobName(snap, "miles"))
+	if !strings.HasPrefix(cloneDownloadJobName(snap, "worker-2"), "clone-dl-") {
+		t.Errorf("name must carry the clone-dl- prefix; got %q", cloneDownloadJobName(snap, "worker-2"))
 	}
 	// Different node → different Job (each node's cache is a separate hostPath).
-	if cloneDownloadJobName(snap, "miles") == cloneDownloadJobName(snap, "boba") {
+	if cloneDownloadJobName(snap, "worker-2") == cloneDownloadJobName(snap, "worker-1") {
 		t.Error("different nodes must yield different download Job names")
 	}
 	// Different snapshot → different Job.
 	other := s3CloneSnap()
 	other.Name = "snap2"
-	if cloneDownloadJobName(snap, "miles") == cloneDownloadJobName(other, "miles") {
+	if cloneDownloadJobName(snap, "worker-2") == cloneDownloadJobName(other, "worker-2") {
 		t.Error("different snapshots must yield different download Job names")
 	}
 }
@@ -287,9 +287,9 @@ func TestEnsureCloneDownloadJob_DedupPerNodeSnapshot(t *testing.T) {
 	r, c := newCloneReconciler(t, gA, gB, snap)
 	r.SnapshotS3Image = "img"
 
-	// Two distinct clone guests, both targeting node "miles".
+	// Two distinct clone guests, both targeting node "worker-2".
 	for _, g := range []*swiftv1alpha1.SwiftGuest{gA, gB} {
-		done, fail, err := r.ensureCloneDownloadJob(context.Background(), g, snap, "miles")
+		done, fail, err := r.ensureCloneDownloadJob(context.Background(), g, snap, "worker-2")
 		if err != nil || fail != "" || done {
 			t.Fatalf("%s: expected in-progress (not done, no fail); done=%v fail=%q err=%v", g.Name, done, fail, err)
 		}
@@ -300,11 +300,11 @@ func TestEnsureCloneDownloadJob_DedupPerNodeSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(jobs.Items) != 1 {
-		t.Fatalf("expected exactly ONE shared download Job for (miles, snap); got %d: %v", len(jobs.Items), jobNames(jobs))
+		t.Fatalf("expected exactly ONE shared download Job for (worker-2, snap); got %d: %v", len(jobs.Items), jobNames(jobs))
 	}
 	job := jobs.Items[0]
-	if job.Name != cloneDownloadJobName(snap, "miles") {
-		t.Errorf("shared Job name = %q, want %q", job.Name, cloneDownloadJobName(snap, "miles"))
+	if job.Name != cloneDownloadJobName(snap, "worker-2") {
+		t.Errorf("shared Job name = %q, want %q", job.Name, cloneDownloadJobName(snap, "worker-2"))
 	}
 	// Owned by the race-winner (clone-a, created first here); the sibling reads it.
 	if oc := metav1.GetControllerOf(&job); oc == nil || oc.Kind != "SwiftGuest" || oc.Name != "clone-a" {
@@ -312,7 +312,7 @@ func TestEnsureCloneDownloadJob_DedupPerNodeSnapshot(t *testing.T) {
 	}
 
 	// A clone on a DIFFERENT node gets its own Job (separate node-local cache).
-	if _, _, err := r.ensureCloneDownloadJob(context.Background(), gA, snap, "boba"); err != nil {
+	if _, _, err := r.ensureCloneDownloadJob(context.Background(), gA, snap, "worker-1"); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.List(context.Background(), &jobs, client.InNamespace("ns")); err != nil {
@@ -435,7 +435,7 @@ func completeCloneDownload(t *testing.T, r *SwiftGuestReconciler, c client.Clien
 		t.Fatalf("first pass should create the oci download Job + requeue; fail=%q requeue=%v err=%v", fail, requeue, err)
 	}
 	var job batchv1.Job
-	if err := c.Get(context.Background(), client.ObjectKey{Name: cloneDownloadJobName(snap, "boba"), Namespace: "ns"}, &job); err != nil {
+	if err := c.Get(context.Background(), client.ObjectKey{Name: cloneDownloadJobName(snap, "worker-1"), Namespace: "ns"}, &job); err != nil {
 		t.Fatalf("oci download Job not created: %v", err)
 	}
 	job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
@@ -446,7 +446,7 @@ func completeCloneDownload(t *testing.T, r *SwiftGuestReconciler, c client.Clien
 
 func TestPrepareCloneFromSnapshot_SourceGone_FullState_ResolvesFromCaptured(t *testing.T) {
 	g := cloneGuest()
-	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	g.Spec.CloneFromSnapshot.TargetNode = "worker-1"
 	g.Spec.GuestClassRef = corev1.LocalObjectReference{Name: "cls"}
 	snap := fullStateSnap()
 	// NO source guest in the cluster — the source-independent path must fire.
@@ -492,7 +492,7 @@ func TestPrepareCloneFromSnapshot_SourceGone_FullState_ResolvesFromCaptured(t *t
 
 func TestPrepareCloneFromSnapshot_SourceGone_MemoryOnly_Fails(t *testing.T) {
 	g := cloneGuest()
-	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	g.Spec.CloneFromSnapshot.TargetNode = "worker-1"
 	snap := ociCloneSnap() // memory-only: no status.oci.disk, no captured surface
 	r, c := newCloneReconciler(t, g, snap)
 	r.SnapshotORASImage = "img"
@@ -509,7 +509,7 @@ func TestPrepareCloneFromSnapshot_SourceGone_MemoryOnly_Fails(t *testing.T) {
 
 func TestPrepareCloneFromSnapshot_SourceGone_DataDisks_Fails(t *testing.T) {
 	g := cloneGuest()
-	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	g.Spec.CloneFromSnapshot.TargetNode = "worker-1"
 	g.Spec.GuestClassRef = corev1.LocalObjectReference{Name: "cls"}
 	snap := fullStateSnap()
 	snap.Status.GuestSpec.HasDataDisks = true
@@ -528,7 +528,7 @@ func TestPrepareCloneFromSnapshot_SourceGone_DataDisks_Fails(t *testing.T) {
 
 func TestPrepareCloneFromSnapshot_SourceGone_NoGuestClass_Fails(t *testing.T) {
 	g := cloneGuest()
-	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	g.Spec.CloneFromSnapshot.TargetNode = "worker-1"
 	g.Spec.GuestClassRef = corev1.LocalObjectReference{Name: "missing-cls"}
 	snap := fullStateSnap()
 	r, c := newCloneReconciler(t, g, snap) // class NOT in the cluster

--- a/internal/controller/swiftguest/coldmig_import_test.go
+++ b/internal/controller/swiftguest/coldmig_import_test.go
@@ -36,9 +36,9 @@ func fsRG() *resolved.ResolvedGuest {
 
 func TestBuildDiskFromOCIJob_Filesystem(t *testing.T) {
 	guest := cloneGuest()
-	job := buildDiskFromOCIJob(guest, fullStateCloneSnap(), "oras:img", "miles", "j", "swiftguest-root-clone-a", "sha256:disk123", false)
+	job := buildDiskFromOCIJob(guest, fullStateCloneSnap(), "oras:img", "worker-2", "j", "swiftguest-root-clone-a", "sha256:disk123", false)
 	pod := job.Spec.Template.Spec
-	if pod.NodeName != "miles" {
+	if pod.NodeName != "worker-2" {
 		t.Errorf("download Job must pin to the clone node; got %q", pod.NodeName)
 	}
 	c := pod.Containers[0]
@@ -77,7 +77,7 @@ func TestBuildDiskFromOCIJob_Filesystem(t *testing.T) {
 }
 
 func TestBuildDiskFromOCIJob_Block(t *testing.T) {
-	job := buildDiskFromOCIJob(cloneGuest(), fullStateCloneSnap(), "oras:img", "boba", "j", "swiftguest-root-clone-a", "sha256:disk123", true)
+	job := buildDiskFromOCIJob(cloneGuest(), fullStateCloneSnap(), "oras:img", "worker-1", "j", "swiftguest-root-clone-a", "sha256:disk123", true)
 	c := job.Spec.Template.Spec.Containers[0]
 	if !strings.Contains(strings.Join(c.Args, " "), "--file="+DiskRootDevicePath) {
 		t.Errorf("Block root must download to the raw device; got %q", strings.Join(c.Args, " "))
@@ -99,7 +99,7 @@ func TestBuildDiskFromOCIJob_Block(t *testing.T) {
 func TestBuildDiskFromOCIJob_Creds(t *testing.T) {
 	snap := fullStateCloneSnap()
 	snap.Spec.Backend.OCI.CredentialsSecretRef = &snapshotv1alpha1.SecretObjectReference{Name: "reg-creds"}
-	job := buildDiskFromOCIJob(cloneGuest(), snap, "oras:img", "miles", "j", "swiftguest-root-clone-a", "sha256:disk123", false)
+	job := buildDiskFromOCIJob(cloneGuest(), snap, "oras:img", "worker-2", "j", "swiftguest-root-clone-a", "sha256:disk123", false)
 	c := job.Spec.Template.Spec.Containers[0]
 	var dockerCfg bool
 	for _, e := range c.Env {
@@ -126,7 +126,7 @@ func TestBuildDiskFromOCIJob_Creds(t *testing.T) {
 // falls through to the base-image clone path.
 func TestMaybeRootDiskFromOCI_NotFullState(t *testing.T) {
 	g := cloneGuest()
-	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	g.Spec.CloneFromSnapshot.TargetNode = "worker-1"
 	r, _ := newCloneReconciler(t, g, ociCloneSnap()) // no status.oci.disk
 	r.SnapshotORASImage = "img"
 	handled, res, err := r.maybeRootDiskFromOCI(context.Background(), g, fsRG())
@@ -149,7 +149,7 @@ func TestMaybeRootDiskFromOCI_NoClone(t *testing.T) {
 func TestMaybeRootDiskFromOCI_MaterializesDiskThenReady(t *testing.T) {
 	ctx := context.Background()
 	g := cloneGuest()
-	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	g.Spec.CloneFromSnapshot.TargetNode = "worker-1"
 	r, c := newCloneReconciler(t, g, fullStateCloneSnap())
 	r.SnapshotORASImage = "img"
 	cloneName := RootDiskCloneName(g.Name)
@@ -184,8 +184,8 @@ func TestMaybeRootDiskFromOCI_MaterializesDiskThenReady(t *testing.T) {
 	if err := c.Get(ctx, client.ObjectKey{Name: jobName, Namespace: "ns"}, &job); err != nil {
 		t.Fatalf("download Job not created: %v", err)
 	}
-	if job.Spec.Template.Spec.NodeName != "boba" {
-		t.Errorf("download Job must pin to targetNode boba; got %q", job.Spec.Template.Spec.NodeName)
+	if job.Spec.Template.Spec.NodeName != "worker-1" {
+		t.Errorf("download Job must pin to targetNode worker-1; got %q", job.Spec.Template.Spec.NodeName)
 	}
 	if !strings.Contains(strings.Join(job.Spec.Template.Spec.Containers[0].Args, " "), "--digest=sha256:disk123") {
 		t.Errorf("download Job must pull the disk artifact by digest; args=%v", job.Spec.Template.Spec.Containers[0].Args)
@@ -229,7 +229,7 @@ func fullStateWithDataDisk() *snapshotv1alpha1.SwiftSnapshot {
 func TestMaybeRootDiskFromOCI_MaterializesDataDisks(t *testing.T) {
 	ctx := context.Background()
 	g := cloneGuest()
-	g.Spec.CloneFromSnapshot.TargetNode = "boba"
+	g.Spec.CloneFromSnapshot.TargetNode = "worker-1"
 	r, c := newCloneReconciler(t, g, fullStateWithDataDisk())
 	r.SnapshotORASImage = "img"
 	cloneName := RootDiskCloneName(g.Name)

--- a/internal/controller/swiftguest/failure_reason_metrics_test.go
+++ b/internal/controller/swiftguest/failure_reason_metrics_test.go
@@ -29,11 +29,11 @@ func TestRecordGuestMetrics_FailureReasonIsBoundedToken(t *testing.T) {
 		Conditions: []metav1.Condition{
 			// A healthy True condition whose Reason must NOT be picked.
 			{Type: "PodScheduled", Status: metav1.ConditionTrue, Reason: "PodScheduled",
-				Message: "pod scheduled to node miles"},
+				Message: "pod scheduled to node worker-2"},
 			// The failing condition: Reason is the bounded token, Message the
 			// free text that previously leaked into the label.
 			{Type: "GuestRunning", Status: metav1.ConditionFalse, Reason: "PodFailed",
-				Message: "launcher pod g-mig-abc123 failed on node miles: init container gpu-init exited 1"},
+				Message: "launcher pod g-mig-abc123 failed on node worker-2: init container gpu-init exited 1"},
 		},
 	}
 

--- a/internal/controller/swiftguest/gpu_test.go
+++ b/internal/controller/swiftguest/gpu_test.go
@@ -470,8 +470,8 @@ func TestGPUIntentDeviceConstruction(t *testing.T) {
 // time, so this branch normally never fires; the check exists to catch
 // any webhook bypass or future Phase 4 controller bug.
 func TestBuildPodDispatcher_NodeNameGPUDisagreement(t *testing.T) {
-	guest := gpuGuest("miles", []string{"0000:01:00.0"}, -1)
-	guest.Spec.NodeName = "boba" // disagrees with status.GPU.NodeName
+	guest := gpuGuest("worker-2", []string{"0000:01:00.0"}, -1)
+	guest.Spec.NodeName = "worker-1" // disagrees with status.GPU.NodeName
 	// Mark GPUAllocated=True so the dispatcher reaches the GPU branch
 	// (not strictly necessary — the precedence check fires first — but
 	// matches the realistic state).
@@ -487,7 +487,7 @@ func TestBuildPodDispatcher_NodeNameGPUDisagreement(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 	c := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}).Build()
+		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-2"}}).Build()
 	r := &SwiftGuestReconciler{Client: c, Scheme: scheme}
 
 	pod, err := r.buildPod(context.Background(), guest, rg, "seed-cm", "intent-cm", nil)
@@ -502,8 +502,8 @@ func TestBuildPodDispatcher_NodeNameGPUDisagreement(t *testing.T) {
 	if !strings.Contains(err.Error(), "must commit both together") {
 		t.Errorf("error message should mention the cutover-consistency assertion; got %q", err.Error())
 	}
-	if !strings.Contains(err.Error(), "boba") || !strings.Contains(err.Error(), "miles") {
-		t.Errorf("error message should name both spec.nodeName (boba) and status.gpu.nodeName (miles); got %q", err.Error())
+	if !strings.Contains(err.Error(), "worker-1") || !strings.Contains(err.Error(), "worker-2") {
+		t.Errorf("error message should name both spec.nodeName (worker-1) and status.gpu.nodeName (worker-2); got %q", err.Error())
 	}
 }
 
@@ -522,7 +522,7 @@ func TestBuildPodDispatcher_NodeNameSetGPUNil(t *testing.T) {
 			GuestClassRef:  corev1.LocalObjectReference{Name: "class"},
 			SeedProfileRef: &corev1.LocalObjectReference{Name: "seed"},
 			GPUProfileRef:  &corev1.LocalObjectReference{Name: "gpu-profile"},
-			NodeName:       "miles",
+			NodeName:       "worker-2",
 		},
 		// Status.GPU intentionally nil.
 	}
@@ -532,7 +532,7 @@ func TestBuildPodDispatcher_NodeNameSetGPUNil(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 	c := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}).Build()
+		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-2"}}).Build()
 	r := &SwiftGuestReconciler{Client: c, Scheme: scheme}
 
 	// Precedence check should NOT fire (status.GPU is nil). The dispatcher
@@ -569,7 +569,7 @@ func TestBuildPodDispatcher_NodeName_RestoreBranch(t *testing.T) {
 			ImageRef:       &corev1.LocalObjectReference{Name: "img"},
 			GuestClassRef:  corev1.LocalObjectReference{Name: "class"},
 			SeedProfileRef: &corev1.LocalObjectReference{Name: "seed"},
-			NodeName:       "miles",
+			NodeName:       "worker-2",
 		},
 	}
 	rg := &resolved.ResolvedGuest{
@@ -583,7 +583,7 @@ func TestBuildPodDispatcher_NodeName_RestoreBranch(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 	c := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}).Build()
+		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-2"}}).Build()
 	r := &SwiftGuestReconciler{Client: c, Scheme: scheme}
 
 	pod, err := r.buildPod(context.Background(), guest, rg, "seed-cm", "intent-cm", nil)
@@ -593,8 +593,8 @@ func TestBuildPodDispatcher_NodeName_RestoreBranch(t *testing.T) {
 	if pod == nil {
 		t.Fatal("buildPod returned nil pod on restore branch")
 	}
-	if pod.Spec.NodeName != "miles" {
-		t.Errorf("restore-branch pod.Spec.NodeName = %q, want miles (applyNodeName must run on restore branch)", pod.Spec.NodeName)
+	if pod.Spec.NodeName != "worker-2" {
+		t.Errorf("restore-branch pod.Spec.NodeName = %q, want worker-2 (applyNodeName must run on restore branch)", pod.Spec.NodeName)
 	}
 }
 
@@ -602,8 +602,8 @@ func TestBuildPodDispatcher_NodeName_RestoreBranch(t *testing.T) {
 // spec.NodeName matches status.GPU.NodeName, the dispatcher builds the
 // pod normally (does not error out).
 func TestBuildPodDispatcher_NodeNameGPUAgreement(t *testing.T) {
-	guest := gpuGuest("miles", []string{"0000:01:00.0"}, -1)
-	guest.Spec.NodeName = "miles" // matches status.GPU.NodeName
+	guest := gpuGuest("worker-2", []string{"0000:01:00.0"}, -1)
+	guest.Spec.NodeName = "worker-2" // matches status.GPU.NodeName
 	guest.Status.Conditions = []metav1.Condition{
 		{Type: swiftv1alpha1.ConditionGPUAllocated, Status: metav1.ConditionTrue},
 	}
@@ -632,7 +632,7 @@ func TestBuildPodDispatcher_NodeNameGPUAgreement(t *testing.T) {
 	}
 	// The node must exist: buildPod resolves spec.NodeName for the taint check.
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(profile,
-		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}).Build()
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-2"}}).Build()
 	r := &SwiftGuestReconciler{Client: c, Scheme: scheme}
 
 	pod, err := r.buildPod(context.Background(), guest, rg, "seed-cm", "intent-cm", nil)
@@ -647,8 +647,8 @@ func TestBuildPodDispatcher_NodeNameGPUAgreement(t *testing.T) {
 	// validated on Hetzner by switching the GPU path to direct binding;
 	// the precedence check above guarantees the pinned node matches either
 	// way.
-	if pod.Spec.NodeSelector["kubernetes.io/hostname"] != "miles" {
-		t.Errorf("GPU pod NodeSelector hostname = %q, want miles", pod.Spec.NodeSelector["kubernetes.io/hostname"])
+	if pod.Spec.NodeSelector["kubernetes.io/hostname"] != "worker-2" {
+		t.Errorf("GPU pod NodeSelector hostname = %q, want worker-2", pod.Spec.NodeSelector["kubernetes.io/hostname"])
 	}
 	// Lock in the architect's "GPU pods stay on selector, not direct
 	// binding" decision: pod.Spec.NodeName must remain empty even when
@@ -665,7 +665,7 @@ func TestBuildPodDispatcher_NodeNameGPUAgreement(t *testing.T) {
 // GPU branch. The precedence guard short-circuits cleanly. This is the
 // pre-Phase-1 GPU happy path and must not regress.
 func TestBuildPodDispatcher_GPUOnlyNoMigrationNodeName(t *testing.T) {
-	guest := gpuGuest("miles", []string{"0000:01:00.0"}, -1)
+	guest := gpuGuest("worker-2", []string{"0000:01:00.0"}, -1)
 	// spec.NodeName intentionally empty.
 	guest.Status.Conditions = []metav1.Condition{
 		{Type: swiftv1alpha1.ConditionGPUAllocated, Status: metav1.ConditionTrue},
@@ -700,8 +700,8 @@ func TestBuildPodDispatcher_GPUOnlyNoMigrationNodeName(t *testing.T) {
 	if pod == nil {
 		t.Fatal("buildPod returned nil pod")
 	}
-	if pod.Spec.NodeSelector["kubernetes.io/hostname"] != "miles" {
-		t.Errorf("GPU pod NodeSelector hostname = %q, want miles", pod.Spec.NodeSelector["kubernetes.io/hostname"])
+	if pod.Spec.NodeSelector["kubernetes.io/hostname"] != "worker-2" {
+		t.Errorf("GPU pod NodeSelector hostname = %q, want worker-2", pod.Spec.NodeSelector["kubernetes.io/hostname"])
 	}
 }
 

--- a/internal/controller/swiftguest/nodeplacement_test.go
+++ b/internal/controller/swiftguest/nodeplacement_test.go
@@ -30,8 +30,8 @@ var cpTaint = corev1.Taint{
 // launcher from landing there.
 func TestCheckNodePlacement_RefusesUntoleratedControlPlane(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
-		WithObjects(node("frida", cpTaint)).Build()
-	guest := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "frida"}}
+		WithObjects(node("cp-1", cpTaint)).Build()
+	guest := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "cp-1"}}
 	err := checkNodePlacement(context.Background(), c, guest, &corev1.Pod{})
 	if err == nil {
 		t.Fatal("accepted an untolerated control-plane node")
@@ -45,8 +45,8 @@ func TestCheckNodePlacement_RefusesUntoleratedControlPlane(t *testing.T) {
 // — exactly as an ordinary pod would.
 func TestCheckNodePlacement_AllowsWithToleration(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
-		WithObjects(node("frida", cpTaint)).Build()
-	guest := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "frida"}}
+		WithObjects(node("cp-1", cpTaint)).Build()
+	guest := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "cp-1"}}
 	pod := &corev1.Pod{Spec: corev1.PodSpec{Tolerations: []corev1.Toleration{{
 		Key:      "node-role.kubernetes.io/control-plane",
 		Operator: corev1.TolerationOpExists,
@@ -59,9 +59,9 @@ func TestCheckNodePlacement_AllowsWithToleration(t *testing.T) {
 
 func TestCheckNodePlacement_UntaintedAndUnpinned(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
-		WithObjects(node("miles")).Build()
+		WithObjects(node("worker-2")).Build()
 	// Pinned to a clean node: fine.
-	g := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "miles"}}
+	g := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "worker-2"}}
 	if err := checkNodePlacement(context.Background(), c, g, &corev1.Pod{}); err != nil {
 		t.Errorf("clean node rejected: %v", err)
 	}
@@ -83,9 +83,9 @@ func TestCheckNodePlacement_MissingNode(t *testing.T) {
 // so enforcing it here would be stricter than Kubernetes itself.
 func TestCheckNodePlacement_IgnoresPreferNoSchedule(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
-		node("miles", corev1.Taint{Key: "soft", Effect: corev1.TaintEffectPreferNoSchedule}),
+		node("worker-2", corev1.Taint{Key: "soft", Effect: corev1.TaintEffectPreferNoSchedule}),
 	).Build()
-	g := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "miles"}}
+	g := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{NodeName: "worker-2"}}
 	if err := checkNodePlacement(context.Background(), c, g, &corev1.Pod{}); err != nil {
 		t.Errorf("PreferNoSchedule should not block: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestTolerated_Wildcard(t *testing.T) {
 // the old call site inside buildPod and the guest stalled with no reason set.
 func TestCheckNodePlacementFor_RunsWithoutAPod(t *testing.T) {
 	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "frida"},
+		ObjectMeta: metav1.ObjectMeta{Name: "cp-1"},
 		Spec: corev1.NodeSpec{Taints: []corev1.Taint{{
 			Key: "node-role.kubernetes.io/control-plane", Effect: corev1.TaintEffectNoSchedule,
 		}}},
@@ -113,7 +113,7 @@ func TestCheckNodePlacementFor_RunsWithoutAPod(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(node).Build()
 	guest := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "g1"},
-		Spec:       swiftv1alpha1.SwiftGuestSpec{NodeName: "frida"},
+		Spec:       swiftv1alpha1.SwiftGuestSpec{NodeName: "cp-1"},
 	}
 
 	err := checkNodePlacementFor(context.Background(), c, guest, nil)
@@ -124,17 +124,17 @@ func TestCheckNodePlacementFor_RunsWithoutAPod(t *testing.T) {
 	if strings.Contains(err.Error(), "spec.tolerations") {
 		t.Errorf("error points at spec.tolerations, which SwiftGuest does not have: %v", err)
 	}
-	if !strings.Contains(err.Error(), "frida") {
+	if !strings.Contains(err.Error(), "cp-1") {
 		t.Errorf("error does not name the node: %v", err)
 	}
 }
 
 func TestCheckNodePlacementFor_UntaintedNodeIsFine(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
-		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "miles"}}).Build()
+		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-2"}}).Build()
 	guest := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "g1"},
-		Spec:       swiftv1alpha1.SwiftGuestSpec{NodeName: "miles"},
+		Spec:       swiftv1alpha1.SwiftGuestSpec{NodeName: "worker-2"},
 	}
 	if err := checkNodePlacementFor(context.Background(), c, guest, nil); err != nil {
 		t.Errorf("rejected an untainted node: %v", err)

--- a/internal/controller/swiftguest/pod_test.go
+++ b/internal/controller/swiftguest/pod_test.go
@@ -531,7 +531,7 @@ func TestBuildPod_NodeName_DiskBoot(t *testing.T) {
 		Spec: swiftv1alpha1.SwiftGuestSpec{
 			ImageRef:      &corev1.LocalObjectReference{Name: "img"},
 			GuestClassRef: corev1.LocalObjectReference{Name: "class"},
-			NodeName:      "miles",
+			NodeName:      "worker-2",
 		},
 	}
 	rg := &resolved.ResolvedGuest{
@@ -542,8 +542,8 @@ func TestBuildPod_NodeName_DiskBoot(t *testing.T) {
 
 	pod := BuildPod(guest, rg, "", "test-intent", nil)
 
-	if pod.Spec.NodeName != "miles" {
-		t.Errorf("pod.Spec.NodeName = %q, want miles", pod.Spec.NodeName)
+	if pod.Spec.NodeName != "worker-2" {
+		t.Errorf("pod.Spec.NodeName = %q, want worker-2", pod.Spec.NodeName)
 	}
 	if pod.Spec.NodeSelector != nil {
 		t.Errorf("disk-boot pod should not have NodeSelector when spec.NodeName is set; got %v", pod.Spec.NodeSelector)
@@ -561,7 +561,7 @@ func TestBuildPod_NodeName_KernelBoot(t *testing.T) {
 		Spec: swiftv1alpha1.SwiftGuestSpec{
 			KernelRef:     &corev1.LocalObjectReference{Name: "k"},
 			GuestClassRef: corev1.LocalObjectReference{Name: "class"},
-			NodeName:      "miles",
+			NodeName:      "worker-2",
 		},
 	}
 	rg := &resolved.ResolvedGuest{
@@ -575,8 +575,8 @@ func TestBuildPod_NodeName_KernelBoot(t *testing.T) {
 
 	pod := BuildPod(guest, rg, "", "test-intent", nil)
 
-	if pod.Spec.NodeName != "miles" {
-		t.Errorf("pod.Spec.NodeName = %q, want miles", pod.Spec.NodeName)
+	if pod.Spec.NodeName != "worker-2" {
+		t.Errorf("pod.Spec.NodeName = %q, want worker-2", pod.Spec.NodeName)
 	}
 	if pod.Spec.NodeSelector["kubeswift.io/kernel-node"] != "true" {
 		t.Errorf("kubeswift.io/kernel-node selector should be preserved; got %v", pod.Spec.NodeSelector)
@@ -852,11 +852,11 @@ func TestApplySchedulerName_EmptyLeavesClusterDefault(t *testing.T) {
 // would be inert text in the pod spec that reads as if it took effect.
 func TestApplySchedulerName_NodeNameWins(t *testing.T) {
 	pod := &corev1.Pod{}
-	guest := schedulerNameGuest("least-allocated", "boba")
+	guest := schedulerNameGuest("least-allocated", "worker-1")
 	applyNodeName(pod, guest)
 	applySchedulerName(pod, guest)
-	if pod.Spec.NodeName != "boba" {
-		t.Fatalf("nodeName = %q, want boba", pod.Spec.NodeName)
+	if pod.Spec.NodeName != "worker-1" {
+		t.Fatalf("nodeName = %q, want worker-1", pod.Spec.NodeName)
 	}
 	if pod.Spec.SchedulerName != "" {
 		t.Fatalf("schedulerName = %q, want empty: direct binding skips the scheduler", pod.Spec.SchedulerName)

--- a/internal/controller/swiftguest/restore_test.go
+++ b/internal/controller/swiftguest/restore_test.go
@@ -19,7 +19,7 @@ func minimalGuest() *swiftv1alpha1.SwiftGuest {
 			Annotations: map[string]string{
 				AnnotationActiveRestore:       "r1",
 				AnnotationRestoreSnapshotPath: "/var/lib/kubeswift/snapshots/default-snap1",
-				AnnotationRestoreNodeName:     "boba",
+				AnnotationRestoreNodeName:     "worker-1",
 			},
 		},
 		Spec: swiftv1alpha1.SwiftGuestSpec{
@@ -210,7 +210,7 @@ func TestBuildRestorePod_InPlaceFastPath_NoStagerInitContainer(t *testing.T) {
 	rg := minimalResolved()
 	params := RestoreParams{
 		SnapshotPath: "/var/lib/kubeswift/snapshots/default-snap1",
-		NodeName:     "boba",
+		NodeName:     "worker-1",
 		Mode:         RestoreModeInPlace,
 	}
 
@@ -219,8 +219,8 @@ func TestBuildRestorePod_InPlaceFastPath_NoStagerInitContainer(t *testing.T) {
 	if pod.Name != "g1" {
 		t.Errorf("pod.Name = %q, want g1", pod.Name)
 	}
-	if pod.Spec.NodeSelector["kubernetes.io/hostname"] != "boba" {
-		t.Errorf("nodeSelector hostname = %q, want boba", pod.Spec.NodeSelector["kubernetes.io/hostname"])
+	if pod.Spec.NodeSelector["kubernetes.io/hostname"] != "worker-1" {
+		t.Errorf("nodeSelector hostname = %q, want worker-1", pod.Spec.NodeSelector["kubernetes.io/hostname"])
 	}
 	if findInit(pod, SnapshotStagerInitContainerName) != nil {
 		t.Errorf("in-place must NOT include a snapshot-stager init container")
@@ -257,7 +257,7 @@ func TestBuildRestorePod_CloneAddsStagerAndStagingVolume(t *testing.T) {
 	rg := minimalResolved()
 	params := RestoreParams{
 		SnapshotPath:        "/var/lib/kubeswift/snapshots/default-snap1",
-		NodeName:            "boba",
+		NodeName:            "worker-1",
 		Mode:                RestoreModeClone,
 		MACRewrites:         "52:54:00:aa:bb:01",
 		AppendCmdlineMarker: true,
@@ -461,7 +461,7 @@ func TestBuildRestorePod_AttachesDataDisks(t *testing.T) {
 	rg.DataDisks = []resolved.ResolvedDataDisk{
 		{Name: "scratch", PVCName: "g1-data-scratch", Block: true, HostPath: "/dev/kubeswift-data-scratch", Format: "raw", Ready: true},
 	}
-	params := RestoreParams{SnapshotPath: "/snap", NodeName: "boba", Mode: RestoreModeInPlace}
+	params := RestoreParams{SnapshotPath: "/snap", NodeName: "worker-1", Mode: RestoreModeInPlace}
 
 	pod := BuildRestorePod(guest, rg, "", "g1-runtime-intent", nil, params)
 

--- a/internal/controller/swiftguest/rootdisk_source_clone_test.go
+++ b/internal/controller/swiftguest/rootdisk_source_clone_test.go
@@ -27,7 +27,7 @@ func localCloneSnap() *snapshotv1alpha1.SwiftSnapshot {
 		},
 		Status: snapshotv1alpha1.SwiftSnapshotStatus{
 			Phase:    snapshotv1alpha1.SwiftSnapshotPhaseReady,
-			NodeName: "boba",
+			NodeName: "worker-1",
 		},
 	}
 }

--- a/internal/controller/swiftguest/rootdisk_test.go
+++ b/internal/controller/swiftguest/rootdisk_test.go
@@ -64,11 +64,11 @@ func TestCreateCloneJob_PinsToLauncherNode(t *testing.T) {
 	r := &SwiftGuestReconciler{Client: c, Scheme: scheme}
 	rg := &resolved.ResolvedGuest{} // Filesystem (VolumeMode "")
 
-	// Clone pinned (via the restore-node annotation) to "miles".
+	// Clone pinned (via the restore-node annotation) to "worker-2".
 	guest := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "clone-a", Namespace: "default",
-			Annotations: map[string]string{AnnotationRestoreNodeName: "miles"},
+			Annotations: map[string]string{AnnotationRestoreNodeName: "worker-2"},
 		},
 	}
 	if err := r.createCloneJob(context.Background(), guest, rg, "job-clone-a", "src", "dst", resource.MustParse("10Gi")); err != nil {
@@ -78,8 +78,8 @@ func TestCreateCloneJob_PinsToLauncherNode(t *testing.T) {
 	if err := c.Get(context.Background(), client.ObjectKey{Name: "job-clone-a", Namespace: "default"}, &job); err != nil {
 		t.Fatal(err)
 	}
-	if got := job.Spec.Template.Spec.NodeSelector["kubernetes.io/hostname"]; got != "miles" {
-		t.Errorf("clone Job nodeSelector hostname = %q, want miles (must co-locate with the launcher)", got)
+	if got := job.Spec.Template.Spec.NodeSelector["kubernetes.io/hostname"]; got != "worker-2" {
+		t.Errorf("clone Job nodeSelector hostname = %q, want worker-2 (must co-locate with the launcher)", got)
 	}
 
 	// Unpinned guest -> no nodeSelector (the scheduler places it freely).

--- a/internal/controller/swiftguestpool/clone_test.go
+++ b/internal/controller/swiftguestpool/clone_test.go
@@ -36,16 +36,16 @@ func poolReconciler(t *testing.T, objs ...client.Object) *SwiftGuestPoolReconcil
 
 func TestAssignCloneTargetNode_RoundRobin(t *testing.T) {
 	r := poolReconciler(t,
-		node("boba", true, nil),
-		node("miles", true, nil),
-		node("frida", true, func(n *corev1.Node) { // control-plane: excluded
+		node("worker-1", true, nil),
+		node("worker-2", true, nil),
+		node("cp-1", true, func(n *corev1.Node) { // control-plane: excluded
 			n.Labels = map[string]string{"node-role.kubernetes.io/control-plane": ""}
 		}),
 		node("down", false, nil), // not ready: excluded
 		node("cordoned", true, func(n *corev1.Node) { n.Spec.Unschedulable = true }), // excluded
 	)
-	// schedulable workers sorted: [boba, miles]. Round-robin by index.
-	want := []string{"boba", "miles", "boba", "miles"}
+	// schedulable workers sorted: [worker1, worker2]. Round-robin by index.
+	want := []string{"worker-1", "worker-2", "worker-1", "worker-2"}
 	for i, w := range want {
 		spec := &swiftv1alpha1.SwiftGuestSpec{
 			CloneFromSnapshot: &swiftv1alpha1.CloneFromSnapshotSource{
@@ -62,7 +62,7 @@ func TestAssignCloneTargetNode_RoundRobin(t *testing.T) {
 }
 
 func TestAssignCloneTargetNode_NonCloneNoop(t *testing.T) {
-	r := poolReconciler(t, node("boba", true, nil))
+	r := poolReconciler(t, node("worker-1", true, nil))
 	spec := &swiftv1alpha1.SwiftGuestSpec{ImageRef: &corev1.LocalObjectReference{Name: "img"}}
 	if err := r.assignCloneTargetNode(context.Background(), spec, 0); err != nil {
 		t.Fatalf("non-clone should be a no-op: %v", err)
@@ -70,7 +70,7 @@ func TestAssignCloneTargetNode_NonCloneNoop(t *testing.T) {
 }
 
 func TestAssignCloneTargetNode_NoSchedulableNodes(t *testing.T) {
-	r := poolReconciler(t, node("frida", true, func(n *corev1.Node) {
+	r := poolReconciler(t, node("cp-1", true, func(n *corev1.Node) {
 		n.Labels = map[string]string{"node-role.kubernetes.io/control-plane": ""}
 	}))
 	spec := &swiftv1alpha1.SwiftGuestSpec{

--- a/internal/controller/swiftmigration/cancel_live_test.go
+++ b/internal/controller/swiftmigration/cancel_live_test.go
@@ -25,7 +25,7 @@ func cancelFixture(t *testing.T, dstAge time.Duration) (*migrationv1alpha1.Swift
 	mig := newMigrationWithUID("m1", "default", "abcdef1234567890abcdef1234567890")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	mig.Spec.CancelRequested = true
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhasePreparing
 	mig.Status.Mode = migrationv1alpha1.SwiftMigrationModeLive
 
@@ -38,7 +38,7 @@ func cancelFixture(t *testing.T, dstAge time.Duration) (*migrationv1alpha1.Swift
 			Namespace:         "default",
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-dstAge)),
 		},
-		Spec:   corev1.PodSpec{NodeName: "miles"},
+		Spec:   corev1.PodSpec{NodeName: "worker-2"},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
 	return mig, guest, dst

--- a/internal/controller/swiftmigration/controller_test.go
+++ b/internal/controller/swiftmigration/controller_test.go
@@ -39,7 +39,7 @@ func newMigration(name, ns string) *migrationv1alpha1.SwiftMigration {
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 		Spec: migrationv1alpha1.SwiftMigrationSpec{
 			GuestRef: migrationv1alpha1.SwiftMigrationGuestRef{Name: "guest"},
-			Target:   migrationv1alpha1.SwiftMigrationTarget{NodeName: "miles"},
+			Target:   migrationv1alpha1.SwiftMigrationTarget{NodeName: "worker-2"},
 			Mode:     migrationv1alpha1.SwiftMigrationModeOffline,
 		},
 	}

--- a/internal/controller/swiftmigration/cutover_test.go
+++ b/internal/controller/swiftmigration/cutover_test.go
@@ -377,7 +377,7 @@ func TestCutover_Step2_ChainMigration_DeletesPriorSrcPodNotDstPod_W26(t *testing
 		migrationStatusComplete, sendActionID(mig), "ok")
 	thisDst := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: thisDstName, Namespace: "default", UID: "uid-THIS-DST"},
-		Spec:       corev1.PodSpec{NodeName: "miles"},
+		Spec:       corev1.PodSpec{NodeName: "worker-2"},
 		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.244.1.43"},
 	}
 

--- a/internal/controller/swiftmigration/dst_pod_test.go
+++ b/internal/controller/swiftmigration/dst_pod_test.go
@@ -33,7 +33,7 @@ func templateSrcPod(guestName, ns string) *corev1.Pod {
 			},
 		},
 		Spec: corev1.PodSpec{
-			NodeName:      "boba",
+			NodeName:      "worker-1",
 			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{{
 				Name:  LauncherContainerName,
@@ -108,7 +108,7 @@ func TestDstPodName_OversizeName_Errors(t *testing.T) {
 func TestNewDstPod_SetsNameLabelsAnnotationsEnvNodeName(t *testing.T) {
 	scheme := testScheme(t)
 	mig := newMigrationWithUID("mig-a", "default", "abcdef1234567890abcdef1234567890")
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	guest := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
 	}
@@ -166,8 +166,8 @@ func TestNewDstPod_SetsNameLabelsAnnotationsEnvNodeName(t *testing.T) {
 		t.Errorf("ownerRef.Controller: want true")
 	}
 	// NodeName overridden to dst node
-	if dst.Spec.NodeName != "miles" {
-		t.Errorf("NodeName: want miles, got %q", dst.Spec.NodeName)
+	if dst.Spec.NodeName != "worker-2" {
+		t.Errorf("NodeName: want worker-2, got %q", dst.Spec.NodeName)
 	}
 	// KUBESWIFT_MIGRATION_ROLE=receiver added; preserved env preserved
 	envs := dst.Spec.Containers[0].Env
@@ -205,7 +205,7 @@ func TestNewDstPod_SetsNameLabelsAnnotationsEnvNodeName(t *testing.T) {
 func TestNewDstPod_NoLauncherContainer_Errors(t *testing.T) {
 	scheme := testScheme(t)
 	mig := newMigrationWithUID("m", "default", "abcdef1234567890abcdef1234567890")
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	guest := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
 	}
@@ -236,7 +236,7 @@ func TestNewDstPod_PreservesMultusAnnotation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := testScheme(t)
 			mig := newMigrationWithUID("mig-a", "default", "abcdef1234567890abcdef1234567890")
-			mig.Spec.Target.NodeName = "miles"
+			mig.Spec.Target.NodeName = "worker-2"
 			guest := &swiftv1alpha1.SwiftGuest{
 				ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
 			}
@@ -245,8 +245,8 @@ func TestNewDstPod_PreservesMultusAnnotation(t *testing.T) {
 
 			dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
 				mtlsEnabled: tc.mtls,
-				srcNodeName: "boba",
-				dstNodeName: "miles",
+				srcNodeName: "worker-1",
+				dstNodeName: "worker-2",
 			}, "", nil)
 			if err != nil {
 				t.Fatalf("newDstPod: %v", err)
@@ -269,7 +269,7 @@ func TestNewDstPod_PreservesMultusAnnotation(t *testing.T) {
 func TestNewDstPod_MTLS_InjectsServerSidecar(t *testing.T) {
 	scheme := testScheme(t)
 	mig := newMigrationWithUID("mig-a", "default", "abcdef1234567890abcdef1234567890")
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	guest := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
 	}
@@ -277,8 +277,8 @@ func TestNewDstPod_MTLS_InjectsServerSidecar(t *testing.T) {
 
 	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
 		mtlsEnabled: true,
-		srcNodeName: "boba",  // source node — dst pins this SAN
-		dstNodeName: "miles", // destination node — dst presents this identity
+		srcNodeName: "worker-1", // source node — dst pins this SAN
+		dstNodeName: "worker-2", // destination node — dst presents this identity
 	}, "", nil)
 	if err != nil {
 		t.Fatalf("newDstPod (mTLS): %v", err)
@@ -309,8 +309,8 @@ func TestNewDstPod_MTLS_InjectsServerSidecar(t *testing.T) {
 	if env[envStunnelRole] != stunnelRoleServer {
 		t.Errorf("sidecar role: want %q, got %q", stunnelRoleServer, env[envStunnelRole])
 	}
-	if env[envStunnelCheckHost] != "boba" {
-		t.Errorf("sidecar CHECK_HOST: want source node %q, got %q", "boba", env[envStunnelCheckHost])
+	if env[envStunnelCheckHost] != "worker-1" {
+		t.Errorf("sidecar CHECK_HOST: want source node %q, got %q", "worker-1", env[envStunnelCheckHost])
 	}
 	if _, present := env[envStunnelDstPodIP]; present {
 		t.Errorf("server-role sidecar must NOT set DST_POD_IP (that is client-only, PR 3b)")
@@ -323,8 +323,8 @@ func TestNewDstPod_MTLS_InjectsServerSidecar(t *testing.T) {
 			wantVols[v.Name] = true
 		}
 		if v.Name == stunnelCertVolumeName {
-			if v.Secret == nil || v.Secret.SecretName != "kubeswift-migration-node-miles" {
-				t.Errorf("identity volume must mount the DST node Secret kubeswift-migration-node-miles; got %+v", v.Secret)
+			if v.Secret == nil || v.Secret.SecretName != "kubeswift-migration-node-worker-2" {
+				t.Errorf("identity volume must mount the DST node Secret kubeswift-migration-node-worker-2; got %+v", v.Secret)
 			}
 		}
 		if v.Name == stunnelConfigVolumeName {
@@ -350,7 +350,7 @@ func TestNewDstPod_MTLS_InjectsServerSidecar(t *testing.T) {
 func TestNewDstPod_MTLS_FlipsInheritedClientSidecarToServer(t *testing.T) {
 	scheme := testScheme(t)
 	mig := newMigrationWithUID("mig-a", "default", "abcdef1234567890abcdef1234567890")
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	guest := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
 	}
@@ -371,7 +371,7 @@ func TestNewDstPod_MTLS_FlipsInheritedClientSidecarToServer(t *testing.T) {
 	)
 
 	dst, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
-		mtlsEnabled: true, srcNodeName: "boba", dstNodeName: "miles",
+		mtlsEnabled: true, srcNodeName: "worker-1", dstNodeName: "worker-2",
 	}, "", nil)
 	if err != nil {
 		t.Fatalf("newDstPod: %v", err)
@@ -406,7 +406,7 @@ func TestNewDstPod_MTLS_FlipsInheritedClientSidecarToServer(t *testing.T) {
 			t.Errorf("dst must not carry the client downward-API input volume")
 		}
 		if v.Name == stunnelCertVolumeName {
-			if v.Secret == nil || v.Secret.SecretName != "kubeswift-migration-node-miles" {
+			if v.Secret == nil || v.Secret.SecretName != "kubeswift-migration-node-worker-2" {
 				t.Errorf("dst cert volume must be the dst per-node Secret; got %+v", v.Secret)
 			}
 		}
@@ -423,7 +423,7 @@ func TestNewDstPod_MTLS_FlipsInheritedClientSidecarToServer(t *testing.T) {
 func TestNewDstPod_MTLS_OmitsPlaintextAck(t *testing.T) {
 	scheme := testScheme(t)
 	mig := newMigrationWithUID("mig-a", "default", "abcdef1234567890abcdef1234567890")
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	guest := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
 	}
@@ -438,7 +438,7 @@ func TestNewDstPod_MTLS_OmitsPlaintextAck(t *testing.T) {
 	}
 
 	on, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
-		mtlsEnabled: true, srcNodeName: "boba", dstNodeName: "miles",
+		mtlsEnabled: true, srcNodeName: "worker-1", dstNodeName: "worker-2",
 	}, "", nil)
 	if err != nil {
 		t.Fatalf("newDstPod (mTLS): %v", err)
@@ -451,7 +451,7 @@ func TestNewDstPod_MTLS_OmitsPlaintextAck(t *testing.T) {
 func TestNewDstPod_MTLS_EmptyNode_Errors(t *testing.T) {
 	scheme := testScheme(t)
 	mig := newMigrationWithUID("m", "default", "abcdef1234567890abcdef1234567890")
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	guest := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"},
 	}
@@ -460,7 +460,7 @@ func TestNewDstPod_MTLS_EmptyNode_Errors(t *testing.T) {
 	if _, err := newDstPod(mig, guest, src, scheme, dstSidecarConfig{
 		mtlsEnabled: true,
 		srcNodeName: "", // unresolved
-		dstNodeName: "miles",
+		dstNodeName: "worker-2",
 	}, "", nil); err == nil {
 		t.Errorf("expected error when mTLS enabled but source node name empty")
 	}

--- a/internal/controller/swiftmigration/failure_test.go
+++ b/internal/controller/swiftmigration/failure_test.go
@@ -24,7 +24,7 @@ import (
 func TestCancellation_PreCutover_RestoresRunPolicy(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyStopped // set by Preparing
 	guest.Annotations = map[string]string{
 		migrationv1alpha1.AnnotationMigrationInProgress: "m",
@@ -79,7 +79,7 @@ func TestCancellation_PostCutover_ClearsAnnotationOnly(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyRunning
-	guest.Spec.NodeName = "miles" // post-cutover
+	guest.Spec.NodeName = "worker-2" // post-cutover
 	guest.Annotations = map[string]string{
 		migrationv1alpha1.AnnotationMigrationInProgress: "m",
 	}
@@ -105,8 +105,8 @@ func TestCancellation_PostCutover_ClearsAnnotationOnly(t *testing.T) {
 		t.Fatalf("Get guest: %v", err)
 	}
 	// nodeName patch must NOT be rolled back.
-	if got.Spec.NodeName != "miles" {
-		t.Errorf("post-cutover cancellation should not roll back nodeName: got %q, want miles", got.Spec.NodeName)
+	if got.Spec.NodeName != "worker-2" {
+		t.Errorf("post-cutover cancellation should not roll back nodeName: got %q, want worker-2", got.Spec.NodeName)
 	}
 	if got.Spec.RunPolicy != swiftv1alpha1.RunPolicyRunning {
 		t.Errorf("post-cutover cancellation should leave runPolicy=Running: got %q", got.Spec.RunPolicy)
@@ -123,7 +123,7 @@ func TestCancellation_PostCutover_ClearsAnnotationOnly(t *testing.T) {
 func TestCancellation_NoMatchingAnnotation_NoOp(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyStopped
 	// Annotation names a DIFFERENT migration.
 	guest.Annotations = map[string]string{
@@ -234,7 +234,7 @@ func TestEnsureFinalizer_Idempotent(t *testing.T) {
 func TestOnTerminalPhase_FailedPreCutover_RestoresRunPolicy(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyStopped
 	guest.Annotations = map[string]string{
 		migrationv1alpha1.AnnotationMigrationInProgress: "m",
@@ -249,8 +249,8 @@ func TestOnTerminalPhase_FailedPreCutover_RestoresRunPolicy(t *testing.T) {
 
 	status := &migrationv1alpha1.SwiftMigrationStatus{
 		Phase:           migrationv1alpha1.SwiftMigrationPhaseFailed,
-		SourceNode:      "boba",
-		DestinationNode: "miles",
+		SourceNode:      "worker-1",
+		DestinationNode: "worker-2",
 	}
 	// guest.Spec.NodeName is "" → pre-cutover.
 	if err := r.onTerminalPhase(context.Background(), mig, status); err != nil {
@@ -272,7 +272,7 @@ func TestOnTerminalPhase_FailedPreCutover_RestoresRunPolicy(t *testing.T) {
 func TestOnTerminalPhase_FailedPreCutoverLive_DeletesDstPod_W17(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "miles"
+	guest.Status.NodeName = "worker-2"
 	guest.Annotations = map[string]string{
 		migrationv1alpha1.AnnotationMigrationInProgress: "m",
 	}
@@ -293,8 +293,8 @@ func TestOnTerminalPhase_FailedPreCutoverLive_DeletesDstPod_W17(t *testing.T) {
 	status := &migrationv1alpha1.SwiftMigrationStatus{
 		Phase:           migrationv1alpha1.SwiftMigrationPhaseFailed,
 		Mode:            migrationv1alpha1.SwiftMigrationModeLive,
-		SourceNode:      "miles",
-		DestinationNode: "boba",
+		SourceNode:      "worker-2",
+		DestinationNode: "worker-1",
 		DestinationPodRef: &migrationv1alpha1.SwiftMigrationPodRef{
 			Name: "guest-mig-abcdef",
 		},
@@ -346,7 +346,7 @@ func TestOnTerminalPhase_FailedPostCutoverLive_PreservesDstPod_W17(t *testing.T)
 	status := &migrationv1alpha1.SwiftMigrationStatus{
 		Phase:      migrationv1alpha1.SwiftMigrationPhaseFailed,
 		Mode:       migrationv1alpha1.SwiftMigrationModeLive,
-		SourceNode: "miles",
+		SourceNode: "worker-2",
 		Conditions: mig.Status.Conditions,
 		DestinationPodRef: &migrationv1alpha1.SwiftMigrationPodRef{
 			Name: "guest-mig-abcdef",

--- a/internal/controller/swiftmigration/frozen_intent_test.go
+++ b/internal/controller/swiftmigration/frozen_intent_test.go
@@ -109,7 +109,7 @@ func TestEnsureFrozenDstIntent_MissingLiveCM_SkipsGracefully(t *testing.T) {
 func TestNewDstPod_RepointsRuntimeIntentVolume(t *testing.T) {
 	scheme := testScheme(t)
 	mig := newMigrationWithUID("mig-a", "default", "abcdef1234567890abcdef1234567890")
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default", UID: "guest-uid"}}
 	src := templateSrcPod("guest", "default")
 	// Source carries the runtime-intent volume pointing at the live CM.

--- a/internal/controller/swiftmigration/gpu_offline_test.go
+++ b/internal/controller/swiftmigration/gpu_offline_test.go
@@ -72,7 +72,7 @@ func gpuMig() *migrationv1alpha1.SwiftMigration {
 		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
 		Spec: migrationv1alpha1.SwiftMigrationSpec{
 			GuestRef: migrationv1alpha1.SwiftMigrationGuestRef{Name: "g"},
-			Target:   migrationv1alpha1.SwiftMigrationTarget{NodeName: "boba"},
+			Target:   migrationv1alpha1.SwiftMigrationTarget{NodeName: "worker-1"},
 			Mode:     migrationv1alpha1.SwiftMigrationModeOffline,
 		},
 	}
@@ -100,26 +100,26 @@ func nodeAllocTo(t *testing.T, c client.Client, node, pci string) string {
 }
 
 func TestReserveTargetGPUs(t *testing.T) {
-	r, c := gpuReconciler(srcNode("miles", "default/g", "0000:aa:00.0"),
-		tgtNode("boba", "0000:bb:00.0", true), gpuProfileObj())
-	g := gpuGuestOnSrc("miles", "0000:aa:00.0")
+	r, c := gpuReconciler(srcNode("worker-2", "default/g", "0000:aa:00.0"),
+		tgtNode("worker-1", "0000:bb:00.0", true), gpuProfileObj())
+	g := gpuGuestOnSrc("worker-2", "0000:aa:00.0")
 
 	if res := r.reserveTargetGPUs(context.Background(), gpuMig(), g, &migrationv1alpha1.SwiftMigrationStatus{}); res != nil {
 		t.Fatalf("reserveTargetGPUs returned a phaseResult (failure): %+v", res)
 	}
 	// Target GPU is now reserved for the guest; source is still allocated.
-	if got := nodeAllocTo(t, c, "boba", "0000:bb:00.0"); got != "default/g" {
+	if got := nodeAllocTo(t, c, "worker-1", "0000:bb:00.0"); got != "default/g" {
 		t.Errorf("target GPU should be reserved for default/g; got %q", got)
 	}
-	if got := nodeAllocTo(t, c, "miles", "0000:aa:00.0"); got != "default/g" {
+	if got := nodeAllocTo(t, c, "worker-2", "0000:aa:00.0"); got != "default/g" {
 		t.Errorf("source GPU must stay allocated to default/g pre-cutover; got %q", got)
 	}
 }
 
 func TestReserveTargetGPUs_NotVfioReady_Fails(t *testing.T) {
-	r, _ := gpuReconciler(srcNode("miles", "default/g", "0000:aa:00.0"),
-		tgtNode("boba", "0000:bb:00.0", false), gpuProfileObj())
-	g := gpuGuestOnSrc("miles", "0000:aa:00.0")
+	r, _ := gpuReconciler(srcNode("worker-2", "default/g", "0000:aa:00.0"),
+		tgtNode("worker-1", "0000:bb:00.0", false), gpuProfileObj())
+	g := gpuGuestOnSrc("worker-2", "0000:aa:00.0")
 
 	if res := r.reserveTargetGPUs(context.Background(), gpuMig(), g, &migrationv1alpha1.SwiftMigrationStatus{}); res == nil {
 		t.Errorf("reserve on a non-vfio-ready target must fail (before stopping the source)")
@@ -127,9 +127,9 @@ func TestReserveTargetGPUs_NotVfioReady_Fails(t *testing.T) {
 }
 
 func TestCutoverGPUs_ReleasesSourceAndStampsTarget(t *testing.T) {
-	g := gpuGuestOnSrc("miles", "0000:aa:00.0")
-	r, c := gpuReconciler(srcNode("miles", "default/g", "0000:aa:00.0"),
-		tgtNode("boba", "0000:bb:00.0", true), gpuProfileObj(), g)
+	g := gpuGuestOnSrc("worker-2", "0000:aa:00.0")
+	r, c := gpuReconciler(srcNode("worker-2", "default/g", "0000:aa:00.0"),
+		tgtNode("worker-1", "0000:bb:00.0", true), gpuProfileObj(), g)
 	mig := gpuMig()
 
 	// Reserve first (as Preparing would), then cut over.
@@ -141,10 +141,10 @@ func TestCutoverGPUs_ReleasesSourceAndStampsTarget(t *testing.T) {
 	}
 
 	// Source freed, target committed.
-	if got := nodeAllocTo(t, c, "miles", "0000:aa:00.0"); got != "" {
+	if got := nodeAllocTo(t, c, "worker-2", "0000:aa:00.0"); got != "" {
 		t.Errorf("source GPU must be freed at cutover; got %q", got)
 	}
-	if got := nodeAllocTo(t, c, "boba", "0000:bb:00.0"); got != "default/g" {
+	if got := nodeAllocTo(t, c, "worker-1", "0000:bb:00.0"); got != "default/g" {
 		t.Errorf("target GPU must stay allocated to default/g; got %q", got)
 	}
 	// guest.status.GPU stamped to the target.
@@ -152,8 +152,8 @@ func TestCutoverGPUs_ReleasesSourceAndStampsTarget(t *testing.T) {
 	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "g"}, &gg); err != nil {
 		t.Fatalf("get guest: %v", err)
 	}
-	if gg.Status.GPU == nil || gg.Status.GPU.NodeName != "boba" {
-		t.Fatalf("status.GPU.NodeName must be boba after cutover; got %+v", gg.Status.GPU)
+	if gg.Status.GPU == nil || gg.Status.GPU.NodeName != "worker-1" {
+		t.Fatalf("status.GPU.NodeName must be worker-1 after cutover; got %+v", gg.Status.GPU)
 	}
 	if len(gg.Status.GPU.Devices) != 1 || gg.Status.GPU.Devices[0] != "0000:bb:00.0" {
 		t.Errorf("status.GPU.Devices must be the target device; got %v", gg.Status.GPU.Devices)
@@ -164,13 +164,13 @@ func TestCutoverGPUs_ReleasesSourceAndStampsTarget(t *testing.T) {
 }
 
 func TestCutoverGPUs_Idempotent(t *testing.T) {
-	g := gpuGuestOnSrc("miles", "0000:aa:00.0")
-	r, c := gpuReconciler(srcNode("miles", "default/g", "0000:aa:00.0"),
-		tgtNode("boba", "0000:bb:00.0", true), gpuProfileObj(), g)
+	g := gpuGuestOnSrc("worker-2", "0000:aa:00.0")
+	r, c := gpuReconciler(srcNode("worker-2", "default/g", "0000:aa:00.0"),
+		tgtNode("worker-1", "0000:bb:00.0", true), gpuProfileObj(), g)
 	mig := gpuMig()
 	_ = r.reserveTargetGPUs(context.Background(), mig, g, &migrationv1alpha1.SwiftMigrationStatus{})
 	_ = r.cutoverGPUs(context.Background(), mig, g, &migrationv1alpha1.SwiftMigrationStatus{})
-	// Re-fetch the guest (status.GPU now boba) and cut over again — no-op.
+	// Re-fetch the guest (status.GPU now worker1) and cut over again — no-op.
 	var gg swiftv1alpha1.SwiftGuest
 	_ = c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "g"}, &gg)
 	if res := r.cutoverGPUs(context.Background(), mig, &gg, &migrationv1alpha1.SwiftMigrationStatus{}); res != nil {
@@ -179,9 +179,9 @@ func TestCutoverGPUs_Idempotent(t *testing.T) {
 }
 
 func TestReleaseTargetReservation(t *testing.T) {
-	r, c := gpuReconciler(srcNode("miles", "default/g", "0000:aa:00.0"),
-		tgtNode("boba", "0000:bb:00.0", true), gpuProfileObj())
-	g := gpuGuestOnSrc("miles", "0000:aa:00.0")
+	r, c := gpuReconciler(srcNode("worker-2", "default/g", "0000:aa:00.0"),
+		tgtNode("worker-1", "0000:bb:00.0", true), gpuProfileObj())
+	g := gpuGuestOnSrc("worker-2", "0000:aa:00.0")
 	mig := gpuMig()
 	if res := r.reserveTargetGPUs(context.Background(), mig, g, &migrationv1alpha1.SwiftMigrationStatus{}); res != nil {
 		t.Fatalf("reserve: %+v", res)
@@ -189,23 +189,23 @@ func TestReleaseTargetReservation(t *testing.T) {
 	if err := r.releaseTargetReservation(context.Background(), mig, g); err != nil {
 		t.Fatalf("releaseTargetReservation: %v", err)
 	}
-	if got := nodeAllocTo(t, c, "boba", "0000:bb:00.0"); got != "" {
+	if got := nodeAllocTo(t, c, "worker-1", "0000:bb:00.0"); got != "" {
 		t.Errorf("target reservation must be released; got %q", got)
 	}
 	// Source untouched (the guest resumes there).
-	if got := nodeAllocTo(t, c, "miles", "0000:aa:00.0"); got != "default/g" {
+	if got := nodeAllocTo(t, c, "worker-2", "0000:aa:00.0"); got != "default/g" {
 		t.Errorf("source must stay allocated after a pre-cutover release; got %q", got)
 	}
 }
 
 func TestGPUPreflight(t *testing.T) {
-	r, _ := gpuReconciler(tgtNode("boba", "0000:bb:00.0", true), gpuProfileObj())
-	if res := r.gpuPreflight(context.Background(), gpuMig(), gpuGuestOnSrc("miles", "0000:aa:00.0")); res != nil {
+	r, _ := gpuReconciler(tgtNode("worker-1", "0000:bb:00.0", true), gpuProfileObj())
+	if res := r.gpuPreflight(context.Background(), gpuMig(), gpuGuestOnSrc("worker-2", "0000:aa:00.0")); res != nil {
 		t.Errorf("pre-flight on a vfio-ready target with free GPUs should pass; got %+v", res)
 	}
 
-	r2, _ := gpuReconciler(tgtNode("boba", "0000:bb:00.0", false), gpuProfileObj())
-	if res := r2.gpuPreflight(context.Background(), gpuMig(), gpuGuestOnSrc("miles", "0000:aa:00.0")); res == nil {
+	r2, _ := gpuReconciler(tgtNode("worker-1", "0000:bb:00.0", false), gpuProfileObj())
+	if res := r2.gpuPreflight(context.Background(), gpuMig(), gpuGuestOnSrc("worker-2", "0000:aa:00.0")); res == nil {
 		t.Errorf("pre-flight on a non-vfio-ready target should fail")
 	}
 }

--- a/internal/controller/swiftmigration/live_dispatch_test.go
+++ b/internal/controller/swiftmigration/live_dispatch_test.go
@@ -26,7 +26,7 @@ func TestDispatch_Validating_LiveMode_RoutesToLiveBody(t *testing.T) {
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	guest := &swiftv1alpha1.SwiftGuest{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
-		Status:     swiftv1alpha1.SwiftGuestStatus{NodeName: "miles"},
+		Status:     swiftv1alpha1.SwiftGuestStatus{NodeName: "worker-2"},
 	}
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/internal/controller/swiftmigration/preparing_live_test.go
+++ b/internal/controller/swiftmigration/preparing_live_test.go
@@ -28,7 +28,7 @@ func preparingLiveFixture(t *testing.T, srcUID types.UID) (*migrationv1alpha1.Sw
 	t.Helper()
 	mig := newMigrationWithUID("m1", "default", "abcdef1234567890abcdef1234567890")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhasePreparing
 	mig.Status.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	mig.Status.SourcePodUID = srcUID
@@ -71,8 +71,8 @@ func TestPreparingLive_FirstReconcile_CreatesDstPodAndStampsTimestamp(t *testing
 	if err := c.Get(context.Background(), client.ObjectKey{Name: "guest-mig-abcdef", Namespace: "default"}, &dst); err != nil {
 		t.Fatalf("dst pod not created: %v", err)
 	}
-	if dst.Spec.NodeName != "miles" {
-		t.Errorf("dst NodeName: want miles, got %q", dst.Spec.NodeName)
+	if dst.Spec.NodeName != "worker-2" {
+		t.Errorf("dst NodeName: want worker-2, got %q", dst.Spec.NodeName)
 	}
 	if dst.Annotations[AnnotationMigrationPhase2Ack] != AnnotationMigrationPhase2AckValue {
 		t.Errorf("ack annotation missing on created dst pod")
@@ -235,7 +235,7 @@ func TestPreparingLive_ExistingPodWrongShape_Fails(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"unrelated": "yes"},
 		},
-		Spec: corev1.PodSpec{NodeName: "miles"},
+		Spec: corev1.PodSpec{NodeName: "worker-2"},
 	}
 
 	c := fake.NewClientBuilder().
@@ -364,7 +364,7 @@ func preExistingDstPod(mig *migrationv1alpha1.SwiftMigration, guest *swiftv1alph
 			}},
 		},
 		Spec: corev1.PodSpec{
-			NodeName:      "miles",
+			NodeName:      "worker-2",
 			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{{
 				Name:  LauncherContainerName,

--- a/internal/controller/swiftmigration/preparing_test.go
+++ b/internal/controller/swiftmigration/preparing_test.go
@@ -55,7 +55,7 @@ func newLauncherPod(guestName, namespace string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: guestName, Namespace: namespace},
 		Spec: corev1.PodSpec{
-			NodeName: "boba",
+			NodeName: "worker-1",
 			Containers: []corev1.Container{
 				{Name: "launcher", Image: "ghcr.io/kubeswift-io/kubeswift/swiftletd:test"},
 			},
@@ -72,7 +72,7 @@ func newLauncherPod(guestName, namespace string) *corev1.Pod {
 func TestPreparing_FirstEntry_ClaimsGuestAndDeletesPod(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	pod := newLauncherPod("guest", "default")
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhasePreparing
@@ -135,7 +135,7 @@ func TestPreparing_FirstEntry_ClaimsGuestAndDeletesPod(t *testing.T) {
 func TestPreparing_AfterLiveMigration_DeletesRenamedSourcePod(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	// Prior live migration renamed the canonical pod.
 	const renamedPodName = "guest-mig-511016"
 	guest.Status.PodRef = &corev1.ObjectReference{Name: renamedPodName, Namespace: "default"}
@@ -198,7 +198,7 @@ func TestPreparing_AfterLiveMigration_DeletesRenamedSourcePod(t *testing.T) {
 func TestPreparing_AnnotationConflict_RejectedClearly(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	if guest.Annotations == nil {
 		guest.Annotations = map[string]string{}
 	}
@@ -243,7 +243,7 @@ func TestPreparing_AnnotationConflict_RejectedClearly(t *testing.T) {
 func TestPreparing_NilAnnotationsMap(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	guest.Annotations = nil // nil map, not empty map
 	pod := newLauncherPod("guest", "default")
 	mig := newMigration("m", "default")
@@ -278,7 +278,7 @@ func TestPreparing_NilAnnotationsMap(t *testing.T) {
 func TestPreparing_PodHasDeletionTimestamp_DoesNotReDelete(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	if guest.Annotations == nil {
 		guest.Annotations = map[string]string{}
 	}
@@ -328,7 +328,7 @@ func TestPreparing_PodHasDeletionTimestamp_DoesNotReDelete(t *testing.T) {
 func TestPreparing_ReentryWithMatchingAnnotation_NoOpClaim(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	if guest.Annotations == nil {
 		guest.Annotations = map[string]string{}
 	}
@@ -367,14 +367,14 @@ func TestPreparing_ReentryWithMatchingAnnotation_NoOpClaim(t *testing.T) {
 func TestPreparing_PodGone_VAStillPresent_DoesNotAdvance(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	if guest.Annotations == nil {
 		guest.Annotations = map[string]string{}
 	}
 	guest.Annotations[migrationv1alpha1.AnnotationMigrationInProgress] = "m"
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyStopped
 	pvc := newPVCBoundTo("swiftguest-root-guest", "default", "pv-1")
-	va := newVolumeAttachment("va-stale", "pv-1", "boba") // still attached on source node
+	va := newVolumeAttachment("va-stale", "pv-1", "worker-1") // still attached on source node
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhasePreparing
 
@@ -409,7 +409,7 @@ func TestPreparing_PodGone_VAStillPresent_DoesNotAdvance(t *testing.T) {
 func TestPreparing_PodGoneAndVAGone_Advances(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	if guest.Annotations == nil {
 		guest.Annotations = map[string]string{}
 	}
@@ -473,7 +473,7 @@ func TestPreparing_GuestDeletedMidFlight(t *testing.T) {
 func TestPreparing_PVCNotYetBound_AdvancesGracefully(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	if guest.Annotations == nil {
 		guest.Annotations = map[string]string{}
 	}
@@ -511,7 +511,7 @@ func TestPreparing_PVCNotYetBound_AdvancesGracefully(t *testing.T) {
 func TestPreparing_VAForOtherPVNotMatched(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	if guest.Annotations == nil {
 		guest.Annotations = map[string]string{}
 	}
@@ -519,7 +519,7 @@ func TestPreparing_VAForOtherPVNotMatched(t *testing.T) {
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyStopped
 	pvc := newPVCBoundTo("swiftguest-root-guest", "default", "pv-1")
 	// VA for a totally unrelated PV.
-	otherVA := newVolumeAttachment("va-other", "pv-other", "miles")
+	otherVA := newVolumeAttachment("va-other", "pv-other", "worker-2")
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhasePreparing
 

--- a/internal/controller/swiftmigration/resuming_live_test.go
+++ b/internal/controller/swiftmigration/resuming_live_test.go
@@ -24,10 +24,10 @@ func resumingLiveFixture(t *testing.T) (*migrationv1alpha1.SwiftMigration, *swif
 	t.Helper()
 	mig := newMigrationWithUID("m1", "default", "abcdef1234567890abcdef1234567890")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseResuming
 	mig.Status.Mode = migrationv1alpha1.SwiftMigrationModeLive
-	mig.Status.DestinationNode = "miles"
+	mig.Status.DestinationNode = "worker-2"
 	startedAt := metav1.NewTime(time.Now().Add(-30 * time.Second))
 	mig.Status.StartedAt = &startedAt
 
@@ -43,7 +43,7 @@ func resumingLiveFixture(t *testing.T) (*migrationv1alpha1.SwiftMigration, *swif
 			Name:      dstName,
 			Namespace: "default",
 		},
-		Spec: corev1.PodSpec{NodeName: "miles"},
+		Spec: corev1.PodSpec{NodeName: "worker-2"},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
 		},

--- a/internal/controller/swiftmigration/resuming_test.go
+++ b/internal/controller/swiftmigration/resuming_test.go
@@ -35,7 +35,7 @@ func readyDstPod(name, ns, node string) *corev1.Pod {
 // Resuming test.
 func guestRunning(name, ns string, ip string) *swiftv1alpha1.SwiftGuest {
 	g := newGuestForValidating(name, ns, "class-default")
-	g.Status.NodeName = "miles"
+	g.Status.NodeName = "worker-2"
 	g.Status.Conditions = []metav1.Condition{
 		{Type: guestRunningConditionType, Status: metav1.ConditionTrue},
 	}
@@ -56,12 +56,12 @@ func TestResuming_GuestRunningPlusIP_TransitionsToCompleted(t *testing.T) {
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseResuming
 	startedAt := metav1.NewTime(time.Now().Add(-90 * time.Second))
 	mig.Status.StartedAt = &startedAt
-	mig.Status.SourceNode = "boba"
-	mig.Status.DestinationNode = "miles"
+	mig.Status.SourceNode = "worker-1"
+	mig.Status.DestinationNode = "worker-2"
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(mig, guest, readyDstPod("guest", "default", "miles")).
+		WithObjects(mig, guest, readyDstPod("guest", "default", "worker-2")).
 		WithStatusSubresource(mig).
 		Build()
 	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
@@ -118,7 +118,7 @@ func TestResuming_GuestRunningButNoIP_StaysInResuming(t *testing.T) {
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(mig, guest, readyDstPod("guest", "default", "miles")).
+		WithObjects(mig, guest, readyDstPod("guest", "default", "worker-2")).
 		WithStatusSubresource(mig).
 		Build()
 	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
@@ -144,7 +144,7 @@ func TestResuming_GuestRunningButNoIP_StaysInResuming(t *testing.T) {
 func TestResuming_GuestNotRunning_StaysInResuming(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "miles"
+	guest.Status.NodeName = "worker-2"
 	// No GuestRunning condition; or False.
 	guest.Status.Conditions = []metav1.Condition{
 		{Type: guestRunningConditionType, Status: metav1.ConditionFalse},
@@ -157,7 +157,7 @@ func TestResuming_GuestNotRunning_StaysInResuming(t *testing.T) {
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(mig, guest, readyDstPod("guest", "default", "miles")).
+		WithObjects(mig, guest, readyDstPod("guest", "default", "worker-2")).
 		WithStatusSubresource(mig).
 		Build()
 	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
@@ -207,11 +207,11 @@ func TestResuming_DstInitFailed_Fails(t *testing.T) {
 	guest := guestRunning("guest", "default", "10.244.125.17") // stale True + IP from source
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseResuming
-	mig.Status.DestinationNode = "miles"
+	mig.Status.DestinationNode = "worker-2"
 
 	dstPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
-		Spec:       corev1.PodSpec{NodeName: "miles"},
+		Spec:       corev1.PodSpec{NodeName: "worker-2"},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodPending,
 			InitContainerStatuses: []corev1.ContainerStatus{
@@ -241,11 +241,11 @@ func TestResuming_DstLauncherNotReady_StaysInResuming(t *testing.T) {
 	guest := guestRunning("guest", "default", "10.244.125.17") // stale True + IP
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseResuming
-	mig.Status.DestinationNode = "miles"
+	mig.Status.DestinationNode = "worker-2"
 
 	dstPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
-		Spec:       corev1.PodSpec{NodeName: "miles", Containers: []corev1.Container{{Name: "launcher"}}},
+		Spec:       corev1.PodSpec{NodeName: "worker-2", Containers: []corev1.Container{{Name: "launcher"}}},
 		Status: corev1.PodStatus{
 			Phase:             corev1.PodRunning,
 			ContainerStatuses: []corev1.ContainerStatus{{Name: "launcher", Ready: false}}, // not ready yet

--- a/internal/controller/swiftmigration/source_mtls_test.go
+++ b/internal/controller/swiftmigration/source_mtls_test.go
@@ -246,7 +246,7 @@ func TestStampSourceMigrationInputs_PatchesAndIsIdempotent(t *testing.T) {
 	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(5)}
 	ctx := context.Background()
 
-	if err := r.stampSourceMigrationInputs(ctx, src, "10.0.0.9", "miles"); err != nil {
+	if err := r.stampSourceMigrationInputs(ctx, src, "10.0.0.9", "worker-2"); err != nil {
 		t.Fatalf("stamp: %v", err)
 	}
 	var got corev1.Pod
@@ -256,11 +256,11 @@ func TestStampSourceMigrationInputs_PatchesAndIsIdempotent(t *testing.T) {
 	if got.Annotations[migrationsidecar.AnnotationDstPodIP] != "10.0.0.9" {
 		t.Errorf("dst-ip annotation: got %q", got.Annotations[migrationsidecar.AnnotationDstPodIP])
 	}
-	if got.Annotations[migrationsidecar.AnnotationPeerSAN] != "miles" {
+	if got.Annotations[migrationsidecar.AnnotationPeerSAN] != "worker-2" {
 		t.Errorf("peer-san annotation: got %q", got.Annotations[migrationsidecar.AnnotationPeerSAN])
 	}
 	// Idempotent: second call with same values is a no-op (no error).
-	if err := r.stampSourceMigrationInputs(ctx, &got, "10.0.0.9", "miles"); err != nil {
+	if err := r.stampSourceMigrationInputs(ctx, &got, "10.0.0.9", "worker-2"); err != nil {
 		t.Errorf("idempotent stamp errored: %v", err)
 	}
 }
@@ -272,7 +272,7 @@ func TestPopulateSourceIdentity_CopiesNodeIdentityIntoPerGuestSecret(t *testing.
 	const sysNS = "kubeswift-system"
 	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a", UID: "guest-uid"}}
 	srcNodeSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: migrationcert.MigrationNodeSecretName("boba"), Namespace: sysNS},
+		ObjectMeta: metav1.ObjectMeta{Name: migrationcert.MigrationNodeSecretName("worker-1"), Namespace: sysNS},
 		Type:       corev1.SecretTypeTLS,
 		Data:       map[string][]byte{"tls.crt": []byte("CRT"), "tls.key": []byte("KEY"), "ca.crt": []byte("CA")},
 	}
@@ -280,7 +280,7 @@ func TestPopulateSourceIdentity_CopiesNodeIdentityIntoPerGuestSecret(t *testing.
 	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
 	ctx := context.Background()
 
-	if err := r.populateSourceIdentity(ctx, guest, "boba"); err != nil {
+	if err := r.populateSourceIdentity(ctx, guest, "worker-1"); err != nil {
 		t.Fatalf("populateSourceIdentity: %v", err)
 	}
 	var s corev1.Secret
@@ -294,7 +294,7 @@ func TestPopulateSourceIdentity_CopiesNodeIdentityIntoPerGuestSecret(t *testing.
 		t.Errorf("per-guest identity must be guest-owned; got %+v", s.OwnerReferences)
 	}
 	// Idempotent: second call with identical source is a no-op.
-	if err := r.populateSourceIdentity(ctx, guest, "boba"); err != nil {
+	if err := r.populateSourceIdentity(ctx, guest, "worker-1"); err != nil {
 		t.Errorf("idempotent populate errored: %v", err)
 	}
 }
@@ -304,7 +304,7 @@ func TestPopulateSourceIdentity_UpdatesExistingPlaceholder(t *testing.T) {
 	const sysNS = "kubeswift-system"
 	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a", UID: "guest-uid"}}
 	srcNodeSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: migrationcert.MigrationNodeSecretName("boba"), Namespace: sysNS},
+		ObjectMeta: metav1.ObjectMeta{Name: migrationcert.MigrationNodeSecretName("worker-1"), Namespace: sysNS},
 		Type:       corev1.SecretTypeTLS,
 		Data:       map[string][]byte{"tls.crt": []byte("CRT"), "tls.key": []byte("KEY"), "ca.crt": []byte("CA")},
 	}
@@ -317,7 +317,7 @@ func TestPopulateSourceIdentity_UpdatesExistingPlaceholder(t *testing.T) {
 	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
 	ctx := context.Background()
 
-	if err := r.populateSourceIdentity(ctx, guest, "boba"); err != nil {
+	if err := r.populateSourceIdentity(ctx, guest, "worker-1"); err != nil {
 		t.Fatalf("populateSourceIdentity: %v", err)
 	}
 	var s corev1.Secret
@@ -334,7 +334,7 @@ func TestPopulateSourceIdentity_MissingSourceErrors(t *testing.T) {
 	guest := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "team-a", UID: "guest-uid"}}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest).Build()
 	r := &SwiftMigrationReconciler{Client: c, Scheme: scheme, SystemNamespace: "kubeswift-system"}
-	if err := r.populateSourceIdentity(context.Background(), guest, "boba"); err == nil {
+	if err := r.populateSourceIdentity(context.Background(), guest, "worker-1"); err == nil {
 		t.Errorf("missing source node identity must error; got nil")
 	}
 }

--- a/internal/controller/swiftmigration/stopandcopy_live_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_live_test.go
@@ -26,7 +26,7 @@ func stopAndCopyFixture(t *testing.T, srcUID types.UID) (*migrationv1alpha1.Swif
 	t.Helper()
 	mig := newMigrationWithUID("m1", "default", "abcdef1234567890abcdef1234567890")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseStopAndCopy
 	mig.Status.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	mig.Status.SourcePodUID = srcUID
@@ -50,7 +50,7 @@ func stopAndCopyFixture(t *testing.T, srcUID types.UID) (*migrationv1alpha1.Swif
 			Name:      "guest-mig-abcdef",
 			Namespace: "default",
 		},
-		Spec: corev1.PodSpec{NodeName: "miles"},
+		Spec: corev1.PodSpec{NodeName: "worker-2"},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
 			PodIP: "10.244.1.42",
@@ -774,7 +774,7 @@ func TestStopAndCopyLive_PostCutoverStep1_RaceReconcile_DoesNotFalseFireUIDCheck
 // chain-safe.
 //
 // Discovered on cluster during Phase 3a PR 1 disk-boot E12 validation
-// (S1 run 2, miles→boba→miles). Same code path runs for kernel-boot
+// (S1 run 2, worker2→worker1→worker2). Same code path runs for kernel-boot
 // and disk-boot — workload-class-independent bug; disk-boot validation
 // happened to exercise back-to-back migrations and surface it.
 func TestStopAndCopyLive_ChainMigration_SrcResolvesToPriorDstPod_NoFalseFire_W26(t *testing.T) {

--- a/internal/controller/swiftmigration/stopandcopy_test.go
+++ b/internal/controller/swiftmigration/stopandcopy_test.go
@@ -22,7 +22,7 @@ import (
 func TestStopAndCopy_FirstEntry_PatchesAtomically(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyStopped // set by Preparing
 	guest.Annotations = map[string]string{
 		migrationv1alpha1.AnnotationMigrationInProgress: "m",
@@ -58,8 +58,8 @@ func TestStopAndCopy_FirstEntry_PatchesAtomically(t *testing.T) {
 	if got.Spec.RunPolicy != swiftv1alpha1.RunPolicyRunning {
 		t.Errorf("runPolicy = %q, want Running (atomicity)", got.Spec.RunPolicy)
 	}
-	if got.Spec.NodeName != "miles" {
-		t.Errorf("nodeName = %q, want miles (atomicity)", got.Spec.NodeName)
+	if got.Spec.NodeName != "worker-2" {
+		t.Errorf("nodeName = %q, want worker-2 (atomicity)", got.Spec.NodeName)
 	}
 }
 
@@ -70,7 +70,7 @@ func TestStopAndCopy_FirstEntry_PatchesAtomically(t *testing.T) {
 func TestStopAndCopy_MissingAnnotation_Fails(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	// No annotation — Preparing should have set it but somehow didn't.
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseStopAndCopy
@@ -97,16 +97,16 @@ func TestStopAndCopy_MissingAnnotation_Fails(t *testing.T) {
 func TestStopAndCopy_PodOnDestination_Advances(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyRunning // already patched
-	guest.Spec.NodeName = "miles"                         // already patched
+	guest.Spec.NodeName = "worker-2"                      // already patched
 	guest.Annotations = map[string]string{
 		migrationv1alpha1.AnnotationMigrationInProgress: "m",
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
 		Spec: corev1.PodSpec{
-			NodeName: "miles",
+			NodeName: "worker-2",
 			Containers: []corev1.Container{
 				{Name: "launcher", Image: "ghcr.io/kubeswift-io/kubeswift/swiftletd:test"},
 			},
@@ -148,16 +148,16 @@ func TestStopAndCopy_PodOnDestination_Advances(t *testing.T) {
 func TestStopAndCopy_PodOnWrongNode_Fails(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyRunning
-	guest.Spec.NodeName = "miles"
+	guest.Spec.NodeName = "worker-2"
 	guest.Annotations = map[string]string{
 		migrationv1alpha1.AnnotationMigrationInProgress: "m",
 	}
 	wrongPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
 		Spec: corev1.PodSpec{
-			NodeName: "boba", // landed on the wrong node!
+			NodeName: "worker-1", // landed on the wrong node!
 			Containers: []corev1.Container{
 				{Name: "launcher", Image: "ghcr.io/kubeswift-io/kubeswift/swiftletd:test"},
 			},
@@ -188,15 +188,15 @@ func TestStopAndCopy_PodOnWrongNode_Fails(t *testing.T) {
 func TestStopAndCopy_GPUPodUnscheduled_NodeSelectorTarget_Requeues(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyRunning
-	guest.Spec.NodeName = "miles"
+	guest.Spec.NodeName = "worker-2"
 	guest.Annotations = map[string]string{migrationv1alpha1.AnnotationMigrationInProgress: "m"}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
 		Spec: corev1.PodSpec{
 			NodeName:     "", // not yet scheduled (GPU pod pins via nodeSelector)
-			NodeSelector: map[string]string{"kubernetes.io/hostname": "miles"},
+			NodeSelector: map[string]string{"kubernetes.io/hostname": "worker-2"},
 			Containers:   []corev1.Container{{Name: "launcher", Image: "x"}},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodPending},
@@ -226,15 +226,15 @@ func TestStopAndCopy_GPUPodUnscheduled_NodeSelectorTarget_Requeues(t *testing.T)
 func TestStopAndCopy_GPUPodNodeSelectorWrongNode_Fails(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyRunning
-	guest.Spec.NodeName = "miles"
+	guest.Spec.NodeName = "worker-2"
 	guest.Annotations = map[string]string{migrationv1alpha1.AnnotationMigrationInProgress: "m"}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "guest", Namespace: "default"},
 		Spec: corev1.PodSpec{
 			NodeName:     "",
-			NodeSelector: map[string]string{"kubernetes.io/hostname": "boba"}, // pinned to the WRONG node
+			NodeSelector: map[string]string{"kubernetes.io/hostname": "worker-1"}, // pinned to the WRONG node
 			Containers:   []corev1.Container{{Name: "launcher", Image: "x"}},
 		},
 	}
@@ -282,9 +282,9 @@ func TestStopAndCopy_GuestDeleted_Fails(t *testing.T) {
 func TestStopAndCopy_Idempotent_PatchAlreadyApplied(t *testing.T) {
 	scheme := preparingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
-	guest.Status.NodeName = "boba"
+	guest.Status.NodeName = "worker-1"
 	guest.Spec.RunPolicy = swiftv1alpha1.RunPolicyRunning // already patched
-	guest.Spec.NodeName = "miles"                         // already patched
+	guest.Spec.NodeName = "worker-2"                      // already patched
 	guest.Annotations = map[string]string{
 		migrationv1alpha1.AnnotationMigrationInProgress: "m",
 	}
@@ -312,7 +312,7 @@ func TestStopAndCopy_Idempotent_PatchAlreadyApplied(t *testing.T) {
 	if err := c.Get(context.Background(), client.ObjectKey{Name: "guest", Namespace: "default"}, &got); err != nil {
 		t.Fatalf("Get guest: %v", err)
 	}
-	if got.Spec.RunPolicy != swiftv1alpha1.RunPolicyRunning || got.Spec.NodeName != "miles" {
+	if got.Spec.RunPolicy != swiftv1alpha1.RunPolicyRunning || got.Spec.NodeName != "worker-2" {
 		t.Errorf("idempotent re-entry corrupted spec: runPolicy=%q nodeName=%q", got.Spec.RunPolicy, got.Spec.NodeName)
 	}
 }

--- a/internal/controller/swiftmigration/validating_live_test.go
+++ b/internal/controller/swiftmigration/validating_live_test.go
@@ -72,7 +72,7 @@ func newSourcePod(guestName, ns, uid string) *corev1.Pod {
 			},
 		},
 		Spec: corev1.PodSpec{
-			NodeName: "boba",
+			NodeName: "worker-1",
 		},
 	}
 }
@@ -81,7 +81,7 @@ func TestValidatingLive_HappyPath_AdvancesToPreparing(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	srcPod := newSourcePod("guest", "default", "src-pod-uid-1")
 	mig := newMigration("m", "default")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
@@ -113,11 +113,11 @@ func TestValidatingLive_HappyPath_AdvancesToPreparing(t *testing.T) {
 	if status.SourcePodUID != "src-pod-uid-1" {
 		t.Errorf("SourcePodUID: want src-pod-uid-1, got %q", status.SourcePodUID)
 	}
-	if status.SourceNode != "boba" {
-		t.Errorf("SourceNode: want boba, got %q", status.SourceNode)
+	if status.SourceNode != "worker-1" {
+		t.Errorf("SourceNode: want worker-1, got %q", status.SourceNode)
 	}
-	if status.DestinationNode != "miles" {
-		t.Errorf("DestinationNode: want miles, got %q", status.DestinationNode)
+	if status.DestinationNode != "worker-2" {
+		t.Errorf("DestinationNode: want worker-2, got %q", status.DestinationNode)
 	}
 }
 
@@ -131,15 +131,15 @@ func TestValidatingLive_MTLS_IdentitiesPresent_Advances(t *testing.T) {
 	const sysNS = "kubeswift-system"
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
-	srcPod := withClientStunnelSidecar(newSourcePod("guest", "default", "src-pod-uid-1")) // src node "boba"
+	node := newSpaciousNode("worker-2", 8, 65536)
+	srcPod := withClientStunnelSidecar(newSourcePod("guest", "default", "src-pod-uid-1")) // src node "worker-1"
 	mig := newMigration("m", "default")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	mig.Spec.Timeout = &metav1.Duration{Duration: 5 * 60 * 1e9}
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
 
-	srcSecret := migrationNodeIdentitySecret(sysNS, "boba")
-	dstSecret := migrationNodeIdentitySecret(sysNS, "miles")
+	srcSecret := migrationNodeIdentitySecret(sysNS, "worker-1")
+	dstSecret := migrationNodeIdentitySecret(sysNS, "worker-2")
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -160,7 +160,7 @@ func TestValidatingLive_MTLS_IdentitiesPresent_Advances(t *testing.T) {
 		t.Fatal("expected Advanced=true with both identities present")
 	}
 	// Both node identity Secrets copied into the guest namespace.
-	for _, n := range []string{"boba", "miles"} {
+	for _, n := range []string{"worker-1", "worker-2"} {
 		var s corev1.Secret
 		if err := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: migrationcert.MigrationNodeSecretName(n)}, &s); err != nil {
 			t.Errorf("identity Secret for node %q not distributed into guest namespace: %v", n, err)
@@ -176,7 +176,7 @@ func TestValidatingLive_MTLS_IdentityMissing_FailsNotReady(t *testing.T) {
 	const sysNS = "kubeswift-system"
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	srcPod := withClientStunnelSidecar(newSourcePod("guest", "default", "src-pod-uid-1"))
 	mig := newMigration("m", "default")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
@@ -184,7 +184,7 @@ func TestValidatingLive_MTLS_IdentityMissing_FailsNotReady(t *testing.T) {
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
 
 	// Only the source-node Secret present; destination-node Secret missing.
-	srcSecret := migrationNodeIdentitySecret(sysNS, "boba")
+	srcSecret := migrationNodeIdentitySecret(sysNS, "worker-1")
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -217,7 +217,7 @@ func TestValidatingLive_MTLS_SourceNotSidecarReady_Fails(t *testing.T) {
 	const sysNS = "kubeswift-system"
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	srcPod := newSourcePod("guest", "default", "src-pod-uid-1") // NO sidecar
 	mig := newMigration("m", "default")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
@@ -227,7 +227,7 @@ func TestValidatingLive_MTLS_SourceNotSidecarReady_Fails(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(mig, guest, class, node, srcPod,
-			migrationNodeIdentitySecret(sysNS, "boba"), migrationNodeIdentitySecret(sysNS, "miles")).
+			migrationNodeIdentitySecret(sysNS, "worker-1"), migrationNodeIdentitySecret(sysNS, "worker-2")).
 		WithStatusSubresource(mig).
 		Build()
 	r := &SwiftMigrationReconciler{
@@ -249,7 +249,7 @@ func TestValidatingLive_MTLSDisabled_SkipsPrecondition(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	srcPod := newSourcePod("guest", "default", "src-pod-uid-1")
 	mig := newMigration("m", "default")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
@@ -278,7 +278,7 @@ func TestValidatingLive_NoSourcePod_FailsWithClearMessage(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	mig := newMigration("m", "default")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
@@ -331,7 +331,7 @@ func TestValidatingLive_TargetNodeCordoned_Fails(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	cordonedNode := newSpaciousNode("miles", 8, 65536)
+	cordonedNode := newSpaciousNode("worker-2", 8, 65536)
 	cordonedNode.Spec.Unschedulable = true
 	srcPod := newSourcePod("guest", "default", "uid")
 	mig := newMigration("m", "default")
@@ -360,7 +360,7 @@ func TestValidatingLive_ImageTagMatch_HappyPath(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	// Pin the launcher image via env so the test asserts on a stable
 	// value (independent of LauncherImageDefault drift).
 	t.Setenv(swiftguest.LauncherImageEnv, "ghcr.io/test/swiftletd:v1.0.0")
@@ -399,7 +399,7 @@ func TestValidatingLive_ImageTagMatch_Mismatch_FailsWithImageTagMismatch(t *test
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	t.Setenv(swiftguest.LauncherImageEnv, "ghcr.io/test/swiftletd:v2.0.0")
 	// src pod runs the OLD launcher image; controller default is v2.0.0.
 	srcPod := newSourcePodWithLauncherImage("guest", "default", "uid", "ghcr.io/test/swiftletd:v1.0.0")
@@ -435,7 +435,7 @@ func TestValidatingLive_ImageTagMatch_NoLauncherContainer_DefensiveSkip(t *testi
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	t.Setenv(swiftguest.LauncherImageEnv, "ghcr.io/test/swiftletd:v1.0.0")
 	// newSourcePod produces a pod with NO containers, so
 	// launcherContainerImage returns "" → defensive skip.
@@ -472,7 +472,7 @@ func TestValidatingLive_MigrationDisabled_FailsWithEligibilityMismatch(t *testin
 	disabled := false
 	guest.Spec.Migration = &swiftv1alpha1.MigrationSpec{Enabled: &disabled}
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	srcPod := newSourcePod("guest", "default", "uid")
 	mig := newMigration("m", "default")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive

--- a/internal/controller/swiftmigration/validating_test.go
+++ b/internal/controller/swiftmigration/validating_test.go
@@ -69,7 +69,7 @@ func newGuestForValidating(name, ns, classRef string) *swiftv1alpha1.SwiftGuest 
 			},
 		},
 		Status: swiftv1alpha1.SwiftGuestStatus{
-			NodeName: "boba",
+			NodeName: "worker-1",
 		},
 	}
 }
@@ -78,7 +78,7 @@ func TestValidating_HappyPath(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
 
@@ -107,8 +107,8 @@ func TestValidating_HappyPath(t *testing.T) {
 	if status.Mode != migrationv1alpha1.SwiftMigrationModeOffline {
 		t.Errorf("mode = %q, want offline", status.Mode)
 	}
-	if status.SourceNode != "boba" || status.DestinationNode != "miles" {
-		t.Errorf("source/destination = %s→%s, want boba→miles", status.SourceNode, status.DestinationNode)
+	if status.SourceNode != "worker-1" || status.DestinationNode != "worker-2" {
+		t.Errorf("source/destination = %s→%s, want worker-1→worker-2", status.SourceNode, status.DestinationNode)
 	}
 	// Compatible condition must be True.
 	found := false
@@ -155,7 +155,7 @@ func TestValidating_TargetNodeMissing(t *testing.T) {
 	status := mig.Status.DeepCopy()
 	result := r.handleValidating(context.Background(), mig, status)
 	errMsg := result.FailureMsg
-	if !strings.Contains(errMsg, "no longer exists") || !strings.Contains(errMsg, "miles") {
+	if !strings.Contains(errMsg, "no longer exists") || !strings.Contains(errMsg, "worker-2") {
 		t.Errorf("errMsg = %q, want mention of missing target node", errMsg)
 	}
 }
@@ -164,7 +164,7 @@ func TestValidating_InsufficientCPU(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "big-class")
 	class := newGuestClass("big-class", 64, 2048) // 64 CPU
-	node := newSpaciousNode("miles", 8, 65536)    // 8 allocatable
+	node := newSpaciousNode("worker-2", 8, 65536) // 8 allocatable
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
 
@@ -188,7 +188,7 @@ func TestValidating_InsufficientMemory(t *testing.T) {
 	guest := newGuestForValidating("guest", "default", "big-class")
 	// 64Gi memory request — node has 4Gi.
 	class := newGuestClass("big-class", 1, 64*1024)
-	node := newSpaciousNode("miles", 8, 4096)
+	node := newSpaciousNode("worker-2", 8, 4096)
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
 
@@ -207,12 +207,12 @@ func TestValidating_ExistingPodsCountedInCapacity(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 4, 4096)
-	node := newSpaciousNode("miles", 6, 8192) // headroom only just enough for 1 guest
-	// Existing pod consumes 4 CPU on miles, leaving 2 CPU headroom < 4 needed.
+	node := newSpaciousNode("worker-2", 6, 8192) // headroom only just enough for 1 guest
+	// Existing pod consumes 4 CPU on worker2, leaving 2 CPU headroom < 4 needed.
 	hogger := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "hogger", Namespace: "default"},
 		Spec: corev1.PodSpec{
-			NodeName: "miles",
+			NodeName: "worker-2",
 			Containers: []corev1.Container{{
 				Name: "c",
 				Resources: corev1.ResourceRequirements{
@@ -243,12 +243,12 @@ func TestValidating_FailedPodsExcludedFromCapacity(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 4, 4096)
-	// A Failed pod on miles should NOT count toward used resources.
+	node := newSpaciousNode("worker-2", 4, 4096)
+	// A Failed pod on worker2 should NOT count toward used resources.
 	failed := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "failed", Namespace: "default"},
 		Spec: corev1.PodSpec{
-			NodeName: "miles",
+			NodeName: "worker-2",
 			Containers: []corev1.Container{{
 				Name: "c",
 				Resources: corev1.ResourceRequirements{
@@ -282,7 +282,7 @@ func TestValidating_AllowIPChangeSetsCondition(t *testing.T) {
 	guest := newGuestForValidating("guest", "default", "class-default")
 	guest.Spec.Interfaces = nil // default networking
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	mig := newMigration("m", "default")
 	mig.Spec.AllowIPChange = true
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
@@ -310,7 +310,7 @@ func TestValidating_MigrationDisabledMidFlight(t *testing.T) {
 	disabled := false
 	guest.Spec.Migration = &swiftv1alpha1.MigrationSpec{Enabled: &disabled}
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
 
@@ -330,7 +330,7 @@ func TestValidating_NodeMissingAllocatable(t *testing.T) {
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
 	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "miles"},
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-2"},
 		Status: corev1.NodeStatus{
 			// Allocatable intentionally empty.
 			Conditions: []corev1.NodeCondition{
@@ -356,7 +356,7 @@ func TestValidating_GuestClassNotFound(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "ghost-class")
 	// SwiftGuestClass intentionally absent.
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
 
@@ -375,7 +375,7 @@ func TestValidating_InsufficientMemory_NeedHaveSubstrings(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "big-class")
 	class := newGuestClass("big-class", 1, 64*1024) // 64 GiB memory
-	node := newSpaciousNode("miles", 8, 4096)       // 4 GiB allocatable
+	node := newSpaciousNode("worker-2", 8, 4096)    // 4 GiB allocatable
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
 
@@ -398,11 +398,11 @@ func TestValidating_InitContainerRequestsCounted(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 4, 4096)
-	node := newSpaciousNode("miles", 6, 8192)
+	node := newSpaciousNode("worker-2", 6, 8192)
 	initHog := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "init-hog", Namespace: "default"},
 		Spec: corev1.PodSpec{
-			NodeName: "miles",
+			NodeName: "worker-2",
 			InitContainers: []corev1.Container{{
 				Name: "init",
 				Resources: corev1.ResourceRequirements{
@@ -437,7 +437,7 @@ func TestValidating_Idempotent(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
 
@@ -471,7 +471,7 @@ func TestValidating_NodeCordonedMidFlight(t *testing.T) {
 	scheme := validatingScheme(t)
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
-	node := newSpaciousNode("miles", 8, 65536)
+	node := newSpaciousNode("worker-2", 8, 65536)
 	node.Spec.Unschedulable = true
 	mig := newMigration("m", "default")
 	mig.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseValidating
@@ -492,7 +492,7 @@ func TestValidating_NodeNotReadyMidFlight(t *testing.T) {
 	guest := newGuestForValidating("guest", "default", "class-default")
 	class := newGuestClass("class-default", 2, 2048)
 	notReady := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "miles"},
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-2"},
 		Status: corev1.NodeStatus{
 			Allocatable: corev1.ResourceList{
 				corev1.ResourceCPU:    *resource.NewQuantity(8, resource.DecimalSI),
@@ -548,16 +548,16 @@ func TestHandleValidating_AutoMode_FullPath_EntersLivePath(t *testing.T) {
 	guest := newGuestForValidating("dbg-guest", "default", "live-class")
 	guest.Spec.Migration = &swiftv1alpha1.MigrationSpec{Enabled: &enabled, PreferredMode: "auto"}
 	guest.Spec.Interfaces = nil // default node-local networking
-	guest.Status.NodeName = "miles"
+	guest.Status.NodeName = "worker-2"
 	class := newGuestClass("live-class", 2, 4096)
-	node := newSpaciousNode("boba", 8, 65536)
+	node := newSpaciousNode("worker-1", 8, 65536)
 	// canonicalPodNameForGuest returns guest.Name (no status.PodRef),
 	// so the src pod must be named "dbg-guest".
 	srcPod := newSourcePod("dbg-guest", "default", "src-uid-1")
 
 	mig := newMigration("m", "default")
 	mig.Spec.GuestRef.Name = "dbg-guest"
-	mig.Spec.Target.NodeName = "boba"
+	mig.Spec.Target.NodeName = "worker-1"
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeAuto
 	mig.Spec.AllowIPChange = true
 	mig.Spec.Timeout = &metav1.Duration{Duration: 5 * 60 * 1e9} // satisfies MinLiveTimeout

--- a/internal/controller/swiftrestore/local_inplace_test.go
+++ b/internal/controller/swiftrestore/local_inplace_test.go
@@ -88,7 +88,7 @@ func TestLocal_Pending_InPlaceRestore_StampsExistingGuestAndAdvances(t *testing.
 		t.Errorf("restore mode = %q, want %s",
 			refreshed.Annotations[swiftguestctrl.AnnotationRestoreMode], swiftguestctrl.RestoreModeInPlace)
 	}
-	if refreshed.Annotations[swiftguestctrl.AnnotationRestoreNodeName] != "boba" {
+	if refreshed.Annotations[swiftguestctrl.AnnotationRestoreNodeName] != "worker-1" {
 		t.Errorf("node name annotation = %q", refreshed.Annotations[swiftguestctrl.AnnotationRestoreNodeName])
 	}
 	// In-place path must NOT set MAC rewrites or cmdline marker.

--- a/internal/controller/swiftrestore/local_test.go
+++ b/internal/controller/swiftrestore/local_test.go
@@ -83,7 +83,7 @@ func makeLocalSnap(name, ns, sourceGuest, hostPath, hypervisorVersion string) *s
 		Status: snapshotv1alpha1.SwiftSnapshotStatus{
 			Phase:             snapshotv1alpha1.SwiftSnapshotPhaseReady,
 			HypervisorVersion: hypervisorVersion,
-			NodeName:          "boba",
+			NodeName:          "worker-1",
 		},
 	}
 }
@@ -234,7 +234,7 @@ func TestLocal_Pending_Clone_ReentrantReconcileDoesNotConflict(t *testing.T) {
 	// and not fail with TargetConflict.
 	snap := makeLocalSnap("snap1", "default", "src", "/var/lib/kubeswift/snapshots/default-snap1", "v51.1")
 	snap.Status.Phase = snapshotv1alpha1.SwiftSnapshotPhaseReady
-	snap.Status.NodeName = "boba"
+	snap.Status.NodeName = "worker-1"
 	restore := makeRestore("restore-clone", "default", "snap1", "clone-a", true)
 	restore.Spec.Identity = &snapshotv1alpha1.IdentityRegeneration{
 		Regenerate: []snapshotv1alpha1.IdentityRegenerationItem{
@@ -274,7 +274,7 @@ func TestLocal_Pending_Clone_ExistingSwiftGuestNotOwnedByUs_StillConflicts(t *te
 	// over someone else's resource.
 	snap := makeLocalSnap("snap1", "default", "src", "/var/lib/kubeswift/snapshots/default-snap1", "v51.1")
 	snap.Status.Phase = snapshotv1alpha1.SwiftSnapshotPhaseReady
-	snap.Status.NodeName = "boba"
+	snap.Status.NodeName = "worker-1"
 	restore := makeRestore("restore-clone", "default", "snap1", "clone-a", true)
 	restore.Spec.Identity = &snapshotv1alpha1.IdentityRegeneration{
 		Regenerate: []snapshotv1alpha1.IdentityRegenerationItem{
@@ -335,7 +335,7 @@ func TestRestoreAnnotations_Clone_SetsRuntimeDirPrefixAndNullifyHostMAC(t *testi
 				Local: &snapshotv1alpha1.LocalBackend{HostPath: "/var/lib/kubeswift/snapshots/default-snap1"},
 			},
 		},
-		Status: snapshotv1alpha1.SwiftSnapshotStatus{NodeName: "boba"},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{NodeName: "worker-1"},
 	}
 	source := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: "default"}}
 
@@ -377,7 +377,7 @@ func TestRestoreAnnotations_InPlace_DoesNotSetCloneOnlyAnnotations(t *testing.T)
 				Local: &snapshotv1alpha1.LocalBackend{HostPath: "/var/lib/kubeswift/snapshots/default-snap1"},
 			},
 		},
-		Status: snapshotv1alpha1.SwiftSnapshotStatus{NodeName: "boba"},
+		Status: snapshotv1alpha1.SwiftSnapshotStatus{NodeName: "worker-1"},
 	}
 	source := &swiftv1alpha1.SwiftGuest{ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: "default"}}
 

--- a/internal/controller/swiftrestore/oci_test.go
+++ b/internal/controller/swiftrestore/oci_test.go
@@ -35,7 +35,7 @@ func ociRestore() *snapshotv1alpha1.SwiftRestore {
 		Spec: snapshotv1alpha1.SwiftRestoreSpec{
 			SnapshotRef: snapshotv1alpha1.SwiftRestoreSnapshotRef{Name: "snap1"},
 			TargetGuest: snapshotv1alpha1.SwiftRestoreTarget{Name: "g1"},
-			TargetNode:  "miles",
+			TargetNode:  "worker-2",
 		},
 	}
 }
@@ -52,12 +52,12 @@ func TestOCIRestoreTag(t *testing.T) {
 }
 
 func TestBuildOCIDownloadJob(t *testing.T) {
-	job := buildOCIDownloadJob(ociRestore(), ociSnapForRestore(true), "img:tag", "miles")
+	job := buildOCIDownloadJob(ociRestore(), ociSnapForRestore(true), "img:tag", "worker-2")
 	if job.Name != "r1-oci-download" || job.Namespace != "team-a" {
 		t.Errorf("job meta = %s/%s", job.Namespace, job.Name)
 	}
 	pod := job.Spec.Template.Spec
-	if pod.NodeName != "miles" {
+	if pod.NodeName != "worker-2" {
 		t.Errorf("not pinned to restore node: %q", pod.NodeName)
 	}
 	c := pod.Containers[0]
@@ -93,7 +93,7 @@ func TestBuildOCIDownloadJob(t *testing.T) {
 }
 
 func TestBuildOCIDownloadJob_Anonymous(t *testing.T) {
-	job := buildOCIDownloadJob(ociRestore(), ociSnapForRestore(false), "img:tag", "miles")
+	job := buildOCIDownloadJob(ociRestore(), ociSnapForRestore(false), "img:tag", "worker-2")
 	pod := job.Spec.Template.Spec
 	for _, e := range pod.Containers[0].Env {
 		if e.Name == "DOCKER_CONFIG" {

--- a/internal/controller/swiftrestore/s3_test.go
+++ b/internal/controller/swiftrestore/s3_test.go
@@ -31,7 +31,7 @@ func s3ReadySnap(name, ns, sourceGuest string) *snapshotv1alpha1.SwiftSnapshot {
 		},
 		Status: snapshotv1alpha1.SwiftSnapshotStatus{
 			Phase:    snapshotv1alpha1.SwiftSnapshotPhaseReady,
-			NodeName: "miles",
+			NodeName: "worker-2",
 			S3:       &snapshotv1alpha1.S3SnapshotStatus{Location: "s3://backups/kubeswift/team-a/snap1/"},
 		},
 	}
@@ -50,7 +50,7 @@ func s3Restore(name, ns, snapName, target, targetNode string) *snapshotv1alpha1.
 
 func TestS3Restore_Helpers(t *testing.T) {
 	snap := s3ReadySnap("snap1", "team-a", "g1")
-	restore := s3Restore("r1", "team-a", "snap1", "g1", "boba")
+	restore := s3Restore("r1", "team-a", "snap1", "g1", "worker-1")
 	if got := s3RestoreLocalDir(snap); got != "/var/lib/kubeswift/snapshots/team-a-snap1" {
 		t.Errorf("localDir = %q", got)
 	}
@@ -67,8 +67,8 @@ func TestResolveS3RestoreNode(t *testing.T) {
 
 	t.Run("targetNode wins", func(t *testing.T) {
 		r, _ := newReconciler(t)
-		node, failMsg, err := r.resolveS3RestoreNode(context.Background(), s3Restore("r", "ns", "snap1", "g1", "boba"), snap)
-		if err != nil || failMsg != "" || node != "boba" {
+		node, failMsg, err := r.resolveS3RestoreNode(context.Background(), s3Restore("r", "ns", "snap1", "g1", "worker-1"), snap)
+		if err != nil || failMsg != "" || node != "worker-1" {
 			t.Fatalf("node=%q failMsg=%q err=%v", node, failMsg, err)
 		}
 	})
@@ -76,11 +76,11 @@ func TestResolveS3RestoreNode(t *testing.T) {
 	t.Run("in-place falls back to guest node", func(t *testing.T) {
 		guest := &swiftv1alpha1.SwiftGuest{
 			ObjectMeta: metav1.ObjectMeta{Name: "g1", Namespace: "ns"},
-			Status:     swiftv1alpha1.SwiftGuestStatus{NodeName: "miles"},
+			Status:     swiftv1alpha1.SwiftGuestStatus{NodeName: "worker-2"},
 		}
 		r, _ := newReconciler(t, guest)
 		node, failMsg, err := r.resolveS3RestoreNode(context.Background(), s3Restore("r", "ns", "snap1", "g1", ""), snap)
-		if err != nil || failMsg != "" || node != "miles" {
+		if err != nil || failMsg != "" || node != "worker-2" {
 			t.Fatalf("node=%q failMsg=%q err=%v", node, failMsg, err)
 		}
 	})
@@ -109,10 +109,10 @@ func TestBuildDownloadJob(t *testing.T) {
 	snap.Spec.Backend.S3.ForcePathStyle = true
 	snap.Spec.Backend.S3.Insecure = true
 	snap.Spec.IncludeMemory = true
-	job := buildDownloadJob(s3Restore("r1", "team-a", "snap1", "g1", "boba"), snap, "ghcr.io/x/snapshot-s3:t", "boba")
+	job := buildDownloadJob(s3Restore("r1", "team-a", "snap1", "g1", "worker-1"), snap, "ghcr.io/x/snapshot-s3:t", "worker-1")
 	pod := job.Spec.Template.Spec
 
-	if pod.NodeName != "boba" {
+	if pod.NodeName != "worker-1" {
 		t.Errorf("download Job must pin to the resolved node; got %q", pod.NodeName)
 	}
 	if pod.RestartPolicy != corev1.RestartPolicyOnFailure {
@@ -168,7 +168,7 @@ func TestHandlePendingS3(t *testing.T) {
 		snap := s3ReadySnap("snap1", "ns", "g1")
 		r, c := newReconciler(t, snap)
 		r.SnapshotS3Image = "img"
-		restore := s3Restore("r1", "ns", "snap1", "clone-a", "boba")
+		restore := s3Restore("r1", "ns", "snap1", "clone-a", "worker-1")
 		status := restore.Status.DeepCopy()
 		advanced, _, err := r.handlePendingS3(context.Background(), restore, snap, status)
 		if err != nil || !advanced {
@@ -189,7 +189,7 @@ func TestHandlePendingS3(t *testing.T) {
 		r, _ := newReconciler(t, snap)
 		r.SnapshotS3Image = "img"
 		status := &snapshotv1alpha1.SwiftRestoreStatus{}
-		advanced, _, err := r.handlePendingS3(context.Background(), s3Restore("r1", "ns", "snap1", "g1", "boba"), snap, status)
+		advanced, _, err := r.handlePendingS3(context.Background(), s3Restore("r1", "ns", "snap1", "g1", "worker-1"), snap, status)
 		if err != nil || !advanced || status.Phase != snapshotv1alpha1.SwiftRestorePhaseFailed {
 			t.Fatalf("advanced=%v phase=%s err=%v", advanced, status.Phase, err)
 		}
@@ -217,7 +217,7 @@ func downloadJobWith(restore *snapshotv1alpha1.SwiftRestore, cond batchv1.JobCon
 
 func TestHandleDownloading(t *testing.T) {
 	snap := s3ReadySnap("snap1", "ns", "g1")
-	restore := s3Restore("r1", "ns", "snap1", "clone-a", "boba")
+	restore := s3Restore("r1", "ns", "snap1", "clone-a", "worker-1")
 
 	t.Run("failed -> errMsg", func(t *testing.T) {
 		r, _ := newReconciler(t, snap, downloadJobWith(restore, batchv1.JobFailed))

--- a/internal/controller/swiftsandbox/gpu_test.go
+++ b/internal/controller/swiftsandbox/gpu_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // oneGPUNode is a single-GPU (GTX 1080-class) Tier-1 SwiftGPUNode — the dev
-// lab's boba shape.
+// lab's worker1 shape.
 func oneGPUNode(name string) *gpuv1alpha1.SwiftGPUNode {
 	return &gpuv1alpha1.SwiftGPUNode{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -49,7 +49,7 @@ func nativeGPUSandbox(name, ns, profileName string) *sandboxv1alpha1.SwiftSandbo
 }
 
 func TestReconcileNativeGPU_AllocatesAndReleases(t *testing.T) {
-	node := oneGPUNode("boba")
+	node := oneGPUNode("worker-1")
 	profile := pcieProfile("gtx", "default")
 	sb := nativeGPUSandbox("gpu-sb", "default", "gtx")
 
@@ -70,15 +70,15 @@ func TestReconcileNativeGPU_AllocatesAndReleases(t *testing.T) {
 	if sb.Status.GPU == nil || len(sb.Status.GPU.Devices) != 1 || sb.Status.GPU.Devices[0] != "0000:01:00.0" {
 		t.Fatalf("status.gpu = %+v, want 1 device 0000:01:00.0", sb.Status.GPU)
 	}
-	if sb.Status.GPU.NodeName != "boba" || sb.Status.GPU.Hypervisor != "cloud-hypervisor" {
-		t.Errorf("status.gpu node/hypervisor = %q/%q, want boba/cloud-hypervisor", sb.Status.GPU.NodeName, sb.Status.GPU.Hypervisor)
+	if sb.Status.GPU.NodeName != "worker-1" || sb.Status.GPU.Hypervisor != "cloud-hypervisor" {
+		t.Errorf("status.gpu node/hypervisor = %q/%q, want worker-1/cloud-hypervisor", sb.Status.GPU.NodeName, sb.Status.GPU.Hypervisor)
 	}
 	if !controllerutil.ContainsFinalizer(sb, sandboxGPUFinalizer) {
 		t.Error("release finalizer must be added on native allocation")
 	}
 	// Node capacity consumed.
 	var after gpuv1alpha1.SwiftGPUNode
-	if err := c.Get(ctx, client.ObjectKey{Name: "boba"}, &after); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Name: "worker-1"}, &after); err != nil {
 		t.Fatal(err)
 	}
 	if after.Status.FreeGPUs != 0 || after.Status.GPUs[0].AllocatedTo != "sandbox:default/gpu-sb" {
@@ -89,7 +89,7 @@ func TestReconcileNativeGPU_AllocatesAndReleases(t *testing.T) {
 	if err := r.releaseNativeGPU(ctx, sb); err != nil {
 		t.Fatalf("releaseNativeGPU: %v", err)
 	}
-	if err := c.Get(ctx, client.ObjectKey{Name: "boba"}, &after); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Name: "worker-1"}, &after); err != nil {
 		t.Fatal(err)
 	}
 	if after.Status.FreeGPUs != 1 || after.Status.GPUs[0].AllocatedTo != "" {
@@ -100,7 +100,7 @@ func TestReconcileNativeGPU_AllocatesAndReleases(t *testing.T) {
 // A hgx-shared profile is rejected for a sandbox (mode-3 is CH-only), not
 // silently allocated on a QEMU-less runtime.
 func TestReconcileNativeGPU_HGXTierRejected(t *testing.T) {
-	node := oneGPUNode("boba")
+	node := oneGPUNode("worker-1")
 	profile := pcieProfile("hgx", "default")
 	profile.Spec.Tier = "hgx-shared"
 	profile.Spec.PartitionMode = "shared"
@@ -128,7 +128,7 @@ func TestReconcileNativeGPU_HGXTierRejected(t *testing.T) {
 
 func TestBuildIntent_NativeGPU_ExplicitDevices(t *testing.T) {
 	sb := nativeGPUSandbox("gpu-sb", "default", "gtx")
-	sb.Status.GPU = gpuStatus("boba", "0000:01:00.0")
+	sb.Status.GPU = gpuStatus("worker-1", "0000:01:00.0")
 	ri := buildIntent(sb, "gpu-sandbox", "/cache/x.ext4", "", execSpec{Argv: []string{"/bin/sh"}}, false)
 	if ri.GPU == nil {
 		t.Fatal("native sandbox must carry a GPU intent")
@@ -146,10 +146,10 @@ func TestBuildIntent_NativeGPU_ExplicitDevices(t *testing.T) {
 
 func TestBuildPod_NativeGPU_PinnedWithGpuInitEnv(t *testing.T) {
 	sb := nativeGPUSandbox("gpu-sb", "default", "gtx")
-	sb.Status.GPU = gpuStatus("boba", "0000:01:00.0")
+	sb.Status.GPU = gpuStatus("worker-1", "0000:01:00.0")
 	pod := buildPod(sb, "gpu-sandbox")
 
-	if pod.Spec.NodeSelector["kubernetes.io/hostname"] != "boba" {
+	if pod.Spec.NodeSelector["kubernetes.io/hostname"] != "worker-1" {
 		t.Errorf("native GPU pod must pin to the allocated node; nodeSelector=%v", pod.Spec.NodeSelector)
 	}
 	if pod.Spec.NodeSelector[kernelNodeLabel] != "true" {

--- a/internal/controller/swiftsandbox/pool_gpu_test.go
+++ b/internal/controller/swiftsandbox/pool_gpu_test.go
@@ -25,7 +25,7 @@ func gpuPool(name, ns, profileName string) *sandboxv1alpha1.SwiftSandboxPool {
 }
 
 func TestAllocateSlotGPU_StampsSlotAndConsumesNode(t *testing.T) {
-	node := oneGPUNode("boba")
+	node := oneGPUNode("worker-1")
 	profile := pcieProfile("gtx", "default")
 	pool := gpuPool("gp", "default", "gtx")
 	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
@@ -38,18 +38,18 @@ func TestAllocateSlotGPU_StampsSlotAndConsumesNode(t *testing.T) {
 	}
 	if slot.Spec.GPUProfileRef == nil || slot.Status.GPU == nil ||
 		len(slot.Status.GPU.Devices) != 1 || slot.Status.GPU.Devices[0] != "0000:01:00.0" ||
-		slot.Status.GPU.NodeName != "boba" {
+		slot.Status.GPU.NodeName != "worker-1" {
 		t.Fatalf("slot not stamped for GPU: spec.gpuProfileRef=%v status.gpu=%+v", slot.Spec.GPUProfileRef, slot.Status.GPU)
 	}
 	var after gpuv1alpha1.SwiftGPUNode
-	_ = c.Get(context.Background(), client.ObjectKey{Name: "boba"}, &after)
+	_ = c.Get(context.Background(), client.ObjectKey{Name: "worker-1"}, &after)
 	if after.Status.FreeGPUs != 0 || after.Status.GPUs[0].AllocatedTo != "sandbox:default/gp-slot-aaaaa" {
 		t.Errorf("node not allocated to the slot: free=%d allocatedTo=%q", after.Status.FreeGPUs, after.Status.GPUs[0].AllocatedTo)
 	}
 }
 
 func TestAllocateSlotGPU_RejectsHGXTier(t *testing.T) {
-	node := oneGPUNode("boba")
+	node := oneGPUNode("worker-1")
 	profile := pcieProfile("hgx", "default")
 	profile.Spec.Tier = "hgx-shared"
 	pool := gpuPool("gp", "default", "hgx")
@@ -66,7 +66,7 @@ func TestAllocateSlotGPU_RejectsHGXTier(t *testing.T) {
 // The GC sweep releases the GPU of a slot whose pod is gone, and keeps the GPU
 // of a slot whose pod still exists.
 func TestReconcileSlotGPUGC_ReleasesOrphanedSlots(t *testing.T) {
-	node := oneGPUNode("boba")
+	node := oneGPUNode("worker-1")
 	// Pre-allocate the GPU to a slot whose pod is gone.
 	node.Status.FreeGPUs = 0
 	node.Status.GPUs[0].Allocated = true
@@ -81,7 +81,7 @@ func TestReconcileSlotGPUGC_ReleasesOrphanedSlots(t *testing.T) {
 		t.Fatal(err)
 	}
 	var after gpuv1alpha1.SwiftGPUNode
-	_ = c.Get(context.Background(), client.ObjectKey{Name: "boba"}, &after)
+	_ = c.Get(context.Background(), client.ObjectKey{Name: "worker-1"}, &after)
 	if after.Status.FreeGPUs != 1 || after.Status.GPUs[0].AllocatedTo != "" {
 		t.Fatalf("orphaned slot GPU not released: free=%d allocatedTo=%q", after.Status.FreeGPUs, after.Status.GPUs[0].AllocatedTo)
 	}
@@ -94,7 +94,7 @@ func TestReconcileSlotGPUGC_ReleasesOrphanedSlots(t *testing.T) {
 	if err := r.reconcileSlotGPUGC(context.Background(), pool, map[string]bool{"gp-slot-live": true}); err != nil {
 		t.Fatal(err)
 	}
-	_ = c.Get(context.Background(), client.ObjectKey{Name: "boba"}, &after)
+	_ = c.Get(context.Background(), client.ObjectKey{Name: "worker-1"}, &after)
 	if after.Status.GPUs[0].AllocatedTo != "sandbox:default/gp-slot-live" {
 		t.Errorf("a live slot's GPU must NOT be released, got allocatedTo=%q", after.Status.GPUs[0].AllocatedTo)
 	}

--- a/internal/controller/swiftsnapshot/cleanup_test.go
+++ b/internal/controller/swiftsnapshot/cleanup_test.go
@@ -152,7 +152,7 @@ func TestHandleDeletion_CreatesCleanupPod(t *testing.T) {
 	now := metav1.Now()
 	snap.DeletionTimestamp = &now
 	snap.Finalizers = []string{HostPathFinalizer}
-	snap.Status.NodeName = "boba"
+	snap.Status.NodeName = "worker-1"
 	r, c := newReconciler(t, snap)
 
 	done, err := r.handleDeletion(context.Background(), snap)
@@ -168,8 +168,8 @@ func TestHandleDeletion_CreatesCleanupPod(t *testing.T) {
 		client.ObjectKey{Name: cleanupPodName(snap), Namespace: "default"}, &pod); err != nil {
 		t.Fatalf("cleanup pod not created: %v", err)
 	}
-	if pod.Spec.NodeName != "boba" {
-		t.Errorf("cleanup pod node = %q, want boba", pod.Spec.NodeName)
+	if pod.Spec.NodeName != "worker-1" {
+		t.Errorf("cleanup pod node = %q, want worker-1", pod.Spec.NodeName)
 	}
 	args := strings.Join(pod.Spec.Containers[0].Args, " ")
 	if !strings.Contains(args, "default-snap1") {
@@ -188,7 +188,7 @@ func TestHandleLocalDeletion_Retain(t *testing.T) {
 	now := metav1.Now()
 	snap.DeletionTimestamp = &now
 	snap.Finalizers = []string{HostPathFinalizer}
-	snap.Status.NodeName = "boba"
+	snap.Status.NodeName = "worker-1"
 	snap.Spec.DeletionPolicy = snapshotv1alpha1.SnapshotDeletionPolicyRetain
 	r, c := newReconciler(t, snap)
 
@@ -213,7 +213,7 @@ func TestHandleDeletion_PodSucceeded_RemovesFinalizer(t *testing.T) {
 	now := metav1.Now()
 	snap.DeletionTimestamp = &now
 	snap.Finalizers = []string{HostPathFinalizer}
-	snap.Status.NodeName = "boba"
+	snap.Status.NodeName = "worker-1"
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cleanupPodName(snap),
@@ -246,7 +246,7 @@ func TestHandleDeletion_PodFailed_RetainsFinalizer(t *testing.T) {
 	now := metav1.Now()
 	snap.DeletionTimestamp = &now
 	snap.Finalizers = []string{HostPathFinalizer}
-	snap.Status.NodeName = "boba"
+	snap.Status.NodeName = "worker-1"
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cleanupPodName(snap),
@@ -278,7 +278,7 @@ func TestHandleDeletion_MalformedHostPath_DropsFinalizer(t *testing.T) {
 	now := metav1.Now()
 	snap.DeletionTimestamp = &now
 	snap.Finalizers = []string{HostPathFinalizer}
-	snap.Status.NodeName = "boba"
+	snap.Status.NodeName = "worker-1"
 	snap.Spec.Backend.Local.HostPath = "/tmp/something-weird"
 	r, c := newReconciler(t, snap)
 

--- a/internal/controller/swiftsnapshot/coldmig_test.go
+++ b/internal/controller/swiftsnapshot/coldmig_test.go
@@ -26,9 +26,9 @@ func TestOCIDiskTagAndReference(t *testing.T) {
 }
 
 func TestBuildDiskChunkJob_Filesystem(t *testing.T) {
-	job := buildChunkJob(ociSnap(nil), "oras:img", "miles", diskChunkJobName(ociSnap(nil)), ociDiskTag(ociSnap(nil)), rootDiskPVCName("g1"), false)
+	job := buildChunkJob(ociSnap(nil), "oras:img", "worker-2", diskChunkJobName(ociSnap(nil)), ociDiskTag(ociSnap(nil)), rootDiskPVCName("g1"), false)
 	pod := job.Spec.Template.Spec
-	if pod.NodeName != "miles" {
+	if pod.NodeName != "worker-2" {
 		t.Errorf("disk chunk Job must be pinned to the capture node; got %q", pod.NodeName)
 	}
 	c := pod.Containers[0]
@@ -67,7 +67,7 @@ func TestBuildDiskChunkJob_Filesystem(t *testing.T) {
 }
 
 func TestBuildDiskChunkJob_Block(t *testing.T) {
-	job := buildChunkJob(ociSnap(nil), "oras:img", "boba", diskChunkJobName(ociSnap(nil)), ociDiskTag(ociSnap(nil)), rootDiskPVCName("g1"), true)
+	job := buildChunkJob(ociSnap(nil), "oras:img", "worker-1", diskChunkJobName(ociSnap(nil)), ociDiskTag(ociSnap(nil)), rootDiskPVCName("g1"), true)
 	c := job.Spec.Template.Spec.Containers[0]
 	if !strings.Contains(strings.Join(c.Args, " "), "--file=/dev/kubeswift-root") {
 		t.Errorf("Block root must chunk the raw device; got %q", strings.Join(c.Args, " "))
@@ -91,7 +91,7 @@ func TestBuildDiskChunkJob_InsecureAndCreds(t *testing.T) {
 		o.Insecure = true
 		o.CredentialsSecretRef = &snapshotv1alpha1.SecretObjectReference{Name: "reg-creds"}
 	})
-	job := buildChunkJob(snap, "oras:img", "miles", diskChunkJobName(snap), ociDiskTag(snap), rootDiskPVCName("g1"), false)
+	job := buildChunkJob(snap, "oras:img", "worker-2", diskChunkJobName(snap), ociDiskTag(snap), rootDiskPVCName("g1"), false)
 	c := job.Spec.Template.Spec.Containers[0]
 	if !strings.Contains(strings.Join(c.Args, " "), "--insecure") {
 		t.Errorf("--insecure must be present; got %q", strings.Join(c.Args, " "))
@@ -224,7 +224,7 @@ func TestCapturedDataDisks_BlankFromSpec_AttachedFromPVC(t *testing.T) {
 
 func TestBuildChunkJob_DataDisk(t *testing.T) {
 	snap := ociSnap(nil)
-	job := buildChunkJob(snap, "oras:img", "miles",
+	job := buildChunkJob(snap, "oras:img", "worker-2",
 		diskChunkJobName(snap)+"-scratch", ociDiskTag(snap)+"-scratch", "g1-data-scratch", true)
 	if job.Name != "snap1-oci-disk-scratch" {
 		t.Errorf("job name = %q", job.Name)

--- a/internal/controller/swiftsnapshot/local_test.go
+++ b/internal/controller/swiftsnapshot/local_test.go
@@ -55,7 +55,7 @@ func makeLauncherPod(ns, name, node string) *corev1.Pod {
 func TestLocal_Pending_AdvancesToCapturing_AndWritesActionAnnotations(t *testing.T) {
 	snap := makeLocalSnap("snap1", "default", "g1")
 	guest := makeGuest("default", "g1")
-	pod := makeLauncherPod("default", "g1", "boba")
+	pod := makeLauncherPod("default", "g1", "worker-1")
 
 	r, c := newReconciler(t, snap, guest, pod)
 	reconcile(t, r, "snap1", "default")
@@ -64,8 +64,8 @@ func TestLocal_Pending_AdvancesToCapturing_AndWritesActionAnnotations(t *testing
 	if got.Status.Phase != snapshotv1alpha1.SwiftSnapshotPhaseCapturing {
 		t.Fatalf("phase = %s, want Capturing", got.Status.Phase)
 	}
-	if got.Status.NodeName != "boba" {
-		t.Errorf("status.nodeName = %q, want boba", got.Status.NodeName)
+	if got.Status.NodeName != "worker-1" {
+		t.Errorf("status.nodeName = %q, want worker-1", got.Status.NodeName)
 	}
 	if got.Status.SnapshotDirVersion != SnapshotDirVersionV1 {
 		t.Errorf("status.snapshotDirVersion = %q, want %q", got.Status.SnapshotDirVersion, SnapshotDirVersionV1)
@@ -127,7 +127,7 @@ func TestLocal_Pending_PodNotYetPresent_StaysPending(t *testing.T) {
 func TestLocal_Pending_PodNotRunning_StaysPending(t *testing.T) {
 	snap := makeLocalSnap("snap1", "default", "g1")
 	guest := makeGuest("default", "g1")
-	pod := makeLauncherPod("default", "g1", "boba")
+	pod := makeLauncherPod("default", "g1", "worker-1")
 	pod.Status.Phase = corev1.PodPending
 
 	r, c := newReconciler(t, snap, guest, pod)
@@ -143,7 +143,7 @@ func TestLocal_Capturing_StatusIDMismatch_Requeues(t *testing.T) {
 	snap := makeLocalSnap("snap1", "default", "g1")
 	snap.Status.Phase = snapshotv1alpha1.SwiftSnapshotPhaseCapturing
 	guest := makeGuest("default", "g1")
-	pod := makeLauncherPod("default", "g1", "boba")
+	pod := makeLauncherPod("default", "g1", "worker-1")
 	// Annotations carry a stale status-id from a prior run.
 	pod.Annotations = map[string]string{
 		annoStatusID: "snap1-OLD",
@@ -162,9 +162,9 @@ func TestLocal_Capturing_StatusIDMismatch_Requeues(t *testing.T) {
 func TestLocal_Capturing_StatusReady_FinalizesWithPauseWindow(t *testing.T) {
 	snap := makeLocalSnap("snap1", "default", "g1")
 	snap.Status.Phase = snapshotv1alpha1.SwiftSnapshotPhaseCapturing
-	snap.Status.NodeName = "boba"
+	snap.Status.NodeName = "worker-1"
 	guest := makeGuest("default", "g1")
-	pod := makeLauncherPod("default", "g1", "boba")
+	pod := makeLauncherPod("default", "g1", "worker-1")
 	pod.Annotations = map[string]string{
 		annoStatusID:      "snap1-deadbeef",
 		annoStatus:        "ready",
@@ -194,7 +194,7 @@ func TestLocal_Capturing_StatusFailed_TransitionsToFailed(t *testing.T) {
 	snap := makeLocalSnap("snap1", "default", "g1")
 	snap.Status.Phase = snapshotv1alpha1.SwiftSnapshotPhaseCapturing
 	guest := makeGuest("default", "g1")
-	pod := makeLauncherPod("default", "g1", "boba")
+	pod := makeLauncherPod("default", "g1", "worker-1")
 	pod.Annotations = map[string]string{
 		annoStatusID:     "snap1-deadbeef",
 		annoStatus:       "failed",
@@ -217,7 +217,7 @@ func TestLocal_Capturing_StatusRejected_TransitionsToFailed(t *testing.T) {
 	snap := makeLocalSnap("snap1", "default", "g1")
 	snap.Status.Phase = snapshotv1alpha1.SwiftSnapshotPhaseCapturing
 	guest := makeGuest("default", "g1")
-	pod := makeLauncherPod("default", "g1", "boba")
+	pod := makeLauncherPod("default", "g1", "worker-1")
 	pod.Annotations = map[string]string{
 		annoStatusID:     "snap1-deadbeef",
 		annoStatus:       "rejected",
@@ -240,7 +240,7 @@ func TestLocal_Capturing_PodPhaseFailed_Surfaces_Failed(t *testing.T) {
 	snap := makeLocalSnap("snap1", "default", "g1")
 	snap.Status.Phase = snapshotv1alpha1.SwiftSnapshotPhaseCapturing
 	guest := makeGuest("default", "g1")
-	pod := makeLauncherPod("default", "g1", "boba")
+	pod := makeLauncherPod("default", "g1", "worker-1")
 	pod.Status.Phase = corev1.PodFailed
 
 	r, c := newReconciler(t, snap, guest, pod)
@@ -263,7 +263,7 @@ func TestLocal_Capturing_DeadlineExceeded_TransitionsToFailed(t *testing.T) {
 		Time: metav1.Now().Add(-(time.Duration(DefaultCaptureDeadlineSeconds) + 60) * time.Second),
 	}
 	guest := makeGuest("default", "g1")
-	pod := makeLauncherPod("default", "g1", "boba")
+	pod := makeLauncherPod("default", "g1", "worker-1")
 	pod.Annotations = map[string]string{
 		annoStatusID: "snap1-deadbeef",
 		annoStatus:   "running",
@@ -292,7 +292,7 @@ func TestLocal_Capturing_AnnotationOverride_ExtendsDeadline(t *testing.T) {
 		Time: metav1.Now().Add(-(time.Duration(DefaultCaptureDeadlineSeconds) + 60) * time.Second),
 	}
 	guest := makeGuest("default", "g1")
-	pod := makeLauncherPod("default", "g1", "boba")
+	pod := makeLauncherPod("default", "g1", "worker-1")
 	pod.Annotations = map[string]string{
 		annoStatusID: "snap1-deadbeef",
 		annoStatus:   "running",
@@ -312,7 +312,7 @@ func TestLocal_PodWatcher_MapsCapturingSnapshotsOnly(t *testing.T) {
 	// the pod's namespace and guest-name. Pending or terminal phases
 	// are filtered out so we don't waste reconcile budget on snapshots
 	// that don't observe Pod state.
-	pod := makeLauncherPod("default", "g1", "boba")
+	pod := makeLauncherPod("default", "g1", "worker-1")
 
 	cap := makeLocalSnap("cap-snap", "default", "g1")
 	cap.Status.Phase = snapshotv1alpha1.SwiftSnapshotPhaseCapturing

--- a/internal/controller/swiftsnapshot/oci_test.go
+++ b/internal/controller/swiftsnapshot/oci_test.go
@@ -45,13 +45,13 @@ func TestBuildOCIPushJob_WithCredentials(t *testing.T) {
 		o.Insecure = true
 		o.CredentialsSecretRef = &snapshotv1alpha1.SecretObjectReference{Name: "reg-creds"}
 	})
-	job := buildOCIPushJob(snap, "img:tag", "boba")
+	job := buildOCIPushJob(snap, "img:tag", "worker-1")
 
 	if job.Name != "snap1-oci-push" || job.Namespace != "team-a" {
 		t.Errorf("job meta = %s/%s", job.Namespace, job.Name)
 	}
 	pod := job.Spec.Template.Spec
-	if pod.NodeName != "boba" {
+	if pod.NodeName != "worker-1" {
 		t.Errorf("not pinned to capture node: %q", pod.NodeName)
 	}
 	c := pod.Containers[0]
@@ -97,7 +97,7 @@ func TestBuildOCIPushJob_WithCredentials(t *testing.T) {
 }
 
 func TestBuildOCIPushJob_Anonymous(t *testing.T) {
-	job := buildOCIPushJob(ociSnap(nil), "img:tag", "miles")
+	job := buildOCIPushJob(ociSnap(nil), "img:tag", "worker-2")
 	pod := job.Spec.Template.Spec
 	for _, e := range pod.Containers[0].Env {
 		if e.Name == "DOCKER_CONFIG" {
@@ -138,7 +138,7 @@ func TestBuildOCIPushJob_WithSigning(t *testing.T) {
 	snap := ociSnap(func(o *snapshotv1alpha1.OCIBackend) {
 		o.SigningKeySecretRef = &snapshotv1alpha1.SecretObjectReference{Name: "cosign-key"}
 	})
-	pod := buildOCIPushJob(snap, "img:tag", "boba").Spec.Template.Spec
+	pod := buildOCIPushJob(snap, "img:tag", "worker-1").Spec.Template.Spec
 	c := pod.Containers[0]
 
 	if !strings.Contains(strings.Join(c.Args, " "), "--sign-key=/oras-signing-key/cosign.key") {

--- a/internal/controller/swiftsnapshot/s3_test.go
+++ b/internal/controller/swiftsnapshot/s3_test.go
@@ -61,10 +61,10 @@ func TestBuildUploadJob_Pinning_Mount_Creds(t *testing.T) {
 		s.Spec.Backend.S3.ForcePathStyle = true
 		s.Spec.Backend.S3.Insecure = true
 	})
-	job := buildUploadJob(s, "ghcr.io/x/snapshot-s3:t", "boba")
+	job := buildUploadJob(s, "ghcr.io/x/snapshot-s3:t", "worker-1")
 	pod := job.Spec.Template.Spec
 
-	if pod.NodeName != "boba" {
+	if pod.NodeName != "worker-1" {
 		t.Errorf("job must pin to the capture node; got %q", pod.NodeName)
 	}
 	if pod.RestartPolicy != corev1.RestartPolicyOnFailure {
@@ -122,7 +122,7 @@ func TestBuildUploadJob_Pinning_Mount_Creds(t *testing.T) {
 func TestBuildUploadJob_OptionalFlagsOmitted(t *testing.T) {
 	// No region/endpoint/path-style/memory => those flags absent.
 	s := s3Snap("snap1", "ns", nil)
-	job := buildUploadJob(s, "img", "miles")
+	job := buildUploadJob(s, "img", "worker-2")
 	a := strings.Join(job.Spec.Template.Spec.Containers[0].Args, " ")
 	for _, absent := range []string{"--region", "--endpoint", "--path-style", "--insecure", "--include-memory"} {
 		if strings.Contains(a, absent) {
@@ -141,7 +141,7 @@ func uploadJobWith(snap *snapshotv1alpha1.SwiftSnapshot, cond batchv1.JobConditi
 
 func TestHandleUploading(t *testing.T) {
 	base := s3Snap("snap1", "ns", nil)
-	base.Status.NodeName = "boba"
+	base.Status.NodeName = "worker-1"
 
 	t.Run("complete -> Ready + status.S3", func(t *testing.T) {
 		snap := base.DeepCopy()

--- a/internal/gateway/access_service_test.go
+++ b/internal/gateway/access_service_test.go
@@ -51,7 +51,7 @@ func TestAccess_ListRoles_PredefinedAlwaysPresent(t *testing.T) {
 	unrelated := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "some-operator"}}
 	svc, _ := newFakeAccess(custom, unrelated)
 
-	resp, err := svc.ListRoles(context.Background(), connect.NewRequest(&kubeswiftv1.ListRolesRequest{Cluster: "boba"}))
+	resp, err := svc.ListRoles(context.Background(), connect.NewRequest(&kubeswiftv1.ListRolesRequest{Cluster: "edge-1"}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestAccess_AssignPredefined_ClusterWide_EnsuresRole(t *testing.T) {
 	ctx := context.Background()
 
 	resp, err := svc.AssignRole(ctx, connect.NewRequest(&kubeswiftv1.AssignRoleRequest{
-		Cluster: "boba", Role: "kubeswift-operator",
+		Cluster: "edge-1", Role: "kubeswift-operator",
 		Subject: &kubeswiftv1.Subject{Kind: "Group", Name: "team-a"},
 	}))
 	if err != nil {
@@ -119,7 +119,7 @@ func TestAccess_AssignNamespaced(t *testing.T) {
 	ctx := context.Background()
 
 	resp, err := svc.AssignRole(ctx, connect.NewRequest(&kubeswiftv1.AssignRoleRequest{
-		Cluster: "boba", Role: "kubeswift-viewer", Namespace: "team-a",
+		Cluster: "edge-1", Role: "kubeswift-viewer", Namespace: "team-a",
 		Subject: &kubeswiftv1.Subject{Kind: "User", Name: "alice@example.com"},
 	}))
 	if err != nil {
@@ -139,7 +139,7 @@ func TestAccess_CreateRole_ComposesRules(t *testing.T) {
 	ctx := context.Background()
 
 	resp, err := svc.CreateRole(ctx, connect.NewRequest(&kubeswiftv1.CreateRoleRequest{
-		Cluster: "boba", Name: "vm-console-only", DisplayName: "VM + console",
+		Cluster: "edge-1", Name: "vm-console-only", DisplayName: "VM + console",
 		Capabilities: []string{"view-vms", "console", "bogus-cap"}, // bogus dropped
 	}))
 	if err != nil {
@@ -173,12 +173,12 @@ func TestAccess_CreateRole_Validation(t *testing.T) {
 	svc, _ := newFakeAccess()
 	ctx := context.Background()
 	// A predefined name is rejected.
-	_, err := svc.CreateRole(ctx, connect.NewRequest(&kubeswiftv1.CreateRoleRequest{Cluster: "boba", Name: "kubeswift-admin", Capabilities: []string{"view-vms"}}))
+	_, err := svc.CreateRole(ctx, connect.NewRequest(&kubeswiftv1.CreateRoleRequest{Cluster: "edge-1", Name: "kubeswift-admin", Capabilities: []string{"view-vms"}}))
 	if connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Errorf("predefined name: want InvalidArgument, got %v", err)
 	}
 	// No valid capabilities is rejected.
-	_, err = svc.CreateRole(ctx, connect.NewRequest(&kubeswiftv1.CreateRoleRequest{Cluster: "boba", Name: "empty", Capabilities: []string{"bogus"}}))
+	_, err = svc.CreateRole(ctx, connect.NewRequest(&kubeswiftv1.CreateRoleRequest{Cluster: "edge-1", Name: "empty", Capabilities: []string{"bogus"}}))
 	if connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Errorf("no valid caps: want InvalidArgument, got %v", err)
 	}
@@ -188,13 +188,13 @@ func TestAccess_ListAssignments_Roundtrip(t *testing.T) {
 	svc, _ := newFakeAccess()
 	ctx := context.Background()
 	_, err := svc.AssignRole(ctx, connect.NewRequest(&kubeswiftv1.AssignRoleRequest{
-		Cluster: "boba", Role: "kubeswift-admin",
+		Cluster: "edge-1", Role: "kubeswift-admin",
 		Subject: &kubeswiftv1.Subject{Kind: "User", Name: "root@example.com"},
 	}))
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := svc.ListAssignments(ctx, connect.NewRequest(&kubeswiftv1.ListAssignmentsRequest{Cluster: "boba"}))
+	resp, err := svc.ListAssignments(ctx, connect.NewRequest(&kubeswiftv1.ListAssignmentsRequest{Cluster: "edge-1"}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gateway/cluster_nodes_test.go
+++ b/internal/gateway/cluster_nodes_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 func TestClusterService_ListNodes(t *testing.T) {
-	boba := fakeDyn(uNode("worker-1", true, true), uNode("worker-2", true, false)) // worker-2 cordoned
+	edge1 := fakeDyn(uNode("worker-1", true, true), uNode("worker-2", true, false)) // worker2 cordoned
 	svc := NewClusterService(nil, "kubeswift-system", nil,
-		&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+		&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": edge1}}, NewInsecureAuthenticator())
 
-	resp, err := svc.ListNodes(context.Background(), connect.NewRequest(&kubeswiftv1.ListNodesRequest{Cluster: "boba"}))
+	resp, err := svc.ListNodes(context.Background(), connect.NewRequest(&kubeswiftv1.ListNodesRequest{Cluster: "edge-1"}))
 	if err != nil {
 		t.Fatalf("ListNodes: %v", err)
 	}

--- a/internal/gateway/cluster_service_test.go
+++ b/internal/gateway/cluster_service_test.go
@@ -17,8 +17,8 @@ import (
 
 func TestClusterService_ListClusters_NamespaceScoped(t *testing.T) {
 	hub := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
-		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "boba", Namespace: "kubeswift-system"}},
-		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "miles", Namespace: "kubeswift-system"}},
+		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "edge-1", Namespace: "kubeswift-system"}},
+		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "edge-2", Namespace: "kubeswift-system"}},
 		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "elsewhere", Namespace: "other"}},
 	).Build()
 
@@ -37,7 +37,7 @@ func TestClusterService_ListClusters_NamespaceScoped(t *testing.T) {
 	for _, c := range resp.Msg.Clusters {
 		names[c.Name] = true
 	}
-	if !names["boba"] || !names["miles"] || names["elsewhere"] {
+	if !names["edge-1"] || !names["edge-2"] || names["elsewhere"] {
 		t.Errorf("unexpected cluster set: %v", names)
 	}
 }
@@ -47,11 +47,11 @@ func TestClusterWatcher_EmitSubscribeUnsubscribe(t *testing.T) {
 	sub := w.subscribe()
 
 	w.emit(kubeswiftv1.EventType_EVENT_TYPE_ADDED,
-		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "boba"}})
+		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "edge-1"}})
 
 	select {
 	case ev := <-sub:
-		if ev.Type != kubeswiftv1.EventType_EVENT_TYPE_ADDED || ev.Cluster.GetName() != "boba" {
+		if ev.Type != kubeswiftv1.EventType_EVENT_TYPE_ADDED || ev.Cluster.GetName() != "edge-1" {
 			t.Errorf("unexpected event: %+v", ev)
 		}
 	default:
@@ -91,7 +91,7 @@ func (rejectingAuthenticator) Authenticate(context.Context, http.Header) (Identi
 // without an Authenticate call; these pin them.
 func TestClusterService_ListClusters_RequiresAuth(t *testing.T) {
 	hub := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
-		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "boba", Namespace: "kubeswift-system"}},
+		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "edge-1", Namespace: "kubeswift-system"}},
 	).Build()
 
 	svc := NewClusterService(hub, "kubeswift-system", nil, nil, rejectingAuthenticator{})
@@ -106,7 +106,7 @@ func TestClusterService_ListClusters_RequiresAuth(t *testing.T) {
 
 func TestClusterService_WatchClusters_RequiresAuth(t *testing.T) {
 	hub := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
-		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "boba", Namespace: "kubeswift-system"}},
+		&fleetv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "edge-1", Namespace: "kubeswift-system"}},
 	).Build()
 
 	// nil watcher + nil stream on purpose: the auth check must reject BEFORE

--- a/internal/gateway/console_ws_test.go
+++ b/internal/gateway/console_ws_test.go
@@ -12,16 +12,16 @@ import (
 // WebSocket upgrade — so failures are readable HTTP errors, not a dropped
 // socket. The exec bridge itself is validated on-cluster.
 func TestConsoleHandler_Preflight(t *testing.T) {
-	boba := fakeDyn(uGuest("default", "vm-a", "Running")) // a guest, but no launcher pod
-	h := NewConsoleHandler(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator(), NewOriginPolicy("*", "oidc"))
+	edge1 := fakeDyn(uGuest("default", "vm-a", "Running")) // a guest, but no launcher pod
+	h := NewConsoleHandler(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": edge1}}, NewInsecureAuthenticator(), NewOriginPolicy("*", "oidc"))
 
 	cases := []struct {
 		name, target string
 		want         int
 	}{
-		{"missing params", "/console?cluster=boba", http.StatusBadRequest},
+		{"missing params", "/console?cluster=edge-1", http.StatusBadRequest},
 		{"unknown cluster", "/console?cluster=ghost&namespace=default&name=vm-a", http.StatusNotFound},
-		{"no launcher pod", "/console?cluster=boba&namespace=default&name=vm-a", http.StatusConflict},
+		{"no launcher pod", "/console?cluster=edge-1&namespace=default&name=vm-a", http.StatusConflict},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/gateway/guest_mapper_test.go
+++ b/internal/gateway/guest_mapper_test.go
@@ -22,7 +22,7 @@ func TestGuestToProto(t *testing.T) {
 		},
 		Status: swiftv1alpha1.SwiftGuestStatus{
 			Phase:    swiftv1alpha1.SwiftGuestPhaseRunning,
-			NodeName: "miles",
+			NodeName: "edge-2",
 			Runtime:  &swiftv1alpha1.GuestRuntimeStatus{Hypervisor: "cloud-hypervisor"},
 			Network:  &swiftv1alpha1.GuestNetworkStatus{PrimaryIP: "192.168.99.11"},
 			Conditions: []metav1.Condition{
@@ -30,14 +30,14 @@ func TestGuestToProto(t *testing.T) {
 			},
 		},
 	}
-	got := guestToProto("boba", g)
-	if got.GetRef().GetCluster() != "boba" || got.GetRef().GetNamespace() != "default" || got.GetRef().GetName() != "vm-a" {
+	got := guestToProto("edge-1", g)
+	if got.GetRef().GetCluster() != "edge-1" || got.GetRef().GetNamespace() != "default" || got.GetRef().GetName() != "vm-a" {
 		t.Errorf("ref wrong: %+v", got.GetRef())
 	}
 	if got.Phase != "Running" {
 		t.Errorf("Phase = %q", got.Phase)
 	}
-	if got.NodeName != "miles" {
+	if got.NodeName != "edge-2" {
 		t.Errorf("NodeName = %q", got.NodeName)
 	}
 	if got.Hypervisor != "cloud-hypervisor" {

--- a/internal/gateway/guest_service_test.go
+++ b/internal/gateway/guest_service_test.go
@@ -115,8 +115,8 @@ func fakeDyn(objs ...*unstructured.Unstructured) dynamic.Interface {
 func TestGuestService_ListGuests_FanOutMergeAndPartialError(t *testing.T) {
 	prov := &fakeProvider{
 		clients: map[string]dynamic.Interface{
-			"boba":  fakeDyn(uGuest("default", "vm-a", "Running"), uGuest("default", "vm-b", "Pending")),
-			"miles": fakeDyn(uGuest("default", "vm-c", "Running")),
+			"edge-1": fakeDyn(uGuest("default", "vm-a", "Running"), uGuest("default", "vm-b", "Pending")),
+			"edge-2": fakeDyn(uGuest("default", "vm-c", "Running")),
 		},
 		errs: map[string]error{"down": errors.New("connection refused")},
 	}
@@ -127,21 +127,21 @@ func TestGuestService_ListGuests_FanOutMergeAndPartialError(t *testing.T) {
 		t.Fatalf("ListGuests: %v", err)
 	}
 	if len(resp.Msg.Guests) != 3 {
-		t.Fatalf("got %d guests, want 3 (boba+miles)", len(resp.Msg.Guests))
+		t.Fatalf("got %d guests, want 3 (edge-1+edge-2)", len(resp.Msg.Guests))
 	}
 	// The unreachable member surfaces as a per-cluster error, not a fatal one.
 	if len(resp.Msg.Errors) != 1 || resp.Msg.Errors[0].Cluster != "down" {
 		t.Errorf("want one partial-fleet error for 'down', got %+v", resp.Msg.Errors)
 	}
 	// cluster dimension stamped; merged result sorted by (cluster, ns, name).
-	if resp.Msg.Guests[0].GetRef().GetCluster() != "boba" || resp.Msg.Guests[2].GetRef().GetCluster() != "miles" {
+	if resp.Msg.Guests[0].GetRef().GetCluster() != "edge-1" || resp.Msg.Guests[2].GetRef().GetCluster() != "edge-2" {
 		t.Errorf("not sorted by cluster: %v / %v", resp.Msg.Guests[0].GetRef(), resp.Msg.Guests[2].GetRef())
 	}
 }
 
 func TestGuestService_ListGuests_PhaseFilter(t *testing.T) {
 	prov := &fakeProvider{clients: map[string]dynamic.Interface{
-		"boba": fakeDyn(uGuest("default", "vm-a", "Running"), uGuest("default", "vm-b", "Pending")),
+		"edge-1": fakeDyn(uGuest("default", "vm-a", "Running"), uGuest("default", "vm-b", "Pending")),
 	}}
 	svc := NewGuestService(prov, NewInsecureAuthenticator())
 	resp, err := svc.ListGuests(context.Background(), connect.NewRequest(&kubeswiftv1.ListGuestsRequest{Phase: "Running"}))
@@ -155,26 +155,26 @@ func TestGuestService_ListGuests_PhaseFilter(t *testing.T) {
 
 func TestGuestService_TargetClusters(t *testing.T) {
 	prov := &fakeProvider{clients: map[string]dynamic.Interface{
-		"boba": fakeDyn(), "miles": fakeDyn(), "frida": fakeDyn(),
+		"edge-1": fakeDyn(), "edge-2": fakeDyn(), "edge-3": fakeDyn(),
 	}}
 	svc := NewGuestService(prov, NewInsecureAuthenticator())
 
 	all := svc.targetClusters(nil) // nil selector = whole fleet, sorted
-	if len(all) != 3 || all[0] != "boba" {
+	if len(all) != 3 || all[0] != "edge-1" {
 		t.Errorf("nil selector should return the sorted fleet: %v", all)
 	}
-	sub := svc.targetClusters(&kubeswiftv1.ClusterSelector{Clusters: []string{"miles", "ghost"}})
-	if len(sub) != 1 || sub[0] != "miles" { // unknown 'ghost' dropped
+	sub := svc.targetClusters(&kubeswiftv1.ClusterSelector{Clusters: []string{"edge-2", "ghost"}})
+	if len(sub) != 1 || sub[0] != "edge-2" { // unknown 'ghost' dropped
 		t.Errorf("subset should intersect registered members: %v", sub)
 	}
 }
 
 func TestGuestService_StartStopGuest(t *testing.T) {
-	boba := fakeDyn(uGuest("default", "vm-a", "Running"), uPod("default", "vm-a", "vm-a"))
-	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
-	ref := &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"}
+	edge1 := fakeDyn(uGuest("default", "vm-a", "Running"), uPod("default", "vm-a", "vm-a"))
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": edge1}}, NewInsecureAuthenticator())
+	ref := &kubeswiftv1.ObjectRef{Cluster: "edge-1", Namespace: "default", Name: "vm-a"}
 	podCount := func() int {
-		l, _ := boba.Resource(podGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
+		l, _ := edge1.Resource(podGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
 		return len(l.Items)
 	}
 
@@ -207,51 +207,51 @@ func TestGuestService_StartStopGuest(t *testing.T) {
 }
 
 func TestGuestService_MigrateGuest(t *testing.T) {
-	boba := fakeDyn(uGuest("default", "vm-a", "Running"))
-	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+	edge1 := fakeDyn(uGuest("default", "vm-a", "Running"))
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": edge1}}, NewInsecureAuthenticator())
 
 	resp, err := svc.MigrateGuest(context.Background(), connect.NewRequest(&kubeswiftv1.MigrateGuestRequest{
-		Ref:        &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
-		TargetNode: "miles",
+		Ref:        &kubeswiftv1.ObjectRef{Cluster: "edge-1", Namespace: "default", Name: "vm-a"},
+		TargetNode: "edge-2",
 		Mode:       "offline",
 	}))
 	if err != nil {
 		t.Fatalf("MigrateGuest: %v", err)
 	}
-	if resp.Msg.Migration.GetCluster() != "boba" || resp.Msg.Migration.GetNamespace() != "default" {
+	if resp.Msg.Migration.GetCluster() != "edge-1" || resp.Msg.Migration.GetNamespace() != "default" {
 		t.Errorf("unexpected migration ref: %+v", resp.Msg.Migration)
 	}
 	// A SwiftMigration was actually created in the namespace.
-	migs, _ := boba.Resource(swiftMigrationGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
+	migs, _ := edge1.Resource(swiftMigrationGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
 	if len(migs.Items) != 1 {
 		t.Errorf("want 1 SwiftMigration created, got %d", len(migs.Items))
 	}
 
 	// target_node is required, not silently defaulted.
 	if _, err := svc.MigrateGuest(context.Background(), connect.NewRequest(&kubeswiftv1.MigrateGuestRequest{
-		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "edge-1", Namespace: "default", Name: "vm-a"},
 	})); connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Errorf("missing target_node should be InvalidArgument, got %v", err)
 	}
 }
 
 func TestGuestService_CreateGuest(t *testing.T) {
-	boba := fakeDyn()
-	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+	edge1 := fakeDyn()
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": edge1}}, NewInsecureAuthenticator())
 
 	resp, err := svc.CreateGuest(context.Background(), connect.NewRequest(&kubeswiftv1.CreateGuestRequest{
-		Cluster: "boba", Namespace: "default", Name: "web-1",
+		Cluster: "edge-1", Namespace: "default", Name: "web-1",
 		ImageRef: "ubuntu-noble", GuestClassRef: "small", SeedProfileRef: "default-seed", RunPolicy: "Running",
 		Ports: []*kubeswiftv1.GuestPortSpec{{Name: "ssh", Port: 22, Expose: "ClusterIP"}},
 	}))
 	if err != nil {
 		t.Fatalf("CreateGuest: %v", err)
 	}
-	if resp.Msg.Ref.GetName() != "web-1" || resp.Msg.Ref.GetCluster() != "boba" {
+	if resp.Msg.Ref.GetName() != "web-1" || resp.Msg.Ref.GetCluster() != "edge-1" {
 		t.Errorf("unexpected ref: %+v", resp.Msg.Ref)
 	}
 	// The SwiftGuest exists with the wizard's spec.
-	got, err := boba.Resource(swiftGuestGVR).Namespace("default").Get(context.Background(), "web-1", metav1.GetOptions{})
+	got, err := edge1.Resource(swiftGuestGVR).Namespace("default").Get(context.Background(), "web-1", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("created guest not found: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestGuestService_CreateGuest(t *testing.T) {
 
 	// A name clash fails loudly (no silent overwrite of an existing VM).
 	_, err = svc.CreateGuest(context.Background(), connect.NewRequest(&kubeswiftv1.CreateGuestRequest{
-		Cluster: "boba", Namespace: "default", Name: "web-1", ImageRef: "x", GuestClassRef: "small",
+		Cluster: "edge-1", Namespace: "default", Name: "web-1", ImageRef: "x", GuestClassRef: "small",
 	}))
 	if connect.CodeOf(err) != connect.CodeAlreadyExists {
 		t.Errorf("duplicate name should be AlreadyExists, got %v", err)
@@ -272,18 +272,18 @@ func TestGuestService_CreateGuest(t *testing.T) {
 }
 
 func TestGuestService_DeleteGuest(t *testing.T) {
-	boba := fakeDyn(uGuest("default", "vm-a", "Running"))
-	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+	edge1 := fakeDyn(uGuest("default", "vm-a", "Running"))
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": edge1}}, NewInsecureAuthenticator())
 
 	if _, err := svc.DeleteGuest(context.Background(), connect.NewRequest(&kubeswiftv1.DeleteGuestRequest{})); connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Errorf("missing ref: want InvalidArgument, got %v", err)
 	}
 	if _, err := svc.DeleteGuest(context.Background(), connect.NewRequest(&kubeswiftv1.DeleteGuestRequest{
-		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "edge-1", Namespace: "default", Name: "vm-a"},
 	})); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	list, _ := boba.Resource(swiftGuestGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
+	list, _ := edge1.Resource(swiftGuestGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
 	if len(list.Items) != 0 {
 		t.Errorf("guest should be deleted, got %d", len(list.Items))
 	}
@@ -305,16 +305,16 @@ func uEvent(ns, name, objName, typ, reason, msg, lastTs string) *unstructured.Un
 func TestGuestService_GetGuestEvents(t *testing.T) {
 	guest := uGuest("default", "vm-a", "Pending")
 	ev1 := uEvent("default", "ev1", "vm-a", "Warning", "FailedScheduling", "0/3 nodes available", "2026-01-01T00:00:00Z")
-	ev2 := uEvent("default", "ev2", "vm-a", "Normal", "Scheduled", "assigned to boba", "2026-01-01T00:01:00Z")
+	ev2 := uEvent("default", "ev2", "vm-a", "Normal", "Scheduled", "assigned to edge-1", "2026-01-01T00:01:00Z")
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
 		map[schema.GroupVersionResource]string{
 			swiftGuestGVR: "SwiftGuestList",
 			eventsGVR:     "EventList",
 		}, guest, ev1, ev2)
-	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": dyn}}, NewInsecureAuthenticator())
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": dyn}}, NewInsecureAuthenticator())
 
 	resp, err := svc.GetGuestEvents(context.Background(), connect.NewRequest(&kubeswiftv1.GetGuestEventsRequest{
-		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "edge-1", Namespace: "default", Name: "vm-a"},
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -342,10 +342,10 @@ func TestGuestService_GetGuestDetail_Spec(t *testing.T) {
 			"runPolicy":     "Running",
 		},
 	}}
-	boba := fakeDyn(g)
-	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+	edge1 := fakeDyn(g)
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": edge1}}, NewInsecureAuthenticator())
 	resp, err := svc.GetGuestDetail(context.Background(), connect.NewRequest(&kubeswiftv1.GetGuestDetailRequest{
-		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "edge-1", Namespace: "default", Name: "vm-a"},
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -383,9 +383,9 @@ func TestGuestService_GetGuestDetail_Network(t *testing.T) {
 			},
 		},
 	}}
-	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeDyn(g)}}, NewInsecureAuthenticator())
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": fakeDyn(g)}}, NewInsecureAuthenticator())
 	resp, err := svc.GetGuestDetail(context.Background(), connect.NewRequest(&kubeswiftv1.GetGuestDetailRequest{
-		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "edge-1", Namespace: "default", Name: "vm-a"},
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -417,9 +417,9 @@ func TestGuestService_GetGuestDetail_NoNetwork(t *testing.T) {
 		"metadata": map[string]interface{}{"namespace": "default", "name": "vm-b"},
 		"spec":     map[string]interface{}{"imageRef": map[string]interface{}{"name": "ubuntu"}, "guestClassRef": map[string]interface{}{"name": "small"}},
 	}}
-	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeDyn(g)}}, NewInsecureAuthenticator())
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": fakeDyn(g)}}, NewInsecureAuthenticator())
 	resp, err := svc.GetGuestDetail(context.Background(), connect.NewRequest(&kubeswiftv1.GetGuestDetailRequest{
-		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-b"},
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "edge-1", Namespace: "default", Name: "vm-b"},
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -430,15 +430,15 @@ func TestGuestService_GetGuestDetail_NoNetwork(t *testing.T) {
 }
 
 func TestGuestService_CreateGuest_Validation(t *testing.T) {
-	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeDyn()}}, NewInsecureAuthenticator())
+	svc := NewGuestService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": fakeDyn()}}, NewInsecureAuthenticator())
 	cases := []struct {
 		name string
 		req  *kubeswiftv1.CreateGuestRequest
 	}{
-		{"missing name", &kubeswiftv1.CreateGuestRequest{Cluster: "boba", Namespace: "default", ImageRef: "x", GuestClassRef: "small"}},
-		{"missing class", &kubeswiftv1.CreateGuestRequest{Cluster: "boba", Namespace: "default", Name: "g", ImageRef: "x"}},
-		{"no boot source", &kubeswiftv1.CreateGuestRequest{Cluster: "boba", Namespace: "default", Name: "g", GuestClassRef: "small"}},
-		{"two boot sources", &kubeswiftv1.CreateGuestRequest{Cluster: "boba", Namespace: "default", Name: "g", ImageRef: "x", KernelRef: "y", GuestClassRef: "small"}},
+		{"missing name", &kubeswiftv1.CreateGuestRequest{Cluster: "edge-1", Namespace: "default", ImageRef: "x", GuestClassRef: "small"}},
+		{"missing class", &kubeswiftv1.CreateGuestRequest{Cluster: "edge-1", Namespace: "default", Name: "g", ImageRef: "x"}},
+		{"no boot source", &kubeswiftv1.CreateGuestRequest{Cluster: "edge-1", Namespace: "default", Name: "g", GuestClassRef: "small"}},
+		{"two boot sources", &kubeswiftv1.CreateGuestRequest{Cluster: "edge-1", Namespace: "default", Name: "g", ImageRef: "x", KernelRef: "y", GuestClassRef: "small"}},
 	}
 	for _, tc := range cases {
 		if _, err := svc.CreateGuest(context.Background(), connect.NewRequest(tc.req)); connect.CodeOf(err) != connect.CodeInvalidArgument {

--- a/internal/gateway/mapper_test.go
+++ b/internal/gateway/mapper_test.go
@@ -13,7 +13,7 @@ import (
 func TestClusterToProto(t *testing.T) {
 	now := metav1.NewTime(time.Now())
 	c := &fleetv1alpha1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "boba", Namespace: "kubeswift-system"},
+		ObjectMeta: metav1.ObjectMeta{Name: "edge-1", Namespace: "kubeswift-system"},
 		Spec:       fleetv1alpha1.ClusterSpec{Server: "https://10.0.0.1:6443"},
 		Status: fleetv1alpha1.ClusterStatus{
 			KubernetesVersion: "v1.34.3",
@@ -26,11 +26,11 @@ func TestClusterToProto(t *testing.T) {
 		},
 	}
 	got := clusterToProto(c)
-	if got.Name != "boba" {
+	if got.Name != "edge-1" {
 		t.Errorf("Name = %q", got.Name)
 	}
-	if got.DisplayName != "boba" {
-		t.Errorf("DisplayName fallback = %q, want boba", got.DisplayName)
+	if got.DisplayName != "edge-1" {
+		t.Errorf("DisplayName fallback = %q, want edge-1", got.DisplayName)
 	}
 	if got.Server != "https://10.0.0.1:6443" {
 		t.Errorf("Server = %q", got.Server)
@@ -57,12 +57,12 @@ func TestClusterToProto(t *testing.T) {
 
 func TestClusterToProto_ExplicitDisplayNameAndNoCounts(t *testing.T) {
 	c := &fleetv1alpha1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "boba"},
-		Spec:       fleetv1alpha1.ClusterSpec{DisplayName: "Boba (lab)"},
+		ObjectMeta: metav1.ObjectMeta{Name: "edge-1"},
+		Spec:       fleetv1alpha1.ClusterSpec{DisplayName: "Edge 1 (lab)"},
 	}
 	got := clusterToProto(c)
-	if got.DisplayName != "Boba (lab)" {
-		t.Errorf("DisplayName = %q, want Boba (lab)", got.DisplayName)
+	if got.DisplayName != "Edge 1 (lab)" {
+		t.Errorf("DisplayName = %q, want Edge 1 (lab)", got.DisplayName)
 	}
 	// No status: ready/reachable false, guestCount 0, lastConnected nil.
 	if got.Ready || got.Reachable || got.GuestCount != 0 || got.LastConnected != nil {

--- a/internal/gateway/migration_service_test.go
+++ b/internal/gateway/migration_service_test.go
@@ -25,14 +25,14 @@ func uMigration(ns, name, guest, target, phase string, progress int64) *unstruct
 			"phase":            phase,
 			"transferProgress": progress,
 			"observedDowntime": "1.8s",
-			"sourceNode":       "boba",
+			"sourceNode":       "edge-1",
 		},
 	}}
 }
 
 func TestMigrationService_ListMigrations(t *testing.T) {
-	boba := fakeDyn(uMigration("default", "m1", "vm-a", "miles", "StopAndCopy", 65))
-	svc := NewMigrationService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}}, NewInsecureAuthenticator())
+	edge1 := fakeDyn(uMigration("default", "m1", "vm-a", "edge-2", "StopAndCopy", 65))
+	svc := NewMigrationService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": edge1}}, NewInsecureAuthenticator())
 
 	resp, err := svc.ListMigrations(context.Background(), connect.NewRequest(&kubeswiftv1.ListMigrationsRequest{}))
 	if err != nil {
@@ -42,7 +42,7 @@ func TestMigrationService_ListMigrations(t *testing.T) {
 		t.Fatalf("want 1 migration, got %d", len(resp.Msg.Migrations))
 	}
 	m := resp.Msg.Migrations[0]
-	if m.GetGuest() != "vm-a" || m.GetTargetNode() != "miles" || m.GetSourceNode() != "boba" {
+	if m.GetGuest() != "vm-a" || m.GetTargetNode() != "edge-2" || m.GetSourceNode() != "edge-1" {
 		t.Errorf("node/guest mapping wrong: %+v", m)
 	}
 	if m.GetPhase() != "StopAndCopy" || m.GetMode() != "live" {
@@ -54,7 +54,7 @@ func TestMigrationService_ListMigrations(t *testing.T) {
 	if d := m.GetObservedDowntimeSeconds(); d < 1.7 || d > 1.9 {
 		t.Errorf("observedDowntime = %v, want ~1.8 (parsed from \"1.8s\")", d)
 	}
-	if m.GetRef().GetCluster() != "boba" {
+	if m.GetRef().GetCluster() != "edge-1" {
 		t.Errorf("cluster dimension missing: %+v", m.GetRef())
 	}
 }

--- a/internal/gateway/resource_service_test.go
+++ b/internal/gateway/resource_service_test.go
@@ -73,7 +73,7 @@ func uSecret(ns, name string) *unstructured.Unstructured {
 }
 
 func TestResourceService_ListResourceKinds(t *testing.T) {
-	svc := NewResourceService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeExplorerDyn()}}, NewInsecureAuthenticator())
+	svc := NewResourceService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": fakeExplorerDyn()}}, NewInsecureAuthenticator())
 	resp, err := svc.ListResourceKinds(context.Background(), connect.NewRequest(&kubeswiftv1.ListResourceKindsRequest{}))
 	if err != nil {
 		t.Fatal(err)
@@ -108,10 +108,10 @@ func TestResourceService_ListResourceKinds(t *testing.T) {
 // TestResourceService_SecretRedaction is the load-bearing E4 test: Secret values
 // (base64 or decoded) must never reach the response — only key names + type.
 func TestResourceService_SecretRedaction(t *testing.T) {
-	prov := &fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeExplorerDyn(uSecret("default", "db-creds"))}}
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{"edge-1": fakeExplorerDyn(uSecret("default", "db-creds"))}}
 	svc := NewResourceService(prov, NewInsecureAuthenticator())
 
-	resp, err := svc.ListResources(context.Background(), connect.NewRequest(&kubeswiftv1.ListResourcesRequest{Cluster: "boba", Kind: "secrets"}))
+	resp, err := svc.ListResources(context.Background(), connect.NewRequest(&kubeswiftv1.ListResourcesRequest{Cluster: "edge-1", Kind: "secrets"}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,10 +137,10 @@ func TestResourceService_SecretRedaction(t *testing.T) {
 }
 
 func TestResourceService_NodeProjection(t *testing.T) {
-	prov := &fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeExplorerDyn(mkNode("miles", true))}}
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{"edge-1": fakeExplorerDyn(mkNode("edge-2", true))}}
 	svc := NewResourceService(prov, NewInsecureAuthenticator())
 
-	resp, err := svc.ListResources(context.Background(), connect.NewRequest(&kubeswiftv1.ListResourcesRequest{Cluster: "boba", Kind: "nodes"}))
+	resp, err := svc.ListResources(context.Background(), connect.NewRequest(&kubeswiftv1.ListResourcesRequest{Cluster: "edge-1", Kind: "nodes"}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +148,7 @@ func TestResourceService_NodeProjection(t *testing.T) {
 		t.Fatalf("want 1 node, got %d", len(resp.Msg.Resources))
 	}
 	r := resp.Msg.Resources[0]
-	if r.Ref.Cluster != "boba" || r.Ref.Name != "miles" {
+	if r.Ref.Cluster != "edge-1" || r.Ref.Name != "edge-2" {
 		t.Errorf("ref = %+v", r.Ref)
 	}
 	for k, want := range map[string]string{"status": "Ready", "roles": "control-plane", "version": "v1.34.3", "internalIP": "10.0.0.1"} {
@@ -159,10 +159,10 @@ func TestResourceService_NodeProjection(t *testing.T) {
 }
 
 func TestResourceService_UnknownKindAndCluster(t *testing.T) {
-	svc := NewResourceService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeExplorerDyn()}}, NewInsecureAuthenticator())
+	svc := NewResourceService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": fakeExplorerDyn()}}, NewInsecureAuthenticator())
 
 	// Unknown kind -> hard InvalidArgument (a client bug, not a cluster problem).
-	_, err := svc.ListResources(context.Background(), connect.NewRequest(&kubeswiftv1.ListResourcesRequest{Cluster: "boba", Kind: "frobnicators"}))
+	_, err := svc.ListResources(context.Background(), connect.NewRequest(&kubeswiftv1.ListResourcesRequest{Cluster: "edge-1", Kind: "frobnicators"}))
 	if connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Errorf("unknown kind: want InvalidArgument, got %v", err)
 	}
@@ -184,10 +184,10 @@ func TestResourceService_UnknownKindAndCluster(t *testing.T) {
 // GetResource on a Secret must also redact values (E4) — it returns the FULL
 // object, so without the redaction it would leak what ListResources hides.
 func TestResourceService_GetResource_RedactsSecret(t *testing.T) {
-	prov := &fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeExplorerDyn(uSecret("default", "db-creds"))}}
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{"edge-1": fakeExplorerDyn(uSecret("default", "db-creds"))}}
 	svc := NewResourceService(prov, NewInsecureAuthenticator())
 	resp, err := svc.GetResource(context.Background(), connect.NewRequest(&kubeswiftv1.GetResourceRequest{
-		Cluster: "boba", Kind: "secrets", Namespace: "default", Name: "db-creds",
+		Cluster: "edge-1", Kind: "secrets", Namespace: "default", Name: "db-creds",
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -203,36 +203,36 @@ func TestResourceService_GetResource_RedactsSecret(t *testing.T) {
 }
 
 func TestResourceService_DeleteResource(t *testing.T) {
-	prov := &fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeExplorerDyn(mkNode("miles", true))}}
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{"edge-1": fakeExplorerDyn(mkNode("edge-2", true))}}
 	svc := NewResourceService(prov, NewInsecureAuthenticator())
 
 	// Missing name -> InvalidArgument.
-	_, err := svc.DeleteResource(context.Background(), connect.NewRequest(&kubeswiftv1.DeleteResourceRequest{Cluster: "boba", Kind: "nodes"}))
+	_, err := svc.DeleteResource(context.Background(), connect.NewRequest(&kubeswiftv1.DeleteResourceRequest{Cluster: "edge-1", Kind: "nodes"}))
 	if connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Errorf("missing name: want InvalidArgument, got %v", err)
 	}
 	// Delete then confirm gone.
-	if _, err := svc.DeleteResource(context.Background(), connect.NewRequest(&kubeswiftv1.DeleteResourceRequest{Cluster: "boba", Kind: "nodes", Name: "miles"})); err != nil {
+	if _, err := svc.DeleteResource(context.Background(), connect.NewRequest(&kubeswiftv1.DeleteResourceRequest{Cluster: "edge-1", Kind: "nodes", Name: "edge-2"})); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	list, _ := svc.ListResources(context.Background(), connect.NewRequest(&kubeswiftv1.ListResourcesRequest{Cluster: "boba", Kind: "nodes"}))
+	list, _ := svc.ListResources(context.Background(), connect.NewRequest(&kubeswiftv1.ListResourcesRequest{Cluster: "edge-1", Kind: "nodes"}))
 	if len(list.Msg.Resources) != 0 {
 		t.Errorf("node should be deleted, got %d", len(list.Msg.Resources))
 	}
 }
 
 func TestResourceService_ApplyResource_Validation(t *testing.T) {
-	svc := NewResourceService(&fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeExplorerDyn()}}, NewInsecureAuthenticator())
+	svc := NewResourceService(&fakeProvider{clients: map[string]dynamic.Interface{"edge-1": fakeExplorerDyn()}}, NewInsecureAuthenticator())
 	cases := []struct {
 		name string
 		req  *kubeswiftv1.ApplyResourceRequest
 	}{
 		{"missing cluster", &kubeswiftv1.ApplyResourceRequest{Kind: "nodes", Yaml: "apiVersion: v1\nkind: Node\nmetadata:\n  name: x"}},
-		{"unknown kind", &kubeswiftv1.ApplyResourceRequest{Cluster: "boba", Kind: "frobnicators", Yaml: "x"}},
-		{"empty yaml", &kubeswiftv1.ApplyResourceRequest{Cluster: "boba", Kind: "nodes", Yaml: "   "}},
-		{"non-object yaml", &kubeswiftv1.ApplyResourceRequest{Cluster: "boba", Kind: "nodes", Yaml: "- a\n- b"}},
-		{"no identity", &kubeswiftv1.ApplyResourceRequest{Cluster: "boba", Kind: "nodes", Yaml: "metadata: {}"}},
-		{"namespaced needs ns", &kubeswiftv1.ApplyResourceRequest{Cluster: "boba", Kind: "secrets", Yaml: "apiVersion: v1\nkind: Secret\nmetadata:\n  name: s"}},
+		{"unknown kind", &kubeswiftv1.ApplyResourceRequest{Cluster: "edge-1", Kind: "frobnicators", Yaml: "x"}},
+		{"empty yaml", &kubeswiftv1.ApplyResourceRequest{Cluster: "edge-1", Kind: "nodes", Yaml: "   "}},
+		{"non-object yaml", &kubeswiftv1.ApplyResourceRequest{Cluster: "edge-1", Kind: "nodes", Yaml: "- a\n- b"}},
+		{"no identity", &kubeswiftv1.ApplyResourceRequest{Cluster: "edge-1", Kind: "nodes", Yaml: "metadata: {}"}},
+		{"namespaced needs ns", &kubeswiftv1.ApplyResourceRequest{Cluster: "edge-1", Kind: "secrets", Yaml: "apiVersion: v1\nkind: Secret\nmetadata:\n  name: s"}},
 	}
 	for _, tc := range cases {
 		_, err := svc.ApplyResource(context.Background(), connect.NewRequest(tc.req))
@@ -244,10 +244,10 @@ func TestResourceService_ApplyResource_Validation(t *testing.T) {
 
 // ApplyResource server-side-applies a (cluster-scoped) object as the user.
 func TestResourceService_ApplyResource_Creates(t *testing.T) {
-	prov := &fakeProvider{clients: map[string]dynamic.Interface{"boba": fakeExplorerDyn()}}
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{"edge-1": fakeExplorerDyn()}}
 	svc := NewResourceService(prov, NewInsecureAuthenticator())
 	y := "apiVersion: v1\nkind: Node\nmetadata:\n  name: newnode\n  resourceVersion: \"999\"\n"
-	resp, err := svc.ApplyResource(context.Background(), connect.NewRequest(&kubeswiftv1.ApplyResourceRequest{Cluster: "boba", Kind: "nodes", Yaml: y}))
+	resp, err := svc.ApplyResource(context.Background(), connect.NewRequest(&kubeswiftv1.ApplyResourceRequest{Cluster: "edge-1", Kind: "nodes", Yaml: y}))
 	if err != nil {
 		t.Skipf("fake dynamic client SSA Apply unsupported in this client-go: %v", err)
 	}

--- a/internal/gateway/telemetry_service_test.go
+++ b/internal/gateway/telemetry_service_test.go
@@ -29,15 +29,15 @@ func fakeProm() *httptest.Server {
 func TestTelemetryService_GetGuestMetrics(t *testing.T) {
 	prom := fakeProm()
 	defer prom.Close()
-	boba := fakeDyn(uGuest("default", "vm-a", "Running"), uPod("default", "vm-a", "vm-a"))
+	edge1 := fakeDyn(uGuest("default", "vm-a", "Running"), uPod("default", "vm-a", "vm-a"))
 	prov := &fakeProvider{
-		clients: map[string]dynamic.Interface{"boba": boba},
-		prom:    map[string]string{"boba": prom.URL},
+		clients: map[string]dynamic.Interface{"edge-1": edge1},
+		prom:    map[string]string{"edge-1": prom.URL},
 	}
 	svc := NewTelemetryService(prov, NewInsecureAuthenticator())
 
 	resp, err := svc.GetGuestMetrics(context.Background(), connect.NewRequest(&kubeswiftv1.GetGuestMetricsRequest{
-		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "edge-1", Namespace: "default", Name: "vm-a"},
 	}))
 	if err != nil {
 		t.Fatalf("GetGuestMetrics: %v", err)
@@ -63,18 +63,18 @@ func TestTelemetryService_GetGuestMetrics(t *testing.T) {
 }
 
 func TestTelemetryService_NoEndpoint(t *testing.T) {
-	boba := fakeDyn(uGuest("default", "vm-a", "Running"), uPod("default", "vm-a", "vm-a"))
-	prov := &fakeProvider{clients: map[string]dynamic.Interface{"boba": boba}} // no prom endpoint
+	edge1 := fakeDyn(uGuest("default", "vm-a", "Running"), uPod("default", "vm-a", "vm-a"))
+	prov := &fakeProvider{clients: map[string]dynamic.Interface{"edge-1": edge1}} // no prom endpoint
 	svc := NewTelemetryService(prov, NewInsecureAuthenticator())
 
 	resp, err := svc.GetGuestMetrics(context.Background(), connect.NewRequest(&kubeswiftv1.GetGuestMetricsRequest{
-		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "edge-1", Namespace: "default", Name: "vm-a"},
 	}))
 	if err != nil {
 		t.Fatalf("GetGuestMetrics: %v", err)
 	}
 	// No silent empty chart: an unconfigured endpoint surfaces as a cluster error.
-	if resp.Msg.Error == nil || resp.Msg.Error.Cluster != "boba" {
+	if resp.Msg.Error == nil || resp.Msg.Error.Cluster != "edge-1" {
 		t.Errorf("want a cluster error for the missing endpoint, got %+v", resp.Msg.Error)
 	}
 }
@@ -95,15 +95,15 @@ func TestTelemetryService_GetNodeMetrics_ValidPromQL(t *testing.T) {
 	}))
 	defer prom.Close()
 
-	boba := fakeExplorerDyn(mkNode("boba", true)) // mkNode sets InternalIP 10.0.0.1
+	edge1 := fakeExplorerDyn(mkNode("edge-1", true)) // mkNode sets InternalIP 10.0.0.1
 	prov := &fakeProvider{
-		clients: map[string]dynamic.Interface{"boba": boba},
-		prom:    map[string]string{"boba": prom.URL},
+		clients: map[string]dynamic.Interface{"edge-1": edge1},
+		prom:    map[string]string{"edge-1": prom.URL},
 	}
 	svc := NewTelemetryService(prov, NewInsecureAuthenticator())
 
 	resp, err := svc.GetNodeMetrics(context.Background(), connect.NewRequest(&kubeswiftv1.GetNodeMetricsRequest{
-		Cluster: "boba", Node: "boba",
+		Cluster: "edge-1", Node: "edge-1",
 	}))
 	if err != nil {
 		t.Fatalf("GetNodeMetrics: %v", err)
@@ -136,15 +136,15 @@ func TestTelemetryService_GetNodeMetrics_ValidPromQL(t *testing.T) {
 func TestTelemetryService_StoppedGuestNoPod(t *testing.T) {
 	prom := fakeProm()
 	defer prom.Close()
-	boba := fakeDyn(uGuest("default", "vm-a", "Stopped")) // no launcher pod
+	edge1 := fakeDyn(uGuest("default", "vm-a", "Stopped")) // no launcher pod
 	prov := &fakeProvider{
-		clients: map[string]dynamic.Interface{"boba": boba},
-		prom:    map[string]string{"boba": prom.URL},
+		clients: map[string]dynamic.Interface{"edge-1": edge1},
+		prom:    map[string]string{"edge-1": prom.URL},
 	}
 	svc := NewTelemetryService(prov, NewInsecureAuthenticator())
 
 	resp, err := svc.GetGuestMetrics(context.Background(), connect.NewRequest(&kubeswiftv1.GetGuestMetricsRequest{
-		Ref: &kubeswiftv1.ObjectRef{Cluster: "boba", Namespace: "default", Name: "vm-a"},
+		Ref: &kubeswiftv1.ObjectRef{Cluster: "edge-1", Namespace: "default", Name: "vm-a"},
 	}))
 	if err != nil {
 		t.Fatalf("GetGuestMetrics: %v", err)

--- a/internal/metrics/state_collector_test.go
+++ b/internal/metrics/state_collector_test.go
@@ -43,8 +43,8 @@ func newStateReader(t *testing.T, objs ...client.Object) client.Reader {
 // every phase.
 func TestStateCollector_GuestGauges(t *testing.T) {
 	c := NewStateCollector(newStateReader(t,
-		guest("a", "g1", swiftv1alpha1.SwiftGuestPhaseRunning, "miles", "cloud-hypervisor"),
-		guest("a", "g2", swiftv1alpha1.SwiftGuestPhaseRunning, "boba", "qemu"),
+		guest("a", "g1", swiftv1alpha1.SwiftGuestPhaseRunning, "worker-2", "cloud-hypervisor"),
+		guest("a", "g2", swiftv1alpha1.SwiftGuestPhaseRunning, "worker-1", "qemu"),
 		guest("a", "g3", swiftv1alpha1.SwiftGuestPhaseFailed, "", ""),
 		guest("b", "g4", swiftv1alpha1.SwiftGuestPhasePending, "", ""),
 	))
@@ -68,8 +68,8 @@ kubeswift_guests{namespace="b",phase="Scheduling"} 0
 kubeswift_guests{namespace="b",phase="Stopped"} 0
 # HELP kubeswift_guests_by_node Scheduled SwiftGuests by node and hypervisor
 # TYPE kubeswift_guests_by_node gauge
-kubeswift_guests_by_node{hypervisor="cloud-hypervisor",node="miles"} 1
-kubeswift_guests_by_node{hypervisor="qemu",node="boba"} 1
+kubeswift_guests_by_node{hypervisor="cloud-hypervisor",node="worker-2"} 1
+kubeswift_guests_by_node{hypervisor="qemu",node="worker-1"} 1
 `
 	if err := testutil.CollectAndCompare(c, strings.NewReader(expected),
 		"kubeswift_guests", "kubeswift_guests_by_node", "kubeswift_guest_running_total"); err != nil {
@@ -86,8 +86,8 @@ kubeswift_guests_by_node{hypervisor="qemu",node="boba"} 1
 // cluster reports identical values with NO transitions ever observed.
 func TestStateCollector_SurvivesRestart(t *testing.T) {
 	reader := newStateReader(t,
-		guest("prod", "g1", swiftv1alpha1.SwiftGuestPhaseRunning, "miles", "cloud-hypervisor"),
-		guest("prod", "g2", swiftv1alpha1.SwiftGuestPhaseRunning, "boba", "cloud-hypervisor"),
+		guest("prod", "g1", swiftv1alpha1.SwiftGuestPhaseRunning, "worker-2", "cloud-hypervisor"),
+		guest("prod", "g2", swiftv1alpha1.SwiftGuestPhaseRunning, "worker-1", "cloud-hypervisor"),
 	)
 
 	first := NewStateCollector(reader)
@@ -130,7 +130,7 @@ func TestStateCollector_PoolsImagesMigrationsGPU(t *testing.T) {
 			Status:     migrationv1alpha1.SwiftMigrationStatus{Phase: migrationv1alpha1.SwiftMigrationPhaseCompleted, Mode: migrationv1alpha1.SwiftMigrationModeLive},
 		},
 		&gpuv1alpha1.SwiftGPUNode{
-			ObjectMeta: metav1.ObjectMeta{Name: "boba"},
+			ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
 			Status: gpuv1alpha1.SwiftGPUNodeStatus{
 				GPUCount: 1, FreeGPUs: 1, GPUModel: "GTX 1080", VfioReady: true,
 				LastDiscovery: &lastDiscovery,
@@ -145,14 +145,14 @@ func TestStateCollector_PoolsImagesMigrationsGPU(t *testing.T) {
 	expected := `
 # HELP kubeswift_gpu_node_gpus GPUs per SwiftGPUNode by state (total|free)
 # TYPE kubeswift_gpu_node_gpus gauge
-kubeswift_gpu_node_gpus{node="boba",state="free"} 1
-kubeswift_gpu_node_gpus{node="boba",state="total"} 1
+kubeswift_gpu_node_gpus{node="worker-1",state="free"} 1
+kubeswift_gpu_node_gpus{node="worker-1",state="total"} 1
 # HELP kubeswift_gpu_node_info SwiftGPUNode inventory info (value is always 1)
 # TYPE kubeswift_gpu_node_info gauge
-kubeswift_gpu_node_info{model="GTX 1080",node="boba",vfio_ready="true"} 1
+kubeswift_gpu_node_info{model="GTX 1080",node="worker-1",vfio_ready="true"} 1
 # HELP kubeswift_gpu_node_last_discovery_timestamp_seconds Unix time of the last successful GPU discovery per node
 # TYPE kubeswift_gpu_node_last_discovery_timestamp_seconds gauge
-kubeswift_gpu_node_last_discovery_timestamp_seconds{node="boba"} 1.7e+09
+kubeswift_gpu_node_last_discovery_timestamp_seconds{node="worker-1"} 1.7e+09
 # HELP kubeswift_migrations_active In-flight (non-terminal) SwiftMigrations by mode
 # TYPE kubeswift_migrations_active gauge
 kubeswift_migrations_active{mode="live"} 1
@@ -190,7 +190,7 @@ kubeswift_images{namespace="a",phase="Validating"} 0
 // naming/label conventions.
 func TestStateCollector_Lint(t *testing.T) {
 	c := NewStateCollector(newStateReader(t,
-		guest("a", "g1", swiftv1alpha1.SwiftGuestPhaseRunning, "miles", "cloud-hypervisor"),
+		guest("a", "g1", swiftv1alpha1.SwiftGuestPhaseRunning, "worker-2", "cloud-hypervisor"),
 	))
 	problems, err := testutil.CollectAndLint(c)
 	if err != nil {

--- a/internal/snapshot/clonecommon/clonecommon_test.go
+++ b/internal/snapshot/clonecommon/clonecommon_test.go
@@ -77,11 +77,11 @@ func TestBuildDownloadJob(t *testing.T) {
 	s.Spec.Backend.S3.Insecure = true
 	s.Spec.IncludeMemory = true
 	job := BuildDownloadJob(DownloadJobParams{
-		Snapshot: s, Image: "img", Name: "dl", Namespace: "team-a", Node: "boba",
+		Snapshot: s, Image: "img", Name: "dl", Namespace: "team-a", Node: "worker-1",
 		Component: "snapshot-s3-download", ExtraLabels: map[string]string{"owner": "x"},
 	})
 	pod := job.Spec.Template.Spec
-	if pod.NodeName != "boba" || pod.RestartPolicy != corev1.RestartPolicyOnFailure {
+	if pod.NodeName != "worker-1" || pod.RestartPolicy != corev1.RestartPolicyOnFailure {
 		t.Errorf("node/restart wrong: %q %q", pod.NodeName, pod.RestartPolicy)
 	}
 	if job.Labels["owner"] != "x" || job.Labels["app.kubernetes.io/component"] != "snapshot-s3-download" {

--- a/internal/webhook/eviction/handler_test.go
+++ b/internal/webhook/eviction/handler_test.go
@@ -94,30 +94,30 @@ func TestHandle(t *testing.T) {
 		},
 		{
 			name:        "non-guest pod allows",
-			objects:     []client.Object{plainPod("app", ns, "miles")},
+			objects:     []client.Object{plainPod("app", ns, "worker-2")},
 			req:         evictReq(ns, "app", false),
 			wantAllowed: true,
 		},
 		{
 			name:        "guest pod without SwiftGuest CR allows (orphan)",
-			objects:     []client.Object{guestPod("g-pod", ns, "g", "miles")},
+			objects:     []client.Object{guestPod("g-pod", ns, "g", "worker-2")},
 			req:         evictReq(ns, "g-pod", false),
 			wantAllowed: true,
 		},
 		{
 			name: "migratable default policy denies and marks",
 			objects: []client.Object{
-				guestPod("g-pod", ns, "g", "miles"),
+				guestPod("g-pod", ns, "g", "worker-2"),
 				swiftGuest("g", ns, nil), // nil migration → defaults (enabled, Migrate)
 			},
 			req:         evictReq(ns, "g-pod", false),
 			wantAllowed: false,
-			wantMarked:  "miles",
+			wantMarked:  "worker-2",
 		},
 		{
 			name: "dry-run denies but does not mark",
 			objects: []client.Object{
-				guestPod("g-pod", ns, "g", "miles"),
+				guestPod("g-pod", ns, "g", "worker-2"),
 				swiftGuest("g", ns, nil),
 			},
 			req:         evictReq(ns, "g-pod", true),
@@ -127,7 +127,7 @@ func TestHandle(t *testing.T) {
 		{
 			name: "migration disabled denies without marking",
 			objects: []client.Object{
-				guestPod("g-pod", ns, "g", "miles"),
+				guestPod("g-pod", ns, "g", "worker-2"),
 				swiftGuest("g", ns, &swiftv1alpha1.MigrationSpec{Enabled: boolPtr(false)}),
 			},
 			req:         evictReq(ns, "g-pod", false),
@@ -137,7 +137,7 @@ func TestHandle(t *testing.T) {
 		{
 			name: "drainPolicy Block denies without marking",
 			objects: []client.Object{
-				guestPod("g-pod", ns, "g", "miles"),
+				guestPod("g-pod", ns, "g", "worker-2"),
 				swiftGuest("g", ns, &swiftv1alpha1.MigrationSpec{DrainPolicy: swiftv1alpha1.DrainPolicyBlock}),
 			},
 			req:         evictReq(ns, "g-pod", false),
@@ -147,7 +147,7 @@ func TestHandle(t *testing.T) {
 		{
 			name: "VFIO guest with LiveMigrate denies without marking",
 			objects: []client.Object{
-				guestPod("g-pod", ns, "g", "miles"),
+				guestPod("g-pod", ns, "g", "worker-2"),
 				vfioGuestSpec("g", swiftv1alpha1.DrainPolicyLiveMigrate),
 			},
 			req:         evictReq(ns, "g-pod", false),
@@ -157,17 +157,17 @@ func TestHandle(t *testing.T) {
 		{
 			name: "GPU guest with Migrate marks (offline release-and-reallocate)",
 			objects: []client.Object{
-				guestPod("g-pod", ns, "g", "miles"),
+				guestPod("g-pod", ns, "g", "worker-2"),
 				vfioGuestSpec("g", swiftv1alpha1.DrainPolicyMigrate),
 			},
 			req:         evictReq(ns, "g-pod", false),
 			wantAllowed: false,
-			wantMarked:  "miles",
+			wantMarked:  "worker-2",
 		},
 		{
 			name: "SR-IOV guest with Migrate denies without marking (NIC reattach unsupported)",
 			objects: []client.Object{
-				guestPod("g-pod", ns, "g", "miles"),
+				guestPod("g-pod", ns, "g", "worker-2"),
 				sriovGuest("g", swiftv1alpha1.DrainPolicyMigrate),
 			},
 			req:         evictReq(ns, "g-pod", false),
@@ -177,12 +177,12 @@ func TestHandle(t *testing.T) {
 		{
 			name: "LiveMigrate on non-VFIO guest denies and marks",
 			objects: []client.Object{
-				guestPod("g-pod", ns, "g", "miles"),
+				guestPod("g-pod", ns, "g", "worker-2"),
 				swiftGuest("g", ns, &swiftv1alpha1.MigrationSpec{DrainPolicy: swiftv1alpha1.DrainPolicyLiveMigrate}),
 			},
 			req:         evictReq(ns, "g-pod", false),
 			wantAllowed: false,
-			wantMarked:  "miles",
+			wantMarked:  "worker-2",
 		},
 	}
 
@@ -218,17 +218,17 @@ func TestHandle_MarkerIdempotent(t *testing.T) {
 	const ns = "default"
 	s := scheme.Scheme
 	g := swiftGuest("g", ns, nil)
-	g.Annotations = map[string]string{swiftv1alpha1.AnnotationDrainRequested: "miles"}
+	g.Annotations = map[string]string{swiftv1alpha1.AnnotationDrainRequested: "worker-2"}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(guestPod("g-pod", ns, "g", "miles"), g).Build()
+		WithObjects(guestPod("g-pod", ns, "g", "worker-2"), g).Build()
 	h := &Handler{Client: c}
 
 	resp := h.Handle(context.Background(), evictReq(ns, "g-pod", false))
 	if resp.Allowed {
 		t.Fatalf("already-marked migratable guest must still be denied; got allowed")
 	}
-	if got := markerOf(t, c, ns, "g"); got != "miles" {
-		t.Errorf("marker = %q, want miles (unchanged)", got)
+	if got := markerOf(t, c, ns, "g"); got != "worker-2" {
+		t.Errorf("marker = %q, want worker-2 (unchanged)", got)
 	}
 }
 

--- a/internal/webhook/swiftmigration/validator_test.go
+++ b/internal/webhook/swiftmigration/validator_test.go
@@ -41,7 +41,7 @@ func newSwiftMigration(name, ns string) *migrationv1alpha1.SwiftMigration {
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 		Spec: migrationv1alpha1.SwiftMigrationSpec{
 			GuestRef: migrationv1alpha1.SwiftMigrationGuestRef{Name: "guest"},
-			Target:   migrationv1alpha1.SwiftMigrationTarget{NodeName: "miles"},
+			Target:   migrationv1alpha1.SwiftMigrationTarget{NodeName: "worker-2"},
 			Mode:     migrationv1alpha1.SwiftMigrationModeAuto,
 		},
 	}
@@ -55,7 +55,7 @@ func newSwiftGuest(name, ns string) *swiftv1alpha1.SwiftGuest {
 			GuestClassRef: corev1.LocalObjectReference{Name: "class"},
 		},
 		Status: swiftv1alpha1.SwiftGuestStatus{
-			NodeName: "boba",
+			NodeName: "worker-1",
 		},
 	}
 }
@@ -394,7 +394,7 @@ func TestValidateClusterState_MigrationDisabled(t *testing.T) {
 	guest := newSwiftGuest("guest", "default")
 	disabled := false
 	guest.Spec.Migration = &swiftv1alpha1.MigrationSpec{Enabled: &disabled}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -417,17 +417,17 @@ func TestValidateClusterState_MigrationDisabled(t *testing.T) {
 // offline in auto_mode.go). The primary UDN withholds the migration channel from the pod.
 func TestValidateClusterState_ModelA_LiveRejected(t *testing.T) {
 	scheme := migrationScheme(t)
-	guest := newSwiftGuest("guest", "model-a") // status.NodeName = boba
+	guest := newSwiftGuest("guest", "model-a") // status.NodeName = worker1
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name:   "model-a",
 		Labels: map[string]string{"k8s.ovn.org/primary-user-defined-network": ""},
 	}}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, ns, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, ns, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "model-a")
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
-	mig.Spec.Target.NodeName = "miles"
+	mig.Spec.Target.NodeName = "worker-2"
 	mig.Spec.AllowIPChange = true
 	_, err := v.validate(context.Background(), mig)
 	if err == nil || !strings.Contains(err.Error(), "primary OVN-K UDN") {
@@ -437,12 +437,12 @@ func TestValidateClusterState_ModelA_LiveRejected(t *testing.T) {
 
 func TestValidateClusterState_SameNodeRejected(t *testing.T) {
 	scheme := migrationScheme(t)
-	guest := newSwiftGuest("guest", "default") // status.NodeName = boba
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("boba")).Build()
+	guest := newSwiftGuest("guest", "default") // status.NodeName = worker1
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-1")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
-	mig.Spec.Target.NodeName = "boba"
+	mig.Spec.Target.NodeName = "worker-1"
 	_, err := v.validate(context.Background(), mig)
 	if err == nil {
 		t.Fatal("validate same-node migration should reject")
@@ -450,7 +450,7 @@ func TestValidateClusterState_SameNodeRejected(t *testing.T) {
 	// Operators need to see both the target name and the source name in
 	// the message — names are how they diagnose "wait, that's where it
 	// is already." Lock both in.
-	if !strings.Contains(err.Error(), `"boba"`) {
+	if !strings.Contains(err.Error(), `"worker-1"`) {
 		t.Errorf("error should name the conflicting node; got %q", err.Error())
 	}
 	if !strings.Contains(err.Error(), "same-node migration is meaningless") {
@@ -474,7 +474,7 @@ func TestValidateClusterState_TargetNodeMissing(t *testing.T) {
 func TestValidateClusterState_TargetNodeCordoned(t *testing.T) {
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default")
-	cordoned := newReadyNode("miles")
+	cordoned := newReadyNode("worker-2")
 	cordoned.Spec.Unschedulable = true
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, cordoned).Build()
 	v := &Validator{Client: c}
@@ -490,7 +490,7 @@ func TestValidateClusterState_TargetNodeNotReady(t *testing.T) {
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default")
 	notReady := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "miles"},
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-2"},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
 				{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
@@ -512,7 +512,7 @@ func TestValidateClusterState_KernelBootMissingLabel(t *testing.T) {
 	guest := newSwiftGuest("guest", "default")
 	guest.Spec.ImageRef = nil
 	guest.Spec.KernelRef = &corev1.LocalObjectReference{Name: "kernel-1"}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -530,7 +530,7 @@ func TestValidateClusterState_GPULiveRejected(t *testing.T) {
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default")
 	guest.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu-pcie"}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -554,7 +554,7 @@ func TestValidateClusterState_GPUUnscheduledLiveRejected(t *testing.T) {
 	guest := newSwiftGuest("guest", "default")
 	guest.Status.NodeName = "" // unscheduled
 	guest.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu-pcie"}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -574,7 +574,7 @@ func TestValidateClusterState_SRIOVLiveRejected(t *testing.T) {
 	guest.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
 		{Name: "data", Type: swiftv1alpha1.InterfaceTypeSRIOV, ResourceName: "intel.com/sriov_netdevice"},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -593,7 +593,7 @@ func TestValidateClusterState_VFIOOfflineNotRejected(t *testing.T) {
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default")
 	guest.Spec.GPUProfileRef = &corev1.LocalObjectReference{Name: "gpu-pcie"}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -613,7 +613,7 @@ func TestValidateClusterState_SRIOVOfflineRejected(t *testing.T) {
 	guest.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
 		{Name: "data", Type: swiftv1alpha1.InterfaceTypeSRIOV, ResourceName: "intel.com/sriov_netdevice"},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -627,7 +627,7 @@ func TestValidateClusterState_SRIOVOfflineRejected(t *testing.T) {
 func TestValidateClusterState_DefaultNetworkingNeedsAllowIPChange(t *testing.T) {
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default") // no spec.interfaces, default networking
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default") // allowIPChange=false (default)
@@ -640,7 +640,7 @@ func TestValidateClusterState_DefaultNetworkingNeedsAllowIPChange(t *testing.T) 
 func TestValidateClusterState_DefaultNetworkingWithAllowIPChange(t *testing.T) {
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default")
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -672,7 +672,7 @@ func TestValidateClusterState_MultusInterface_NoIPChangeNeeded(t *testing.T) {
 			},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default") // allowIPChange=false; should still pass
@@ -691,7 +691,7 @@ func TestValidateClusterState_HappyPath(t *testing.T) {
 			NetworkRef: &swiftv1alpha1.NetworkReference{Name: "macvlan", Namespace: "default"},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -717,7 +717,7 @@ func TestValidateClusterState_SourceNotYetScheduled(t *testing.T) {
 	guest.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
 		{Name: "data", NetworkRef: &swiftv1alpha1.NetworkReference{Name: "macvlan", Namespace: "default"}},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -739,7 +739,7 @@ func TestValidateClusterState_MixedInterfaces_DefaultPlusMultus(t *testing.T) {
 		{Name: "mgmt"}, // default node-local bridge = the primary IP
 		{Name: "data", NetworkRef: &swiftv1alpha1.NetworkReference{Name: "macvlan", Namespace: "default"}},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default") // allowIPChange=false
@@ -758,7 +758,7 @@ func TestValidateClusterState_PrimaryOnNAD(t *testing.T) {
 	guest.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
 		{Name: "mgmt", Primary: true, NetworkRef: &swiftv1alpha1.NetworkReference{Name: "ovn-l2", Namespace: "default"}},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default") // allowIPChange=false
@@ -778,12 +778,12 @@ func TestValidateClusterState_PrimaryOnNAD(t *testing.T) {
 // error, not the less-specific "default networking" error.
 func TestValidateClusterState_SameNodeOnDefaultNet_RejectionOrdering(t *testing.T) {
 	scheme := migrationScheme(t)
-	guest := newSwiftGuest("guest", "default") // status.NodeName = boba, default networking
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("boba")).Build()
+	guest := newSwiftGuest("guest", "default") // status.NodeName = worker1, default networking
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-1")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
-	mig.Spec.Target.NodeName = "boba" // same node
+	mig.Spec.Target.NodeName = "worker-1" // same node
 	_, err := v.validate(context.Background(), mig)
 	if err == nil {
 		t.Fatal("validate same-node default-net migration should reject")
@@ -807,7 +807,7 @@ func TestValidateClusterState_SameNodeOnDefaultNet_RejectionOrdering(t *testing.
 func TestValidateClusterState_CrossNamespaceReferenceAsNotFound(t *testing.T) {
 	scheme := migrationScheme(t)
 	otherNsGuest := newSwiftGuest("guest", "other-namespace")
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(otherNsGuest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(otherNsGuest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default") // namespace=default, guest.Name=guest, but guest is in other-namespace
@@ -845,12 +845,12 @@ func TestValidateUpdate_SpecImmutable(t *testing.T) {
 	guest.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
 		{Name: "data", NetworkRef: &swiftv1alpha1.NetworkReference{Name: "macvlan", Namespace: "default"}},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles"), newReadyNode("frida")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2"), newReadyNode("cp-1")).Build()
 	v := &Validator{Client: c}
 
 	old := newSwiftMigration("m", "default")
 	new := newSwiftMigration("m", "default")
-	new.Spec.Target.NodeName = "frida" // changed
+	new.Spec.Target.NodeName = "cp-1" // changed
 	_, err := v.ValidateUpdate(context.Background(), old, new)
 	if err == nil || !strings.Contains(err.Error(), "immutable") {
 		t.Errorf("ValidateUpdate with spec change should reject as immutable; got %v", err)
@@ -863,7 +863,7 @@ func TestValidateUpdate_NoSpecChange(t *testing.T) {
 	guest.Spec.Interfaces = []swiftv1alpha1.GuestInterface{
 		{Name: "data", NetworkRef: &swiftv1alpha1.NetworkReference{Name: "macvlan", Namespace: "default"}},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	old := newSwiftMigration("m", "default")
@@ -932,8 +932,8 @@ func TestValidateUpdate_DeletionTimestamp_NoClusterState(t *testing.T) {
 func TestValidateUpdate_TerminalPhase_NoClusterState(t *testing.T) {
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default")
-	guest.Status.NodeName = "miles" // matches mig.Spec.Target.NodeName
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	guest.Status.NodeName = "worker-2" // matches mig.Spec.Target.NodeName
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	for _, phase := range []migrationv1alpha1.SwiftMigrationPhase{
@@ -1172,7 +1172,7 @@ func TestValidate_ModeLiveDiskBootRejectedByStorageGate(t *testing.T) {
 	scheme := migrationScheme(t)
 	guest := newSwiftGuest("guest", "default")
 	class := &swiftv1alpha1.SwiftGuestClass{ObjectMeta: metav1.ObjectMeta{Name: "class"}}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, class, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, class, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -1201,7 +1201,7 @@ func TestValidate_ModeLiveKernelBootAcceptsAtStorageGate(t *testing.T) {
 	guest.Spec.ImageRef = nil
 	guest.Spec.KernelRef = &corev1.LocalObjectReference{Name: "faas-minimal"}
 	class := &swiftv1alpha1.SwiftGuestClass{ObjectMeta: metav1.ObjectMeta{Name: "class"}}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, class, newReadyKernelNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, class, newReadyKernelNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -1225,19 +1225,19 @@ func TestValidate_ModeLivePerSourceNodeConcurrencyRejected(t *testing.T) {
 	guest2.Spec.ImageRef = nil
 	guest2.Spec.KernelRef = &corev1.LocalObjectReference{Name: "k"}
 	class := &swiftv1alpha1.SwiftGuestClass{ObjectMeta: metav1.ObjectMeta{Name: "class"}}
-	// Existing live migration from sourceNode=boba.
+	// Existing live migration from sourceNode=worker1.
 	existing := newSwiftMigration("existing", "default")
 	existing.Spec.GuestRef.Name = "guest1"
 	existing.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
-	existing.Status.SourceNode = "boba"
+	existing.Status.SourceNode = "worker-1"
 	existing.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseStopAndCopy
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-		guest1, guest2, class, newReadyKernelNode("miles"), existing,
+		guest1, guest2, class, newReadyKernelNode("worker-2"), existing,
 	).Build()
 	v := &Validator{Client: c}
 
-	// New migration also from sourceNode=boba (guest2 lives on boba).
+	// New migration also from sourceNode=worker1 (guest2 lives on worker1).
 	mig := newSwiftMigration("new", "default")
 	mig.Spec.GuestRef.Name = "guest2"
 	mig.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
@@ -1269,11 +1269,11 @@ func TestValidate_ModeLivePerSourceNodeConcurrency_TerminalPeerOk(t *testing.T) 
 	completed := newSwiftMigration("completed", "default")
 	completed.Spec.GuestRef.Name = "guest1"
 	completed.Spec.Mode = migrationv1alpha1.SwiftMigrationModeLive
-	completed.Status.SourceNode = "boba"
+	completed.Status.SourceNode = "worker-1"
 	completed.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseCompleted
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-		guest1, guest2, class, newReadyKernelNode("miles"), completed,
+		guest1, guest2, class, newReadyKernelNode("worker-2"), completed,
 	).Build()
 	v := &Validator{Client: c}
 
@@ -1303,11 +1303,11 @@ func TestValidate_ModeLivePerSourceNodeConcurrency_OfflinePeerOk(t *testing.T) {
 	offline := newSwiftMigration("offline", "default")
 	offline.Spec.GuestRef.Name = "guest1"
 	offline.Spec.Mode = migrationv1alpha1.SwiftMigrationModeOffline
-	offline.Status.SourceNode = "boba"
+	offline.Status.SourceNode = "worker-1"
 	offline.Status.Phase = migrationv1alpha1.SwiftMigrationPhaseStopAndCopy
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-		guest1, guest2, class, newReadyKernelNode("miles"), offline,
+		guest1, guest2, class, newReadyKernelNode("worker-2"), offline,
 	).Build()
 	v := &Validator{Client: c}
 
@@ -1331,7 +1331,7 @@ func TestValidateClusterState_VirtiofsLiveRejected(t *testing.T) {
 	guest.Spec.Filesystems = []swiftv1alpha1.Filesystem{
 		{Name: "data", Source: swiftv1alpha1.FilesystemSource{HostPath: &hp}},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -1348,7 +1348,7 @@ func TestValidateClusterState_VhostUserDeviceLiveRejected(t *testing.T) {
 	guest.Spec.VhostUserDevices = []swiftv1alpha1.VhostUserDevice{
 		{Name: "blk0", Type: swiftv1alpha1.VhostUserDeviceTypeBlk, Socket: "/run/spdk/0"},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -1366,7 +1366,7 @@ func TestValidateClusterState_VhostUserNICLiveRejected(t *testing.T) {
 		{Name: "mgmt"},
 		{Name: "fast0", Type: swiftv1alpha1.InterfaceTypeVhostUser, Socket: "/var/run/vhost/fast0.sock"},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")
@@ -1387,7 +1387,7 @@ func TestValidateClusterState_VirtiofsOfflineNotRejected(t *testing.T) {
 	guest.Spec.Filesystems = []swiftv1alpha1.Filesystem{
 		{Name: "data", Source: swiftv1alpha1.FilesystemSource{HostPath: &hp}},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("miles")).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(guest, newReadyNode("worker-2")).Build()
 	v := &Validator{Client: c}
 
 	mig := newSwiftMigration("m", "default")

--- a/rust/swiftletd/src/kube_client.rs
+++ b/rust/swiftletd/src/kube_client.rs
@@ -5,7 +5,7 @@ use kube::Client;
 
 /// Creates a kube Client. Tries Config::incluster_dns first (https://kubernetes.default.svc),
 /// then Client::try_default as fallback. Some clusters (e.g. external API server at
-/// frida.labk8s.io:6443) have KUBERNETES_SERVICE_HOST set but the cluster IP unreachable
+/// k8s-api.example.com:6443) have KUBERNETES_SERVICE_HOST set but the cluster IP unreachable
 /// from pods; kubernetes.default.svc DNS often resolves and routes correctly.
 pub async fn create_client() -> Result<Client, kube::Error> {
     // Prefer incluster_dns: uses kubernetes.default.svc, more reliable when cluster IP is unreachable

--- a/test/migration/manual/README.md
+++ b/test/migration/manual/README.md
@@ -35,7 +35,7 @@ The demo:
 
 ## Prerequisites
 
-- Two-node cluster with both nodes labelled `kubeswift.io/launcher-node=true` (the smoke-test cluster — miles + boba — is the validated configuration).
+- Two-node cluster with both nodes labelled `kubeswift.io/launcher-node=true` (the smoke-test cluster — worker-2 + worker-1 — is the validated configuration).
 - The same swiftletd image deployed to all nodes. Phase 2 mandates exact-image-tag match across source and destination CH (Decision 3 — `spec.allowVersionSkew` lands in Phase 3).
 - A running SwiftGuest on the SOURCE node with a sentinel marker the operator can verify post-migration. Example:
   ```
@@ -70,7 +70,7 @@ SWIFTGUEST=my-guest NAMESPACE=default ./source.sh
 
 # 2. Destination prep: render the dst pod YAML, apply it, wait for Ready.
 #    Provide the target node hostname (must be different from the src pod's node).
-TARGET_NODE=boba ./destination.sh
+TARGET_NODE=worker-1 ./destination.sh
 
 # 3. End-to-end orchestration: write start-receive on dst, observe listening,
 #    write start-send on src, observe terminal statuses on both.

--- a/tools/manual-demo/phase-3b-pr1/README.md
+++ b/tools/manual-demo/phase-3b-pr1/README.md
@@ -19,7 +19,7 @@ set it for you. Phase 3c+ adds mTLS for production use.
 ## What this demonstrates
 
 End-to-end live migration of a 4Gi RWX+Block Ubuntu Noble guest from
-`miles` to `boba` via Cloud Hypervisor's `vm.send-migration` /
+`worker-2` to `worker-1` via Cloud Hypervisor's `vm.send-migration` /
 `vm.receive-migration` RPCs over the default pod network, with:
 
 - **Pre-dispatch `receive-ready` annotation** emitted by swiftletd on
@@ -47,7 +47,7 @@ The companion walkthrough captured the 8-test matrix.
 
 ## Prerequisites
 
-- 3-node k0s cluster `miles` + `boba` + `frida` (CP) with the
+- 3-node k0s cluster `worker-2` + `worker-1` + `cp-1` (CP) with the
   `longhorn-migratable` StorageClass present
   (`parameters.migratable: "true"`).
 - swiftletd image carrying Phase 3b PR 1 deployed cluster-wide
@@ -82,11 +82,11 @@ mid-flow interrupt requires `cleanup.sh` first to reset state.
 [1/5] namespace phase-3b-pr1-demo created
 [2/5] SwiftImage ubuntu-noble Ready (~90s)
 [3/5] SwiftSeedProfile + SwiftGuestClass applied
-[4/5] SwiftGuest pr1-guest reaches phase=Running on miles (~140s); IP=192.168.99.X
-[5/5] Destination pod pr1-guest-dst created on boba, phase=Running
+[4/5] SwiftGuest pr1-guest reaches phase=Running on worker-2 (~140s); IP=192.168.99.X
+[5/5] Destination pod pr1-guest-dst created on worker-1, phase=Running
 
-source pod:      pr1-guest         (node=miles)
-destination pod: pr1-guest-dst     (node=boba)
+source pod:      pr1-guest         (node=worker-2)
+destination pod: pr1-guest-dst     (node=worker-1)
 guest IP:        192.168.99.X
 ```
 

--- a/tools/manual-demo/phase-3b-pr1/launch-pods.sh
+++ b/tools/manual-demo/phase-3b-pr1/launch-pods.sh
@@ -7,7 +7,7 @@
 # hand-trigger the send action via annotations).
 #
 # Destination: hand-crafted from `kubectl get pod <src> -o yaml`,
-# with metadata reset + nodeName=boba + KUBESWIFT_MIGRATION_ROLE=
+# with metadata reset + nodeName=worker-1 + KUBESWIFT_MIGRATION_ROLE=
 # receiver env added. This mirrors what `newDstPod` does at runtime
 # (Phase 3a dst_pod.go::newDstPod, LBA-1) — we replicate the spec
 # by hand for PR 1's controller-less manual demo, then PR 2 wires
@@ -16,8 +16,8 @@ set -euo pipefail
 
 NS="${NS:-phase-3b-pr1-demo}"
 GUEST_NAME="${GUEST_NAME:-pr1-guest}"
-SRC_NODE="${SRC_NODE:-miles}"
-DST_NODE="${DST_NODE:-boba}"
+SRC_NODE="${SRC_NODE:-worker-2}"
+DST_NODE="${DST_NODE:-worker-1}"
 DST_POD_NAME="${GUEST_NAME}-dst"
 
 step() { printf '\n[%s] %s\n' "$1" "$2"; }


### PR DESCRIPTION
Test fixtures, sample manifests and docs carried the real hostnames of the maintainer's lab machines, plus its API-server domain, as arbitrary string values. In a public repo that is an inventory of private infrastructure that cannot be recalled once indexed — and none of it was load-bearing: every occurrence is an opaque string standing in for "some node" or "some cluster".

## Placeholders

| was | now | why |
|---|---|---|
| node names | `worker-1` / `worker-2` / `cp-1` | plain node roles |
| fleet members | `edge-1` / `edge-2` / `edge-3` | these denote **clusters**, not nodes, in `api/fleet/`, `internal/gateway/`, `config/samples/gateway/` and `docs/ui/` — a blanket "worker" rename would have mislabelled them |
| API-server host | `k8s-api.example.com` | the surrounding text is about *external* API servers, so an example domain is the honest stand-in |

`internal/gateway/cluster_nodes_test.go` already used `worker-1`/`worker-2` for nodes, so this adopts the convention the repo had started rather than inventing one.

## It is a pure rename

```
95 files changed, 800 insertions(+), 800 deletions(-)
```

Symmetric, and every changed line contains one of the renamed tokens — no behaviour, no logic, no schema. `make generate` produces no CRD diff.

## One trap worth recording

Several of these names were Go **identifiers**, not just string values. A blanket textual rename produced:

```go
worker-1 := fakeDyn(...)   // a minus sign in a variable name
```

The repair rewrites identifier positions to `worker1` / `edge1` / `cp1` while leaving **quoted strings hyphenated** — inside a string they are Kubernetes object names and must stay DNS-1123. That distinction is why the fix is quote-aware rather than another global replace.

Caught by the compiler, not by review.

## Verification

Go build / vet / full test suite, `cargo build` / `fmt` / full test suite, `gofmt -s`, and `helm lint` all green. Residual sweep for the old tokens and the lab domain across every tracked file: none.

Note this does not rewrite git history, which still contains the old values — the point is that the working tree and everything published from here on is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
