### PR TITLE
feat(swiftguestclass): hugepage-backed guest memory on Cloud Hypervisor

### DIFF
--- a/api/swift/v1alpha1/swiftguestclass_types.go
+++ b/api/swift/v1alpha1/swiftguestclass_types.go
@@ -82,6 +82,33 @@ const (
 	SMTPolicyPack   SMTPolicy = "pack"
 )
 
+// Hugepages selects the page size backing a guest's RAM
+// (Cloud Hypervisor `--memory hugepages=on,hugepage_size=`).
+//
+//	""    (default) guest RAM is ordinary 4K pages.
+//	2Mi   back guest RAM with 2MiB hugepages.
+//	1Gi   back guest RAM with 1GiB hugepages.
+//
+// Hugepages cut TLB misses and page-table walks for memory-heavy guests, and
+// are a prerequisite for DPDK-style workloads inside the guest. They are also
+// never swapped, so guest RAM stays resident.
+//
+// The node must have the pages reserved BEFORE the guest is scheduled: the
+// kubelet advertises them as a `hugepages-2Mi` / `hugepages-1Gi` resource, and
+// the launcher pod requests that resource instead of ordinary memory. A class
+// asking for a size the node has not reserved simply will not schedule, which
+// is the intended failure mode — it is visible, and it happens before any VM
+// starts.
+//
+// +kubebuilder:validation:Enum="";"2Mi";"1Gi"
+type Hugepages string
+
+const (
+	HugepagesNone Hugepages = ""
+	Hugepages2Mi  Hugepages = "2Mi"
+	Hugepages1Gi  Hugepages = "1Gi"
+)
+
 // SwiftGuestClassSpec defines the desired state of SwiftGuestClass.
 type SwiftGuestClassSpec struct {
 	CPU      resource.Quantity `json:"cpu"`
@@ -112,6 +139,13 @@ type SwiftGuestClassSpec struct {
 	// +kubebuilder:default=spread
 	// +optional
 	SMTPolicy SMTPolicy `json:"smtPolicy,omitempty"`
+	// Hugepages backs this class's guest RAM with hugepages of the given size.
+	// Empty (default) keeps ordinary 4K pages. The launcher pod then requests
+	// `hugepages-<size>` equal to the guest's memory instead of that much
+	// ordinary memory, so the node must have the pages reserved or the pod will
+	// not schedule.
+	// +optional
+	Hugepages Hugepages `json:"hugepages,omitempty"`
 }
 
 // SwiftGuestClass is the Schema for the swiftguestclasses API.

--- a/charts/kubeswift/crds/swift.kubeswift.io_swiftguestclasses.yaml
+++ b/charts/kubeswift/crds/swift.kubeswift.io_swiftguestclasses.yaml
@@ -82,6 +82,18 @@ spec:
                 - none
                 - static
                 type: string
+              hugepages:
+                description: |-
+                  Hugepages backs this class's guest RAM with hugepages of the given size.
+                  Empty (default) keeps ordinary 4K pages. The launcher pod then requests
+                  `hugepages-<size>` equal to the guest's memory instead of that much
+                  ordinary memory, so the node must have the pages reserved or the pod will
+                  not schedule.
+                enum:
+                - ""
+                - 2Mi
+                - 1Gi
+                type: string
               memory:
                 anyOf:
                 - type: integer

--- a/config/crd/bases/swift.kubeswift.io_swiftguestclasses.yaml
+++ b/config/crd/bases/swift.kubeswift.io_swiftguestclasses.yaml
@@ -82,6 +82,18 @@ spec:
                 - none
                 - static
                 type: string
+              hugepages:
+                description: |-
+                  Hugepages backs this class's guest RAM with hugepages of the given size.
+                  Empty (default) keeps ordinary 4K pages. The launcher pod then requests
+                  `hugepages-<size>` equal to the guest's memory instead of that much
+                  ordinary memory, so the node must have the pages reserved or the pod will
+                  not schedule.
+                enum:
+                - ""
+                - 2Mi
+                - 1Gi
+                type: string
               memory:
                 anyOf:
                 - type: integer

--- a/config/samples/performance/swiftguestclass-hugepages.yaml
+++ b/config/samples/performance/swiftguestclass-hugepages.yaml
@@ -1,0 +1,46 @@
+# A guest class whose RAM is backed by hugepages.
+#
+# Hugepages cut TLB misses and page-table walks for memory-heavy guests, keep
+# guest RAM permanently resident (hugepages are never swapped), and are a
+# prerequisite for DPDK-style workloads running inside the guest.
+#
+# THE NODE MUST RESERVE THE PAGES FIRST. The kubelet only advertises
+# hugepages-2Mi / hugepages-1Gi that are already reserved on the host, and it
+# reads them at startup:
+#
+#   # 8GiB as 2MiB pages, persisted across reboot
+#   sysctl -w vm.nr_hugepages=4096
+#   echo "vm.nr_hugepages = 4096" > /etc/sysctl.d/90-kubeswift-hugepages.conf
+#   # then restart the kubelet so it re-reads capacity
+#
+# 1Gi pages generally cannot be reserved reliably at runtime on a host that has
+# been up for a while — memory is too fragmented. Reserve them at boot instead:
+#
+#   GRUB_CMDLINE_LINUX="... default_hugepagesz=1G hugepagesz=1G hugepages=8"
+#
+# Confirm the node advertises them before creating a guest:
+#
+#   kubectl get node <node> -o jsonpath='{.status.allocatable}' | tr ',' '\n' | grep hugepages
+#
+# A class asking for a size the node has not reserved simply will not schedule.
+# That is the intended failure mode: it is visible, and it happens before any
+# VM starts rather than halfway through boot.
+#
+# ACCOUNTING: guest RAM MOVES to the hugepages resource, it is not requested
+# twice. The launcher pod requests `hugepages-2Mi: <memory>` plus only its own
+# overhead as ordinary memory — the kubelet already subtracts reserved
+# hugepages from the node's allocatable memory, so booking both would consume
+# twice the guest's RAM from the node.
+apiVersion: swift.kubeswift.io/v1alpha1
+kind: SwiftGuestClass
+metadata:
+  name: hugepage-backed
+spec:
+  cpu: 2
+  memory: 4Gi
+  rootDisk: { format: raw, size: 20Gi }
+  hugepages: 2Mi
+  # Hugepages compose with the CPU-placement knobs — a latency-sensitive guest
+  # typically wants both.
+  cpuPinning: static
+  smtPolicy: spread

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ KubeSwift runs Linux and Windows VMs on Kubernetes. [Cloud Hypervisor](https://w
 ### Performance
 
 - [CPU pinning and SMT placement](performance/cpu-pinning.md) — pin vCPUs to dedicated host CPUs, choose hyper-thread siblings, interaction with the kubelet CPU Manager
+- [Hugepage-backed guest memory](performance/hugepages.md) — back guest RAM with 2MiB/1GiB pages, node reservation, and how the launcher accounts for it
 
 ### Sandboxes
 

--- a/docs/performance/hugepages.md
+++ b/docs/performance/hugepages.md
@@ -1,0 +1,93 @@
+# Hugepage-backed guest memory
+
+`SwiftGuestClass.spec.hugepages` backs a guest's RAM with 2MiB or 1GiB pages
+instead of the default 4K, rendered as Cloud Hypervisor
+`--memory hugepages=on,hugepage_size=`.
+
+| Value | Effect |
+|---|---|
+| *(unset)* | ordinary 4K pages — unchanged behaviour |
+| `2Mi` | guest RAM from 2MiB hugepages |
+| `1Gi` | guest RAM from 1GiB hugepages |
+
+Hugepages cut TLB misses and page-table walks for memory-heavy guests, keep
+guest RAM permanently resident (hugepages are never swapped), and are a
+prerequisite for DPDK-style workloads inside the guest.
+
+## Reserve the pages on the node first
+
+The kubelet only advertises hugepages already reserved on the host, and it
+reads them **at startup**. A class asking for a size the node has not reserved
+will not schedule — which is the intended failure mode: it is visible, and it
+happens before any VM starts.
+
+### 2Mi — runtime, no reboot
+
+```
+sysctl -w vm.nr_hugepages=4096                                    # 8GiB
+echo "vm.nr_hugepages = 4096" > /etc/sysctl.d/90-kubeswift-hugepages.conf
+```
+
+### 1Gi — boot time
+
+1Gi pages need physically contiguous memory and generally cannot be reserved
+reliably on a host that has been up for a while. Reserve at boot:
+
+```
+GRUB_CMDLINE_LINUX="... default_hugepagesz=1G hugepagesz=1G hugepages=8"
+```
+
+Then `update-grub` and reboot.
+
+### Make the kubelet notice
+
+Restarting the kubelet is required either way. Restarting the whole node agent
+usually also restarts the container runtime, which bounces every pod on the
+node — check how your distribution supervises the two before doing it on a node
+with running guests.
+
+Confirm the node advertises the resource:
+
+```
+kubectl get node <node> -o jsonpath='{.status.allocatable}' | tr ',' '\n' | grep hugepages
+```
+
+## How the launcher accounts for it
+
+Guest RAM **moves** to the hugepages resource rather than being requested
+twice. With `hugepages: 2Mi` on a 4Gi class the launcher pod requests:
+
+- `hugepages-2Mi: 4Gi` — the guest's RAM
+- `memory:` the launcher overhead only
+
+The kubelet subtracts reserved hugepages from the node's allocatable `memory`,
+so a pod booking both would consume twice the guest's RAM from the node and
+stop scheduling long before the hugepages ran out.
+
+The container gets a size-qualified `emptyDir` (`medium: HugePages-2Mi`)
+mounted at `/dev/hugepages`, which is where Cloud Hypervisor allocates from.
+
+## Units
+
+The CRD uses Kubernetes units (`2Mi`, `1Gi`) because that is what the matching
+node resource is called. Cloud Hypervisor rejects those —
+`ParseMemory(Conversion("hugepage_size", "2Mi"))` — so the controller
+translates to `2M` / `1G` when writing the runtime intent.
+
+## `reserve=on` is load-bearing here
+
+KubeSwift always emits `reserve=on` on `--memory`. With hugepages that is not
+merely a fail-fast nicety:
+
+| Config, on a node with no pages reserved | Result |
+|---|---|
+| `hugepages=on` **with** `reserve=on` | clean `GuestMemoryRegion(Mmap(OutOfMemory))` |
+| `hugepages=on` **without** `reserve=on` | **SIGBUS** — the VMM dies (exit 135) |
+
+Verified against Cloud Hypervisor v53.0. Do not drop `reserve=on`.
+
+## Related
+
+`hugepages` composes with `cpuPinning` and `smtPolicy`
+(see [cpu-pinning.md](cpu-pinning.md)) — a latency-sensitive guest usually
+wants both. It is independent of `coreScheduling`.

--- a/internal/controller/swiftguest/hugepages.go
+++ b/internal/controller/swiftguest/hugepages.go
@@ -1,0 +1,59 @@
+package swiftguest
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kubeswift-io/kubeswift/internal/resolved"
+)
+
+// HugepagesMountPath is where the launcher gets its hugetlbfs mount. Cloud
+// Hypervisor's `hugepages=on` allocates guest RAM from the default hugetlbfs
+// mount, which is this path.
+const HugepagesMountPath = "/dev/hugepages"
+
+// applyHugepages rewrites a launcher pod's memory accounting when the guest
+// class asks for hugepage-backed RAM, and returns the volume/mount that give
+// the container a hugetlbfs to allocate from.
+//
+// The load-bearing part is that guest RAM MOVES from `memory` to
+// `hugepages-<size>` rather than being requested twice. The kubelet subtracts
+// reserved hugepages from the node's allocatable `memory` (observed directly:
+// reserving 8Gi of 2Mi pages dropped allocatable memory by exactly that much),
+// so a pod that asked for both would consume 2x its guest RAM worth of the
+// node and stop scheduling long before the hugepages ran out.
+//
+// The launcher overhead stays on ordinary `memory`: it is the VMM's own
+// working set (page tables, device emulation, virtiofsd), which is not
+// allocated from hugetlbfs.
+//
+// Requests and limits are set to the same value because Kubernetes requires it
+// for hugepages — they are a non-overcommittable resource.
+func applyHugepages(res *corev1.ResourceRequirements, rg *resolved.ResolvedGuest, guestMemMiB int) (*corev1.Volume, *corev1.VolumeMount) {
+	name := rg.GetHugepagesResourceName()
+	if name == "" {
+		return nil, nil
+	}
+
+	qty := *resource.NewQuantity(int64(guestMemMiB)*1024*1024, resource.BinarySI)
+	rn := corev1.ResourceName(name)
+	res.Requests[rn] = qty
+	res.Limits[rn] = qty
+
+	// Guest RAM now comes from hugetlbfs, so leave only the launcher overhead
+	// on ordinary memory. Without this the pod double-books the node.
+	overhead := *resource.NewQuantity(int64(LauncherMemoryOverheadMiB)*1024*1024, resource.BinarySI)
+	res.Requests[corev1.ResourceMemory] = overhead
+	res.Limits[corev1.ResourceMemory] = overhead
+
+	// medium is size-qualified ("HugePages-2Mi"), not bare "HugePages": a bare
+	// medium is only unambiguous on a node offering a single hugepage size, and
+	// these nodes expose both pools.
+	medium := corev1.StorageMedium("HugePages-" + rg.Hugepages)
+	vol := &corev1.Volume{
+		Name:         "hugepages",
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: medium}},
+	}
+	mount := &corev1.VolumeMount{Name: "hugepages", MountPath: HugepagesMountPath}
+	return vol, mount
+}

--- a/internal/controller/swiftguest/hugepages_test.go
+++ b/internal/controller/swiftguest/hugepages_test.go
@@ -1,0 +1,123 @@
+package swiftguest
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kubeswift-io/kubeswift/internal/resolved"
+)
+
+func baseResources(memMiB int) corev1.ResourceRequirements {
+	q := *resource.NewQuantity(int64(memMiB+LauncherMemoryOverheadMiB)*1024*1024, resource.BinarySI)
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceMemory: q},
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: q},
+	}
+}
+
+// The whole point of the feature: guest RAM MOVES to hugepages, it is not
+// requested twice. The kubelet subtracts reserved hugepages from allocatable
+// `memory`, so double-booking would consume 2x the guest's RAM from the node
+// and wedge scheduling well before the hugepages ran out.
+func TestApplyHugepagesMovesGuestRAMOffOrdinaryMemory(t *testing.T) {
+	const mem = 4096
+	res := baseResources(mem)
+	rg := &resolved.ResolvedGuest{}
+	rg.Hugepages = "2Mi"
+
+	vol, mount := applyHugepages(&res, rg, mem)
+	if vol == nil || mount == nil {
+		t.Fatal("expected a hugetlbfs volume and mount")
+	}
+
+	hp, ok := res.Limits["hugepages-2Mi"]
+	if !ok {
+		t.Fatal("no hugepages-2Mi limit set")
+	}
+	if got := hp.Value(); got != int64(mem)*1024*1024 {
+		t.Errorf("hugepages-2Mi = %d, want %d (the full guest RAM)", got, int64(mem)*1024*1024)
+	}
+
+	// Ordinary memory must now be ONLY the launcher overhead.
+	wantOverhead := int64(LauncherMemoryOverheadMiB) * 1024 * 1024
+	if got := res.Limits[corev1.ResourceMemory]; got.Value() != wantOverhead {
+		t.Errorf("memory limit = %d, want %d — guest RAM must not be booked twice",
+			got.Value(), wantOverhead)
+	}
+
+	// Kubernetes requires request == limit for hugepages.
+	if req := res.Requests["hugepages-2Mi"]; req.Value() != hp.Value() {
+		t.Errorf("hugepages request %d != limit %d; Kubernetes rejects unequal hugepage requests",
+			req.Value(), hp.Value())
+	}
+}
+
+// The emptyDir medium must name the SIZE. A bare "HugePages" medium is only
+// unambiguous on a node offering one page size, and these nodes expose both.
+func TestApplyHugepagesUsesSizeQualifiedMedium(t *testing.T) {
+	for _, tc := range []struct{ size, wantMedium, wantResource string }{
+		{"2Mi", "HugePages-2Mi", "hugepages-2Mi"},
+		{"1Gi", "HugePages-1Gi", "hugepages-1Gi"},
+	} {
+		res := baseResources(2048)
+		rg := &resolved.ResolvedGuest{}
+		rg.Hugepages = tc.size
+
+		vol, mount := applyHugepages(&res, rg, 2048)
+		if vol == nil {
+			t.Fatalf("%s: no volume", tc.size)
+		}
+		if got := string(vol.VolumeSource.EmptyDir.Medium); got != tc.wantMedium {
+			t.Errorf("%s: medium = %q, want %q", tc.size, got, tc.wantMedium)
+		}
+		if _, ok := res.Limits[corev1.ResourceName(tc.wantResource)]; !ok {
+			t.Errorf("%s: missing %s limit", tc.size, tc.wantResource)
+		}
+		if mount.MountPath != HugepagesMountPath {
+			t.Errorf("%s: mount path = %q, want %q", tc.size, mount.MountPath, HugepagesMountPath)
+		}
+	}
+}
+
+// Unset must be a complete no-op — every existing class keeps its exact
+// resource block and gains no volume.
+func TestApplyHugepagesUnsetIsANoOp(t *testing.T) {
+	const mem = 4096
+	res := baseResources(mem)
+	before := res.Limits[corev1.ResourceMemory]
+	rg := &resolved.ResolvedGuest{} // Hugepages == ""
+
+	vol, mount := applyHugepages(&res, rg, mem)
+	if vol != nil || mount != nil {
+		t.Fatal("unset hugepages must not add a volume or mount")
+	}
+	if got := res.Limits[corev1.ResourceMemory]; got.Value() != before.Value() {
+		t.Errorf("memory limit changed with hugepages unset: %d -> %d", before.Value(), got.Value())
+	}
+	for name := range res.Limits {
+		if name != corev1.ResourceMemory {
+			t.Errorf("unexpected resource added: %s", name)
+		}
+	}
+}
+
+// The CRD speaks Kubernetes units; Cloud Hypervisor rejects them. If this
+// translation is lost, CH fails with Conversion("hugepage_size", "2Mi").
+func TestGetHugepagesTranslatesToCloudHypervisorUnits(t *testing.T) {
+	for _, tc := range []struct{ in, wantCH, wantResource string }{
+		{"", "", ""},
+		{"2Mi", "2M", "hugepages-2Mi"},
+		{"1Gi", "1G", "hugepages-1Gi"},
+	} {
+		rg := &resolved.ResolvedGuest{}
+		rg.Hugepages = tc.in
+		if got := rg.GetHugepages(); got != tc.wantCH {
+			t.Errorf("GetHugepages(%q) = %q, want %q", tc.in, got, tc.wantCH)
+		}
+		if got := rg.GetHugepagesResourceName(); got != tc.wantResource {
+			t.Errorf("GetHugepagesResourceName(%q) = %q, want %q", tc.in, got, tc.wantResource)
+		}
+	}
+}

--- a/internal/controller/swiftguest/pod.go
+++ b/internal/controller/swiftguest/pod.go
@@ -476,6 +476,13 @@ func buildKernelBootPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGu
 	}
 	AddSRIOVResourceLimits(&resources, guest)
 
+	// Hugepage-backed guest RAM moves the guest's memory from `memory` to
+	// `hugepages-<size>` and hands the launcher a hugetlbfs mount.
+	if hpVol, hpMount := applyHugepages(&resources, rg, mem); hpVol != nil {
+		volumes = append(volumes, *hpVol)
+		mounts = append(mounts, *hpMount)
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        guest.Name,
@@ -604,6 +611,13 @@ func buildDiskBootPod(guest *swiftv1alpha1.SwiftGuest, rg *resolved.ResolvedGues
 		},
 	}
 	AddSRIOVResourceLimits(&resources, guest)
+
+	// Hugepage-backed guest RAM moves the guest's memory from `memory` to
+	// `hugepages-<size>` and hands the launcher a hugetlbfs mount.
+	if hpVol, hpMount := applyHugepages(&resources, rg, mem); hpVol != nil {
+		volumes = append(volumes, *hpVol)
+		mounts = append(mounts, *hpMount)
+	}
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/resolved/merge.go
+++ b/internal/resolved/merge.go
@@ -38,6 +38,7 @@ func Merge(
 		// args carry no affinity param, i.e. today's behaviour.
 		rg.CPUPinning = string(guestClass.Spec.CPUPinning)
 		rg.SMTPolicy = string(guestClass.Spec.SMTPolicy)
+		rg.Hugepages = string(guestClass.Spec.Hugepages)
 	}
 
 	// RootDisk: from GuestClass

--- a/internal/resolved/types.go
+++ b/internal/resolved/types.go
@@ -81,6 +81,9 @@ type ResolvedGuest struct {
 	// SMTPolicy is the sibling-placement policy from the SwiftGuestClass
 	// ("spread"/"pack"), meaningful only when CPUPinning is "static".
 	SMTPolicy string `json:"smtPolicy,omitempty"`
+	// Hugepages is the guest-RAM page size from the SwiftGuestClass, in
+	// Kubernetes units ("2Mi"/"1Gi"); empty means ordinary 4K pages.
+	Hugepages string `json:"hugepages,omitempty"`
 	// GuestAgentEnabled is true for a SOURCE guest that opted into the in-guest
 	// identity agent (spec.guestAgentEnabled). It gates the CH --vsock device.
 	// The resolver sets it false for a clone (cloneFromSnapshot): a clone
@@ -352,6 +355,33 @@ func (r *ResolvedGuest) GetCPUPinning() string {
 // It is only consulted when GetCPUPinning() is non-empty, but defaulting here
 // (rather than in swiftletd) keeps the emitted intent explicit about which
 // policy a guest actually ran under.
+// GetHugepages returns the guest-RAM page size in CLOUD HYPERVISOR units
+// ("2M"/"1G"), or "" for ordinary pages.
+//
+// The CRD speaks Kubernetes units ("2Mi"/"1Gi") because that is what the
+// matching node resource is called; Cloud Hypervisor rejects those outright
+// (`ParseMemory(Conversion("hugepage_size", "2Mi"))`, verified against v53.0),
+// so the translation happens here — the same split the GPU path already uses.
+func (r *ResolvedGuest) GetHugepages() string {
+	switch r.Hugepages {
+	case string(swiftv1alpha1.Hugepages2Mi):
+		return "2M"
+	case string(swiftv1alpha1.Hugepages1Gi):
+		return "1G"
+	default:
+		return ""
+	}
+}
+
+// GetHugepagesResourceName returns the Kubernetes node resource backing this
+// class ("hugepages-2Mi"/"hugepages-1Gi"), or "" when unset.
+func (r *ResolvedGuest) GetHugepagesResourceName() string {
+	if r.Hugepages == "" {
+		return ""
+	}
+	return "hugepages-" + r.Hugepages
+}
+
 func (r *ResolvedGuest) GetSMTPolicy() string {
 	if r.SMTPolicy == "" {
 		return string(swiftv1alpha1.SMTPolicySpread)

--- a/internal/runtimeintent/build.go
+++ b/internal/runtimeintent/build.go
@@ -34,6 +34,7 @@ type ResolvedGuest interface {
 	GetCoreScheduling() string
 	GetCPUPinning() string
 	GetSMTPolicy() string
+	GetHugepages() string
 	// GetVsockCID returns the vsock CID for a SOURCE guest that opted into the
 	// in-guest identity agent, or 0 when the agent is not enabled (or the guest
 	// is a clone — a clone reopens the captured vsock device from config.json).
@@ -51,6 +52,7 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 	vhostUserDevices := rg.GetVhostUserDevices()
 	coreScheduling := rg.GetCoreScheduling()
 	cpuPinning := rg.GetCPUPinning()
+	hugepages := rg.GetHugepages()
 	// smtPolicy is only meaningful alongside cpuPinning; keep the intent
 	// clean by omitting it when the guest is not pinned.
 	smtPolicy := ""
@@ -87,6 +89,7 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 			CoreScheduling:      coreScheduling,
 			CPUPinning:          cpuPinning,
 			SMTPolicy:           smtPolicy,
+			Hugepages:           hugepages,
 			Vsock:               vsock,
 			KernelBoot: &KernelBootSpec{
 				KernelPath:    rg.GetKernelPath(),
@@ -135,6 +138,7 @@ func Build(rg ResolvedGuest) *RuntimeIntent {
 		CoreScheduling:      coreScheduling,
 		CPUPinning:          cpuPinning,
 		SMTPolicy:           smtPolicy,
+		Hugepages:           hugepages,
 		Vsock:               vsock,
 	}
 }

--- a/internal/runtimeintent/build_test.go
+++ b/internal/runtimeintent/build_test.go
@@ -26,6 +26,7 @@ type mockResolvedGuest struct {
 	coreScheduling      string
 	cpuPinning          string
 	smtPolicy           string
+	hugepages           string
 	vsockCID            uint32
 	primaryUDNInterface string
 }
@@ -59,6 +60,7 @@ func (m *mockResolvedGuest) GetVhostUserDevices() []VhostUserDeviceIntent {
 }
 func (m *mockResolvedGuest) GetCoreScheduling() string { return m.coreScheduling }
 func (m *mockResolvedGuest) GetCPUPinning() string     { return m.cpuPinning }
+func (m *mockResolvedGuest) GetHugepages() string      { return m.hugepages }
 func (m *mockResolvedGuest) GetSMTPolicy() string {
 	if m.smtPolicy == "" {
 		return "spread"

--- a/internal/runtimeintent/types.go
+++ b/internal/runtimeintent/types.go
@@ -28,7 +28,11 @@ type RuntimeIntent struct {
 	// SMTPolicy is the sibling-placement policy ("spread"/"pack") used when
 	// CPUPinning is set. Emitted whenever CPUPinning is, so the intent records
 	// which policy the guest actually ran under.
-	SMTPolicy string     `json:"smtPolicy,omitempty"`
+	SMTPolicy string `json:"smtPolicy,omitempty"`
+	// Hugepages is the guest-RAM page size in CLOUD HYPERVISOR units ("2M"/"1G"),
+	// empty for ordinary pages. swiftletd appends
+	// hugepages=on,hugepage_size=<v> to --memory.
+	Hugepages string     `json:"hugepages,omitempty"`
 	GPU       *GPUIntent `json:"gpu,omitempty"` // populated when gpuProfileRef is set
 	// DataDisks are the secondary VM disks, in deterministic order. Each becomes
 	// one CH --disk and enumerates in the guest as /dev/vdc, /dev/vdd, ... in

--- a/rust/swift-ch-client/src/config.rs
+++ b/rust/swift-ch-client/src/config.rs
@@ -65,6 +65,13 @@ pub struct VmConfig {
     /// swiftletd computes the mapping from the launcher pod's effective cpuset;
     /// this crate only renders what it is given.
     pub cpu_affinity: Vec<(u32, Vec<u32>)>,
+    /// Guest-RAM hugepage size ("2M"/"1G"). None = ordinary 4K pages.
+    /// Appended to --memory as `hugepages=on,hugepage_size=<v>`.
+    ///
+    /// CH units, NOT Kubernetes units: `hugepage_size=2Mi` is rejected with
+    /// `ParseMemory(Conversion("hugepage_size", "2Mi"))` (verified against
+    /// v53.0). The controller does the translation.
+    pub hugepages: Option<String>,
     /// Path for Cloud Hypervisor API socket.
     pub api_socket: String,
     /// Optional path to seed media (NoCloud dir or ISO). Empty = no seed.
@@ -217,7 +224,18 @@ impl VmConfig {
             // requests the full guest RAM, so a scheduled guest's node has it; this
             // only trips on real node-level memory pressure, which is exactly when
             // we want to refuse to start rather than OOM later.
-            format!("size={}M,shared=on,reserve=on", self.memory_mib),
+            {
+                // reserve=on is load-bearing WITH hugepages, not just without.
+                // On a node with no pages reserved, `hugepages=on` without
+                // reserve=on SIGBUSes the VMM (exit 135); with reserve=on the
+                // same config fails cleanly as GuestMemoryRegion(Mmap(OutOfMemory)).
+                // Verified against v53.0 -- keep them together.
+                let mut m = format!("size={}M,shared=on,reserve=on", self.memory_mib);
+                if let Some(ref hp) = self.hugepages {
+                    m.push_str(&format!(",hugepages=on,hugepage_size={}", hp));
+                }
+                m
+            },
             "--cpus".to_string(),
             {
                 let mut cpus = format!("boot={}", self.cpus.max(1));
@@ -473,6 +491,7 @@ mod tests {
             kvm_hyperv: false,
             core_scheduling: None,
             cpu_affinity: Vec::new(),
+            hugepages: None,
             api_socket: "/tmp/ch.sock".to_string(),
             seed_path: "/data/seed".to_string(),
             serial_socket_path: Some("/tmp/serial.sock".to_string()),
@@ -671,6 +690,41 @@ mod tests {
     ///   affinity=0@[0]:1@[1]    -> ParseCpus(Conversion("affinity"))
     /// This test is what keeps that shape from regressing.
     #[test]
+    /// hugepage_size must be CH units ("2M"/"1G"). Kubernetes units are
+    /// rejected by CH (`Conversion("hugepage_size", "2Mi")`), so if a
+    /// translation is ever lost upstream this test is where it surfaces.
+    ///
+    /// reserve=on must SURVIVE alongside hugepages: without it, a node with no
+    /// reserved pages SIGBUSes the VMM instead of failing cleanly.
+    #[test]
+    fn test_hugepages_emit_on_memory_and_keep_reserve() {
+        let mut cfg = make_disk_boot_config();
+        cfg.hugepages = Some("2M".to_string());
+        let joined = cfg.to_args().join(" ");
+        assert!(
+            joined
+                .contains("--memory size=2048M,shared=on,reserve=on,hugepages=on,hugepage_size=2M"),
+            "hugepages must append to --memory and keep reserve=on: {}",
+            joined
+        );
+
+        let mut g = make_disk_boot_config();
+        g.hugepages = Some("1G".to_string());
+        assert!(g
+            .to_args()
+            .join(" ")
+            .contains(",hugepages=on,hugepage_size=1G"));
+
+        // None -> byte-identical to the pre-feature arg.
+        let none = make_disk_boot_config().to_args().join(" ");
+        assert!(
+            none.contains("--memory size=2048M,shared=on,reserve=on")
+                && !none.contains("hugepages"),
+            "unpinned memory arg changed: {}",
+            none
+        );
+    }
+
     fn test_cpu_affinity_emits_bracketed_list_on_cpus() {
         let mut cfg = make_disk_boot_config();
         cfg.cpu_affinity = vec![(0, vec![2]), (1, vec![3])];

--- a/rust/swiftletd/src/intent.rs
+++ b/rust/swiftletd/src/intent.rs
@@ -62,6 +62,11 @@ pub struct RuntimeIntent {
     /// set. Absent = spread.
     #[serde(default)]
     pub smt_policy: Option<String>,
+    /// Guest-RAM page size in CLOUD HYPERVISOR units ("2M"/"1G"); absent/empty
+    /// = ordinary 4K pages. The Go controller translates the CRD's Kubernetes
+    /// units ("2Mi"/"1Gi"), which CH rejects.
+    #[serde(default)]
+    pub hugepages: Option<String>,
     /// Optional secondary data disk (appears as /dev/vdb in guest).
     /// LEGACY singular field — superseded by `data_disks`. Retained so a
     /// new swiftletd still honors intent JSON written by an older

--- a/rust/swiftletd/src/launch.rs
+++ b/rust/swiftletd/src/launch.rs
@@ -462,6 +462,7 @@ where
                 .clone()
                 .filter(|s| !s.is_empty() && s != "off"),
             cpu_affinity: cpu_affinity.clone(),
+            hugepages: intent.hugepages.clone().filter(|s| !s.is_empty()),
             api_socket: runtime_dir.api_socket().to_string_lossy().to_string(),
             seed_path: String::new(),
             serial_socket_path: Some(serial_socket_path.clone()),
@@ -493,6 +494,7 @@ where
                 .clone()
                 .filter(|s| !s.is_empty() && s != "off"),
             cpu_affinity: cpu_affinity.clone(),
+            hugepages: intent.hugepages.clone().filter(|s| !s.is_empty()),
             api_socket: runtime_dir.api_socket().to_string_lossy().to_string(),
             seed_path,
             serial_socket_path: Some(serial_socket_path.clone()),


### PR DESCRIPTION
Closes part of #393 (P1), and answers the "hugepage-aware placement" ask in #561.

Adds one field to `SwiftGuestClass`:

| Field | Values | Meaning |
|---|---|---|
| `hugepages` | *(unset)*, `2Mi`, `1Gi` | back guest RAM with hugepages |

Rendered as Cloud Hypervisor `--memory hugepages=on,hugepage_size=`. Unset by
default, so every existing class emits a byte-identical `--memory` arg.

## The load-bearing decision: guest RAM *moves*, it is not requested twice

The kubelet subtracts reserved hugepages from the node's allocatable `memory`.
I measured this directly — reserving 8Gi of 2Mi pages dropped allocatable
memory by exactly 8Gi. So a launcher pod requesting **both** `memory: 4Gi` and
`hugepages-2Mi: 4Gi` would consume twice the guest's RAM from the node and stop
scheduling long before the hugepages ran out.

The pod therefore requests `hugepages-<size>` equal to the guest RAM, and keeps
only its own overhead on ordinary memory. Observed on a running guest:

```
requests: {cpu: 2, hugepages-2Mi: 4Gi, memory: 512Mi}
limits  : {cpu: 2, hugepages-2Mi: 4Gi, memory: 512Mi}
volume  : {medium: HugePages-2Mi}  ->  /dev/hugepages
```

The `emptyDir` medium is size-qualified (`HugePages-2Mi`), not bare
`HugePages`: a bare medium is only unambiguous on a node offering one page
size, and these nodes expose both pools.

## Two behaviours verified against the binary, not the docs

**`hugepage_size` takes CH units, not Kubernetes ones.** `2Mi` is rejected with
`ParseMemory(Conversion("hugepage_size", "2Mi"))`, so the controller translates
`2Mi`→`2M` / `1Gi`→`1G` when writing the intent. The CRD keeps Kubernetes units
because that is what the matching node resource is called. Same split the GPU
path already uses.

**`reserve=on` is load-bearing *with* hugepages, not just without them.** On a
node with no pages reserved:

| Config | Result |
|---|---|
| `hugepages=on` **with** `reserve=on` | clean `GuestMemoryRegion(Mmap(OutOfMemory))` |
| `hugepages=on` **without** `reserve=on` | **SIGBUS**, VMM dies (exit 135) |

KubeSwift already emits `reserve=on`; the renderer test now pins the two
together so it cannot be dropped by a later cleanup.

## Cluster-validated

Reserved 8Gi of 2Mi pages on one worker, built the branch images, ran a guest.

| Layer | Result |
|---|---|
| CH arg | `--memory size=4096M,shared=on,reserve=on,hugepages=on,hugepage_size=2M` |
| Kernel | `HugePages_Free 3684` + `Rsvd 1636` = **2048 pages = exactly 4GiB** |
| Guest | Running, `NetworkReady=IPAcquired`, `EgressReady=ClusterServicesReachable` |
| Composition | `--cpus boot=2,affinity=[0@[0],1@[1]]` — composes with `cpuPinning` |
| Cleanup | all 4096 pages returned to the pool after deletion — no leak |

The kernel numbers are the point: 2048 committed pages is precisely the guest's
4GiB, so the RAM genuinely comes from hugetlbfs rather than CH silently falling
back to 4K pages.

**Negative case, deliberately included.** A class asking for `1Gi` on a cluster
where no node reserved 1Gi pages stays unschedulable:

```
0/3 nodes are available: 3 Insufficient hugepages-1Gi.
```

It never boots. That is the intended failure mode — visible, and *before* any
VM starts rather than halfway through boot.

## Tests

9 new (pod accounting moves RAM off ordinary memory, size-qualified medium for
both sizes, unset is a complete no-op, unit translation) plus a renderer test
that pins the `--memory` shape and the `reserve=on` pairing.

`docs/performance/hugepages.md` covers node reservation for both sizes,
including that restarting the whole node agent usually restarts the container
runtime too — worth knowing before doing it on a node with running guests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)