### PR TITLE
ci: move all codeql-action pins to v4.37.7 together, and group them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,22 @@ updates:
     directory: /
     schedule: {interval: weekly}
     open-pull-requests-limit: 5
+    groups:
+      # codeql-action/{init,analyze,upload-sarif} are ONE tool split across three
+      # action paths, and init/analyze refuse to interoperate across versions:
+      #
+      #   Loaded a configuration file for version '4.31.0', but running version '4.37.6'
+      #
+      # Ungrouped, Dependabot opens a PR per sub-action, and each one is red on
+      # its own because it desyncs the trio. That happened twice: #506 (analyze
+      # alone) and #540/#541 (analyze and init, as two PRs that still could not
+      # be combined into a complete set — the third bump never even appeared,
+      # because five other github-actions PRs were open and hit the limit above).
+      #
+      # Grouped, the trio arrives as one mergeable PR and the pins cannot drift.
+      codeql-action:
+        patterns: ["github/codeql-action*"]
+        update-types: [major, minor, patch]
 
   # Base images for the 9 published containers. swiftletd is the one to watch:
   # it carries Cloud Hypervisor and QEMU and runs privileged.

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -114,7 +114,7 @@ jobs:
           test -s "trivy-${{ matrix.image }}.sarif"
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         if: always()
         with:
           sarif_file: trivy-${{ matrix.image }}.sarif

--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -96,12 +96,14 @@ jobs:
       #
       #   Loaded a configuration file for version '4.31.0', but running version '4.37.6'
       #
-      # Dependabot treats each sub-action as its own dependency, so it opens a PR
-      # bumping only the one whose path changed (#506 bumped analyze alone and the
-      # job failed on exactly that error). When a bump lands, check all three SHAs
-      # match before merging.
+      # Dependabot treats each sub-action as its own dependency, so left to
+      # itself it opens a PR bumping only the one whose path changed, and that
+      # PR is red on arrival (#506 bumped analyze alone; #540/#541 then did it
+      # again as two PRs). They are now grouped in .github/dependabot.yml under
+      # `codeql-action`, so the trio arrives as a single PR — keep that group if
+      # you touch these pins, it is what keeps them in step.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           languages: go
           # The DEFAULT query suite, not security-extended. #466 chose this for
@@ -121,7 +123,7 @@ jobs:
         run: go build ./api/... ./internal/... ./cmd/...
 
       - name: Analyze
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           category: codeql-go
 
@@ -160,7 +162,7 @@ jobs:
           test -s gosec.sarif
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         if: always()
         with:
           sarif_file: gosec.sarif


### PR DESCRIPTION
Supersedes #540 and #541.

## Why those two cannot be merged

`codeql-action/{init,analyze,upload-sarif}` are one tool split across three
action paths. `init` writes a config stamped with its own version and `analyze`
refuses to read one written by a different version:

```
Loaded a configuration file for version '4.31.0', but running version '4.37.6'
```

Dependabot treats each sub-action path as its own dependency, so it proposes
them one at a time — and each such PR is red on arrival because it desyncs the
trio. `.github/workflows/sast.yaml` already documented this after #506 bumped
`analyze` alone. #540 and #541 are the same failure again, and merging *both*
would not have fixed it either: no PR existed for `upload-sarif`, because five
other `github-actions` PRs were already open and hit `open-pull-requests-limit`.
The complete set was not assemblable from what Dependabot could offer.

## What this does

- Moves all four `codeql-action` pins to `v4.37.7`
  (`ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd`, verified against the upstream tag).
- Groups `github/codeql-action*` in `.github/dependabot.yml` so future bumps
  arrive as one mergeable PR and the pins cannot drift apart again.
- Updates the load-bearing comment in `sast.yaml` to point at that group.

The fourth pin, `upload-sarif` in `image-scan.yaml`, was a standalone uploader
with no `init` to disagree with — so its skew was silent rather than red, which
is how it sat on `v4.31.0` for ten months. It joins the group here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)