### PR TITLE
fix(chart): appVersion carried a leading v, rendering every image tag as vv0.13.11

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -86,6 +86,14 @@ jobs:
           ./hack/render-lint-profile.sh > /tmp/rendered.yaml
           test -s /tmp/rendered.yaml
 
+      # Tag plausibility, which no other check in this job covers: kubeconform
+      # validates schema and kube-linter validates policy, and a nonexistent
+      # image tag is valid under both. It only fails later, on a node, at pull
+      # time. `vv0.13.11` shipped on the install-from-a-checkout path for
+      # several releases exactly this way.
+      - name: Verify image tags
+        run: ./hack/verify-image-tags.sh
+
       # STEP 1. -strict is the flag that matters: it rejects unknown and
       # duplicate fields, which is exactly the class that bites this project —
       # the API server silently DROPS unknown fields, so a typo'd key becomes a

--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -26,6 +26,7 @@ on:
       - 'config/crd/**'
       - 'hack/lint-values/**'
       - 'hack/verify-render-coverage.sh'
+      - 'hack/verify-image-tags.sh'
       - '.github/workflows/manifests.yaml'
   push:
     branches: [main]
@@ -43,6 +44,7 @@ on:
       - 'config/crd/**'
       - 'hack/lint-values/**'
       - 'hack/verify-render-coverage.sh'
+      - 'hack/verify-image-tags.sh'
       - '.github/workflows/manifests.yaml'
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,9 @@ verify-crd-sync:
 verify-render-coverage:
 	./hack/verify-render-coverage.sh
 
+verify-image-tags:
+	./hack/verify-image-tags.sh
+
 verify-cosign-interop: ## Cross-check that our cosign signatures verify (#486). Needs docker.
 	@# Not in any CI gate: it pulls release binaries and runs a local registry.
 	@# Run it before changing how anything is signed or verified.

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -3,7 +3,13 @@ name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
 version: 0.13.11
-appVersion: "v0.13.11"
+# Bare X.Y.Z, with NO leading "v". The imageTag helper adds the "v" when it
+# derives a default image tag, so "v0.13.11" here renders "vv0.13.11" and every
+# image points at a tag that was never published. The helper now trims a stray
+# "v" and hack/verify-image-tags.sh fails the build on a malformed tag, but
+# write it bare: the release workflows pass `--app-version "${TAG#v}"`, and this
+# line should match what they publish.
+appVersion: "0.13.11"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/charts/kubeswift/templates/_helpers.tpl
+++ b/charts/kubeswift/templates/_helpers.tpl
@@ -3,16 +3,27 @@ Default image tag: matches what CI publishes.
 - Dev (0.0.0-dev.<sha>): sha-<sha>
 - RC/Stable (X.Y.Z): vX.Y.Z
 Override with controllerManager.image.tag / swiftletd.image.tag when using local builds (e.g. latest).
+
+appVersion is expected BARE (X.Y.Z). The release workflows pass it that way
+(`--app-version "${TAG#v}"`), but Chart.yaml is hand-edited at release time and
+once carried "v0.13.11", which this helper then turned into the tag `vv0.13.11`:
+a nonexistent image for the controller AND for the five launcher images it
+passes on by env var. Released charts were unaffected (the workflow flag wins),
+so only `helm install`/`helm template` from a checkout broke — quietly, and only
+at pod-pull time. trimPrefix makes the leading "v" unspellable rather than
+merely currently-absent; hack/verify-image-tags.sh fails the build if a rendered
+tag is malformed anyway.
 */}}
 {{- define "kubeswift.imageTag" -}}
 {{- $tag := .tag | default "latest" -}}
 {{- if ne $tag "latest" -}}
 {{- $tag -}}
 {{- else -}}
-{{- if hasPrefix "0.0.0-dev." .appVersion -}}
-{{- printf "sha-%s" (trimPrefix "0.0.0-dev." .appVersion) -}}
+{{- $app := trimPrefix "v" .appVersion -}}
+{{- if hasPrefix "0.0.0-dev." $app -}}
+{{- printf "sha-%s" (trimPrefix "0.0.0-dev." $app) -}}
 {{- else -}}
-{{- printf "v%s" .appVersion -}}
+{{- printf "v%s" $app -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/hack/verify-image-tags.sh
+++ b/hack/verify-image-tags.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# verify-image-tags — every image reference the chart renders must carry a tag
+# CI could actually have published.
+#
+# Why this exists: Chart.yaml's appVersion is hand-edited at release time, and
+# `kubeswift.imageTag` used to prepend "v" unconditionally. When appVersion was
+# written as "v0.13.11" the helper produced the tag `vv0.13.11` — an image that
+# does not exist, for the controller AND for the five launcher images it hands
+# on via env var. Nothing failed at render, lint, or install time: kubeconform
+# validates schema, not tag plausibility, and the pull only fails later, on a
+# node. Released charts were unaffected because the workflows pass
+# `--app-version "${TAG#v}"`, so the bug lived exclusively on the
+# install-from-a-checkout path and stayed invisible for several releases.
+#
+# The helper now trims the prefix, so that exact bug is unspellable. This checks
+# the property instead of that one spelling: a rendered tag must look like
+# something the release pipeline emits.
+#
+# Accepted tag shapes:
+#   vX.Y.Z[-suffix]   stable / rc   (release-stable, release-rc)
+#   sha-<hex>         dev builds    (release-dev)
+#   latest            local builds  (values default, pre-resolution)
+#
+# Rendered through hack/render-lint-profile.sh, NOT an inline `helm template`
+# line, for the reason that script's header gives: a second caller drifts, and
+# a check that renders fewer objects than it thinks still reports green. That
+# profile also supplies the OIDC placeholders the gateway fail-closes without.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+RENDER=$("$ROOT/hack/render-lint-profile.sh")
+
+# Both spellings matter: `image:` on containers, and `value:` on the env vars
+# the controller uses to tell launcher pods which image to run. The latter is
+# where five of the six bad tags lived.
+mapfile -t REFS < <(
+  printf '%s\n' "$RENDER" \
+    | grep -oE '(image|value):[[:space:]]*"?[A-Za-z0-9.-]+/[A-Za-z0-9./_-]+:[A-Za-z0-9._-]+"?' \
+    | sed -E 's/^(image|value):[[:space:]]*//; s/"//g' \
+    | sort -u
+)
+
+# A vacuous pass is the failure mode this whole file exists to prevent, so an
+# empty extraction is an error, not a success.
+if [[ ${#REFS[@]} -eq 0 ]]; then
+  echo "verify-image-tags: found no image references to check." >&2
+  echo "  The extraction regex has drifted from the templates, or the render" >&2
+  echo "  is empty. Failing rather than passing vacuously." >&2
+  exit 1
+fi
+
+bad=0
+for ref in "${REFS[@]}"; do
+  tag="${ref##*:}"
+  if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.+][A-Za-z0-9._-]+)?$ ]] \
+     || [[ "$tag" =~ ^sha-[0-9a-f]{7,40}$ ]] \
+     || [[ "$tag" == "latest" ]]; then
+    continue
+  fi
+  echo "verify-image-tags: BAD TAG  $ref" >&2
+  echo "    tag '$tag' is not vX.Y.Z, sha-<hex>, or latest" >&2
+  bad=1
+done
+
+if [[ $bad -ne 0 ]]; then
+  echo >&2
+  echo "  Most likely cause: charts/kubeswift/Chart.yaml appVersion is not a" >&2
+  echo "  bare X.Y.Z. It must NOT carry a leading 'v' — the imageTag helper" >&2
+  echo "  adds it." >&2
+  exit 1
+fi
+
+echo "verify-image-tags: ${#REFS[@]} image references, all well-formed"


### PR DESCRIPTION
`charts/kubeswift/Chart.yaml` held `appVersion: "v0.13.11"`, and `kubeswift.imageTag` prepends `v` when deriving a default tag. The chart therefore rendered:

```
image: ghcr.io/kubeswift-io/kubeswift/controller-manager:vv0.13.11
value: ghcr.io/kubeswift-io/kubeswift/swiftletd:vv0.13.11
value: ghcr.io/kubeswift-io/kubeswift/snapshot-s3:vv0.13.11
value: ghcr.io/kubeswift-io/kubeswift/snapshot-oras:vv0.13.11
value: ghcr.io/kubeswift-io/kubeswift/migration-stunnel:vv0.13.11
value: ghcr.io/kubeswift-io/kubeswift/sandbox-materialize:vv0.13.11
```

Five of those six are the images the controller hands to launcher pods by env var, so an affected install would fail to **start VMs**, not merely fail to start itself.

## Blast radius

**Released charts were never affected.** The release workflows package with `--app-version "${TAG#v}"`, and the flag wins over the file. The bug existed only where the chart is used straight from a checkout: `helm install ./charts/kubeswift`, `helm template` for review, air-gapped installs from source. `make deploy` renders through `config/` kustomize and never touched it either, which is how it survived several releases unnoticed.

## Fix, in three layers

The value alone would just be correct until the next hand-edit, and `appVersion` is hand-edited at every release.

| Layer | Change |
|---|---|
| `Chart.yaml` | `appVersion` bare, with the constraint stated **at the point of edit** |
| `kubeswift.imageTag` | trims a stray leading `v` before adding its own, making the bad spelling unspellable rather than merely currently-absent |
| `hack/verify-image-tags.sh` | asserts every rendered tag looks like something CI publishes (`vX.Y.Z`, `sha-<hex>`, `latest`) |

The new check fills a real gap: nothing in the manifests job covers tag plausibility. kubeconform validates schema, kube-linter validates policy, and a nonexistent tag is valid under both — it only fails later, on a node, at pull time.

It renders through `hack/render-lint-profile.sh` rather than its own `helm template` line, per that script's header (a second caller drifts, and a check that renders fewer objects than it thinks still reports green). It also treats an empty extraction as a failure, so it cannot pass vacuously.

## Verified by injection

Reverting **both** the value and the helper reproduces the original bug, and the check goes red on all nine rendered tags and names the cause:

```
verify-image-tags: BAD TAG  .../controller-manager:vv0.13.11
    tag 'vv0.13.11' is not vX.Y.Z, sha-<hex>, or latest
  Most likely cause: charts/kubeswift/Chart.yaml appVersion is not a
  bare X.Y.Z. It must NOT carry a leading 'v' — the imageTag helper adds it.
```

Reverting the value **alone** now stays green, which is the point of the helper change. The deliberately pinned `ui.image.tag` is correctly left alone in both cases.

No CHANGELOG entry: this repo writes those at release time, and the version is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)