### PR TITLE
feat(swiftguestclass): vCPU pinning and SMT placement on Cloud Hypervisor

### DIFF
--- a/api/swift/v1alpha1/swiftguestclass_types.go
+++ b/api/swift/v1alpha1/swiftguestclass_types.go
@@ -40,6 +40,48 @@ const (
 	CoreSchedulingVCPU CoreScheduling = "vcpu"
 )
 
+// CPUPinning selects how a guest's vCPUs are placed on host CPUs
+// (Cloud Hypervisor `--cpus affinity=`).
+//
+//	none   (default) vCPU threads float across every CPU the launcher pod is
+//	       allowed to use; the host scheduler places them.
+//	static each vCPU is pinned to one distinct host CPU, chosen from the
+//	       launcher pod's OWN cpuset. Trades scheduler flexibility for
+//	       run-to-run latency predictability.
+//
+// The candidate CPUs are always the launcher pod's effective cpuset, never the
+// node's full CPU list: under the kubelet CPU Manager `static` policy that set
+// is the pod's exclusive allocation, and pinning outside it would be clamped or
+// rejected by the kernel. With the policy at `none` the set is simply every
+// host CPU, so the same code is correct either way.
+//
+// +kubebuilder:validation:Enum=none;static
+type CPUPinning string
+
+const (
+	CPUPinningNone   CPUPinning = "none"
+	CPUPinningStatic CPUPinning = "static"
+)
+
+// SMTPolicy selects which SMT (hyper-thread) siblings a statically pinned
+// guest's vCPUs land on. Ignored unless cpuPinning is static.
+//
+//	spread (default) use one thread per physical core before any core's
+//	       second thread — each vCPU gets a core's full pipeline and L1/L2.
+//	pack   fill both siblings of a core before moving to the next core —
+//	       touches fewer cores, leaving whole cores free for other work.
+//
+// This is placement, and is independent of coreScheduling, which decides who
+// may share a core (an isolation control). A guest can set both.
+//
+// +kubebuilder:validation:Enum=spread;pack
+type SMTPolicy string
+
+const (
+	SMTPolicySpread SMTPolicy = "spread"
+	SMTPolicyPack   SMTPolicy = "pack"
+)
+
 // SwiftGuestClassSpec defines the desired state of SwiftGuestClass.
 type SwiftGuestClassSpec struct {
 	CPU      resource.Quantity `json:"cpu"`
@@ -58,6 +100,18 @@ type SwiftGuestClassSpec struct {
 	// +kubebuilder:default=off
 	// +optional
 	CoreScheduling CoreScheduling `json:"coreScheduling,omitempty"`
+	// CPUPinning pins guests of this class 1:1 onto host CPUs drawn from the
+	// launcher pod's own cpuset. Default none (the host scheduler places
+	// vCPUs). Requires at least as many CPUs in that cpuset as the class
+	// requests vCPUs; the launcher refuses to start rather than pin partially.
+	// +kubebuilder:default=none
+	// +optional
+	CPUPinning CPUPinning `json:"cpuPinning,omitempty"`
+	// SMTPolicy selects sibling placement when cpuPinning is static, and is
+	// ignored otherwise. Default spread.
+	// +kubebuilder:default=spread
+	// +optional
+	SMTPolicy SMTPolicy `json:"smtPolicy,omitempty"`
 }
 
 // SwiftGuestClass is the Schema for the swiftguestclasses API.

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestclasses.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestclasses.yaml
@@ -71,6 +71,17 @@ spec:
                 - type: string
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+              cpuPinning:
+                default: none
+                description: |-
+                  CPUPinning pins guests of this class 1:1 onto host CPUs drawn from the
+                  launcher pod's own cpuset. Default none (the host scheduler places
+                  vCPUs). Requires at least as many CPUs in that cpuset as the class
+                  requests vCPUs; the launcher refuses to start rather than pin partially.
+                enum:
+                - none
+                - static
+                type: string
               memory:
                 anyOf:
                 - type: integer
@@ -96,6 +107,15 @@ spec:
                 - format
                 - size
                 type: object
+              smtPolicy:
+                default: spread
+                description: |-
+                  SMTPolicy selects sibling placement when cpuPinning is static, and is
+                  ignored otherwise. Default spread.
+                enum:
+                - spread
+                - pack
+                type: string
               storage:
                 description: |-
                   Storage is the cluster default for PVCs the SwiftGuest controller

--- a/config/crd/bases/swift.kubeswift.io_swiftguestclasses.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestclasses.yaml
@@ -71,6 +71,17 @@ spec:
                 - type: string
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+              cpuPinning:
+                default: none
+                description: |-
+                  CPUPinning pins guests of this class 1:1 onto host CPUs drawn from the
+                  launcher pod's own cpuset. Default none (the host scheduler places
+                  vCPUs). Requires at least as many CPUs in that cpuset as the class
+                  requests vCPUs; the launcher refuses to start rather than pin partially.
+                enum:
+                - none
+                - static
+                type: string
               memory:
                 anyOf:
                 - type: integer
@@ -96,6 +107,15 @@ spec:
                 - format
                 - size
                 type: object
+              smtPolicy:
+                default: spread
+                description: |-
+                  SMTPolicy selects sibling placement when cpuPinning is static, and is
+                  ignored otherwise. Default spread.
+                enum:
+                - spread
+                - pack
+                type: string
               storage:
                 description: |-
                   Storage is the cluster default for PVCs the SwiftGuest controller

--- a/config/samples/performance/swiftguestclass-cpu-pinning.yaml
+++ b/config/samples/performance/swiftguestclass-cpu-pinning.yaml
@@ -1,0 +1,33 @@
+# A guest class that pins each vCPU to a dedicated host CPU.
+#
+# cpuPinning: static tells the launcher to pin vCPU N to one host CPU, chosen
+# from the launcher pod's OWN cpuset — not from the node's full CPU list. That
+# matters when the kubelet CPU Manager `static` policy is enabled: the pod's
+# exclusive CPUs are assigned at admission, and anything pinned outside that set
+# is clamped or rejected by the kernel. With the policy at `none` the cpuset is
+# every host CPU, so this class behaves sensibly either way.
+#
+# smtPolicy chooses which SMT siblings get used:
+#   spread (default) one thread per physical core before any core's second
+#          thread — each vCPU gets a whole core's pipeline and L1/L2.
+#   pack   both siblings of a core before moving on — touches fewer cores.
+#
+# The class must fit: cpuPinning=static needs at least `cpu` CPUs in the
+# launcher pod's cpuset. If it does not fit, the launcher fails to start with an
+# explicit error rather than quietly running the guest unpinned.
+#
+# This is placement. coreScheduling (see ../security/) is isolation — it decides
+# who may share a core. They are independent and can be combined.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestClass
+metadata:
+  name: latency-sensitive
+spec:
+  cpu: 2
+  memory: 4Gi
+  rootDisk: { format: raw, size: 20Gi }
+  cpuPinning: static
+  smtPolicy: spread
+  # Optional: combine with core-scheduling so the sibling of each pinned core
+  # cannot run another tenant's vCPU.
+  coreScheduling: vm

--- a/docs/api/swiftguestclass.md
+++ b/docs/api/swiftguestclass.md
@@ -12,6 +12,9 @@ SwiftGuestClass is a **cluster-scoped template** for CPU, memory, and root disk.
 | `memory` | Yes | Memory request (e.g. `"2Gi"`, `"512Mi"`) |
 | `rootDisk.size` | Yes | Root disk size (e.g. `"10Gi"`); must fit imported image |
 | `rootDisk.format` | Yes | `raw` or `qcow2` — must match SwiftImage format |
+| `coreScheduling` | No | `off` (default), `vm`, `vcpu` — SMT side-channel isolation |
+| `cpuPinning` | No | `none` (default), `static` — pin vCPUs to host CPUs ([guide](../performance/cpu-pinning.md)) |
+| `smtPolicy` | No | `spread` (default), `pack` — sibling placement when pinned |
 
 ```yaml
 apiVersion: swift.kubeswift.io/v1alpha1

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -127,6 +127,9 @@ Cluster-scoped template defining default CPU, memory, and disk resources for VMs
 | `memory` | Quantity | Yes | Memory size (e.g. `"2Gi"`). |
 | `rootDisk.size` | Quantity | Yes | Root disk PVC size (e.g. `"40Gi"`). Should match SwiftImage's `rootDisk.size`. |
 | `rootDisk.format` | enum | Yes | `raw` only at runtime. |
+| `coreScheduling` | enum | No | `off` (default), `vm`, `vcpu` — SMT side-channel isolation: who may share a physical core. |
+| `cpuPinning` | enum | No | `none` (default), `static` — pin each vCPU to one host CPU from the launcher pod's cpuset. See [CPU pinning](performance/cpu-pinning.md). |
+| `smtPolicy` | enum | No | `spread` (default), `pack` — which SMT siblings a pinned guest uses. Ignored unless `cpuPinning: static`. |
 
 ### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,10 @@ KubeSwift runs Linux and Windows VMs on Kubernetes. [Cloud Hypervisor](https://w
 
 - [virtiofs & vhost-user devices](virtiofs.md) — shared filesystems (virtiofs), vhost-user-net/blk/generic (operator backends)
 
+### Performance
+
+- [CPU pinning and SMT placement](performance/cpu-pinning.md) — pin vCPUs to dedicated host CPUs, choose hyper-thread siblings, interaction with the kubelet CPU Manager
+
 ### Sandboxes
 
 - [Ephemeral OCI-rootfs sandboxes](sandbox/overview.md) — SwiftSandbox: run an OCI image as a microVM (CI runners, agent/code execution, untrusted code)

--- a/docs/performance/cpu-pinning.md
+++ b/docs/performance/cpu-pinning.md
@@ -1,0 +1,109 @@
+# CPU pinning and SMT placement
+
+Pin a guest's vCPUs to dedicated host CPUs, and choose how they land on
+hyper-thread siblings. Set on `SwiftGuestClass`, so every guest of the class
+inherits it.
+
+```yaml
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestClass
+metadata:
+  name: latency-sensitive
+spec:
+  cpu: 2
+  memory: 4Gi
+  rootDisk: { format: raw, size: 20Gi }
+  cpuPinning: static     # none (default) | static
+  smtPolicy: spread      # spread (default) | pack
+```
+
+| Field | Values | Meaning |
+|---|---|---|
+| `cpuPinning` | `none` (default), `static` | `static` pins vCPU *N* to one host CPU. `none` lets the host scheduler place vCPU threads. |
+| `smtPolicy` | `spread` (default), `pack` | Which SMT siblings to use. Ignored unless `cpuPinning: static`. |
+
+`spread` uses one thread per physical core before touching any core's second
+thread, so a guest smaller than the core count gets a whole core's pipeline and
+L1/L2 per vCPU. `pack` fills both siblings of a core before moving on, touching
+fewer cores and leaving whole cores free for other work.
+
+## Which CPUs get used
+
+The candidate CPUs are **the launcher pod's own effective cpuset**, never the
+node's full CPU list. This is the important detail:
+
+- With the kubelet CPU Manager policy at **`static`**, the pod's exclusive CPUs
+  are assigned at admission — *after* the controller has written the guest's
+  runtime intent. A CPU chosen ahead of that assignment is not honoured: the
+  kernel clamps or rejects it, and the guest would run unpinned while still
+  reporting as pinned.
+- With the policy at **`none`** (the default), the effective cpuset is simply
+  every host CPU, so the result is what you would expect.
+
+Because the set is read at launch time, the same configuration stays correct if
+a node's policy changes later. Nothing in the class needs to know which policy a
+node runs.
+
+The launcher pod already requests equal CPU requests and limits with a whole
+number of CPUs, which is what the CPU Manager `static` policy requires before it
+will grant a pod exclusive CPUs. No extra configuration is needed on the
+KubeSwift side to benefit from it.
+
+## It fails loudly, not quietly
+
+`cpuPinning: static` needs at least as many CPUs in the launcher pod's cpuset as
+the class requests vCPUs. If it does not, **the launcher refuses to start** and
+the guest reports the failure:
+
+```
+cpuPinning=static needs at least 4 CPUs in the launcher pod's cpuset, found 2 ([0, 1]).
+Reduce the class's cpu, or give the pod more CPUs.
+```
+
+Pinning two vCPUs onto one host CPU would report success while delivering worse
+latency than not pinning at all, so it is refused rather than approximated.
+
+## Relationship to `coreScheduling`
+
+They solve different problems and compose:
+
+- `cpuPinning` / `smtPolicy` are **placement** — *which* CPUs this guest runs on.
+- [`coreScheduling`](../security-hardening-notes.md) is **isolation** — *who else*
+  may run on a core's sibling thread, a defence against cross-thread SMT side
+  channels.
+
+A latency-sensitive multi-tenant class typically wants both:
+
+```yaml
+  cpuPinning: static
+  smtPolicy: spread
+  coreScheduling: vm
+```
+
+## Verifying
+
+The guest's vCPU threads live in the launcher pod. Check what they are actually
+allowed to run on:
+
+```bash
+kubectl exec -n <ns> <guest> -- sh -c 'grep Cpus_allowed_list /proc/self/status'
+```
+
+The launcher also logs the plan it computed at start-up:
+
+```bash
+kubectl logs -n <ns> <guest> | grep cpuPinning
+```
+
+```
+cpuPinning=static (Spread): vcpu0->cpu[0] vcpu1->cpu[1]
+```
+
+## Limits
+
+- **NUMA placement is not covered here.** Aligning vCPUs, memory and passthrough
+  devices on one NUMA node is separate work and needs a multi-socket host to be
+  meaningful.
+- **Hugepage-backed guest memory is not covered here.**
+- vCPU pinning applies to the Cloud Hypervisor path. The QEMU (HGX GPU) path has
+  its own pinning, computed from GPU NUMA locality.

--- a/internal/resolved/merge.go
+++ b/internal/resolved/merge.go
@@ -34,6 +34,10 @@ func Merge(
 	// means no core_scheduling on the CH --cpus args.
 	if guestClass != nil {
 		rg.CoreScheduling = string(guestClass.Spec.CoreScheduling)
+		// CPU placement: also from GuestClass. Empty/none means the CH --cpus
+		// args carry no affinity param, i.e. today's behaviour.
+		rg.CPUPinning = string(guestClass.Spec.CPUPinning)
+		rg.SMTPolicy = string(guestClass.Spec.SMTPolicy)
 	}
 
 	// RootDisk: from GuestClass

--- a/internal/resolved/types.go
+++ b/internal/resolved/types.go
@@ -75,6 +75,12 @@ type ResolvedGuest struct {
 	// CoreScheduling is the vCPU core-scheduling policy from the SwiftGuestClass
 	// ("off"/"vm"/"vcpu"). Empty/"off" omits the CH --cpus core_scheduling param.
 	CoreScheduling string `json:"coreScheduling,omitempty"`
+	// CPUPinning is the vCPU placement policy from the SwiftGuestClass
+	// ("none"/"static"). Empty/"none" omits the CH --cpus affinity param.
+	CPUPinning string `json:"cpuPinning,omitempty"`
+	// SMTPolicy is the sibling-placement policy from the SwiftGuestClass
+	// ("spread"/"pack"), meaningful only when CPUPinning is "static".
+	SMTPolicy string `json:"smtPolicy,omitempty"`
 	// GuestAgentEnabled is true for a SOURCE guest that opted into the in-guest
 	// identity agent (spec.guestAgentEnabled). It gates the CH --vsock device.
 	// The resolver sets it false for a clone (cloneFromSnapshot): a clone
@@ -330,6 +336,27 @@ func (r *ResolvedGuest) GetCoreScheduling() string {
 		return ""
 	}
 	return r.CoreScheduling
+}
+
+// GetCPUPinning returns the vCPU placement policy ("static"), or "" when the
+// class asks for none. "" leaves the CH --cpus arg without an affinity param,
+// which is the pre-existing behaviour for every class that never sets it.
+func (r *ResolvedGuest) GetCPUPinning() string {
+	if r.CPUPinning == "" || r.CPUPinning == string(swiftv1alpha1.CPUPinningNone) {
+		return ""
+	}
+	return r.CPUPinning
+}
+
+// GetSMTPolicy returns the sibling-placement policy, defaulting to "spread".
+// It is only consulted when GetCPUPinning() is non-empty, but defaulting here
+// (rather than in swiftletd) keeps the emitted intent explicit about which
+// policy a guest actually ran under.
+func (r *ResolvedGuest) GetSMTPolicy() string {
+	if r.SMTPolicy == "" {
+		return string(swiftv1alpha1.SMTPolicySpread)
+	}
+	return r.SMTPolicy
 }
 
 // IsWindows reports whether the resolved guest is a Windows guest.

--- a/internal/resolved/types_test.go
+++ b/internal/resolved/types_test.go
@@ -459,3 +459,32 @@ func TestGetVsockCID(t *testing.T) {
 		t.Errorf("disabled guest CID = %d, want 0", cid)
 	}
 }
+
+func TestGetCPUPinning(t *testing.T) {
+	// "none" and "" both mean unpinned, and must produce the empty string so
+	// the CH --cpus arg carries no affinity param at all — the behaviour every
+	// existing SwiftGuestClass relies on.
+	for _, tc := range []struct{ in, want string }{
+		{"", ""},
+		{"none", ""},
+		{"static", "static"},
+	} {
+		rg := &ResolvedGuest{CPUPinning: tc.in}
+		if got := rg.GetCPUPinning(); got != tc.want {
+			t.Errorf("GetCPUPinning(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestGetSMTPolicy_DefaultsToSpread(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"", "spread"},
+		{"spread", "spread"},
+		{"pack", "pack"},
+	} {
+		rg := &ResolvedGuest{SMTPolicy: tc.in}
+		if got := rg.GetSMTPolicy(); got != tc.want {
+			t.Errorf("GetSMTPolicy(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/runtimeintent/build.go
+++ b/internal/runtimeintent/build.go
@@ -32,6 +32,8 @@ type ResolvedGuest interface {
 	GetFilesystems() []FilesystemIntent
 	GetVhostUserDevices() []VhostUserDeviceIntent
 	GetCoreScheduling() string
+	GetCPUPinning() string
+	GetSMTPolicy() string
 	// GetVsockCID returns the vsock CID for a SOURCE guest that opted into the
 	// in-guest identity agent, or 0 when the agent is not enabled (or the guest
 	// is a clone — a clone reopens the captured vsock device from config.json).
@@ -48,6 +50,13 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 	filesystems := rg.GetFilesystems()
 	vhostUserDevices := rg.GetVhostUserDevices()
 	coreScheduling := rg.GetCoreScheduling()
+	cpuPinning := rg.GetCPUPinning()
+	// smtPolicy is only meaningful alongside cpuPinning; keep the intent
+	// clean by omitting it when the guest is not pinned.
+	smtPolicy := ""
+	if cpuPinning != "" {
+		smtPolicy = rg.GetSMTPolicy()
+	}
 
 	var vsock *VsockIntent
 	if cid := rg.GetVsockCID(); cid != 0 {
@@ -76,6 +85,8 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 			Filesystems:         filesystems,
 			VhostUserDevices:    vhostUserDevices,
 			CoreScheduling:      coreScheduling,
+			CPUPinning:          cpuPinning,
+			SMTPolicy:           smtPolicy,
 			Vsock:               vsock,
 			KernelBoot: &KernelBootSpec{
 				KernelPath:    rg.GetKernelPath(),
@@ -122,6 +133,8 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 		Filesystems:         filesystems,
 		VhostUserDevices:    vhostUserDevices,
 		CoreScheduling:      coreScheduling,
+		CPUPinning:          cpuPinning,
+		SMTPolicy:           smtPolicy,
 		Vsock:               vsock,
 	}
 }

--- a/internal/runtimeintent/build_test.go
+++ b/internal/runtimeintent/build_test.go
@@ -24,6 +24,8 @@ type mockResolvedGuest struct {
 	filesystems         []FilesystemIntent
 	vhostUserDevices    []VhostUserDeviceIntent
 	coreScheduling      string
+	cpuPinning          string
+	smtPolicy           string
 	vsockCID            uint32
 	primaryUDNInterface string
 }
@@ -56,7 +58,14 @@ func (m *mockResolvedGuest) GetVhostUserDevices() []VhostUserDeviceIntent {
 	return m.vhostUserDevices
 }
 func (m *mockResolvedGuest) GetCoreScheduling() string { return m.coreScheduling }
-func (m *mockResolvedGuest) GetVsockCID() uint32       { return m.vsockCID }
+func (m *mockResolvedGuest) GetCPUPinning() string     { return m.cpuPinning }
+func (m *mockResolvedGuest) GetSMTPolicy() string {
+	if m.smtPolicy == "" {
+		return "spread"
+	}
+	return m.smtPolicy
+}
+func (m *mockResolvedGuest) GetVsockCID() uint32 { return m.vsockCID }
 
 func TestBuild_VsockSetWhenCIDNonZero(t *testing.T) {
 	// disk boot with an agent CID -> intent carries Vsock
@@ -506,5 +515,38 @@ func TestBuild_CoreScheduling(t *testing.T) {
 	none := Build(&mockResolvedGuest{hasSeed: true, format: "raw", guestID: "x"})
 	if none.CoreScheduling != "" {
 		t.Errorf("CoreScheduling = %q, want empty", none.CoreScheduling)
+	}
+}
+
+// The intent must carry the POLICY, not a vCPU->host-CPU map: the map depends
+// on the launcher pod's cpuset, which does not exist when this runs.
+func TestBuild_CPUPinningPolicyReachesTheIntent(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		kernel               bool
+		pinning, smt         string
+		wantPinning, wantSMT string
+	}{
+		{name: "unpinned omits both", wantPinning: "", wantSMT: ""},
+		{name: "static defaults to spread", pinning: "static", wantPinning: "static", wantSMT: "spread"},
+		{name: "static honours pack", pinning: "static", smt: "pack", wantPinning: "static", wantSMT: "pack"},
+		{name: "kernel boot carries it too", kernel: true, pinning: "static", wantPinning: "static", wantSMT: "spread"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &mockResolvedGuest{guestID: "default/pin", cpuPinning: tc.pinning, smtPolicy: tc.smt}
+			if tc.kernel {
+				m.hasKernel = true
+				m.kernelPath, m.initramfsPath = "/k/bzImage", "/k/initrd"
+			}
+			got := Build(m)
+			if got.CPUPinning != tc.wantPinning {
+				t.Errorf("CPUPinning = %q, want %q", got.CPUPinning, tc.wantPinning)
+			}
+			// smtPolicy must be absent when unpinned — emitting a placement
+			// policy for a guest that is not pinned would misreport how it ran.
+			if got.SMTPolicy != tc.wantSMT {
+				t.Errorf("SMTPolicy = %q, want %q", got.SMTPolicy, tc.wantSMT)
+			}
+		})
 	}
 }

--- a/internal/runtimeintent/types.go
+++ b/internal/runtimeintent/types.go
@@ -15,8 +15,21 @@ type RuntimeIntent struct {
 	OSType     string          `json:"osType,omitempty"`     // "linux" (default) or "windows" — windows adds kvm_hyperv on the CH --cpus arg
 	// CoreScheduling is the CH vCPU core-scheduling policy ("vm"/"vcpu"), empty
 	// when off. When set, swiftletd appends core_scheduling=<v> to --cpus.
-	CoreScheduling string     `json:"coreScheduling,omitempty"`
-	GPU            *GPUIntent `json:"gpu,omitempty"` // populated when gpuProfileRef is set
+	CoreScheduling string `json:"coreScheduling,omitempty"`
+	// CPUPinning is the vCPU placement policy ("static"), empty when none.
+	//
+	// This carries the POLICY, not a vCPU->host-CPU map: the map is computed in
+	// swiftletd from the launcher pod's own effective cpuset, which the
+	// controller cannot know. Under the kubelet CPU Manager `static` policy the
+	// pod's exclusive CPUs are assigned at admission, after this intent is
+	// written, and pinning to controller-chosen CPUs outside that set would be
+	// clamped or rejected by the kernel.
+	CPUPinning string `json:"cpuPinning,omitempty"`
+	// SMTPolicy is the sibling-placement policy ("spread"/"pack") used when
+	// CPUPinning is set. Emitted whenever CPUPinning is, so the intent records
+	// which policy the guest actually ran under.
+	SMTPolicy string     `json:"smtPolicy,omitempty"`
+	GPU       *GPUIntent `json:"gpu,omitempty"` // populated when gpuProfileRef is set
 	// DataDisks are the secondary VM disks, in deterministic order. Each becomes
 	// one CH --disk and enumerates in the guest as /dev/vdc, /dev/vdd, ... in
 	// this order. Path is opaque to swiftletd (a file for Filesystem disks, a

--- a/rust/swift-ch-client/src/config.rs
+++ b/rust/swift-ch-client/src/config.rs
@@ -53,6 +53,18 @@ pub struct VmConfig {
     /// vCPU core-scheduling policy ("vm"/"vcpu"), appended to --cpus as
     /// core_scheduling=<v>. None = off (param omitted). SMT side-channel mitigation.
     pub core_scheduling: Option<String>,
+    /// vCPU -> host-CPU pinning, appended to --cpus as
+    /// `affinity=[<vcpu>@[<cpuset>],...]`. Empty = unpinned (param omitted).
+    ///
+    /// The bracketing is not cosmetic: CH's option parser splits `--cpus` on
+    /// commas, so the affinity list must be wrapped in `[...]` for its own
+    /// commas to be read as list separators rather than as new --cpus keys.
+    /// Verified against the v53.0 binary — the unbracketed form is accepted as
+    /// a key but fails value conversion (`ParseCpus(Conversion("affinity"))`).
+    ///
+    /// swiftletd computes the mapping from the launcher pod's effective cpuset;
+    /// this crate only renders what it is given.
+    pub cpu_affinity: Vec<(u32, Vec<u32>)>,
     /// Path for Cloud Hypervisor API socket.
     pub api_socket: String,
     /// Optional path to seed media (NoCloud dir or ISO). Empty = no seed.
@@ -217,6 +229,22 @@ impl VmConfig {
                     // vCPU core-scheduling (SMT side-channel mitigation): "vm"
                     // or "vcpu". Omitted when off.
                     cpus.push_str(&format!(",core_scheduling={}", cs));
+                }
+                if !self.cpu_affinity.is_empty() {
+                    let list = self
+                        .cpu_affinity
+                        .iter()
+                        .map(|(vcpu, hosts)| {
+                            let set = hosts
+                                .iter()
+                                .map(|c| c.to_string())
+                                .collect::<Vec<_>>()
+                                .join(",");
+                            format!("{}@[{}]", vcpu, set)
+                        })
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    cpus.push_str(&format!(",affinity=[{}]", list));
                 }
                 cpus
             },
@@ -444,6 +472,7 @@ mod tests {
             cpus: 2,
             kvm_hyperv: false,
             core_scheduling: None,
+            cpu_affinity: Vec::new(),
             api_socket: "/tmp/ch.sock".to_string(),
             seed_path: "/data/seed".to_string(),
             serial_socket_path: Some("/tmp/serial.sock".to_string()),
@@ -635,6 +664,36 @@ mod tests {
     }
 
     #[test]
+    /// The affinity list MUST be wrapped in `[...]`. CH's option parser splits
+    /// --cpus on commas, so an unbracketed list is read as stray --cpus keys and
+    /// fails value conversion. Verified against the v53.0 binary:
+    ///   affinity=[0@[0],1@[1]]  -> accepted
+    ///   affinity=0@[0]:1@[1]    -> ParseCpus(Conversion("affinity"))
+    /// This test is what keeps that shape from regressing.
+    #[test]
+    fn test_cpu_affinity_emits_bracketed_list_on_cpus() {
+        let mut cfg = make_disk_boot_config();
+        cfg.cpu_affinity = vec![(0, vec![2]), (1, vec![3])];
+        let joined = cfg.to_args().join(" ");
+        assert!(
+            joined.contains(",affinity=[0@[2],1@[3]]"),
+            "affinity must be a bracketed list: {}",
+            joined
+        );
+
+        // A multi-CPU set for one vCPU stays inside that vCPU's brackets.
+        let mut multi = make_disk_boot_config();
+        multi.cpu_affinity = vec![(0, vec![0, 4])];
+        assert!(
+            multi.to_args().join(" ").contains(",affinity=[0@[0,4]]"),
+            "multi-cpu set mis-rendered"
+        );
+
+        // Empty -> no affinity param at all (the unpinned default).
+        let none = make_disk_boot_config().to_args().join(" ");
+        assert!(!none.contains("affinity"), "unexpected affinity: {}", none);
+    }
+
     fn test_core_scheduling_emits_on_cpus() {
         let mut cfg = make_disk_boot_config();
         cfg.core_scheduling = Some("vm".to_string());

--- a/rust/swiftletd/src/cpuset.rs
+++ b/rust/swiftletd/src/cpuset.rs
@@ -1,0 +1,336 @@
+//! vCPU placement: choose which host CPUs a guest's vCPUs are pinned to.
+//!
+//! The candidate CPUs are the launcher pod's OWN effective cpuset, never the
+//! node's full CPU list. That distinction is the whole point of computing the
+//! plan here rather than in the controller:
+//!
+//!   * Under the kubelet CPU Manager `static` policy the pod's exclusive CPUs
+//!     are assigned at admission — after the controller has written the intent.
+//!     A controller-chosen CPU outside that set is not honoured: the kernel
+//!     clamps or rejects it, and the guest silently runs unpinned.
+//!   * With the policy at `none` the effective cpuset is simply every host CPU,
+//!     so the same code produces the same result the naive approach would.
+//!
+//! Reading the cpuset at launch time is therefore correct under both policies,
+//! and is the only form that stays correct if the node's policy changes later.
+//!
+//! The planner is pure: topology is passed in, so the placement rules are unit
+//! tested without sysfs and without a tuned node.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Sibling-placement policy (SwiftGuestClass.spec.smtPolicy).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SmtPolicy {
+    /// One thread per physical core before any core's second thread.
+    Spread,
+    /// Both siblings of a core before moving to the next core.
+    Pack,
+}
+
+impl SmtPolicy {
+    /// Parse the intent string. Anything unrecognised (including absent) is
+    /// Spread — the documented default.
+    pub fn from_intent(s: Option<&str>) -> Self {
+        match s {
+            Some("pack") => Self::Pack,
+            _ => Self::Spread,
+        }
+    }
+}
+
+/// One vCPU's host-CPU assignment. `host_cpus` is a set because Cloud
+/// Hypervisor's `affinity=` accepts one, though static pinning always yields
+/// exactly one entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VcpuAffinity {
+    pub vcpu: u32,
+    pub host_cpus: Vec<u32>,
+}
+
+/// Parse a Linux CPU list ("0-3", "0,2,4", "0-1,4-5") into sorted CPU ids.
+///
+/// This format is shared by cpuset.cpus.effective, Cpus_allowed_list and the
+/// sysfs topology files, so one parser serves all three.
+pub fn parse_cpu_list(s: &str) -> Result<Vec<u32>, String> {
+    let mut out = Vec::new();
+    for part in s.trim().split(',').filter(|p| !p.is_empty()) {
+        match part.split_once('-') {
+            Some((lo, hi)) => {
+                let lo: u32 = lo
+                    .trim()
+                    .parse()
+                    .map_err(|_| format!("bad cpu range low {lo:?}"))?;
+                let hi: u32 = hi
+                    .trim()
+                    .parse()
+                    .map_err(|_| format!("bad cpu range high {hi:?}"))?;
+                if hi < lo {
+                    return Err(format!("inverted cpu range {part:?}"));
+                }
+                out.extend(lo..=hi);
+            }
+            None => out.push(
+                part.trim()
+                    .parse()
+                    .map_err(|_| format!("bad cpu id {part:?}"))?,
+            ),
+        }
+    }
+    out.sort_unstable();
+    out.dedup();
+    Ok(out)
+}
+
+/// The launcher pod's effective cpuset.
+///
+/// cgroup v2 exposes it directly; the fallback covers cgroup v1 and any
+/// environment where the cgroup file is absent. `Cpus_allowed_list` is the
+/// authoritative last word either way — it is what the kernel will actually
+/// permit — so it is a safe backstop rather than a guess.
+pub fn effective_cpuset() -> Result<Vec<u32>, String> {
+    for p in [
+        "/sys/fs/cgroup/cpuset.cpus.effective",
+        "/sys/fs/cgroup/cpuset/cpuset.cpus",
+    ] {
+        if let Ok(s) = std::fs::read_to_string(p) {
+            if !s.trim().is_empty() {
+                return parse_cpu_list(&s);
+            }
+        }
+    }
+    let status = std::fs::read_to_string("/proc/self/status")
+        .map_err(|e| format!("read /proc/self/status: {e}"))?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("Cpus_allowed_list:") {
+            return parse_cpu_list(rest);
+        }
+    }
+    Err("could not determine the launcher pod's effective cpuset".to_string())
+}
+
+/// Read a CPU's SMT sibling list from sysfs. A CPU with no topology entry is
+/// treated as its own sole sibling (no SMT).
+pub fn thread_siblings(cpu: u32) -> Vec<u32> {
+    let p = format!("/sys/devices/system/cpu/cpu{cpu}/topology/thread_siblings_list");
+    if let Ok(s) = std::fs::read_to_string(Path::new(&p)) {
+        if let Ok(v) = parse_cpu_list(&s) {
+            if !v.is_empty() {
+                return v;
+            }
+        }
+    }
+    vec![cpu]
+}
+
+/// Group the available CPUs into physical cores, preserving ascending order.
+///
+/// A core is keyed by the lowest sibling id that is actually in `available`, so
+/// a partial cpuset (CPU Manager handing us one thread of a core) still yields
+/// a coherent grouping rather than dropping the CPU.
+fn cores(available: &[u32], siblings: &dyn Fn(u32) -> Vec<u32>) -> Vec<Vec<u32>> {
+    let set: std::collections::BTreeSet<u32> = available.iter().copied().collect();
+    let mut by_core: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
+    for &cpu in available {
+        let mut sibs: Vec<u32> = siblings(cpu)
+            .into_iter()
+            .filter(|c| set.contains(c))
+            .collect();
+        sibs.sort_unstable();
+        let key = *sibs.first().unwrap_or(&cpu);
+        by_core.entry(key).or_default().push(cpu);
+    }
+    let mut out: Vec<Vec<u32>> = by_core
+        .into_values()
+        .map(|mut v| {
+            v.sort_unstable();
+            v.dedup();
+            v
+        })
+        .collect();
+    out.sort_by_key(|c| c[0]);
+    out
+}
+
+/// Order the available CPUs according to `policy`, then take the first `vcpus`.
+///
+/// Spread walks thread 0 of every core, then thread 1 of every core, and so on,
+/// so a guest smaller than the core count never doubles up on a core. Pack
+/// walks each core's threads together.
+pub fn plan_with_topology(
+    vcpus: u32,
+    available: &[u32],
+    policy: SmtPolicy,
+    siblings: &dyn Fn(u32) -> Vec<u32>,
+) -> Result<Vec<VcpuAffinity>, String> {
+    if vcpus == 0 {
+        return Err("cannot pin a guest with 0 vCPUs".to_string());
+    }
+    if (available.len() as u32) < vcpus {
+        // Refuse rather than oversubscribe. Pinning two vCPUs to one host CPU
+        // would report as "pinned" while delivering worse latency than not
+        // pinning at all, which is exactly the silent-degradation this feature
+        // exists to remove.
+        return Err(format!(
+            "cpuPinning=static needs at least {vcpus} CPUs in the launcher pod's cpuset, found {} ({available:?}). \
+             Reduce the class's cpu, or give the pod more CPUs.",
+            available.len()
+        ));
+    }
+
+    let cores = cores(available, siblings);
+    let mut ordered: Vec<u32> = Vec::with_capacity(available.len());
+    match policy {
+        SmtPolicy::Spread => {
+            let depth = cores.iter().map(|c| c.len()).max().unwrap_or(0);
+            for t in 0..depth {
+                for core in &cores {
+                    if let Some(&cpu) = core.get(t) {
+                        ordered.push(cpu);
+                    }
+                }
+            }
+        }
+        SmtPolicy::Pack => {
+            for core in &cores {
+                ordered.extend(core.iter().copied());
+            }
+        }
+    }
+
+    Ok(ordered
+        .into_iter()
+        .take(vcpus as usize)
+        .enumerate()
+        .map(|(i, cpu)| VcpuAffinity {
+            vcpu: i as u32,
+            host_cpus: vec![cpu],
+        })
+        .collect())
+}
+
+/// Build the plan from the live host: the pod's own cpuset plus sysfs topology.
+pub fn plan(vcpus: u32, policy: SmtPolicy) -> Result<Vec<VcpuAffinity>, String> {
+    let available = effective_cpuset()
+        .map_err(|e| format!("determine launcher cpuset for cpuPinning=static: {e}"))?;
+    plan_with_topology(vcpus, &available, policy, &thread_siblings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An 8-CPU SMT host: cores (0,4) (1,5) (2,6) (3,7) — the enumeration used
+    /// by the dev nodes this was validated on.
+    fn smt8(cpu: u32) -> Vec<u32> {
+        vec![cpu % 4, cpu % 4 + 4]
+    }
+    fn no_smt(cpu: u32) -> Vec<u32> {
+        vec![cpu]
+    }
+    fn cpus(p: &[VcpuAffinity]) -> Vec<u32> {
+        p.iter().map(|a| a.host_cpus[0]).collect()
+    }
+
+    #[test]
+    fn parse_cpu_list_forms() {
+        assert_eq!(parse_cpu_list("0-3").unwrap(), vec![0, 1, 2, 3]);
+        assert_eq!(parse_cpu_list("0,2,4").unwrap(), vec![0, 2, 4]);
+        assert_eq!(parse_cpu_list("0-1,4-5").unwrap(), vec![0, 1, 4, 5]);
+        assert_eq!(parse_cpu_list(" 2 \n").unwrap(), vec![2]);
+        assert!(parse_cpu_list("3-1").is_err());
+        assert!(parse_cpu_list("abc").is_err());
+    }
+
+    /// Spread must not put two vCPUs on one physical core while another core is
+    /// still free — that is the entire behavioural difference from pack.
+    #[test]
+    fn spread_uses_a_distinct_core_per_vcpu_first() {
+        let p = plan_with_topology(4, &[0, 1, 2, 3, 4, 5, 6, 7], SmtPolicy::Spread, &smt8).unwrap();
+        assert_eq!(
+            cpus(&p),
+            vec![0, 1, 2, 3],
+            "spread should take one thread of each core"
+        );
+    }
+
+    #[test]
+    fn spread_falls_back_to_second_siblings_when_it_must() {
+        let p = plan_with_topology(6, &[0, 1, 2, 3, 4, 5, 6, 7], SmtPolicy::Spread, &smt8).unwrap();
+        assert_eq!(cpus(&p), vec![0, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn pack_fills_both_siblings_of_a_core_first() {
+        let p = plan_with_topology(4, &[0, 1, 2, 3, 4, 5, 6, 7], SmtPolicy::Pack, &smt8).unwrap();
+        assert_eq!(
+            cpus(&p),
+            vec![0, 4, 1, 5],
+            "pack should consume core (0,4) before core (1,5)"
+        );
+    }
+
+    /// The CPU Manager case: the pod owns an arbitrary subset, and the plan must
+    /// stay inside it.
+    #[test]
+    fn plan_never_leaves_the_pods_cpuset() {
+        let avail = vec![2, 3, 6, 7];
+        for policy in [SmtPolicy::Spread, SmtPolicy::Pack] {
+            let p = plan_with_topology(4, &avail, policy, &smt8).unwrap();
+            let got = cpus(&p);
+            assert_eq!(got.len(), 4);
+            for c in &got {
+                assert!(
+                    avail.contains(c),
+                    "{policy:?} planned cpu {c} outside the cpuset {avail:?}"
+                );
+            }
+        }
+    }
+
+    /// A cpuset holding only one thread of each core must still be usable.
+    #[test]
+    fn partial_cores_are_not_dropped() {
+        let avail = vec![0, 1, 2, 3];
+        let p = plan_with_topology(4, &avail, SmtPolicy::Spread, &smt8).unwrap();
+        assert_eq!(cpus(&p), vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn no_smt_host_is_sequential_under_both_policies() {
+        for policy in [SmtPolicy::Spread, SmtPolicy::Pack] {
+            let p = plan_with_topology(3, &[0, 1, 2, 3], policy, &no_smt).unwrap();
+            assert_eq!(cpus(&p), vec![0, 1, 2]);
+        }
+    }
+
+    /// Oversubscription is refused, not silently accepted — a guest reported as
+    /// pinned must actually be 1:1.
+    #[test]
+    fn too_few_cpus_is_an_error_not_a_double_pin() {
+        let err = plan_with_topology(4, &[0, 1], SmtPolicy::Spread, &smt8).unwrap_err();
+        let msg = err;
+        assert!(
+            msg.contains("at least 4"),
+            "error should name the requirement: {msg}"
+        );
+    }
+
+    #[test]
+    fn vcpu_ids_are_dense_and_ordered() {
+        let p = plan_with_topology(4, &[0, 1, 2, 3, 4, 5, 6, 7], SmtPolicy::Spread, &smt8).unwrap();
+        assert_eq!(
+            p.iter().map(|a| a.vcpu).collect::<Vec<_>>(),
+            vec![0, 1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn smt_policy_parses_with_spread_as_default() {
+        assert_eq!(SmtPolicy::from_intent(Some("pack")), SmtPolicy::Pack);
+        assert_eq!(SmtPolicy::from_intent(Some("spread")), SmtPolicy::Spread);
+        assert_eq!(SmtPolicy::from_intent(None), SmtPolicy::Spread);
+        assert_eq!(SmtPolicy::from_intent(Some("nonsense")), SmtPolicy::Spread);
+    }
+}

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -52,6 +52,16 @@ pub struct RuntimeIntent {
     /// swiftletd appends core_scheduling=<v> to the CH --cpus arg.
     #[serde(default)]
     pub core_scheduling: Option<String>,
+    /// vCPU placement policy ("static"); absent/empty = unpinned. swiftletd
+    /// computes the concrete vCPU->host-CPU map from the launcher pod's own
+    /// effective cpuset (see `cpuset`), because the controller cannot know
+    /// which CPUs the kubelet will hand this pod.
+    #[serde(default)]
+    pub cpu_pinning: Option<String>,
+    /// SMT sibling-placement policy ("spread"/"pack") used when cpu_pinning is
+    /// set. Absent = spread.
+    #[serde(default)]
+    pub smt_policy: Option<String>,
     /// Optional secondary data disk (appears as /dev/vdb in guest).
     /// LEGACY singular field — superseded by `data_disks`. Retained so a
     /// new swiftletd still honors intent JSON written by an older

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -547,6 +547,21 @@ fn run_qemu<F>(
 where
     F: FnOnce(u32, String, String),
 {
+    // cpuPinning is a Cloud-Hypervisor-path control (CH --cpus affinity=). The
+    // QEMU path is only taken for HGX GPU guests, which derive their own vCPU
+    // pinning from GPU NUMA locality below. Say so rather than letting the
+    // class's setting look effective when nothing here reads it.
+    if intent
+        .cpu_pinning
+        .as_deref()
+        .is_some_and(|s| !s.is_empty() && s != "none")
+    {
+        log::warn!(
+            "cpuPinning is ignored on the QEMU path: this guest's vCPU pinning \
+             comes from its GPU NUMA topology instead"
+        );
+    }
+
     let serial_socket = runtime_dir.root().join("serial.sock");
     let qmp_socket = runtime_dir.root().join("qmp.sock");
     let ovmf_vars = runtime_dir.root().join("OVMF_VARS.fd");

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -424,6 +424,32 @@ where
         }
     });
 
+    // vCPU pinning (cpuPinning=static). Computed here, not in the controller:
+    // the map must come from THIS pod's effective cpuset, which is only known
+    // once the kubelet has admitted the pod. A failure is fatal rather than
+    // best-effort — a guest that asked to be pinned and silently was not is the
+    // degradation this feature exists to remove.
+    let cpu_affinity: Vec<(u32, Vec<u32>)> = match intent
+        .cpu_pinning
+        .as_deref()
+        .filter(|s| !s.is_empty() && *s != "none")
+    {
+        None => Vec::new(),
+        Some(_) => {
+            let policy = crate::cpuset::SmtPolicy::from_intent(intent.smt_policy.as_deref());
+            let plan = crate::cpuset::plan(intent.cpu.max(1), policy)?;
+            log::info!(
+                "cpuPinning=static ({:?}): {}",
+                policy,
+                plan.iter()
+                    .map(|a| format!("vcpu{}->cpu{:?}", a.vcpu, a.host_cpus))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            );
+            plan.into_iter().map(|a| (a.vcpu, a.host_cpus)).collect()
+        }
+    };
+
     let config = if intent.has_kernel() {
         let kb = intent.kernel_boot.as_ref().unwrap();
         VmConfig {
@@ -435,6 +461,7 @@ where
                 .core_scheduling
                 .clone()
                 .filter(|s| !s.is_empty() && s != "off"),
+            cpu_affinity: cpu_affinity.clone(),
             api_socket: runtime_dir.api_socket().to_string_lossy().to_string(),
             seed_path: String::new(),
             serial_socket_path: Some(serial_socket_path.clone()),
@@ -465,6 +492,7 @@ where
                 .core_scheduling
                 .clone()
                 .filter(|s| !s.is_empty() && s != "off"),
+            cpu_affinity: cpu_affinity.clone(),
             api_socket: runtime_dir.api_socket().to_string_lossy().to_string(),
             seed_path,
             serial_socket_path: Some(serial_socket_path.clone()),

--- a/rust/swiftletd/src/main.rs
+++ b/rust/swiftletd/src/main.rs
@@ -1,4 +1,5 @@
 mod action;
+mod cpuset;
 mod intent;
 mod kube_client;
 mod launch;


### PR DESCRIPTION
Closes part of #393 (P1), and answers the first three asks in #561.

Adds two fields to `SwiftGuestClass`:

| Field | Values | Meaning |
|---|---|---|
| `cpuPinning` | `none` (default), `static` | pin vCPU *N* to one host CPU |
| `smtPolicy` | `spread` (default), `pack` | which SMT siblings a pinned guest uses |

Rendered as Cloud Hypervisor `--cpus affinity=`. Default `none` on both, so
every existing class emits byte-identical args.

## Why this was missing

The NUMA/pinning/hugepage data model already existed — but inside `GPUIntent`,
so it was reachable only through a `gpuProfileRef`, and the only implementation
was QEMU-side (`swift-qemu-client/src/pinning.rs`). The CH client had no
affinity support at all: `--cpus` emitted `boot=N[,kvm_hyperv][,core_scheduling]`
and nothing else. This generalises the capability off the GPU dependency for the
default runtime.

## The load-bearing decision: the map is computed in swiftletd, not the controller

The existing GPU path computes its pinning map controller-side from
`SwiftGPUNode` topology. **That approach is not correct here, and this PR
deliberately inverts it.**

Under the kubelet CPU Manager `static` policy, a pod's exclusive CPUs are
assigned at admission — *after* the controller has written the runtime intent.
A CPU chosen before that assignment lies outside the pod's cgroup `cpuset.cpus`,
so `sched_setaffinity`/CH affinity is clamped or rejected and the guest runs
unpinned while still reporting as pinned.

So the intent carries the **policy**, and `swiftletd` reads the launcher pod's
own `cpuset.cpus.effective` at launch and computes the map from it. With the
policy at `none` that set is every host CPU, so the same code is correct under
both policies, and stays correct if a node's policy changes later.

The launcher pod already sets `Requests == Limits` with an integral CPU count,
which is what CPU Manager `static` requires before granting exclusive CPUs — so
no pod-spec change was needed to benefit from it.

## No silent degradation

- A cpuset smaller than the vCPU count **fails the launch** with an explicit
  message naming the requirement. Pinning two vCPUs onto one host CPU would
  report success while being slower than not pinning at all.
- `cpuPinning` on the QEMU (HGX GPU) path now **warns** that it is ignored there
  — that path derives its pinning from GPU NUMA locality.

## The affinity syntax was verified against the binary, not the docs

Probed `cloud-hypervisor v53.0` directly. The list must be bracketed:

```
affinity=[0@[0],1@[1]]   accepted
affinity=0@[0]:1@[1]     ParseCpus(Conversion("affinity"))
```

The unbracketed form is accepted as a *key* and then fails value conversion,
because CH's option parser splits `--cpus` on commas. A renderer test pins that
shape so it cannot regress.

## Scope

Placement only. **NUMA alignment and hugepage-backed memory are deliberately
excluded** — neither can be validated on a single-NUMA-node host, and shipping
an unvalidatable NUMA API is how it ends up subtly wrong.

## Tests

10 new planner tests (spread vs pack, partial cores, non-SMT hosts, staying
inside an arbitrary cpuset, refusing oversubscription), 1 renderer test, 3 Go
tests. Planner is pure — topology is injected, so placement is tested without
sysfs or a tuned node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)