### PR TITLE
release: v0.13.10

### DIFF
--- a/.github/workflows/verify-release.yaml
+++ b/.github/workflows/verify-release.yaml
@@ -36,7 +36,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to verify (e.g. v0.13.9)'
+        description: 'Release tag to verify (e.g. v0.13.10)'
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,27 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
-## [Unreleased]
+## [v0.13.10] — 2026-08-14
+
+An observability-and-hygiene release. A guest that never gets an IP now says why
+instead of looking healthy forever; per-launcher-pod RBAC covers every launcher
+class; swiftletd moves four majors of kube-rs and sheds 26 crates.
+
+No CRD schema changes, no API changes. One new values key
+(`scopedLauncherRBAC.enabled`, default `false`).
+
+### Upgrade
+
+```bash
+helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.10 \
+  -n kubeswift-system -f <(helm get values kubeswift -n kubeswift-system -o yaml)
+kubectl apply -f charts/kubeswift/crds/    # helm does not upgrade CRDs
+```
+
+The controller ClusterRole gains `roles` and `delete` on `rolebindings` (needed
+by `scopedLauncherRBAC`). `helm upgrade` applies it; a controller image newer
+than its ClusterRole logs the failure and keeps running rather than blocking
+workloads.
 
 ### Fixed
 
@@ -36,6 +56,14 @@ All notable changes to KubeSwift are documented here.
   prohibition. No CRD schema change (conditions are not schema).
 
 ### Changed
+
+- **Lab infrastructure names replaced with placeholders across tests, samples
+  and docs** (#529). Node names are now `worker-1` / `worker-2` / `cp-1`, fleet
+  members `edge-1` / `edge-2` / `edge-3`, and the external-API-server example
+  `k8s-api.example.com`. 95 files, 800 insertions and 800 deletions — a pure
+  rename with no behaviour, logic or schema change. Affects nothing at run time;
+  listed because sample manifests and docs an operator copies from now use the
+  placeholder names.
 
 - **swiftletd: kube-rs 0.92 → 4.2, k8s-openapi 0.22 → 0.28** (#499, #501). Four
   majors of kube-rs, no source changes required: swiftletd only uses the stable

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.9 \
+  --version 0.13.10 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.9
-appVersion: "0.13.9"
+version: 0.13.10
+appVersion: "0.13.10"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/charts/kubeswift/README.md
+++ b/charts/kubeswift/README.md
@@ -197,6 +197,29 @@ on clusters below Kubernetes 1.30, where it does not render — **treat anyone w
 can create a Pod in a KubeSwift workload namespace as a node administrator**. See
 `docs/security-audit.md`.
 
+### Per-launcher-pod RBAC
+
+| Parameter | Description | Default |
+|---|---|---|
+| `scopedLauncherRBAC.enabled` | Retire the shared namespace-wide launcher RoleBinding, leaving each launcher pod with a Role scoped to **only its own pod**. Defence in depth — read below | `false` |
+
+The controller **always** creates the per-pod Role + RoleBinding, for guests,
+migration targets, sandboxes and warm pool slots alike. That alone narrows
+nothing: RBAC is a union, so while the shared binding also exists a launcher
+keeps namespace-wide access. Enabling this deletes that shared binding.
+
+It is **not** what closes the escalation above — the `launcherSAGate` policy is.
+RBAC is additive on a shared ServiceAccount, so scoping cannot stop an attacker
+who obtains the token by naming the SA. What it buys is that a token leaked some
+*other* way (a stolen projected token, a compromised node) is worth one pod
+rather than the whole namespace.
+
+Off by default because turning it on deletes a live grant. A pool converges
+grants for the slots it already has, so enabling it on a running pool does not
+cut off live slots. Cost is two objects per launcher pod, garbage-collected with
+it. If the shared binding cannot be removed the controller logs at ERROR and
+keeps going — it never blocks a workload from booting.
+
 ### Observability
 
 | Parameter | Description | Default |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.9 \
+  --set controllerManager.image.tag=v0.13.10 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.9
+  --set swiftletd.image.tag=v0.13.10
 ```
 
 ### Release workflow

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.9 -n kubeswift-system --create-namespace \
+  --version 0.13.10 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.9 \
+  --version 0.13.10 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.9 \
+  --version 0.13.10 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.9 \
+  --version 0.13.10 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.9 \
+  --set controllerManager.image.tag=v0.13.10 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.9
+  --set swiftletd.image.tag=v0.13.10
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.9 \
+  --version 0.13.10 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.9 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.9 \
-    --set swiftletd.image.tag=v0.13.9
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.10 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.10 \
+    --set swiftletd.image.tag=v0.13.10
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.9 \
+  --version 0.13.10 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.9 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.10 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows


### PR DESCRIPTION
Cuts **v0.13.10**. Chart + appVersion `0.13.10`, full version-reference sweep, CHANGELOG finalised.

## What's in it

| | |
|---|---|
| **#527** | A guest that never gets an IP now says why — `NetworkReady=False` / `DHCPTimeout` instead of `Running` with an empty `primaryIP` forever and only a launcher-log warning. The message names the missing `seedProfileRef` when that's the cause. |
| **#515** | Per-launcher-pod scoped RBAC now covers **every** launcher class — guests, migration targets, sandboxes, warm pool slots — behind `scopedLauncherRBAC.enabled` (default `false`). |
| **#499 / #501** | swiftletd on kube-rs 4.2 + k8s-openapi 0.28 (`v1_34`). Four majors, zero source changes; dropping the never-used `runtime`/`derive` features takes 237 → 211 crates. |
| **#529** | Lab infrastructure names replaced with placeholders across tests, samples and docs. |

No CRD schema changes, no API changes. One new values key.

## Docs

`scopedLauncherRBAC` is new and user-facing, so it gets a chart-README section next to `launcherSAGate` — the two are easy to confuse, and only the latter closes the #443 escalation. The new section says so explicitly.

Version sweep covers README, quickstart, deploy, install/helm-oci, install/remote-cluster, releases, gpu/dra-allocation, operator/troubleshooting, and the `verify-release` workflow input example.

## Upgrade note

The controller ClusterRole gains `roles` and `delete` on `rolebindings` (needed by the RBAC gate). `helm upgrade` applies it. A controller image newer than its ClusterRole logs at ERROR and keeps running rather than blocking workloads — that degradation is deliberate and tested.

## Downstream regression check (done before cutting)

| repo | verdict |
|---|---|
| `cluster-api-provider-kubeswift` | **no regression** — sets `seedProfileRef`, reads no SwiftGuest conditions, no launcher-RBAC coupling |
| `gpucellpool` | **no regression** — sets `seedProfileRef`; its only condition read is an informational "first non-True message" that gates nothing, so it would *benefit* from the new actionable message |
| `kubeswift-ui` | **no regression** — renders conditions generically (`@for (c of conditions())`), no allowlist; the typed `guestRunning`/`egressReady`/`portsProgrammed` proto fields are untouched |

Neither Go repo depends on the kubeswift module, so the additive `ConditionNetworkReady` const cannot break a build.

## Pre-flight

Go build / vet / tests, cargo build / fmt / tests, `gofmt -s`, `helm lint`, `make generate` (no CRD drift) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)