### PR TITLE
fix(seed): userDataFrom was unusable, the CRD required the field it replaces

### DIFF
--- a/api/seed/v1alpha1/swiftseedprofile_types.go
+++ b/api/seed/v1alpha1/swiftseedprofile_types.go
@@ -26,9 +26,36 @@ type SeedDataValueFrom struct {
 }
 
 // SwiftSeedProfileSpec defines the desired state of SwiftSeedProfile.
+//
+// UserData and UserDataFrom are alternatives, and the rule below is what says
+// so to the apiserver. Until it existed, UserData was a bare required field, so
+// the CRD schema rejected every userDataFrom-only profile with
+// "spec.userData: Required value" — before admission ran, which meant the
+// validating webhook's own (correct) either-or check never got to see the
+// object. The Secret-backed path was implemented, sampled and documented as the
+// way to keep credentials out of Git, and could not be used at all.
+//
+// Expressed as CEL rather than left to the webhook because the webhook is off
+// by default: a rule that only holds when webhook.enabled=true is not a rule.
+//
+// The emptiness test is size(...) and not a comparison against a quoted empty
+// string ON PURPOSE. gofmt rewrites a doubled apostrophe inside a comment to a
+// typographic closing quote, and a kubebuilder marker IS a comment: writing the
+// CEL literal the obvious way silently turns the rule into a comparison against
+// a curly quote the next time anyone runs gofmt, and controller-gen then bakes
+// that into the CRD. CI runs gofmt, so CI would have been the thing that broke
+// it. size() needs no quotes and cannot be rewritten.
+// +kubebuilder:validation:XValidation:rule="(has(self.userData) && size(self.userData) > 0) || has(self.userDataFrom)",message="one of spec.userData or spec.userDataFrom is required"
 type SwiftSeedProfileSpec struct {
-	Datasource   DatasourceType     `json:"datasource"`
-	UserData     string             `json:"userData"` // Inline; use UserDataFrom for ref
+	Datasource DatasourceType `json:"datasource"`
+	// UserData is inline cloud-init user-data.
+	//
+	// Optional at the schema level, but a profile needs EITHER this or
+	// UserDataFrom: see the XValidation rule on this struct. Prefer
+	// UserDataFrom for anything carrying credentials, so the content lives in
+	// a Secret rather than in the manifest (docs/gitops/secrets.md).
+	// +optional
+	UserData     string             `json:"userData,omitempty"`
 	UserDataFrom *SeedDataValueFrom `json:"userDataFrom,omitempty"`
 	// MetaData is inline NoCloud instance metadata (use MetaDataFrom for a ref).
 	//

--- a/charts/kubeswift/crds/seed.kubeswift.io_swiftseedprofiles.yaml
+++ b/charts/kubeswift/crds/seed.kubeswift.io_swiftseedprofiles.yaml
@@ -46,7 +46,27 @@ spec:
           metadata:
             type: object
           spec:
-            description: SwiftSeedProfileSpec defines the desired state of SwiftSeedProfile.
+            description: |-
+              SwiftSeedProfileSpec defines the desired state of SwiftSeedProfile.
+
+              UserData and UserDataFrom are alternatives, and the rule below is what says
+              so to the apiserver. Until it existed, UserData was a bare required field, so
+              the CRD schema rejected every userDataFrom-only profile with
+              "spec.userData: Required value" — before admission ran, which meant the
+              validating webhook's own (correct) either-or check never got to see the
+              object. The Secret-backed path was implemented, sampled and documented as the
+              way to keep credentials out of Git, and could not be used at all.
+
+              Expressed as CEL rather than left to the webhook because the webhook is off
+              by default: a rule that only holds when webhook.enabled=true is not a rule.
+
+              The emptiness test is size(...) and not a comparison against a quoted empty
+              string ON PURPOSE. gofmt rewrites a doubled apostrophe inside a comment to a
+              typographic closing quote, and a kubebuilder marker IS a comment: writing the
+              CEL literal the obvious way silently turns the rule into a comparison against
+              a curly quote the next time anyone runs gofmt, and controller-gen then bakes
+              that into the CRD. CI runs gofmt, so CI would have been the thing that broke
+              it. size() needs no quotes and cannot be rewritten.
             properties:
               datasource:
                 description: DatasourceType is the cloud-init datasource type.
@@ -171,6 +191,13 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               userData:
+                description: |-
+                  UserData is inline cloud-init user-data.
+
+                  Optional at the schema level, but a profile needs EITHER this or
+                  UserDataFrom: see the XValidation rule on this struct. Prefer
+                  UserDataFrom for anything carrying credentials, so the content lives in
+                  a Secret rather than in the manifest (docs/gitops/secrets.md).
                 type: string
               userDataFrom:
                 description: SeedDataValueFrom holds a reference to Secret or ConfigMap.
@@ -226,8 +253,10 @@ spec:
                 type: object
             required:
             - datasource
-            - userData
             type: object
+            x-kubernetes-validations:
+            - message: one of spec.userData or spec.userDataFrom is required
+              rule: (has(self.userData) && size(self.userData) > 0) || has(self.userDataFrom)
         type: object
     served: true
     storage: true

--- a/config/crd/bases/seed.kubeswift.io_swiftseedprofiles.yaml
+++ b/config/crd/bases/seed.kubeswift.io_swiftseedprofiles.yaml
@@ -46,7 +46,27 @@ spec:
           metadata:
             type: object
           spec:
-            description: SwiftSeedProfileSpec defines the desired state of SwiftSeedProfile.
+            description: |-
+              SwiftSeedProfileSpec defines the desired state of SwiftSeedProfile.
+
+              UserData and UserDataFrom are alternatives, and the rule below is what says
+              so to the apiserver. Until it existed, UserData was a bare required field, so
+              the CRD schema rejected every userDataFrom-only profile with
+              "spec.userData: Required value" — before admission ran, which meant the
+              validating webhook's own (correct) either-or check never got to see the
+              object. The Secret-backed path was implemented, sampled and documented as the
+              way to keep credentials out of Git, and could not be used at all.
+
+              Expressed as CEL rather than left to the webhook because the webhook is off
+              by default: a rule that only holds when webhook.enabled=true is not a rule.
+
+              The emptiness test is size(...) and not a comparison against a quoted empty
+              string ON PURPOSE. gofmt rewrites a doubled apostrophe inside a comment to a
+              typographic closing quote, and a kubebuilder marker IS a comment: writing the
+              CEL literal the obvious way silently turns the rule into a comparison against
+              a curly quote the next time anyone runs gofmt, and controller-gen then bakes
+              that into the CRD. CI runs gofmt, so CI would have been the thing that broke
+              it. size() needs no quotes and cannot be rewritten.
             properties:
               datasource:
                 description: DatasourceType is the cloud-init datasource type.
@@ -171,6 +191,13 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               userData:
+                description: |-
+                  UserData is inline cloud-init user-data.
+
+                  Optional at the schema level, but a profile needs EITHER this or
+                  UserDataFrom: see the XValidation rule on this struct. Prefer
+                  UserDataFrom for anything carrying credentials, so the content lives in
+                  a Secret rather than in the manifest (docs/gitops/secrets.md).
                 type: string
               userDataFrom:
                 description: SeedDataValueFrom holds a reference to Secret or ConfigMap.
@@ -226,8 +253,10 @@ spec:
                 type: object
             required:
             - datasource
-            - userData
             type: object
+            x-kubernetes-validations:
+            - message: one of spec.userData or spec.userDataFrom is required
+              rule: (has(self.userData) && size(self.userData) > 0) || has(self.userDataFrom)
         type: object
     served: true
     storage: true

--- a/config/samples/golden-image/swiftimage-oci.yaml
+++ b/config/samples/golden-image/swiftimage-oci.yaml
@@ -11,6 +11,11 @@ kind: SwiftImage
 metadata:
   name: golden-noble
 spec:
+  # Set explicitly rather than leaning on the defaulting webhook: format is a
+  # required field in the CRD schema, so a manifest omitting it applies on a
+  # webhook-enabled cluster and is rejected by the apiserver on one where
+  # webhook.enabled=false. raw is what `swiftctl image publish` produces.
+  format: raw
   source:
     oci:
       repository: zot.registry.svc:5000/vm-images


### PR DESCRIPTION
Result of sweeping every shipped manifest against the CRD schemas **client-side**, which is the configuration these defects live in: `kubectl apply --dry-run=server` against a webhook-enabled cluster cannot see this class, because the defaulting webhook papers over it.

157 KubeSwift objects across 162 files. Two real findings; both fixed here.

## 1. `userDataFrom` was unusable

`SwiftSeedProfileSpec.UserData` was a bare required field, so the apiserver rejected every `userDataFrom`-only profile:

```
The SwiftSeedProfile "with-secret" is invalid: spec.userData: Required value
```

The Secret-backed path is implemented end to end (`internal/seed/render.go`, `internal/resolved/merge.go`), ships a sample (`config/samples/advanced/swiftseedprofile-with-secret.yaml`), is accepted by the validating webhook's own either-or check, and is what `docs/gitops/secrets.md` recommends for keeping credentials out of Git. None of it was reachable: the schema refused the object before admission ran, so the webhook never saw it. The Go type even says so — `// Inline; use UserDataFrom for ref`.

`UserData` becomes optional and the either-or moves into a CEL `XValidation` rule on the spec. CEL rather than webhook code because **the webhook is off by default**, and a rule that only holds when `webhook.enabled=true` is not a rule. The webhook check stays; it is now agreement rather than the sole enforcement.

Verified on a cluster, all four cases:

| Case | Before | After |
|---|---|---|
| neither field | rejected | rejected, clearer message |
| `userData` only | accepted | accepted |
| `userDataFrom` only | **rejected** | **accepted** |
| `userData: ""` | rejected | rejected |

The existing profile on the test cluster round-trips unchanged; this only relaxes a constraint.

## 2. A sample that could not apply without the webhook

`config/samples/golden-image/swiftimage-oci.yaml` omitted `spec.format`, which is required in the schema and supplied only by the defaulting webhook. It applied on a default install and was rejected wherever `webhook.enabled=false`. Now set explicitly, with the reason inline.

## One trap worth knowing about

The CEL emptiness test is `size(self.userData) > 0`, **not** a comparison against a quoted empty string. `gofmt` rewrites a doubled apostrophe inside a comment to a typographic closing quote, and a kubebuilder marker *is* a comment:

```
-rule="... self.userData != '' ..."
+rule="... self.userData != ” ..."
```

Written the obvious way, the rule silently became a comparison against a curly quote on the next `gofmt` run, and controller-gen baked that into the CRD. CI runs gofmt, so **CI would have been the thing that broke it**. `size()` needs no quotes and cannot be rewritten. This is called out in a comment above the marker so nobody reintroduces it.

## Not included

Six findings from the first sweep pass were false positives of my own validator: `vcpuPinning`, `pcieTopology.noMmap` and `SwiftSandbox.memory` are required *with* a CRD `default:`, and the apiserver applies defaults before checking required. The sweep applies defaults before validating, and the corrected run reports zero violations across all 157 objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
