### PR TITLE
docs(images): record Rook Ceph RBD clone-strategy validation

### DIFF
--- a/docs/images/clone-strategies.md
+++ b/docs/images/clone-strategies.md
@@ -92,10 +92,20 @@ The behaviour you observe depends on what your CSI driver does for `VolumeSnapsh
 | CSI driver | Snapshot semantics | Clone semantics | Speedup vs copy |
 |---|---|---|---|
 | **Longhorn (validated)** | Block-level snapshot | Full-copy from snapshot at clone time | ≈3–10× depending on source size |
-| **Rook Ceph RBD** (untested in Phase 0) | RBD snapshot (CoW) | RBD clone (CoW) | Expected: very large (instantaneous clones) |
+| **Rook Ceph RBD** (validated 2026-08-16) | RBD snapshot (CoW) | RBD clone (CoW) | Measured ~1.5x to first boot at a 6 GiB source; the clone PVC itself binds with no data movement. **Filesystem root disks only — see the warning below.** |
 | **AWS EBS** (untested in Phase 0) | EBS snapshot | EBS clone (CoW with hydration) | Expected: large (no full data copy) |
 | **GCE PD** (untested in Phase 0) | PD snapshot | PD clone | Expected: large |
 | **local-path / NFS / hostPath** | Not supported — must use `cloneStrategy: copy` | n/a | n/a |
+
+> **Rook Ceph RBD: `snapshot` is unsafe for a `volumeMode: Block` root disk.**
+> The SwiftImage import PVC holds the disk as a *file inside* an ext4
+> filesystem, so a volume snapshot captures the filesystem, not the disk. Ceph
+> accepts the Filesystem→Block mode change (it honours
+> `allow-volume-mode-change`), the PVC binds with **no error**, and
+> `clone-grow-init`'s `sgdisk -e` then writes a fresh empty GPT over it. The
+> guest reaches `Running` and never boots. Use `cloneStrategy: copy` for any
+> Block root disk — which includes every RWX+Block class used for live
+> migration. Filesystem→Filesystem clones are unaffected and boot normally.
 
 If your driver isn't listed and you validate it, please send a PR adding a row.
 


### PR DESCRIPTION
`docs/images/clone-strategies.md` listed Rook Ceph RBD as *untested in Phase 0*
with "Expected: very large (instantaneous clones)". Validated it on a 3-node
test cluster (Rook v1.19.8 / Ceph v19.2.2, replica-3 RBD pool, KubeSwift
v0.13.10). The expectation holds for Filesystem root disks; the Block path
fails, and fails silently.

## The Block failure

The SwiftImage import PVC stores the disk as a **file inside an ext4
filesystem** (`image.raw`), so a volume-level snapshot captures the filesystem,
not the disk image. Ceph *honours* `allow-volume-mode-change`, so the
Filesystem→Block clone binds with **no error**; `clone-grow-init` then runs
`sgdisk -e`, finds no GPT, and writes a fresh empty one over it.

Result: root disk is a valid GPT with zero partitions, firmware reports
`[Bds] Unable to boot!`, and the guest sits at `Running` with
`StorageReady=True`. Only the `NetworkReady=False/DHCPTimeout` condition
(added in #528) hints that anything is wrong.

Isolated by cloning the same image **Filesystem→Filesystem**, which boots
normally — so the fault is the mode change, not Ceph snapshots.

**Consequence:** `cloneStrategy: snapshot` is unusable for any `volumeMode:
Block` root disk on Ceph RBD, which includes every RWX+Block class used for
live migration. Those must use `cloneStrategy: copy`.

## What else was measured

With a `copy`-strategy image the same RWX+Block class works end to end:
cross-node **live migration completed with 2.81 s downtime**, sentinel md5
byte-identical, `boot_id` unchanged. Filesystem→Filesystem CoW clone reached
first boot ~1.5x faster than `copy` at a 6 GiB source, with the clone PVC
binding with no data movement.

Docs-only change — no code, no CRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)