### PR TITLE
docs(gitops): refresh for v0.13.x, add OCI artifacts and the missing example kinds

### DIFF
--- a/docs/gitops/README.md
+++ b/docs/gitops/README.md
@@ -1,9 +1,10 @@
 # GitOps for KubeSwift
 
-- [overview.md](overview.md) — the three-layer model, when to use GitOps with KubeSwift, trade-offs
+- [overview.md](overview.md) — the three-layer model, what does *not* belong in Git, trade-offs
 - [quickstart.md](quickstart.md) — Flux install, bootstrap, and the platform layer
-- [infrastructure.md](infrastructure.md) — Layer 2: classes, images, seeds, GPU profiles
-- [workloads.md](workloads.md) — Layer 3: guests and pools, multi-environment patterns
+- [infrastructure.md](infrastructure.md) — Layer 2: classes, images, kernels, seeds, GPU profiles
+- [workloads.md](workloads.md) — Layer 3: guests, pools, sandbox pools, snapshot schedules
+- [oci-artifacts.md](oci-artifacts.md) — the registry as the artifact store: golden disks, kernels and snapshots alongside the chart
 - [secrets.md](secrets.md) — keeping seed user-data credentials out of Git (SOPS)
 - [troubleshooting.md](troubleshooting.md) — common failure modes
 

--- a/docs/gitops/infrastructure.md
+++ b/docs/gitops/infrastructure.md
@@ -1,9 +1,9 @@
 # Layer 2 — infrastructure resources
 
 `infrastructure/kubeswift/` holds the cluster's shared VM building blocks:
-classes, images, seed profiles, GPU profiles (and NADs if you use multi-NIC /
-multi-node L2). It is shared across environments by default — environment
-differences belong in the workloads layer or in per-cluster patches.
+classes, images, seed profiles, kernels, GPU profiles (and NADs if you use
+multi-NIC / multi-node L2). It is shared across environments by default —
+environment differences belong in the workloads layer or in per-cluster patches.
 
 Working examples: [`examples/gitops-flux/infrastructure/kubeswift/`](../../examples/gitops-flux/infrastructure/kubeswift/).
 
@@ -12,14 +12,67 @@ Working examples: [`examples/gitops-flux/infrastructure/kubeswift/`](../../examp
 - **Imports are slow and asynchronous** (download → qcow2-to-raw → resize).
   Keep `wait: false` on the infra Kustomization so workloads aren't blocked;
   guests referencing a not-yet-Ready image wait in `Pending`.
-- **A Ready SwiftImage's spec is immutable** (webhook-enforced). To roll a new
-  image version, add a NEW SwiftImage (e.g. `ubuntu-noble-2026-06`) and point
-  guests/pools at it — don't edit the URL of a Ready image in Git; the webhook
-  will reject the update and the Kustomization will show it.
-  Metadata-only edits (labels/annotations) on Ready images are fine.
 - **Pruning an image** deletes its prepared PVC (and with
   `cloneStrategy: snapshot`, its clone-seed). Ensure no guest references it;
   guests keep running but cannot be recreated from a pruned image.
+
+### Immutability: three rules, and two of them bite early
+
+A Ready SwiftImage's spec is immutable, webhook-enforced. Two fields are
+stricter than that and freeze **as soon as the import leaves `Pending`**, which
+is the part that surprises people in review: the manifest looked fine, and the
+Kustomization went `Ready=False` anyway.
+
+| Field | Frozen from | Why |
+|---|---|---|
+| whole `spec` | phase `Ready` | the prepared disk already exists |
+| `spec.cloneStrategy` | import started | the clone-seed is built during import |
+| `spec.importStorageClassName` | import started | the import PVC is already bound to a class |
+
+To roll a new image version, add a NEW SwiftImage (e.g.
+`ubuntu-noble-2026-08`) and point guests/pools at it. Do not edit the URL of a
+Ready image in Git; the webhook rejects the update and the Kustomization
+surfaces it. Metadata-only edits (labels/annotations) on Ready images are fine.
+The same applies to the two early-freezing fields: moving an image to another
+storage class means deleting and recreating the SwiftImage, not editing it.
+
+### `importStorageClassName` and clone strategy
+
+`spec.importStorageClassName` (v0.13.11) pins the storage class of the *import*
+PVC. Without it the import lands on the cluster default, which is the wrong
+class on any cluster whose default is not the one you want VM disks on. Set it
+explicitly in Git rather than relying on a cluster-wide default that a different
+team may change underneath you.
+
+`cloneStrategy: snapshot` needs a snapshot-capable CSI driver and a
+VolumeSnapshotClass, and it clones the *source volume*, so the clone only
+produces a usable disk when the volume mode matches. A guest class that resolves
+to Block backed by a Filesystem import cannot be cloned by snapshot; the
+controller detects that mismatch and downgrades that guest to the copy path
+rather than producing an unbootable disk. Nothing fails, so watch for it in the
+controller logs if you expected snapshot-speed provisioning and got copy-speed.
+
+## SwiftKernel: the one that will not re-pull
+
+SwiftKernel is **namespaced**, and pulls its OCI artifact per node onto nodes
+labelled `kubeswift.io/kernel-node=true`.
+
+The GitOps trap: the pull is a Job named `swiftkernel-pull-<name>-<node>`, so
+re-pull is keyed on **(name, node)** and not on the artifact reference. Changing
+`spec.ociRef.image` to a new tag in Git will **not** re-pull on nodes that
+already ran the Job — Flux applies the change, the object updates, and nothing
+downloads. Either give the new kernel a new SwiftKernel name (the clean GitOps
+move, and the same pattern as SwiftImage), or delete the Job on each affected
+node to force it. The Jobs carry no distinguishing labels, so delete them by
+name (they are owned by the SwiftKernel and live in its namespace):
+
+```bash
+kubectl -n <ns> get jobs | grep swiftkernel-pull
+kubectl -n <ns> delete job swiftkernel-pull-<name>-<node>
+```
+
+Prefer the rename. Deleting Jobs is an imperative fix to a declarative problem
+and it will need doing again on the next tag.
 
 ## Classes and GPU profiles
 
@@ -27,3 +80,7 @@ SwiftGuestClass and SwiftGPUProfile are small and safe to manage in Git —
 changes only affect newly created/recreated guests. The example ships a
 `default` class and a `gpu-pcie` class with `coreScheduling: vm` (the
 multi-tenant SMT mitigation) plus a Tier-1 `pcie-single` GPU profile.
+
+SwiftGuestClass is **cluster-scoped**, so it is shared across every namespace a
+fleet repo manages. Two environments in one cluster cannot hold different
+definitions of a class with the same name; give them distinct names instead.

--- a/docs/gitops/infrastructure.md
+++ b/docs/gitops/infrastructure.md
@@ -7,6 +7,10 @@ environment differences belong in the workloads layer or in per-cluster patches.
 
 Working examples: [`examples/gitops-flux/infrastructure/kubeswift/`](../../examples/gitops-flux/infrastructure/kubeswift/).
 
+Images and kernels can both come from an OCI registry rather than a vendor
+URL, which is worth doing under GitOps for the digest-pinning alone. See
+[oci-artifacts.md](oci-artifacts.md).
+
 ## SwiftImage lifecycle nuances under GitOps
 
 - **Imports are slow and asynchronous** (download → qcow2-to-raw → resize).

--- a/docs/gitops/oci-artifacts.md
+++ b/docs/gitops/oci-artifacts.md
@@ -1,0 +1,116 @@
+# The registry as the artifact store
+
+If you are already running Flux, you are already pulling KubeSwift from an OCI
+registry: `oci://ghcr.io/kubeswift-io/charts/kubeswift` is an OCI artifact, and
+the reconciler resolves it, optionally verifies its signature, and applies it.
+
+KubeSwift puts three more artifact types through that same channel. The payoff
+is not novelty, it is that one registry, one credential and one signing key
+cover the platform and everything it runs.
+
+| Artifact | Kind / field | Direction |
+|---|---|---|
+| Helm chart | `OCIRepository` (Flux) | pull |
+| Golden VM disk | `SwiftImage.spec.source.oci` | pull |
+| Kernel + initramfs | `SwiftKernel.spec.ociRef.image` | pull |
+| VM snapshot | `SwiftSnapshot.spec.backend.type: oci` | **push** |
+
+Working manifests for all four:
+[`examples/gitops-flux/`](../../examples/gitops-flux/). Producer-side detail
+lives in [`docs/registry/golden-images.md`](../registry/golden-images.md) and
+[`docs/snapshots/cold-migration.md`](../snapshots/cold-migration.md); this page
+is only about what changes when a reconciler owns the manifests.
+
+## Pin by digest, for the reason you already pin the chart
+
+A tag is mutable. Someone re-pushing `noble-24.04` changes what every future
+guest boots, with no commit in the fleet repository to show for it, and the
+change lands only on the clusters that happen to import after the re-push. Two
+clusters tracking identical Git state diverge, which is the one thing GitOps is
+supposed to make impossible.
+
+```yaml
+spec:
+  source:
+    oci:
+      repository: ghcr.io/example-org/vm-images
+      digest: sha256:...        # not: tag: noble-24.04
+```
+
+`swiftctl image publish` prints the digest. Treat a new disk as a new commit,
+the same way you treat a chart bump.
+
+The same argument applies to a `SwiftSandboxPool.spec.image` and to a sandbox
+`spec.model`: an unpinned tag makes slot churn nondeterministic, because slots
+re-materialize when the resolved digest changes.
+
+## Verify before you trust the bytes
+
+`verifyKeySecretRef` points at a Secret holding a cosign **public** key. The
+import verifies the artifact's signature before the bytes become a root disk,
+and fails closed if it does not verify.
+
+```yaml
+      verifyKeySecretRef:
+        name: vm-image-cosign-pub
+```
+
+A public key is not a secret, so that Secret belongs in Git as-is. The
+*signing* key used by an OCI snapshot export (`signingKeySecretRef`, a cosign
+private key plus password) is genuinely secret and needs SOPS or sealed-secrets
+like any other, see [secrets.md](secrets.md).
+
+Two constraints worth knowing before you plan around it: cosign cannot verify
+over a plaintext registry, so `verifyKeySecretRef` together with `insecure: true`
+is rejected at admission; and `insecure` exists for an in-cluster test registry
+and nothing else.
+
+## Snapshots are the direction that flows outward
+
+Everything else here is a pull. An OCI snapshot backend is a push, and that is
+what makes it useful in a fleet: a CSI snapshot is trapped in the cluster that
+took it, while an OCI artifact is portable. The registry your reconciler already
+pulls the chart from becomes the transport for moving VM state to another
+cluster, to an edge site, or into cold storage, with nothing bespoke in between.
+
+Commit the **schedule**, never the snapshots. A `SwiftSnapshot` is a one-shot
+verb that goes terminal; a `SwiftSnapshotSchedule` is desired state:
+
+```yaml
+spec:
+  schedule: "0 4 * * 0"
+  retention: { keepLast: 4 }
+  template:
+    spec:
+      guestRef: { name: db }
+      backend:
+        type: oci
+        oci: { repository: ghcr.io/example-org/vm-snapshots }
+```
+
+Restoring is a `SwiftRestore` pinned to the pushed digest, which
+`SwiftSnapshot.status.oci` records. It is imperative and one-shot, so it does not
+belong in the workloads directory either.
+
+## Credentials
+
+One `kubernetes.io/dockerconfigjson` Secret per namespace covers images,
+kernels and snapshot pushes, referenced as `credentialsSecretRef`. It must live
+in the same namespace as the resource using it, so a fleet repo spanning
+namespaces needs one per namespace, and each one SOPS-encrypted.
+
+This is the same registry credential your `OCIRepository` uses for the chart,
+which is worth saying out loud: if the reconciler can pull the platform, the
+only thing standing between it and pulling VM disks is that KubeSwift resources
+read a Secret rather than the reconciler's own auth.
+
+## What this does not do
+
+- **No cache.** Every cluster imports independently. A registry near your nodes
+  is the fix, not a KubeSwift feature.
+- **The import is still asynchronous.** OCI skips the download-and-convert of
+  the http path, but materializing the disk still takes minutes, so `wait: false`
+  on the infra Kustomization still applies. See
+  [infrastructure.md](infrastructure.md).
+- **Registry outage is a boot-time failure, not a running-VM failure.** Guests
+  already running are unaffected; new imports and cold sandbox starts are not.

--- a/docs/gitops/overview.md
+++ b/docs/gitops/overview.md
@@ -10,9 +10,9 @@ cluster converged to it.
 
 | Layer | What | Git objects | Changes |
 |---|---|---|---|
-| **1 — Platform** | KubeSwift itself: controllers, webhooks, **CRDs** | `OCIRepository` + `HelmRelease` for `oci://ghcr.io/kubeswift-io/charts/kubeswift` | rarely (version bumps) |
-| **2 — Infrastructure** | SwiftGuestClass, SwiftImage, SwiftSeedProfile, SwiftGPUProfile, NADs | plain manifests under `infrastructure/` | occasionally |
-| **3 — Workloads** | SwiftGuest, SwiftGuestPool | per-environment manifests under `workloads/<env>/` | often |
+| **1 — Platform** | KubeSwift itself: controllers, webhooks, admission policy, **CRDs** | `OCIRepository` + `HelmRelease` for `oci://ghcr.io/kubeswift-io/charts/kubeswift` | rarely (version bumps) |
+| **2 — Infrastructure** | SwiftGuestClass, SwiftImage, SwiftSeedProfile, SwiftKernel, SwiftGPUProfile, NADs | plain manifests under `infrastructure/` | occasionally |
+| **3 — Workloads** | SwiftGuest, SwiftGuestPool, SwiftSandboxPool, SwiftSnapshotSchedule | per-environment manifests under `workloads/<env>/` | often |
 
 Layers are wired with Flux `dependsOn` so apply order is **platform (CRDs) →
 infra → workloads**. Two KubeSwift-specific nuances make this ordering safe and
@@ -23,11 +23,32 @@ fast:
   stale CRD schema doesn't know — the most insidious upgrade failure mode
   KubeSwift has (the "stale-CRD-silent-strip": a new controller writes a new
   status/spec field, the old CRD strips it, and everything looks fine while
-  being subtly broken).
+  being subtly broken). **This is the strongest single argument for driving
+  KubeSwift with GitOps**: `helm upgrade` on the CLI cannot upgrade CRDs at all
+  (Helm treats `crds/` as install-only, with no flag to change it), so every
+  CLI upgrade must be followed by a manual `kubectl apply -f
+  charts/kubeswift/crds/`. Flux's helm-controller applies CRDs itself, so
+  `upgrade.crds: CreateReplace` closes the hole the CLI leaves open.
 - **Image imports are asynchronous.** A SwiftImage takes minutes to download,
   convert, and resize. Set `wait: false` on the infra Kustomization: workloads
   apply immediately and SwiftGuests sit in `Pending` until their image is
   `Ready` — the controller handles the wait gracefully.
+
+## What does NOT belong in Git
+
+Roughly half of KubeSwift's fifteen CRDs are not declarative desired state, and
+committing them causes real problems rather than merely being untidy:
+
+| Kind | Why not | What happens if you do |
+|---|---|---|
+| **SwiftSandbox** | Ephemeral. It runs a workload once and stops at `Completed`/`Failed` | With `spec.ttl` set, the controller deletes it and Flux recreates it on the next reconcile — a sandbox that reruns on a loop instead of once. Without `ttl` it instead sits terminal forever, and since re-running means deleting it, Git can never express "run this again" either way |
+| **SwiftSnapshot**, **SwiftRestore**, **SwiftMigration** | One-shot imperative verbs, terminal once complete | Same recreate loop: a snapshot every reconcile interval, or a migration re-fired after it succeeded |
+| **SwiftGPUNode** | Discovery-owned. `spec` is intentionally empty and `status` is written by the discovery DaemonSet | Nothing useful; you are committing an object whose whole content the cluster owns |
+| **fleet `Cluster`** for the local cluster | The chart self-registers it when `federation.role=hub` and `federation.selfRegister.enabled` | Two managers of one object. Git-manage *remote* fleet members if you like; leave the self-registered local one to the chart |
+
+Schedules are the declarative counterpart of one-shot verbs, and those *do*
+belong in Git: commit a `SwiftSnapshotSchedule` rather than a stream of
+`SwiftSnapshot` objects.
 
 ## When to use it
 
@@ -53,5 +74,15 @@ the audit trail of every VM-fleet change). For a single dev cluster,
   migration controller is a *spec* change on a Git-managed object — keep
   `nodeName` out of Git-managed guest specs (let the scheduler/migration own
   placement), or Flux will fight the migration controller.
+- **Scale subresources and Git are two writers.** `SwiftGuestPool.spec.replicas`
+  and `SwiftSandboxPool.spec.minWarm` both back a `scale` subresource, so
+  `kubectl scale` and any HPA-style autoscaler write the same field Git owns.
+  Pick one: scale from Git, or drop the field from the Git manifest and let the
+  autoscaler own it. Doing both produces a pool that oscillates on the
+  reconcile interval.
+- **Some fields are immutable once a resource starts working.** SwiftImage in
+  particular rejects spec edits after import begins, so a Kustomization can go
+  `Ready=False` on a change that looks harmless in review. See
+  [infrastructure.md](infrastructure.md).
 
 Reference layout + working manifests: [`examples/gitops-flux/`](../../examples/gitops-flux/).

--- a/docs/gitops/quickstart.md
+++ b/docs/gitops/quickstart.md
@@ -27,7 +27,7 @@ metadata: { name: kubeswift, namespace: flux-system }
 spec:
   interval: 10m
   url: oci://ghcr.io/kubeswift-io/charts/kubeswift
-  ref: { semver: ">=0.1.0" }
+  ref: { semver: "0.13.x" }
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -42,15 +42,45 @@ spec:
     webhook: { enabled: true }
 ```
 
-Two load-bearing choices:
+Three load-bearing choices:
 
-- **`crds: CreateReplace` on BOTH install and upgrade.** Helm's default skips
-  CRD upgrades; KubeSwift CRDs evolve with every release, and a stale CRD makes
-  the apiserver silently strip new fields (see [overview.md](overview.md)).
+- **`crds: CreateReplace` on BOTH install and upgrade.** Helm's CLI cannot
+  upgrade CRDs at all; Flux's helm-controller can, and this is what tells it to.
+  KubeSwift CRDs evolve with every release, and a stale CRD makes the apiserver
+  silently strip new fields (see [overview.md](overview.md)).
+- **Pin the chart to a minor range, not `>=0.1.0`.** KubeSwift is pre-1.0 and
+  its APIs are `v1alpha1`: a wide-open range lets Flux roll the platform across
+  a breaking minor unattended. `"0.13.x"` takes patches automatically and makes
+  a minor bump a reviewed commit. Pin exactly (`0.13.11`) if you want even
+  patches gated.
 - **`webhook.enabled: true` needs cert-manager** on the cluster (the chart's
   Certificate/Issuer objects require its CRDs). Without cert-manager, set it
   false — admission validation is then skipped and the controllers' reconcile-
-  time checks are your only guard.
+  time checks are your only guard. Note that
+  `swiftGuest.allowedHostPathPrefixes` is webhook-enforced, so it does nothing
+  with the webhook off.
+
+### Image tags come from the chart version
+
+Every KubeSwift image tag defaults to the chart's `appVersion`, so pinning the
+chart pins the whole platform. You do not need to list image tags in `values`,
+and you should not: hand-pinned tags are how a controller ends up newer than
+the RBAC its chart shipped.
+
+The one exception is the optional web console: **`ui.image.tag` is not
+chart-derived**, because `kubeswift-ui` releases from its own repository on its
+own cadence. A chart bump will not move it. If you enable the UI, raise that tag
+deliberately when you want a newer console.
+
+### Values worth setting explicitly
+
+| Value | Default | Why it matters under GitOps |
+|---|---|---|
+| `launcherSAGate.enabled` | `true` | A ValidatingAdmissionPolicy closing a privilege escalation on launcher ServiceAccounts. Rendered only where the cluster serves `ValidatingAdmissionPolicy` (GA in k8s 1.30+); on older clusters it is **silently skipped** and the namespace becomes your trust boundary. Leave on. |
+| `scopedLauncherRBAC.enabled` | `false` | Retires the shared namespace-wide launcher binding, leaving per-pod grants. Enabling it **deletes a live grant** — a one-way change to make deliberately, not as part of an unrelated values edit. |
+| `swiftGuest.allowedHostPathPrefixes` | `[]` (deny all) | Host paths a SwiftGuest may mount into its privileged launcher. Empty denies everything. Anything you add here is effectively node-root for whoever can author a SwiftGuest. |
+| `monitoring.*` | off | Needs the Prometheus Operator CRDs (`monitoring.coreos.com`) already present. Enabling it before they exist fails the HelmRelease. |
+| `gateway.*`, `ui.*`, `federation.*` | off | Multi-cluster console and fleet federation. `federation.selfRegister` makes the chart create a fleet `Cluster` for this cluster — do not also declare that object in Git. |
 
 ## 3. Layers 2 and 3
 
@@ -64,5 +94,18 @@ pointing at `infrastructure/kubeswift/` and `workloads/<env>/`, chained with
 ```bash
 flux get kustomizations            # all Ready
 kubectl get swiftimages            # imports running/Ready
+kubectl get swiftkernels           # per-node kernel artifacts, if used
 kubectl get swiftguests,swiftguestpools -A
 ```
+
+Confirm the CRDs actually moved with the chart, which is the failure this
+layout exists to prevent:
+
+```bash
+kubectl get crd swiftguests.swift.kubeswift.io \
+  -o jsonpath='{.metadata.annotations.controller-gen\.kubebuilder\.io/version}{"\n"}'
+kubectl explain swiftimage.spec.importStorageClassName   # a v0.13.11 field
+```
+
+If `kubectl explain` cannot find a field your chart version should have, the
+CRDs are stale and every manifest using that field is being silently stripped.

--- a/docs/gitops/troubleshooting.md
+++ b/docs/gitops/troubleshooting.md
@@ -1,13 +1,45 @@
 # GitOps troubleshooting
 
+## Platform and CRDs
+
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `kubeswift-infra` Kustomization fails with `no matches for kind "SwiftGuestClass"` | CRDs not installed yet — `dependsOn` mis-wired or HelmRelease not Ready | `flux get helmreleases`; fix the dependsOn chain (platform → infra → workloads) |
-| New CR field "doesn't work" after a chart upgrade (silently ignored) | **Stale CRD** — HelmRelease upgraded the controllers but not the CRDs | Ensure `upgrade.crds: CreateReplace`; verify with `kubectl explain <kind>.spec.<field>` |
+| New CR field "doesn't work" after a chart upgrade (silently ignored) | **Stale CRD** — the release upgraded the controllers but not the CRDs | Ensure `upgrade.crds: CreateReplace`; verify with `kubectl explain <kind>.spec.<field>` |
+| CR create fails `connection refused ... :9443` | Webhook configurations exist but the controller runs webhook-disabled (cluster-state drift) | align `values.webhook.enabled` with the installed VWC/MWC, or `kubectl delete -k config/webhook` |
+| HelmRelease fails on `monitoring.coreos.com` kinds | `monitoring.*` enabled without the Prometheus Operator CRDs present | install kube-prometheus-stack first, or leave monitoring off |
+| Platform jumped a minor version unattended | `OCIRepository` `ref.semver` is a wide range such as `">=0.1.0"` | pin to a minor range (`"0.13.x"`) or an exact version |
+| Web console is old after a chart upgrade | `ui.image.tag` is not chart-derived; `kubeswift-ui` releases separately | raise `ui.image.tag` deliberately; a chart bump never moves it |
+
+## Admission and RBAC
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Pods in a guest namespace rejected for naming a launcher ServiceAccount | `launcherSAGate` doing its job — only the controller may create launcher pods | expected; do not disable to work around it. Author a SwiftGuest instead of a raw Pod |
+| The gate appears to do nothing on an older cluster | ValidatingAdmissionPolicy is GA in k8s 1.30+; below that the chart **silently skips** it | treat the namespace as the trust boundary, or upgrade the cluster |
+| Launcher lost access right after a values change | `scopedLauncherRBAC.enabled` flipped to `true`, which **deletes** the shared namespace-wide binding | intended and one-way; confirm the per-pod Role/RoleBinding exist for the pod |
+| SwiftGuest rejected for a hostPath it used to be allowed | `swiftGuest.allowedHostPathPrefixes` is empty by default and denies all | add the prefix explicitly, knowing it grants node-root to guest authors; requires `webhook.enabled: true` |
+
+## Images, kernels and disks
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
 | Guests stuck `Pending` for minutes after bootstrap | SwiftImage still importing (normal) | `kubectl get swiftimages` — wait for `Ready`; guests proceed automatically |
 | Infra Kustomization stuck `Ready=False` waiting forever | `wait: true` blocking on async image import | set `wait: false` on the infra Kustomization |
 | Edit to a Ready SwiftImage rejected ("spec is immutable") | Image specs are immutable post-import by design | add a NEW SwiftImage with a new name; repoint guests |
+| Edit to `cloneStrategy` or `importStorageClassName` rejected while the image is still importing | those two freeze as soon as the import leaves `Pending`, earlier than the whole-spec rule | delete and recreate the SwiftImage; you cannot move a started import to another class |
+| A new kernel tag in Git never lands on the nodes | SwiftKernel re-pull is keyed on **(name, node)**, not on `spec.ociRef.image` — the pull Job already exists | give the new kernel a new SwiftKernel name, or delete `swiftkernel-pull-<name>-<node>` per node |
+| Provisioning is copy-speed when `cloneStrategy: snapshot` was requested | volume-mode mismatch between the import PVC and the resolved guest storage; the controller downgrades to copy rather than build an unbootable disk | check controller logs; align the guest class volume mode with the image, or accept the copy path |
+
+## Workloads
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
 | A guest you edited with `kubectl` keeps reverting | That's GitOps drift correction | make the change in Git (or remove the resource from Git management) |
 | Migration "fights" Flux — guest bounces between nodes | `spec.nodeName` pinned in the Git manifest while the migration controller rewrites it | remove `nodeName` from the Git-managed spec |
-| CR create fails `connection refused ... :9443` | Webhook configurations exist but the controller runs webhook-disabled (cluster-state drift) | align `values.webhook.enabled` with the installed VWC/MWC, or `kubectl delete -k config/webhook` |
+| A sandbox runs over and over on the reconcile interval | A `SwiftSandbox` with `spec.ttl` is committed to Git: it reaches a terminal phase, the TTL deletes it, Flux recreates it | do not Git-manage SwiftSandbox. Commit a `SwiftSandboxPool` and create sandboxes imperatively or from a job |
+| A committed sandbox shows `Completed` and never runs again | Expected: a SwiftSandbox runs once. Re-running means deleting it, which Git cannot express | same as above — sandboxes are not desired state |
+| A snapshot or migration re-fires after it succeeded | Same loop, with `SwiftSnapshot` / `SwiftMigration` / `SwiftRestore` | commit a `SwiftSnapshotSchedule` instead; keep one-shot verbs out of Git |
+| Pool replica count flaps every few minutes | Both Git and an autoscaler write the `scale` field (`spec.replicas`, or `spec.minWarm` on a sandbox pool) | pick one owner: scale from Git, or drop the field from the manifest |
+| Warm GPU pool never reaches `minWarm` | Each warm slot holds a whole GPU; `minWarm` exceeds the free GPUs on the cluster | lower `minWarm` to at most the number of free GPUs |
 | Whole fleet deleted after a merge | `prune: true` + manifests removed | restore the manifests in Git (guests recreate; root disks were pruned with the guests) — protect fleets with review rules and `prune: false` for stateful guests |

--- a/docs/gitops/workloads.md
+++ b/docs/gitops/workloads.md
@@ -1,18 +1,37 @@
 # Layer 3 — workloads
 
-`workloads/<env>/` holds the environment's guests and pools. Unlike the infra
-layer, it is **environment-specific by design** — staging and production run
-different fleets at different sizes.
+`workloads/<env>/` holds the environment's guests, pools and schedules. Unlike
+the infra layer, it is **environment-specific by design** — staging and
+production run different fleets at different sizes.
 
 Working examples: [`examples/gitops-flux/workloads/`](../../examples/gitops-flux/workloads/)
 (production: 3-replica `web` pool + a `db` guest; staging: 1-replica pool + a
 test guest).
+
+## What belongs here
+
+| Kind | Notes |
+|---|---|
+| `SwiftGuest` | a long-lived VM |
+| `SwiftGuestPool` | a fleet; `spec.replicas` backs a `scale` subresource |
+| `SwiftSandboxPool` | warm pre-booted sandbox slots; `spec.minWarm` backs a `scale` subresource |
+| `SwiftSnapshotSchedule` | cron snapshots with keep-N retention |
+
+`SwiftSandbox` does **not** belong here, and neither do `SwiftSnapshot`,
+`SwiftRestore` or `SwiftMigration`. They are one-shot and terminal, so Git
+management turns them into a loop — see [overview.md](overview.md).
 
 ## Patterns
 
 - **Scaling is a Git commit**: change `spec.replicas` on the pool. Pool rolling
   updates trigger on template **spec** changes only (the template hash is
   spec-only — metadata edits don't roll the fleet).
+- **Do not let an autoscaler and Git both own a scale field.** Both pool kinds
+  expose `scale`, so `kubectl scale`, an HPA or a KEDA ScaledObject write the
+  same field the manifest declares. Either scale from Git, or omit the field
+  from the manifest and let the autoscaler own it. Both at once gives you a pool
+  that flaps on the reconcile interval, and the Kustomization looks healthy the
+  whole time.
 - **Separate dirs vs overlays**: the reference uses separate per-env dirs
   (simplest, fleets genuinely differ). If your environments converge, use a
   shared base + Kustomize overlays patching `replicas`/`imageRef` per env —
@@ -24,9 +43,50 @@ test guest).
   dedicated Kustomization so a mis-merge can't delete them, and prefer
   `runPolicy: RestartOnFailure`.
 
+## Sandbox pools
+
+A `SwiftSandboxPool` keeps `minWarm` pre-booted slots so a sandbox checkout is
+sub-second instead of a cold boot. It is ordinary declarative state and belongs
+in Git. Two things to know:
+
+- **A warm slot is a Pod, not a SwiftSandbox.** You will not see custom
+  resources for the slots, and you should not try to declare them.
+- **GPU is the slot's shape.** A pool with `spec.gpuProfileRef` pre-boots slots
+  each holding a GPU, so `minWarm` should stay at or below the number of free
+  GPUs — a pool asking for more warm GPU slots than the cluster has will sit
+  partially unfilled. The consuming `SwiftSandbox` sets `poolRef` only and
+  inherits the GPU; it never asks for one itself.
+
+## Snapshot schedules
+
+`SwiftSnapshotSchedule` is the declarative form of backup, and the right thing
+to commit:
+
+```yaml
+apiVersion: snapshot.kubeswift.io/v1alpha1
+kind: SwiftSnapshotSchedule
+metadata: { name: nightly-db }
+spec:
+  schedule: "0 2 * * *"          # 5-field cron, UTC
+  concurrencyPolicy: Forbid      # skip a tick while a prior capture runs
+  retention:
+    keepLast: 7                  # note: under retention, not at spec level
+  template:
+    spec:
+      guestRef: { name: db }
+      backend: { type: csi-volume-snapshot }
+```
+
+More variants in [`config/samples/snapshot-schedule/`](../../config/samples/snapshot-schedule/).
+
+`suspend: true` is the GitOps-friendly way to pause backups: a reviewed commit
+rather than a `kubectl` edit that the next reconcile reverts. Retention is
+enforced by the controller, so the SwiftSnapshot objects it creates and deletes
+must stay out of Git.
+
 ## Day-2 operations that stay imperative
 
-Migration, snapshot/restore, console/SSH, and drain are **not** Git-managed —
-they're operational verbs (`swiftctl migrate/snapshot/console`, `kubectl
-drain`). They don't modify Git-managed specs (except as noted for nodeName),
-so they coexist with Flux cleanly.
+Migration, snapshot/restore, console/SSH, sandbox exec, and drain are **not**
+Git-managed — they're operational verbs (`swiftctl migrate/snapshot/console`,
+`kubectl drain`). They don't modify Git-managed specs (except as noted for
+nodeName), so they coexist with Flux cleanly.

--- a/docs/gitops/workloads.md
+++ b/docs/gitops/workloads.md
@@ -77,7 +77,11 @@ spec:
       backend: { type: csi-volume-snapshot }
 ```
 
-More variants in [`config/samples/snapshot-schedule/`](../../config/samples/snapshot-schedule/).
+More variants in [`config/samples/snapshot-schedule/`](../../config/samples/snapshot-schedule/),
+and a second schedule exporting to an OCI registry in
+[`examples/gitops-flux/workloads/production/db-snapshot-schedules.yaml`](../../examples/gitops-flux/workloads/production/db-snapshot-schedules.yaml).
+An OCI export is the portable one: a CSI snapshot is trapped in the cluster
+that took it. See [oci-artifacts.md](oci-artifacts.md).
 
 `suspend: true` is the GitOps-friendly way to pause backups: a reviewed commit
 rather than a `kubectl` edit that the next reconcile reverts. Retention is

--- a/examples/gitops-flux/README.md
+++ b/examples/gitops-flux/README.md
@@ -9,9 +9,15 @@ clusters/<env>/          # per-cluster Flux entry points
   kubeswift-platform.yaml   # Layer 1: OCIRepository + HelmRelease (chart + CRDs)
   kubeswift-infra.yaml      # Layer 2: Kustomization -> infrastructure/kubeswift
   kubeswift-workloads.yaml  # Layer 3: Kustomization -> workloads/<env>
-infrastructure/kubeswift/   # shared classes, images, seeds, GPU profiles
-workloads/<env>/            # environment-specific guests + pools
+infrastructure/kubeswift/   # shared classes, images, kernels, seeds, GPU profiles
+  images/                     #   http (vendor cloud image) AND oci (golden disk)
+  kernels/                    #   kernel + initramfs from an OCI artifact
+workloads/<env>/            # environment-specific guests, pools, schedules
 ```
+
+Four artifact types come out of one OCI registry here: the chart (via Flux's
+`OCIRepository`), a golden VM disk, a kernel, and VM snapshots pushed back out
+by a schedule. See [`docs/gitops/oci-artifacts.md`](../../docs/gitops/oci-artifacts.md).
 
 Apply order is enforced with `dependsOn`: **platform (CRDs) → infra →
 workloads**. Image imports are async — `wait: false` on the infra

--- a/examples/gitops-flux/clusters/production/kubeswift-platform.yaml
+++ b/examples/gitops-flux/clusters/production/kubeswift-platform.yaml
@@ -10,7 +10,11 @@ spec:
   interval: 10m
   url: oci://ghcr.io/kubeswift-io/charts/kubeswift
   ref:
-    semver: ">=0.1.0"
+    # Pin to a MINOR range, not ">=0.1.0". KubeSwift is pre-1.0 with v1alpha1
+    # APIs, so a wide-open range lets Flux roll the platform across a breaking
+    # minor unattended. "0.13.x" takes patches automatically and makes a minor
+    # bump a reviewed commit; pin exactly (0.13.11) to gate patches too.
+    semver: "0.13.x"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/examples/gitops-flux/clusters/staging/kubeswift-platform.yaml
+++ b/examples/gitops-flux/clusters/staging/kubeswift-platform.yaml
@@ -10,7 +10,11 @@ spec:
   interval: 10m
   url: oci://ghcr.io/kubeswift-io/charts/kubeswift
   ref:
-    semver: ">=0.1.0"
+    # Pin to a MINOR range, not ">=0.1.0". KubeSwift is pre-1.0 with v1alpha1
+    # APIs, so a wide-open range lets Flux roll the platform across a breaking
+    # minor unattended. "0.13.x" takes patches automatically and makes a minor
+    # bump a reviewed commit; pin exactly (0.13.11) to gate patches too.
+    semver: "0.13.x"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/examples/gitops-flux/infrastructure/kubeswift/images/golden-noble-oci.yaml
+++ b/examples/gitops-flux/infrastructure/kubeswift/images/golden-noble-oci.yaml
@@ -1,0 +1,90 @@
+# Golden VM disk pulled from an OCI registry.
+#
+# This is the same distribution channel Flux already uses for the KubeSwift
+# chart, pointed at a different artifact type. One registry, one credential,
+# one signing key, for the platform and the VM disks both.
+#
+# Why prefer this over the http source (see ubuntu-noble.yaml): that one
+# downloads a vendor cloud image and converts it on every cluster. This pulls a
+# disk you built once, already qcow2-to-raw converted, already carrying your
+# agent/CA/hardening, and it is content-addressable and signable.
+#
+# PRODUCER SIDE, once, from a workstation. No cluster involved:
+#
+#   swiftctl image publish noble-hardened.raw \
+#     --to ghcr.io/example-org/vm-images \
+#     --tag noble-24.04 \
+#     --sign-key cosign.key
+#
+# It prints the manifest digest. Put THAT below, not the tag: see the comment
+# on `digest`.
+apiVersion: image.kubeswift.io/v1alpha1
+kind: SwiftImage
+metadata:
+  name: golden-noble
+spec:
+  source:
+    oci:
+      repository: ghcr.io/example-org/vm-images
+
+      # Replace both of these when you fork this repo.
+      #
+      # A TAG IS MUTABLE, which is the same reason you pin the chart in
+      # clusters/<env>/kubeswift-platform.yaml. Someone re-pushing
+      # `noble-24.04` changes what every future guest boots, with no commit in
+      # this repository to show for it, and the change lands only on clusters
+      # that happen to import after the re-push. A digest cannot do that: the
+      # bytes are the name.
+      #
+      # Pin by digest in production and treat a new disk as a new commit:
+      #   digest: sha256:<the digest swiftctl printed>
+      tag: noble-24.04
+
+      # cosign verify BEFORE the bytes are trusted. The import fails closed if
+      # the signature does not verify, so an unsigned or tampered golden disk
+      # never becomes a root disk. Mirrors Flux's own OCIRepository
+      # `spec.verify` — same discipline, same registry, one layer down.
+      #
+      # The Secret holds the PUBLIC key under the key "cosign.pub", and belongs
+      # in Git (a public key is not a secret). Create it with:
+      #   kubectl create secret generic vm-image-cosign-pub \
+      #     --from-file=cosign.pub=cosign.pub
+      verifyKeySecretRef:
+        name: vm-image-cosign-pub
+
+      # Private registry auth. kubernetes.io/dockerconfigjson, same namespace.
+      # This one IS a secret: SOPS-encrypt it, see docs/gitops/secrets.md.
+      # credentialsSecretRef:
+      #   name: regcreds
+
+  # Set explicitly, even though the defaulting webhook would fill in "raw".
+  # A manifest that relies on that default applies cleanly on a webhook-enabled
+  # cluster and is REJECTED by the apiserver on one where webhook.enabled is
+  # false, because format is a required field in the CRD schema. Git-managed
+  # manifests get applied to whichever cluster the reconciler points at, so
+  # spell out anything a webhook would otherwise supply.
+  #
+  # raw is what `swiftctl image publish` produces; qcow2 is for vendor cloud
+  # images fetched over http, which KubeSwift converts on import.
+  format: raw
+
+  # Pin the storage class of the IMPORT PVC rather than inheriting the cluster
+  # default, which is a different class on every cluster this repo targets and
+  # can be changed by someone else entirely. Immutable once the import starts.
+  importStorageClassName: standard
+
+  # Snapshot cloning gives per-guest root disks in seconds instead of a copy
+  # Job. Immutable once the import starts, like importStorageClassName.
+  #
+  # The webhook requires volumeSnapshotClassName whenever cloneStrategy is
+  # snapshot, and rejects the object without it rather than silently falling
+  # back — so both of these names have to be real on every cluster this repo
+  # targets. They are cluster-specific in a layer that is otherwise shared, so
+  # if your environments run different CSI drivers, patch these two per cluster
+  # rather than editing them here. On a driver with no snapshot support, drop
+  # both lines and take the copy path.
+  cloneStrategy: snapshot
+  volumeSnapshotClassName: csi-snapclass
+
+  rootDisk:
+    size: 40Gi

--- a/examples/gitops-flux/infrastructure/kubeswift/kernels/sandbox.yaml
+++ b/examples/gitops-flux/infrastructure/kubeswift/kernels/sandbox.yaml
@@ -1,0 +1,32 @@
+# The sandbox kernel, pulled per node from an OCI artifact.
+#
+# Third artifact type out of the same registry: the chart (Flux), the golden VM
+# disk (golden-noble-oci.yaml), and now a kernel + initramfs. Required by the
+# SwiftSandboxPool in workloads/<env>/.
+#
+# Nodes opt in with the label `kubeswift.io/kernel-node=true`. The controller
+# runs one pull Job per labelled node and reports per-node status; nodes without
+# the label are skipped entirely.
+#
+# THE ONE THING THAT WILL CATCH YOU OUT UNDER GITOPS
+#
+# The pull Job is named `swiftkernel-pull-<name>-<node>`, so re-pull is keyed on
+# (name, node) and NOT on spec.ociRef.image. Editing the tag below to
+# `sandbox:6.6.14` and committing will update this object and download nothing:
+# the Job already exists on every node, so the reconciler reports success while
+# the kernel on disk stays exactly as it was.
+#
+# Roll a kernel the way you roll a golden image: add a NEW SwiftKernel under a
+# new name and repoint the pools at it. Deleting the Jobs by hand also works and
+# is the wrong habit, because it needs doing again on the next tag.
+apiVersion: kernel.kubeswift.io/v1alpha1
+kind: SwiftKernel
+metadata:
+  name: sandbox
+spec:
+  ociRef:
+    # Digest-pinnable like any OCI reference, and worth doing for the same
+    # reason as the golden disk. Kept as a tag here because this artifact is
+    # published by the KubeSwift project rather than by you.
+    image: ghcr.io/kubeswift-io/kubeswift/kernels/sandbox:6.6.13
+  profile: sandbox

--- a/examples/gitops-flux/infrastructure/kubeswift/kustomization.yaml
+++ b/examples/gitops-flux/infrastructure/kubeswift/kustomization.yaml
@@ -6,5 +6,7 @@ resources:
   - classes/gpu-pcie.yaml
   - images/ubuntu-noble.yaml
   - images/rocky9.yaml
+  - images/golden-noble-oci.yaml
+  - kernels/sandbox.yaml
   - seeds/default.yaml
   - gpu/pcie-single.yaml

--- a/examples/gitops-flux/workloads/production/ci-sandbox-pool.yaml
+++ b/examples/gitops-flux/workloads/production/ci-sandbox-pool.yaml
@@ -1,0 +1,39 @@
+# A warm pool of pre-booted microVMs for CI jobs.
+#
+# The pool is desired state and belongs in Git. The sandboxes that check out of
+# it are NOT: a SwiftSandbox runs its workload once and goes terminal, so your
+# CI system creates those imperatively (or from a Job) and they never appear in
+# this repository. See docs/gitops/overview.md.
+#
+# What this buys: a checkout from a warm slot starts in sub-second time instead
+# of paying the cold materialize-and-boot, which is roughly fifteen seconds. A
+# slot is a Pod, not a custom resource, so do not look for one per slot.
+#
+# Requires the `sandbox` SwiftKernel from the infrastructure layer and at least
+# one node labelled kubeswift.io/kernel-node=true.
+apiVersion: sandbox.kubeswift.io/v1alpha1
+kind: SwiftSandboxPool
+metadata:
+  name: ci-runners
+spec:
+  # Digest-pin the runner image for the same reason the golden disk is pinned:
+  # a mutable tag changes what every future job runs, with no commit here to
+  # show for it. Slots also re-materialize on a digest change, so an unpinned
+  # tag makes pool churn nondeterministic.
+  image: ghcr.io/example-org/ci-runner:v1.4.0
+  cpu: 2
+  memory: 2Gi
+
+  # minWarm backs a `scale` subresource, so `kubectl scale` and an HPA write the
+  # same field this manifest declares. Pick ONE owner. If you want the pool to
+  # scale to zero when the queue is quiet, drop minWarm from this manifest and
+  # let an autoscaler own it; leaving both in place makes the pool oscillate on
+  # the reconcile interval while every Kustomization stays green.
+  minWarm: 3
+  maxWarm: 10
+
+  # restricted is the default and the right one for CI: a job gets egress to
+  # what it needs and nothing else. `open` gives full egress; `none` isolates
+  # completely. This is a real VM boundary either way, not a namespace.
+  network:
+    mode: restricted

--- a/examples/gitops-flux/workloads/production/db-snapshot-schedules.yaml
+++ b/examples/gitops-flux/workloads/production/db-snapshot-schedules.yaml
@@ -1,0 +1,79 @@
+# Backups as desired state.
+#
+# A SwiftSnapshot is a one-shot verb and must NOT be committed: it goes terminal,
+# and a reconciler that owns it either recreates it forever or holds a finished
+# object that can never run again. A SCHEDULE is the declarative counterpart, and
+# is exactly the kind of thing that belongs in Git: the retention policy and the
+# cron line are reviewed, versioned, and identical on every cluster this repo
+# targets.
+#
+# Two schedules, because they answer different questions.
+---
+# 1. Nightly, local to the cluster's CSI driver. Fast, cheap, and what you
+#    actually restore from day to day. Disk-only and crash-consistent; the VM is
+#    never paused.
+apiVersion: snapshot.kubeswift.io/v1alpha1
+kind: SwiftSnapshotSchedule
+metadata:
+  name: db-nightly
+spec:
+  schedule: "0 2 * * *"           # 5-field cron, UTC
+  concurrencyPolicy: Forbid       # skip a tick if the previous capture still runs
+  retention:
+    keepLast: 7
+  template:
+    metadata:
+      labels:
+        tier: db                  # merged onto every SwiftSnapshot it creates
+    spec:
+      guestRef:
+        name: db
+      backend:
+        type: csi-volume-snapshot
+---
+# 2. Weekly, exported to the OCI registry. The fourth artifact type out of the
+#    same registry as the chart, the golden disk and the kernel.
+#
+#    This is the one that earns its keep in a GitOps estate: a CSI snapshot is
+#    trapped in the cluster that took it, but an OCI artifact is portable. The
+#    same registry your reconciler already pulls the chart from becomes the
+#    channel for moving VM state to another cluster, to an edge site, or into
+#    cold storage, with no bespoke transport.
+#
+#    Restore is a SwiftRestore referencing the pushed artifact by digest, and is
+#    imperative: it is a one-shot verb, so it does not belong in this directory.
+apiVersion: snapshot.kubeswift.io/v1alpha1
+kind: SwiftSnapshotSchedule
+metadata:
+  name: db-weekly-oci
+spec:
+  schedule: "0 4 * * 0"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600   # after an outage, skip a tick missed by >1h
+  retention:
+    keepLast: 4
+  template:
+    spec:
+      guestRef:
+        name: db
+      backend:
+        type: oci
+        oci:
+          repository: ghcr.io/example-org/vm-snapshots
+          # An empty tag defaults to "<namespace>-<snapshot>". status.oci records
+          # the pushed reference AND the manifest digest, which is what a restore
+          # should pin.
+          #
+          # credentialsSecretRef is the same dockerconfigjson Secret the golden
+          # image uses. SOPS-encrypt it: docs/gitops/secrets.md.
+          # credentialsSecretRef:
+          #   name: regcreds
+          #
+          # Sign every pushed snapshot with the cosign PRIVATE key (cosign.key +
+          # cosign.password). This one is genuinely secret, unlike the public key
+          # the golden image verifies with.
+          # signingKeySecretRef:
+          #   name: cosign-key
+      # Disk-only keeps the artifact small and avoids pausing the VM. Set true
+      # to capture RAM as well, which makes the export a resumable full state.
+      includeMemory: false

--- a/examples/gitops-flux/workloads/production/kustomization.yaml
+++ b/examples/gitops-flux/workloads/production/kustomization.yaml
@@ -4,3 +4,5 @@ namespace: default
 resources:
   - web-pool.yaml
   - db-guest.yaml
+  - db-snapshot-schedules.yaml
+  - ci-sandbox-pool.yaml


### PR DESCRIPTION
Two commits. The first corrects docs that had drifted twenty releases; the second extends the reference repo to cover what they now describe.

---

## 1. Refresh for v0.13.x

Last substantively written at v0.5 (2026-06-09).

**Coverage.** The three-layer model named **six of fifteen CRDs**. Adds the rest, plus the inverse table: the kinds that must **not** be committed, because roughly half the CRD surface is one-shot or controller-owned. A `SwiftSandbox` with `spec.ttl` terminates, the controller deletes it, the reconciler recreates it, and the workload reruns every interval. `SwiftSnapshot` / `SwiftRestore` / `SwiftMigration` loop the same way. `SwiftGPUNode` is discovery-owned. The local fleet `Cluster` is chart-created under `federation.selfRegister`.

**Two things were wrong.** The reference pinned `semver: ">=0.1.0"`, which on a pre-1.0 project with `v1alpha1` APIs lets a reconciler roll the platform across a breaking minor unattended. And the CRD guidance undersold itself: `helm upgrade` cannot upgrade CRDs at all, which is why every CLI upgrade in the CHANGELOG is followed by a manual `kubectl apply -f charts/kubeswift/crds/`. Flux's helm-controller can, so `upgrade.crds: CreateReplace` is the strongest argument for driving KubeSwift this way.

**Five traps**, all newer than the docs: SwiftKernel re-pull keyed on (name, node) rather than the artifact ref, so a new tag silently never lands; `cloneStrategy` and `importStorageClassName` freezing at `Pending` rather than `Ready`; both pool kinds exposing a `scale` subresource that Git and an autoscaler can fight over; `launcherSAGate` / `scopedLauncherRBAC` / `allowedHostPathPrefixes`, one of which deletes a live grant when enabled; and `ui.image.tag` not being chart-derived.

## 2. OCI artifacts, and the kinds the reference skipped

The reference had nothing for the kernel, sandbox or snapshot-schedule kinds, and nothing for consuming VM disks from a registry, which is the part that composes best with a reconciler already pulling its chart from one.

**Four artifact types, one registry:**

| Artifact | Kind / field | Direction |
|---|---|---|
| Helm chart | `OCIRepository` (Flux) | pull |
| Golden VM disk | `SwiftImage.spec.source.oci` | pull |
| Kernel + initramfs | `SwiftKernel.spec.ociRef.image` | pull |
| VM snapshot | `SwiftSnapshot.spec.backend.type: oci` | **push** |

One credential, one signing key, covering the platform and everything it runs. `docs/gitops/oci-artifacts.md` is the operator page.

The digest-pinning argument is the one already made for the chart: a tag is mutable, so a re-push changes what every future guest boots with no commit to show for it, and lands only on clusters that import afterwards, so two clusters on identical Git state diverge. Signing gets the same treatment: `verifyKeySecretRef` fails the import closed, and the public key belongs in Git while the snapshot signing key does not.

Also adds the two declarative kinds the docs now describe: a snapshot schedule (CSI nightly + OCI weekly export) and a warm sandbox pool for CI.

## Verification

Every new manifest validated with `kubectl apply --dry-run=server` against a live cluster. That caught two things now explicit in the examples rather than left in a reviewer's head:

- `cloneStrategy: snapshot` is **rejected** without `volumeSnapshotClassName`
- `spec.format` is only optional because the **mutating webhook** defaults it, so a manifest omitting it applies on a webhook-enabled cluster and is rejected by the apiserver on one without

Layer counts accepted server-side: infrastructure 8 objects, workloads/production 5, workloads/staging 2. All `kubectl kustomize` entry points build; every relative link in `docs/gitops/` and the example README resolves.

Docs and examples only, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
