### PR TITLE
release: v0.13.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,109 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.13.13] — 2026-09-05
+
+A feature release: guests can now be pinned to dedicated host CPUs and backed
+by hugepages, both set on the guest class. Also clears the two fixable HIGH
+CVEs that had failed the nightly image scan every night since 2026-08-30, and
+moves the whole build onto Go 1.27.
+
+**Two new SwiftGuestClass fields, so `helm upgrade` alone does not deliver
+them.** Helm treats `crds/` as install-only.
+
+### Upgrade
+
+```bash
+helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.13 \
+  -n kubeswift-system -f <(helm get values kubeswift -n kubeswift-system -o yaml)
+kubectl apply -f charts/kubeswift/crds/    # REQUIRED this release — the new fields live here
+```
+
+One CRD gains fields (`swiftguestclasses.swift.kubeswift.io`). No values keys
+added or removed. Every new field defaults to today's behaviour, so existing
+guest classes are unchanged and need no edit: `cpuPinning` defaults to `none`
+and `hugepages` to unset, which emit byte-identical Cloud Hypervisor arguments
+to v0.13.12.
+
+### Added
+
+- **vCPU pinning and SMT placement** (#566). `SwiftGuestClass.spec.cpuPinning:
+  static` pins each vCPU to one host CPU, and `smtPolicy` (`spread`/`pack`)
+  chooses which hyper-thread siblings it uses — rendered as Cloud Hypervisor
+  `--cpus affinity=`.
+
+  The map is computed in swiftletd from the **launcher pod's own effective
+  cpuset**, not controller-side from node topology. Under the kubelet CPU
+  Manager `static` policy a pod's exclusive CPUs are assigned at admission,
+  after the controller has written the runtime intent, so a CPU chosen earlier
+  falls outside the pod's cgroup and is clamped or rejected — the guest would
+  run unpinned while still reporting as pinned. Reading the cpuset at launch is
+  correct under both policies. A cpuset smaller than the vCPU count fails the
+  launch with an explicit message rather than pinning partially.
+  [`docs/performance/cpu-pinning.md`](docs/performance/cpu-pinning.md).
+
+- **Hugepage-backed guest memory** (#569). `SwiftGuestClass.spec.hugepages`
+  (`2Mi`/`1Gi`) backs guest RAM with hugepages via `--memory hugepages=on`.
+
+  Guest RAM **moves** to the `hugepages-<size>` resource rather than being
+  requested twice: the kubelet already subtracts reserved hugepages from the
+  node's allocatable memory, so a pod booking both would consume twice the
+  guest's RAM and stop scheduling long before the pages ran out. The launcher
+  requests the guest's memory as hugepages plus only its own overhead as
+  ordinary memory, and gets a size-qualified `emptyDir` at `/dev/hugepages`.
+  A class requesting a size the node has not reserved does not schedule — the
+  failure is visible, and it happens before any VM starts.
+  [`docs/performance/hugepages.md`](docs/performance/hugepages.md).
+
+- **`cosign freshness` CI job** (#574). Checks the pinned cosign against the
+  latest upstream release and that the images agree with each other.
+  `COSIGN_VERSION` is a Containerfile `ARG`, invisible to Dependabot, so the
+  pin previously had no watcher at all.
+
+### Fixed
+
+- **Two fixable HIGH CVEs that had failed the nightly image scan since
+  2026-08-30** (#567). `kubeswift-dra-driver` carried
+  `google.golang.org/grpc` CVE-2026-84304, and `migration-stunnel` carried
+  `libcrypto3`/`libssl3` CVE-2026-14456.
+
+  Neither would have fixed itself. grpc is an **indirect** requirement, and
+  Dependabot only proposed direct ones. libcrypto3 lives in the **base layer**,
+  outside stunnel's dependency closure, and `apk add` leaves an
+  already-installed package at whatever version the base image froze — the
+  fixed package sat in the Alpine repo the whole time and no rebuild would ever
+  have picked it up. The image now runs `apk upgrade` before installing, which
+  closes the class rather than the instance.
+
+- **DRA driver did not compile against k8s.io 0.37** (#568).
+  `kubeletplugin.DRAPlugin` gained `WatchHealthStatus`. The driver declines
+  health reporting with `ErrHealthNotSupported` rather than reporting a
+  hardcoded `Healthy`: answering that call promises the kubelet a fresh report
+  inside each device's `HealthCheckTimeout`, so a GPU whose vfio-pci binding
+  had gone would keep reading as usable. A compile-time interface assertion now
+  makes the next such change fail on the type rather than at a call site.
+
+- **`golang.org/x/mod` CVE-2026-56864/56865** (#568), pulled in transitively by
+  the k8s 0.37 bump.
+
+### Changed
+
+- **All nine images build on Go 1.27** (#549–#556), and swiftletd's Rust
+  builder moves to 1.98 (#563).
+- **Dependabot can see indirect Go dependencies, and the `kubernetes` group
+  actually fires** (#570). That group had existed since Phase 1 without ever
+  producing a PR — every `k8s.io` bump arrived inside `go-minor-patch`
+  instead, so an API-breaking Kubernetes minor shipped alongside routine
+  patches. Both catch-all groups now exclude what their paired specific group
+  owns, which is correct regardless of group evaluation order.
+- **Trivy's report pass skips the vendored cosign binary** (#574). It was
+  uploading 16 permanently-unactionable alerts describing sigstore's build
+  rather than ours — the clearest being an `x/crypto` CRITICAL reporting
+  v0.53.0 while KubeSwift's own module graph was already on the fixed v0.55.0.
+  The gate had skipped that file all along.
+- Third-party project references removed across the tree (#548, #560). CRD
+  descriptions only; no schema change.
+
 ## [v0.13.12] — 2026-08-24
 
 A bug-fix release, and the headline is that a documented feature has never

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Boot your first VM → [Quickstart](docs/quickstart.md).
 
 - **Boot paths** — disk boot from cloud images (Linux and Windows) and direct kernel boot from OCI artifacts (sub-second microVMs).
 - **GPU passthrough** — whole-GPU VFIO passthrough with two allocation backends: the native SwiftGPU model (discovery DaemonSet + profiles) or Kubernetes [DRA](docs/gpu/dra-allocation.md) ResourceClaims. PCIe GPUs on Cloud Hypervisor; HGX SXM on QEMU.
+- **Performance tuning** — pin each vCPU to a dedicated host CPU with hyper-thread-aware placement (`cpuPinning`, `smtPolicy`) and back guest RAM with 2MiB or 1GiB hugepages (`hugepages`), set on the guest class. The pinning map is drawn from the launcher pod's own cpuset, so it stays correct under the kubelet CPU Manager; a class asking for hugepages a node has not reserved does not schedule rather than booting slower. See [`docs/performance/cpu-pinning.md`](docs/performance/cpu-pinning.md) and [`docs/performance/hugepages.md`](docs/performance/hugepages.md).
 - **Networking** — tap + bridge + DHCP with the guest IP surfaced in status; multi-NIC via Multus; SR-IOV NIC passthrough; OVN backends supported: OVN-Kubernetes and multi-node L2 with IP-preserving cross-node live migration (kube-ovn primary-on-NAD — see [`docs/networking/ovn-l2-install.md`](docs/networking/ovn-l2-install.md)).
 - **Services** — expose guest ports as Kubernetes Services via `spec.network.ports` (ClusterIP/NodePort/LoadBalancer), a load-balanced Service across pool replicas via `SwiftGuestPool.spec.service`, and a VM→cluster egress reachability probe surfaced as `EgressReady`.
 - **Storage** — per-guest root-disk cloning sized from a class; optional data disks (blank/sized, image-backed, or attached PVC); RWX+Block for live-migration-capable volumes.
@@ -68,6 +69,7 @@ Start at the **[documentation index](docs/index.md)**. Common entry points:
 - [Networking operations](docs/networking/operations-guide.md)
 - [Snapshots](docs/snapshots/csi-snapshots.md) · [Live migration](docs/migration/overview.md)
 - [Sandboxes](docs/sandbox/overview.md) — ephemeral OCI-rootfs microVMs
+- [CPU pinning](docs/performance/cpu-pinning.md) · [Hugepages](docs/performance/hugepages.md) — per-guest performance tuning
 - [swiftctl CLI](docs/swiftctl.md) · [Observability](docs/observability/README.md)
 - [Install (Helm/OCI)](docs/install/helm-oci.md)
 

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.12
+version: 0.13.13
 # Bare X.Y.Z, with NO leading "v". The imageTag helper adds the "v" when it
 # derives a default image tag, so "v0.13.11" here renders "vv0.13.11" and every
 # image points at a tag that was never published. The helper now trims a stray
 # "v" and hack/verify-image-tags.sh fails the build on a malformed tag, but
 # write it bare: the release workflows pass `--app-version "${TAG#v}"`, and this
 # line should match what they publish.
-appVersion: "0.13.12"
+appVersion: "0.13.13"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/docs/api/swiftguestclass.md
+++ b/docs/api/swiftguestclass.md
@@ -15,6 +15,7 @@ SwiftGuestClass is a **cluster-scoped template** for CPU, memory, and root disk.
 | `coreScheduling` | No | `off` (default), `vm`, `vcpu` — SMT side-channel isolation |
 | `cpuPinning` | No | `none` (default), `static` — pin vCPUs to host CPUs ([guide](../performance/cpu-pinning.md)) |
 | `smtPolicy` | No | `spread` (default), `pack` — sibling placement when pinned |
+| `hugepages` | No | `""` (default), `2Mi`, `1Gi` — back guest RAM with hugepages ([guide](../performance/hugepages.md)). The node must reserve them first, or the guest will not schedule. |
 
 ```yaml
 apiVersion: swift.kubeswift.io/v1alpha1

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -130,6 +130,7 @@ Cluster-scoped template defining default CPU, memory, and disk resources for VMs
 | `coreScheduling` | enum | No | `off` (default), `vm`, `vcpu` — SMT side-channel isolation: who may share a physical core. |
 | `cpuPinning` | enum | No | `none` (default), `static` — pin each vCPU to one host CPU from the launcher pod's cpuset. See [CPU pinning](performance/cpu-pinning.md). |
 | `smtPolicy` | enum | No | `spread` (default), `pack` — which SMT siblings a pinned guest uses. Ignored unless `cpuPinning: static`. |
+| `hugepages` | enum | No | `""` (default), `2Mi`, `1Gi` — back guest RAM with hugepages instead of 4K pages. The launcher then requests `hugepages-<size>` equal to the guest's memory, so the node must have the pages reserved or the pod will not schedule. See [hugepages](performance/hugepages.md). |
 
 ### Example
 


### PR DESCRIPTION
Chart `0.13.12 → 0.13.13`, CHANGELOG, and the reference documentation the new
guest-class fields were missing.

## Headline

Guests can be pinned to dedicated host CPUs and backed by hugepages, both set
on `SwiftGuestClass`. Also clears the two fixable HIGH CVEs that failed the
nightly image scan every night since 2026-08-30, and moves all nine images onto
Go 1.27.

## CRD change — `kubectl apply -f charts/kubeswift/crds/` is required

`swiftguestclasses.swift.kubeswift.io` gains three fields. Helm treats `crds/`
as install-only, so `helm upgrade` alone will not deliver them.

Every new field defaults to today's behaviour — `cpuPinning: none`, `hugepages`
unset — and emits byte-identical Cloud Hypervisor arguments to v0.13.12, so
existing classes are unchanged and need no edit.

## Documentation gap this closes

`cpuPinning` and `smtPolicy` reached the API and CRD references when #566
landed. **`hugepages` (#569) reached neither** — a field that changes how a
guest is scheduled was reachable only from its own guide. Both reference tables
now carry it.

README described none of it, and now has a *Performance tuning* capability
bullet plus doc links, in the existing terse register.

The guides themselves (`docs/performance/cpu-pinning.md`,
`docs/performance/hugepages.md`) and both samples shipped with #566/#569 and
are unchanged here.

## Verified before tagging

- Chart renders every image at **`v0.13.13`** — single `v`, i.e. not the
  `vv0.13.11` failure mode from #545
- `hack/verify-image-tags.sh` — 10 references, all well-formed
- `hack/verify-crd-sync.sh` — all 15 CRDs listed
- Both performance samples apply clean under **server-side dry run** against
  the live CRD
- `make generate` idempotent; `gofmt`/`cargo fmt` clean; full Go suite and 11
  Rust suites pass
- Every doc link added resolves

## Note

CLAUDE.md refers to a `/technical-writer` agent for documentation work. No
agent definitions exist in this checkout (`.claude/agents/` is absent), so the
documentation here was written directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)