### PR TITLE
fix(storage): make Ceph RBD usable — clone mode guard + restore disk shape

### DIFF
--- a/docs/images/clone-strategies.md
+++ b/docs/images/clone-strategies.md
@@ -92,10 +92,20 @@ The behaviour you observe depends on what your CSI driver does for `VolumeSnapsh
 | CSI driver | Snapshot semantics | Clone semantics | Speedup vs copy |
 |---|---|---|---|
 | **Longhorn (validated)** | Block-level snapshot | Full-copy from snapshot at clone time | ≈3–10× depending on source size |
-| **Rook Ceph RBD** (untested in Phase 0) | RBD snapshot (CoW) | RBD clone (CoW) | Expected: very large (instantaneous clones) |
+| **Rook Ceph RBD** (validated 2026-08-16) | RBD snapshot (CoW) | RBD clone (CoW) | Measured ~1.5x to first boot at a 6 GiB source; the clone PVC itself binds with no data movement. **Filesystem root disks only — see the warning below.** |
 | **AWS EBS** (untested in Phase 0) | EBS snapshot | EBS clone (CoW with hydration) | Expected: large (no full data copy) |
 | **GCE PD** (untested in Phase 0) | PD snapshot | PD clone | Expected: large |
 | **local-path / NFS / hostPath** | Not supported — must use `cloneStrategy: copy` | n/a | n/a |
+
+> **Rook Ceph RBD: `snapshot` is unsafe for a `volumeMode: Block` root disk.**
+> The SwiftImage import PVC holds the disk as a *file inside* an ext4
+> filesystem, so a volume snapshot captures the filesystem, not the disk. Ceph
+> accepts the Filesystem→Block mode change (it honours
+> `allow-volume-mode-change`), the PVC binds with **no error**, and
+> `clone-grow-init`'s `sgdisk -e` then writes a fresh empty GPT over it. The
+> guest reaches `Running` and never boots. Use `cloneStrategy: copy` for any
+> Block root disk — which includes every RWX+Block class used for live
+> migration. Filesystem→Filesystem clones are unaffected and boot normally.
 
 If your driver isn't listed and you validate it, please send a PR adding a row.
 

--- a/internal/controller/swiftguest/rootdisk.go
+++ b/internal/controller/swiftguest/rootdisk.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/resolved"
@@ -125,9 +126,30 @@ func (r *SwiftGuestReconciler) EnsureRootDiskClone(
 		targetSize = resource.MustParse("40Gi")
 	}
 
-	// Branch: snapshot path requires status.cloneSeed.Kind = VolumeSnapshot.
+	// Branch: snapshot path requires status.cloneSeed.Kind = VolumeSnapshot,
+	// AND that the clone keeps the source volume's volumeMode.
+	//
+	// A CSI VolumeSnapshot clones the SOURCE VOLUME. The SwiftImage import PVC
+	// is Filesystem-mode and holds the disk as a FILE inside it (image.raw), so
+	// restoring that snapshot into a Block root disk yields a block device whose
+	// content is a filesystem, not a disk. clone-grow-init's `sgdisk -e` then
+	// finds no GPT and writes a fresh empty one, and the guest boots nothing.
+	//
+	// Nothing errors along the way: drivers that honour allow-volume-mode-change
+	// (Ceph RBD) bind the PVC happily, so the guest reaches Running with
+	// StorageReady=True and simply never boots. Fall back to the copy path,
+	// which reads image.raw and writes the disk itself and is mode-agnostic.
 	if seed := rg.PreparedImage.CloneSeed; seed != nil && seed.Kind == "VolumeSnapshot" && seed.Name != "" {
-		return r.ensureRootDiskCloneFromSnapshot(ctx, guest, rg, sourcePVC, cloneName, targetSize, seed)
+		mismatch, err := r.cloneSeedModeMismatch(ctx, guest.Namespace, sourcePVC, rg)
+		if err != nil {
+			return nil, err
+		}
+		if mismatch == "" {
+			return r.ensureRootDiskCloneFromSnapshot(ctx, guest, rg, sourcePVC, cloneName, targetSize, seed)
+		}
+		log.FromContext(ctx).Info("clone strategy downgraded from snapshot to copy",
+			"guest", guest.Name, "reason", mismatch,
+			"hint", "a CSI snapshot clone cannot change volumeMode; set cloneStrategy: copy on the SwiftImage to silence this")
 	}
 
 	// Legacy Copy Job path. Behavior preserved byte-for-byte EXCEPT for the
@@ -135,6 +157,44 @@ func (r *SwiftGuestReconciler) EnsureRootDiskClone(
 	// storageClassName) flowing into PVC creation. Defaults preserve the
 	// pre-PR-32 behaviour: RWO + Filesystem + class-of-source-image.
 	return r.ensureRootDiskCloneFromCopy(ctx, guest, rg, sourcePVC, cloneName, targetSize)
+}
+
+// cloneSeedModeMismatch reports why a CSI snapshot clone of sourcePVC cannot
+// serve this guest's root disk, or "" when the snapshot path is safe.
+//
+// The only disqualifier is a volumeMode change: the snapshot carries the source
+// volume's bytes, and a Filesystem volume holds the disk as a file rather than
+// being the disk. Anything else (size, access mode, storage class) the snapshot
+// path already handles.
+//
+// A missing source PVC is NOT treated as a mismatch — that is a separate
+// failure the snapshot path reports with a better message.
+func (r *SwiftGuestReconciler) cloneSeedModeMismatch(
+	ctx context.Context,
+	namespace, sourcePVC string,
+	rg *resolved.ResolvedGuest,
+) (string, error) {
+	var src corev1.PersistentVolumeClaim
+	if err := r.Get(ctx, client.ObjectKey{Name: sourcePVC, Namespace: namespace}, &src); err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("get source PVC %s: %w", sourcePVC, err)
+	}
+	srcMode := corev1.PersistentVolumeFilesystem
+	if src.Spec.VolumeMode != nil {
+		srcMode = *src.Spec.VolumeMode
+	}
+	dstMode := corev1.PersistentVolumeFilesystem
+	if m := resolvedVolumeMode(rg); m != nil {
+		dstMode = *m
+	}
+	if srcMode == dstMode {
+		return "", nil
+	}
+	return fmt.Sprintf("image PVC %s is volumeMode=%s but the root disk is volumeMode=%s; "+
+		"a CSI snapshot clone would reinterpret the source bytes and produce an unbootable disk",
+		sourcePVC, srcMode, dstMode), nil
 }
 
 // ensureRootDiskCloneFromCopy is the legacy copy path. Behaviour is

--- a/internal/controller/swiftguest/rootdisk_modemismatch_test.go
+++ b/internal/controller/swiftguest/rootdisk_modemismatch_test.go
@@ -1,0 +1,95 @@
+package swiftguest
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kubeswift-io/kubeswift/internal/resolved"
+)
+
+// A CSI VolumeSnapshot clones the source VOLUME. The SwiftImage import PVC is
+// Filesystem-mode and holds the disk as a file inside it, so cloning it into a
+// Block root disk yields a block device whose content is a filesystem — an
+// unbootable guest that still reports Running. cloneSeedModeMismatch is the
+// guard that routes those clones to the copy path instead.
+func TestCloneSeedModeMismatch(t *testing.T) {
+	fs := corev1.PersistentVolumeFilesystem
+	blk := corev1.PersistentVolumeBlock
+
+	imagePVC := func(mode *corev1.PersistentVolumeMode) *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "swiftimage-import-x", Namespace: "default"},
+			Spec:       corev1.PersistentVolumeClaimSpec{VolumeMode: mode},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		sourceMode   *corev1.PersistentVolumeMode
+		targetMode   string // resolved storage: "" means Filesystem
+		wantMismatch bool
+	}{
+		// The defect: image PVC is Filesystem, migratable guest class is Block.
+		{"filesystem source into block root disk", &fs, string(blk), true},
+		// The reverse is equally unsound.
+		{"block source into filesystem root disk", &blk, string(fs), true},
+		// Matching modes are exactly what the snapshot path is for — a CoW
+		// clone here must NOT be downgraded, or Ceph/EBS lose their whole point.
+		{"filesystem into filesystem keeps the snapshot path", &fs, string(fs), false},
+		{"block into block keeps the snapshot path", &blk, string(blk), false},
+		// A nil volumeMode means Filesystem on both sides of the comparison.
+		{"nil source and empty target both mean filesystem", nil, "", false},
+		{"nil source (filesystem) into block still mismatches", nil, string(blk), true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(imagePVC(tc.sourceMode)).
+				Build()
+			r := &SwiftGuestReconciler{Client: cl, Scheme: scheme.Scheme}
+
+			rg := &resolved.ResolvedGuest{}
+			rg.Storage.VolumeMode = tc.targetMode
+
+			got, err := r.cloneSeedModeMismatch(context.Background(), "default", "swiftimage-import-x", rg)
+			if err != nil {
+				t.Fatalf("cloneSeedModeMismatch: %v", err)
+			}
+			if tc.wantMismatch && got == "" {
+				t.Fatalf("expected a mismatch (the clone would produce an unbootable disk), got none")
+			}
+			if !tc.wantMismatch && got != "" {
+				t.Fatalf("expected the snapshot path to be kept, got downgrade reason: %s", got)
+			}
+			if tc.wantMismatch && !strings.Contains(got, "unbootable") {
+				t.Errorf("downgrade reason should say why it matters, got: %s", got)
+			}
+		})
+	}
+}
+
+// A missing image PVC is a different failure with a better message downstream;
+// the guard must not swallow it as a "mismatch" and silently downgrade.
+func TestCloneSeedModeMismatch_MissingSourcePVCIsNotAMismatch(t *testing.T) {
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	r := &SwiftGuestReconciler{Client: cl, Scheme: scheme.Scheme}
+
+	rg := &resolved.ResolvedGuest{}
+	rg.Storage.VolumeMode = string(corev1.PersistentVolumeBlock)
+
+	got, err := r.cloneSeedModeMismatch(context.Background(), "default", "does-not-exist", rg)
+	if err != nil {
+		t.Fatalf("a missing source PVC must not be a hard error here: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("a missing source PVC must not report a mode mismatch, got: %s", got)
+	}
+}

--- a/internal/controller/swiftrestore/controller.go
+++ b/internal/controller/swiftrestore/controller.go
@@ -294,14 +294,14 @@ func (r *SwiftRestoreReconciler) handleRestoring(
 		return false, 0, "", err
 	}
 
-	storageClass, err := r.sourceStorageClass(ctx, restore.Namespace, source.Name)
+	shape, err := r.sourceDiskShapeFor(ctx, restore.Namespace, source.Name)
 	if err != nil {
 		return false, 0, "", err
 	}
 
 	// Create the per-guest restore PVC.
 	pvcName := rootPVCName(restore.Spec.TargetGuest.Name)
-	if err := r.ensureRestorePVC(ctx, restore, pvcName, vsName, storageClass, rootDisk.SizeBytes); err != nil {
+	if err := r.ensureRestorePVC(ctx, restore, pvcName, vsName, shape, rootDisk.SizeBytes); err != nil {
 		return false, 0, "", err
 	}
 

--- a/internal/controller/swiftrestore/csi.go
+++ b/internal/controller/swiftrestore/csi.go
@@ -57,7 +57,8 @@ func findRootDisk(status *snapshotv1alpha1.SwiftSnapshotStatus) *snapshotv1alpha
 func (r *SwiftRestoreReconciler) ensureRestorePVC(
 	ctx context.Context,
 	restore *snapshotv1alpha1.SwiftRestore,
-	pvcName, vsName, storageClassName string,
+	pvcName, vsName string,
+	shape sourceDiskShape,
 	sizeBytes int64,
 ) error {
 	var existing corev1.PersistentVolumeClaim
@@ -86,8 +87,11 @@ func (r *SwiftRestoreReconciler) ensureRestorePVC(
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
-			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-			StorageClassName: ptrString(storageClassName),
+			// Reproduce the source disk's shape rather than assuming
+			// RWO+Filesystem — see sourceDiskShape.
+			AccessModes:      shape.AccessModes,
+			VolumeMode:       shape.VolumeMode,
+			StorageClassName: ptrString(shape.StorageClassName),
 			DataSource: &corev1.TypedLocalObjectReference{
 				APIGroup: &apiGroup,
 				Kind:     "VolumeSnapshot",
@@ -157,15 +161,39 @@ func (r *SwiftRestoreReconciler) ensureTargetGuest(
 // sourceStorageClass returns the source per-guest PVC's StorageClassName,
 // or an error if the PVC is missing / has no class set. This determines the
 // class used for the restored PVC.
-func (r *SwiftRestoreReconciler) sourceStorageClass(ctx context.Context, namespace, sourceGuestName string) (string, error) {
+// sourceDiskShape is the storage shape of the disk a snapshot was taken from.
+// The restored disk must reproduce it exactly: a VolumeSnapshot clones the
+// SOURCE VOLUME, so restoring it under a different volumeMode asks the CSI
+// driver to reinterpret the bytes. Drivers that enforce
+// allow-volume-mode-change (Ceph RBD) refuse outright and the PVC never binds;
+// and even where the PVC does bind, the launcher pod builder derives Block or
+// Filesystem from the guest's resolved storage, so a mismatched PVC fails to
+// mount for the lifetime of the guest.
+type sourceDiskShape struct {
+	StorageClassName string
+	AccessModes      []corev1.PersistentVolumeAccessMode
+	VolumeMode       *corev1.PersistentVolumeMode
+}
+
+func (r *SwiftRestoreReconciler) sourceDiskShapeFor(ctx context.Context, namespace, sourceGuestName string) (sourceDiskShape, error) {
 	var pvc corev1.PersistentVolumeClaim
 	if err := r.Get(ctx, client.ObjectKey{Name: rootPVCName(sourceGuestName), Namespace: namespace}, &pvc); err != nil {
-		return "", fmt.Errorf("get source per-guest PVC: %w", err)
+		return sourceDiskShape{}, fmt.Errorf("get source per-guest PVC: %w", err)
 	}
 	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName == "" {
-		return "", fmt.Errorf("source PVC %s has no storage class", pvc.Name)
+		return sourceDiskShape{}, fmt.Errorf("source PVC %s has no storage class", pvc.Name)
 	}
-	return *pvc.Spec.StorageClassName, nil
+	shape := sourceDiskShape{StorageClassName: *pvc.Spec.StorageClassName}
+	if len(pvc.Spec.AccessModes) > 0 {
+		shape.AccessModes = append([]corev1.PersistentVolumeAccessMode(nil), pvc.Spec.AccessModes...)
+	} else {
+		shape.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+	}
+	if pvc.Spec.VolumeMode != nil {
+		mode := *pvc.Spec.VolumeMode
+		shape.VolumeMode = &mode
+	}
+	return shape, nil
 }
 
 func ptrString(s string) *string { return &s }

--- a/internal/controller/swiftrestore/csi_diskshape_test.go
+++ b/internal/controller/swiftrestore/csi_diskshape_test.go
@@ -1,0 +1,107 @@
+package swiftrestore
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+)
+
+func srcRootPVC(name string, modes []corev1.PersistentVolumeAccessMode, vm *corev1.PersistentVolumeMode, sc string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: rootPVCName(name), Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      modes,
+			VolumeMode:       vm,
+			StorageClassName: &sc,
+		},
+	}
+}
+
+// A restore must reproduce the shape of the disk the snapshot was taken from.
+// Provisioning RWO+Filesystem against a Block source asks the CSI driver to
+// reinterpret the bytes: enforcing drivers (Ceph RBD) refuse the mode change so
+// the PVC never binds, and where it does bind the launcher pod builder derives
+// Block from the guest's resolved storage and the mount fails permanently.
+func TestSourceDiskShapePreservesBlockAndRWX(t *testing.T) {
+	blk := corev1.PersistentVolumeBlock
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(srcRootPVC("src", []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}, &blk, "ceph-block")).
+		Build()
+	r := &SwiftRestoreReconciler{Client: cl, Scheme: scheme.Scheme}
+
+	shape, err := r.sourceDiskShapeFor(context.Background(), "default", "src")
+	if err != nil {
+		t.Fatalf("sourceDiskShapeFor: %v", err)
+	}
+	if shape.StorageClassName != "ceph-block" {
+		t.Errorf("storage class = %q, want ceph-block", shape.StorageClassName)
+	}
+	if shape.VolumeMode == nil || *shape.VolumeMode != corev1.PersistentVolumeBlock {
+		t.Errorf("volumeMode = %v, want Block — a Filesystem restore of a Block disk cannot bind on an enforcing driver", shape.VolumeMode)
+	}
+	if len(shape.AccessModes) != 1 || shape.AccessModes[0] != corev1.ReadWriteMany {
+		t.Errorf("accessModes = %v, want [ReadWriteMany] — RWO would silently drop live-migration eligibility", shape.AccessModes)
+	}
+}
+
+// A Filesystem source must stay Filesystem — the fix must not flip everything
+// to Block.
+func TestSourceDiskShapePreservesFilesystemAndRWO(t *testing.T) {
+	fs := corev1.PersistentVolumeFilesystem
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(srcRootPVC("src", []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, &fs, "longhorn")).
+		Build()
+	r := &SwiftRestoreReconciler{Client: cl, Scheme: scheme.Scheme}
+
+	shape, err := r.sourceDiskShapeFor(context.Background(), "default", "src")
+	if err != nil {
+		t.Fatalf("sourceDiskShapeFor: %v", err)
+	}
+	if shape.VolumeMode == nil || *shape.VolumeMode != corev1.PersistentVolumeFilesystem {
+		t.Errorf("volumeMode = %v, want Filesystem", shape.VolumeMode)
+	}
+	if len(shape.AccessModes) != 1 || shape.AccessModes[0] != corev1.ReadWriteOnce {
+		t.Errorf("accessModes = %v, want [ReadWriteOnce]", shape.AccessModes)
+	}
+}
+
+// The shape must land on the PVC the restore actually creates, not just be
+// computed and dropped.
+func TestEnsureRestorePVCAppliesTheSourceShape(t *testing.T) {
+	blk := corev1.PersistentVolumeBlock
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	r := &SwiftRestoreReconciler{Client: cl, Scheme: scheme.Scheme}
+
+	restore := &snapshotv1alpha1.SwiftRestore{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+	}
+	shape := sourceDiskShape{
+		StorageClassName: "ceph-block",
+		AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+		VolumeMode:       &blk,
+	}
+	if err := r.ensureRestorePVC(context.Background(), restore, "swiftguest-root-tgt", "vs1", shape, 6<<30); err != nil {
+		t.Fatalf("ensureRestorePVC: %v", err)
+	}
+
+	var got corev1.PersistentVolumeClaim
+	if err := cl.Get(context.Background(), client.ObjectKey{Name: "swiftguest-root-tgt", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get created PVC: %v", err)
+	}
+	if got.Spec.VolumeMode == nil || *got.Spec.VolumeMode != corev1.PersistentVolumeBlock {
+		t.Errorf("created PVC volumeMode = %v, want Block", got.Spec.VolumeMode)
+	}
+	if len(got.Spec.AccessModes) != 1 || got.Spec.AccessModes[0] != corev1.ReadWriteMany {
+		t.Errorf("created PVC accessModes = %v, want [ReadWriteMany]", got.Spec.AccessModes)
+	}
+	if got.Spec.StorageClassName == nil || *got.Spec.StorageClassName != "ceph-block" {
+		t.Errorf("created PVC storageClass = %v, want ceph-block", got.Spec.StorageClassName)
+	}
+}


### PR DESCRIPTION
Fixes the two defects found validating Rook Ceph RBD (see #531 for the
validation write-up). Both leave a guest broken while reporting nothing wrong.

Neither is Ceph-specific in origin — Ceph *enforces* where Longhorn tolerates,
so it is the driver that exposes them.

## 1. `cloneStrategy: snapshot` silently produced an unbootable Block root disk

A CSI VolumeSnapshot clones the source **volume**. The SwiftImage import PVC is
Filesystem-mode and holds the disk as a *file inside it* (`image.raw`), so
cloning it into a Block root disk yields a block device whose content is a
filesystem, not a disk. `clone-grow-init` then runs `sgdisk -e`, finds no GPT,
and writes a fresh empty one over it.

Nothing errors: drivers honouring `allow-volume-mode-change` bind the PVC
happily, so the guest reached `Running` + `StorageReady=True` and never booted.
Only `NetworkReady=False/DHCPTimeout` (from #528) hinted at it.

`EnsureRootDiskClone` now compares the image PVC's volumeMode against the
resolved root-disk volumeMode and **falls back to the copy path when they
differ**, logging why. Matching modes keep the snapshot path, so CoW clones are
untouched.

This is what made every RWX+Block class — the shape live migration requires —
unusable with a snapshot-strategy image.

## 2. Restore always provisioned RWO+Filesystem regardless of the source

`ensureRestorePVC` hardcoded `ReadWriteOnce` and omitted `VolumeMode`, so
restoring a Block+RWX guest asked the driver to reinterpret the snapshot bytes:

- Ceph refuses the mode change, the PVC never binds, and `SwiftRestore` sits in
  `Restoring` **indefinitely** (60 min of silent retries observed)
- even once bound, the pod builder derives Block from `status.storage`, so the
  mount fails permanently:
  `volume root-disk has volumeMode Filesystem, but is specified in volumeDevices`

The restore now reproduces the source disk's shape (accessMode, volumeMode,
storageClass) — removing the mode change rather than papering over it with the
`allow-volume-mode-change` annotation.

## Tests

Both guards are covered in **both** directions, so a guard that only ever
downgrades — or only ever preserves — fails. Verified by regression injection:
disabling the mode comparison turns 3 subtests red.

Full `go test ./api/... ./internal/... ./cmd/...` green; gofmt clean. No API or
CRD change.

## Not included

The SwiftImage import PVC still has no storage-class field, so importing an
image onto a non-default class requires temporarily flipping the cluster
default. Worth a follow-up (`spec.importStorageClassName`) — it is an API
change and independent of these two fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)