### PR TITLE
docs: repin install commands to the current chart, and put notes in releases

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -27,6 +27,9 @@ on:
       - 'hack/lint-values/**'
       - 'hack/verify-render-coverage.sh'
       - 'hack/verify-image-tags.sh'
+      - 'hack/verify-doc-versions.sh'
+      - 'README.md'
+      - 'docs/**'
       - '.github/workflows/manifests.yaml'
   push:
     branches: [main]
@@ -45,6 +48,9 @@ on:
       - 'hack/lint-values/**'
       - 'hack/verify-render-coverage.sh'
       - 'hack/verify-image-tags.sh'
+      - 'hack/verify-doc-versions.sh'
+      - 'README.md'
+      - 'docs/**'
       - '.github/workflows/manifests.yaml'
 
 jobs:
@@ -95,6 +101,14 @@ jobs:
       # several releases exactly this way.
       - name: Verify image tags
         run: ./hack/verify-image-tags.sh
+
+      # The docs equivalent of the tag check above. README.md and eight pages
+      # sat on `--version 0.13.10` across three releases, so anyone following
+      # the quickstart installed a chart three versions old and got a CRD
+      # without the fields the page described. Bumping them is a manual release
+      # step nobody owned; now it fails the build instead.
+      - name: Verify docs pin the current chart version
+        run: ./hack/verify-doc-versions.sh
 
       # STEP 1. -strict is the flag that matters: it rejects unknown and
       # duplicate fields, which is exactly the class that bites this project —

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -411,6 +411,99 @@ jobs:
             --output-certificate dist/SHA256SUMS.pem \
             dist/SHA256SUMS
 
+      # The release page carried the boilerplate below plus GitHub's
+      # auto-generated "What's Changed" commit list, and nothing that said what
+      # the release DOES. A reader had to leave the page and find the CHANGELOG
+      # to learn whether a CRD changed -- which the Upgrade section then told
+      # them to go and check. This pulls that entry onto the page.
+      #
+      # A missing entry is fatal: shipping a release whose notes are a bare
+      # commit list is the thing being fixed, and it should not degrade back to
+      # that silently.
+      - name: Assemble release notes from the CHANGELOG
+        id: notes
+        run: |
+          set -euo pipefail
+          tag="${{ github.ref_name }}"
+          awk -v t="## [$tag]" 'index($0,t)==1{f=1;print;next} f && /^## \[/{exit} f{print}' \
+            CHANGELOG.md > changelog-section.md
+          if [ ! -s changelog-section.md ]; then
+            echo "::error::no CHANGELOG.md entry found for $tag -- add one before tagging"
+            exit 1
+          fi
+          echo "extracted $(wc -l < changelog-section.md) lines for $tag"
+
+          # Full page: what the release does, then how to install it. The
+          # boilerplate below is unchanged from the previous inline `body:`.
+          {
+            cat changelog-section.md
+            echo
+            cat <<'BOILERPLATE_END'
+          ## Install
+
+          ```bash
+          helm install kubeswift ${{ env.CHART_OCI_INSTALL }} --version ${{ needs.build-and-push.outputs.version }} -n kubeswift-system --create-namespace
+          ```
+
+          ## Upgrade
+
+          `helm upgrade` does **not** upgrade CRDs — Helm treats `crds/` as
+          install-only and offers no flag to change it. Apply them yourself
+          after every upgrade, or the API server silently drops any field a
+          stale schema does not know:
+
+          ```bash
+          helm upgrade kubeswift ${{ env.CHART_OCI_INSTALL }} --version ${{ needs.build-and-push.outputs.version }} \
+            -n kubeswift-system -f <(helm get values kubeswift -n kubeswift-system -o yaml)
+          kubectl apply -k https://github.com/kubeswift-io/kubeswift/config/crd?ref=${{ github.ref_name }}
+          ```
+
+          Check the CHANGELOG entry for this release before upgrading: it says
+          whether any CRD actually changed.
+
+          ## Images
+
+          All nine are signed, and verified by the release workflow before publishing.
+
+          - `ghcr.io/kubeswift-io/kubeswift/controller-manager:${{ needs.build-and-push.outputs.tag }}`
+          - `ghcr.io/kubeswift-io/kubeswift/swiftletd:${{ needs.build-and-push.outputs.tag }}`
+          - `ghcr.io/kubeswift-io/kubeswift/gpu-discovery:${{ needs.build-and-push.outputs.tag }}`
+          - `ghcr.io/kubeswift-io/kubeswift/migration-stunnel:${{ needs.build-and-push.outputs.tag }}`
+          - `ghcr.io/kubeswift-io/kubeswift/kubeswift-gateway:${{ needs.build-and-push.outputs.tag }}`
+          - `ghcr.io/kubeswift-io/kubeswift/kubeswift-dra-driver:${{ needs.build-and-push.outputs.tag }}`
+          - `ghcr.io/kubeswift-io/kubeswift/sandbox-materialize:${{ needs.build-and-push.outputs.tag }}`
+          - `ghcr.io/kubeswift-io/kubeswift/snapshot-s3:${{ needs.build-and-push.outputs.tag }}`
+          - `ghcr.io/kubeswift-io/kubeswift/snapshot-oras:${{ needs.build-and-push.outputs.tag }}`
+
+          ## swiftctl
+
+          Download the `swiftctl` binary for your platform from the Assets below.
+
+          ## Supply chain
+
+          Images and the Helm chart are **cosign-signed** (keyless, GitHub OIDC)
+          and carry **SLSA build provenance + SPDX SBOM** attestations attached
+          in-registry by BuildKit. Verify an image:
+
+          ```bash
+          cosign verify ghcr.io/kubeswift-io/kubeswift/controller-manager:${{ github.ref_name }} \
+            --certificate-identity-regexp 'https://github.com/kubeswift-io/kubeswift/.github/workflows/release-(stable|rc).yaml@.*' \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          docker buildx imagetools inspect ghcr.io/kubeswift-io/kubeswift/controller-manager:${{ github.ref_name }} --format '{{ json .Provenance }}'
+          ```
+
+          Verify the binaries (SHA256SUMS is cosign-signed; the checksums then cover each binary):
+
+          ```bash
+          cosign verify-blob --signature SHA256SUMS.sig --certificate SHA256SUMS.pem \
+            --certificate-identity-regexp 'https://github.com/kubeswift-io/kubeswift/.github/workflows/release-stable.yaml@.*' \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS
+          sha256sum -c SHA256SUMS
+          ```
+          BOILERPLATE_END
+          } > release-body.md
+          echo "release body: $(wc -l < release-body.md) lines"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
@@ -424,67 +517,6 @@ jobs:
           # sandbox-materialize ship unsigned for five releases. Keep the note
           # here, in the workflow: everything under `body:` is published to the
           # release page, where guidance aimed at us is just noise for readers.
-          body: |
-            ## Install
-
-            ```bash
-            helm install kubeswift ${{ env.CHART_OCI_INSTALL }} --version ${{ needs.build-and-push.outputs.version }} -n kubeswift-system --create-namespace
-            ```
-
-            ## Upgrade
-
-            `helm upgrade` does **not** upgrade CRDs — Helm treats `crds/` as
-            install-only and offers no flag to change it. Apply them yourself
-            after every upgrade, or the API server silently drops any field a
-            stale schema does not know:
-
-            ```bash
-            helm upgrade kubeswift ${{ env.CHART_OCI_INSTALL }} --version ${{ needs.build-and-push.outputs.version }} \
-              -n kubeswift-system -f <(helm get values kubeswift -n kubeswift-system -o yaml)
-            kubectl apply -k https://github.com/kubeswift-io/kubeswift/config/crd?ref=${{ github.ref_name }}
-            ```
-
-            Check the CHANGELOG entry for this release before upgrading: it says
-            whether any CRD actually changed.
-
-            ## Images
-
-            All nine are signed, and verified by the release workflow before publishing.
-
-            - `ghcr.io/kubeswift-io/kubeswift/controller-manager:${{ needs.build-and-push.outputs.tag }}`
-            - `ghcr.io/kubeswift-io/kubeswift/swiftletd:${{ needs.build-and-push.outputs.tag }}`
-            - `ghcr.io/kubeswift-io/kubeswift/gpu-discovery:${{ needs.build-and-push.outputs.tag }}`
-            - `ghcr.io/kubeswift-io/kubeswift/migration-stunnel:${{ needs.build-and-push.outputs.tag }}`
-            - `ghcr.io/kubeswift-io/kubeswift/kubeswift-gateway:${{ needs.build-and-push.outputs.tag }}`
-            - `ghcr.io/kubeswift-io/kubeswift/kubeswift-dra-driver:${{ needs.build-and-push.outputs.tag }}`
-            - `ghcr.io/kubeswift-io/kubeswift/sandbox-materialize:${{ needs.build-and-push.outputs.tag }}`
-            - `ghcr.io/kubeswift-io/kubeswift/snapshot-s3:${{ needs.build-and-push.outputs.tag }}`
-            - `ghcr.io/kubeswift-io/kubeswift/snapshot-oras:${{ needs.build-and-push.outputs.tag }}`
-
-            ## swiftctl
-
-            Download the `swiftctl` binary for your platform from the Assets below.
-
-            ## Supply chain
-
-            Images and the Helm chart are **cosign-signed** (keyless, GitHub OIDC)
-            and carry **SLSA build provenance + SPDX SBOM** attestations attached
-            in-registry by BuildKit. Verify an image:
-
-            ```bash
-            cosign verify ghcr.io/kubeswift-io/kubeswift/controller-manager:${{ github.ref_name }} \
-              --certificate-identity-regexp 'https://github.com/kubeswift-io/kubeswift/.github/workflows/release-(stable|rc).yaml@.*' \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com
-            docker buildx imagetools inspect ghcr.io/kubeswift-io/kubeswift/controller-manager:${{ github.ref_name }} --format '{{ json .Provenance }}'
-            ```
-
-            Verify the binaries (SHA256SUMS is cosign-signed; the checksums then cover each binary):
-
-            ```bash
-            cosign verify-blob --signature SHA256SUMS.sig --certificate SHA256SUMS.pem \
-              --certificate-identity-regexp 'https://github.com/kubeswift-io/kubeswift/.github/workflows/release-stable.yaml@.*' \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS
-            sha256sum -c SHA256SUMS
-            ```
+          body_path: release-body.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.10 \
+  --version 0.13.13 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.11 \
+  --set controllerManager.image.tag=v0.13.13 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.11
+  --set swiftletd.image.tag=v0.13.13
 ```
 
 ### Release workflow

--- a/docs/gitops/quickstart.md
+++ b/docs/gitops/quickstart.md
@@ -51,7 +51,7 @@ Three load-bearing choices:
 - **Pin the chart to a minor range, not `>=0.1.0`.** KubeSwift is pre-1.0 and
   its APIs are `v1alpha1`: a wide-open range lets Flux roll the platform across
   a breaking minor unattended. `"0.13.x"` takes patches automatically and makes
-  a minor bump a reviewed commit. Pin exactly (`0.13.11`) if you want even
+  a minor bump a reviewed commit. Pin exactly (`0.13.13`) if you want even
   patches gated.
 - **`webhook.enabled: true` needs cert-manager** on the cluster (the chart's
   Certificate/Issuer objects require its CRDs). Without cert-manager, set it

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.10 -n kubeswift-system --create-namespace \
+  --version 0.13.13 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.10 \
+  --version 0.13.13 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.10 \
+  --version 0.13.13 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.10 \
+  --version 0.13.13 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.11 \
+  --set controllerManager.image.tag=v0.13.13 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.11
+  --set swiftletd.image.tag=v0.13.13
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.10 \
+  --version 0.13.13 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.10 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.11 \
-    --set swiftletd.image.tag=v0.13.11
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.13 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.13 \
+    --set swiftletd.image.tag=v0.13.13
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.10 \
+  --version 0.13.13 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.10 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.13 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows

--- a/hack/verify-doc-versions.sh
+++ b/hack/verify-doc-versions.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Fail when a docs install command pins a version that is not the chart's.
+#
+# README.md and eight docs pages sat on `--version 0.13.10` for three releases
+# (v0.13.11, .12, .13) because bumping them is a manual step nobody owns, and
+# nothing checked. A reader following the quickstart installed a chart three
+# releases old and got a CRD without the fields the page described.
+#
+# WHAT IS CHECKED: pins in commands a reader would copy and run --
+#   --version X.Y.Z          the chart version
+#   image.tag=vX.Y.Z         an image tag override
+#
+# WHAT IS NOT: prose stating when something appeared, e.g. "a v0.13.11 field"
+# or "spec.importStorageClassName (v0.13.11)". Those are history and are
+# CORRECT at their original version -- rewriting them each release would be a
+# lie. Neither pattern above matches prose, which is why the check is written
+# against the command forms rather than "any version-shaped string".
+#
+# Placeholders (0.0.0-dev.<sha>, <version>) are ignored: they are illustrative
+# by construction and have no single right value.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+chart=$(sed -n 's/^version: \(.*\)$/\1/p' charts/kubeswift/Chart.yaml | head -1)
+if [ -z "$chart" ]; then
+  echo "verify-doc-versions: could not read version from charts/kubeswift/Chart.yaml" >&2
+  exit 1
+fi
+
+# Chart pins (--version X.Y.Z) and image pins (image.tag=vX.Y.Z), minus the
+# dev-channel placeholder which is deliberately not a real version.
+bad=$(grep -rnE -- '--version [0-9]+\.[0-9]+\.[0-9]+|image\.tag=v[0-9]+\.[0-9]+\.[0-9]+' \
+        README.md docs/ 2>/dev/null \
+      | grep -v '0\.0\.0-dev' \
+      | grep -vE -- "--version ${chart//./\\.}([^0-9]|\$)|image\.tag=v${chart//./\\.}([^0-9]|\$)" \
+      || true)
+
+if [ -n "$bad" ]; then
+  echo "verify-doc-versions: docs pin a version other than the chart's ($chart):" >&2
+  echo "$bad" | sed 's/^/  /' >&2
+  echo >&2
+  echo "Update the install commands to $chart. Do NOT change prose that records" >&2
+  echo "when a field appeared (\"a v0.13.11 field\") -- that is history, not a pin." >&2
+  exit 1
+fi
+
+count=$(grep -rcE -- '--version [0-9]+\.[0-9]+\.[0-9]+|image\.tag=v[0-9]+\.[0-9]+\.[0-9]+' \
+          README.md docs/ 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+echo "verify-doc-versions: $count install pins, all at $chart"


### PR DESCRIPTION
Both gaps were spotted after v0.13.13 shipped, and both are things a reader
hits on the way in.

## 1. Install commands were three releases stale

`README.md` and **eight** docs pages pinned `--version 0.13.10`. Anyone
following the quickstart installed a chart three versions old and got a CRD
without the fields the page went on to describe.

| File | was |
|---|---|
| `README.md` | `--version 0.13.10` |
| `docs/quickstart.md` | `--version 0.13.10` |
| `docs/releases.md` | `--version 0.13.10` |
| `docs/install/helm-oci.md` | ×3 |
| `docs/install/remote-cluster.md` | `--version 0.13.10` |
| `docs/gpu/dra-allocation.md` | `--version 0.13.10` |
| `docs/operator/troubleshooting.md` | `--version 0.13.10` + image tags |
| `docs/deploy.md` | `image.tag=v0.13.11` |

Bumping these was a manual release step nobody owned and nothing checked, so it
rotted silently across three releases. Repinning them is the small half of this
PR; the guard is the point.

## The guard, and what it deliberately does not check

`hack/verify-doc-versions.sh` fails the build when a docs install command pins
a version other than the chart's. It checks only the forms a reader would copy
and run:

```
--version X.Y.Z
image.tag=vX.Y.Z
```

It does **not** touch prose recording when something appeared — *"a v0.13.11
field"*, *"`spec.importStorageClassName` (v0.13.11)"*. Those are history, they
are correct at their original version, and rewriting them every release would
make them false. That distinction is why the check is written against the
command forms rather than "any version-shaped string", and both existing
historical references in `docs/gitops/` are confirmed untouched.

Regression-injected before landing — a check that cannot fail is worth nothing:

```
clean tree              -> 17 install pins, all at 0.13.13
one pin reverted        -> exit 1, names the file and line
historical prose        -> ignored
```

Wired into `manifests.yaml`, alongside the existing `verify-image-tags.sh`,
with `README.md` and `docs/**` added to the triggers.

## 2. Releases had no release notes

The page carried install boilerplate plus GitHub's auto-generated commit list
and **nothing describing what the release does** — while its own Upgrade
section told the reader to *"check the CHANGELOG entry for this release"* for
exactly that.

`release-stable.yaml` now extracts the CHANGELOG entry for the tag and puts it
at the top of the body. A missing entry **fails the release** rather than
degrading silently to a bare commit list, which is the state being fixed.

Verified by running the extraction against the real CHANGELOG: 103 lines for
`v0.13.13`, stopping correctly before the previous entry (the one `v0.13.12`
string inside it is prose, not a leaked header), and the assembled body carries
`## [v0.13.13]` followed by Install / Upgrade / Images / swiftctl / Supply
chain.

**The v0.13.13 release page was fixed in place** — notes prepended without
disturbing the existing sections or the auto-generated *What's Changed*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)