### PR TITLE
ci(dependabot): make the kubernetes group actually fire, and see indirect deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,44 @@ updates:
     directory: /
     schedule: {interval: weekly}
     open-pull-requests-limit: 5
+    # INDIRECT dependencies too, not only direct ones. Dependabot's default for
+    # gomod is `dependency-type: direct`, and three of the fixable HIGH CVEs
+    # that blocked PRs this cycle were in INDIRECT requirements:
+    #
+    #   google.golang.org/grpc  CVE-2026-84304          (fixed in #567)
+    #   golang.org/x/mod        CVE-2026-56864/56865    (fixed in #568)
+    #
+    # Nothing ever proposed either fix. Both surfaced as a red Trivy gate on an
+    # unrelated PR, were diagnosed by hand, and were patched by hand. govulncheck
+    # and the image scan tell us we are exposed; this is what proposes the
+    # upgrade, and it could not see the dependencies that were actually
+    # vulnerable.
+    #
+    # Cost: more PRs. That is the trade this file already makes elsewhere
+    # (weekly, grouped, capped) -- and the groups below absorb most of it.
+    allow:
+      - dependency-type: all
     groups:
       # k8s libraries move in lockstep; separate PRs for each would not build.
+      #
+      # exclude-patterns on go-minor-patch below is what actually keeps them
+      # together. This group has existed since Phase 1 and has NEVER produced a
+      # PR: every k8s.io bump, including the 0.36.4 -> 0.37.0 minor in #568,
+      # arrived inside go-minor-patch instead. A catch-all group with no
+      # `patterns` matches everything, so whichever of the two Dependabot
+      # evaluates first claims the dependency -- and declaration order is not
+      # reliably what decides that (note that go-minor-patch sorts before
+      # kubernetes alphabetically, while cargo's kube-rs sorts before
+      # rust-minor-patch, which is the difference between the broken config and
+      # the working one).
+      #
+      # Rather than depend on an ordering rule we cannot verify from here, the
+      # catch-all now EXCLUDES these patterns outright. That is correct under
+      # either ordering, which is the point.
       kubernetes:
         patterns: ["k8s.io/*", "sigs.k8s.io/*"]
       go-minor-patch:
+        exclude-patterns: ["k8s.io/*", "sigs.k8s.io/*"]
         update-types: [minor, patch]
 
   - package-ecosystem: cargo
@@ -44,7 +77,13 @@ updates:
           - "k8s-openapi"
         update-types: [major, minor, patch]
 
+      # Excluded here for the same reason go-minor-patch excludes k8s.io/*: a
+      # catch-all with no `patterns` can otherwise claim these before the
+      # specific group above is considered. This pair currently lands in
+      # kube-rs correctly, so this changes no outcome today -- it stops that
+      # from depending on which group Dependabot happens to evaluate first.
       rust-minor-patch:
+        exclude-patterns: ["kube", "kube-*", "k8s-openapi"]
         update-types: [minor, patch]
 
   # The supply-chain one that matters most: a compromised action in a workflow


### PR DESCRIPTION
Two fixes, both prompted by #568 needing three hand-written commits to land.

## 1. The `kubernetes` group has never fired

It has existed since Phase 1 with exactly the right patterns — and has **never
produced a single PR**. Every `k8s.io` bump has arrived inside `go-minor-patch`
instead, including the `0.36.4 → 0.37.0` **minor** in #568 that broke the
`kubeletplugin.DRAPlugin` interface. So an API-breaking Kubernetes bump shipped
alongside routine patches, holding two harmless updates
(`go-containerregistry`, `client_model`) hostage to it.

A group with no `patterns` matches everything, so whichever of the two
Dependabot evaluates first claims the dependency. **Declaration order is not
reliably what decides that** — and the evidence is in this very file:

| ecosystem | declared first | sorts first alphabetically | result |
|---|---|---|---|
| gomod | `kubernetes` | `go-minor-patch` | catch-all wins — **broken** |
| cargo | `kube-rs` | `kube-rs` | specific wins — works |

The one config where the two orderings disagree is the one that is broken. The
existing comment claiming "Dependabot assigns a dependency to the first group
it matches" is doing no work in the cargo case, because there both orderings
agree.

Rather than rely on an ordering rule I cannot verify from here, **both
catch-all groups now `exclude-patterns` whatever their paired specific group
owns.** That is correct under either ordering, which is the point.

The cargo change alters no outcome today — `kube-rs` already wins. It stops
that from being luck.

## 2. gomod could not see indirect dependencies

Dependabot's default for gomod is `dependency-type: direct`. Three fixable HIGH
CVEs that blocked PRs this cycle were **indirect**:

| Dependency | CVE | How it was fixed |
|---|---|---|
| `google.golang.org/grpc` | CVE-2026-84304 | by hand, #567 |
| `golang.org/x/mod` | CVE-2026-56864/56865 | by hand, #568 |

Nothing ever proposed either upgrade. Both surfaced as a red Trivy gate on an
unrelated PR, were diagnosed by hand, and were patched by hand. `govulncheck`
and the image scan tell us we are exposed; this file is what proposes the
upgrade — and it could not see the dependencies that were actually vulnerable.

`allow: [{dependency-type: all}]` closes that.

**Cost:** more PRs. That is the trade this file already makes deliberately
(weekly, grouped, capped), and the groups absorb most of it. If the volume
proves too high, the lever is `open-pull-requests-limit`, not going back to
being blind to transitive CVEs.

## Verification

This is config, so CI cannot prove it — the real test is what Dependabot opens
next week. What I did check: the YAML parses, and the resulting group semantics
are unambiguous.

```
gomod  allow: [{dependency-type: all}]
  kubernetes      patterns=[k8s.io/*, sigs.k8s.io/*]   update-types=(all)
  go-minor-patch  patterns=(ALL)  exclude=[k8s.io/*, sigs.k8s.io/*]  types=[minor,patch]

cargo
  kube-rs           patterns=[kube, kube-*, k8s-openapi]  types=[major,minor,patch]
  rust-minor-patch  patterns=(ALL)  exclude=[kube, kube-*, k8s-openapi]  types=[minor,patch]
```

Each catch-all now explicitly excludes what its paired specific group owns.

**What to watch:** the next `k8s.io` update should arrive as a *kubernetes
group* PR rather than inside `go-minor-patch`. If it does not, the ordering
theory above is wrong and the group needs a different fix — but the
`exclude-patterns` will still have done its job.

For contrast, the `codeql-action` group added in #543 worked first time: #565
moved all four pins in one PR and merged without incident, closing the trap
that broke #506/#540/#541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)