### PR TITLE
docs: add ADOPTERS.md and CONTRIBUTING.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,56 @@
+# KubeSwift Adopters
+
+This is a list of organizations and users of KubeSwift. Adding yourself helps
+the project understand who depends on it, which platforms and hardware matter,
+and which features are actually in use.
+
+If you are using KubeSwift, please add yourself by opening a pull request
+against this file. If you would rather not be listed publicly but are willing
+to be counted, open an issue and say so.
+
+## Adopters
+
+| Organization | Contact | Status | Description of Use |
+|---|---|---|---|
+| _Your organization_ | _@your-github-handle_ | _evaluating_ | _What you run on KubeSwift_ |
+
+<!--
+Add a row in alphabetical order by Organization. Keep it to one line.
+
+  Organization  Company, institution, or project name. Use "(individual)" if
+                you are adopting KubeSwift personally rather than on behalf of
+                an organization.
+  Contact       A GitHub handle, mailing list, or email address the project can
+                reach for questions about your use. Do not list a personal
+                email you do not want indexed by search engines.
+  Status        One of:
+                  evaluating  trying it out, not yet running workloads on it
+                  testing     running non-production workloads
+                  production  running production workloads
+  Description   One sentence on what you run — the workload, and anything about
+                your environment that shapes it (GPU passthrough, sandboxes,
+                live migration, a particular CNI or storage backend). This is
+                the most useful column: it tells maintainers which paths must
+                not break.
+
+Example:
+
+| Example Corp | @example-handle | production | VM-backed CI runners and GPU inference sandboxes on bare metal. |
+-->
+
+## Why add yourself
+
+Adopter entries are used to:
+
+- prioritize work against real deployments rather than assumptions,
+- decide which hardware, CNI, and storage combinations need to keep working,
+- give new users evidence that the project is used elsewhere,
+- reach you if a change is likely to affect your setup.
+
+Entries are never used for marketing outreach.
+
+## Removing yourself
+
+If you stop using KubeSwift, open a pull request removing your row. No
+explanation is required, though a note about why is welcome — an adopter
+leaving is useful information.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,152 @@
+# Contributing to KubeSwift
+
+Thanks for your interest in KubeSwift. This document covers how to get a change
+merged: how to build and test, the conventions the project follows, and the few
+repo-specific traps that are easy to hit.
+
+KubeSwift is pre-1.0 and the `v1alpha1` APIs may change between releases.
+
+## Code of Conduct
+
+Be respectful and constructive. Harassment, personal attacks, and demeaning
+comments are not welcome in issues, pull requests, or any other project space.
+Maintainers may remove comments, reject contributions, or block accounts that
+do not meet that bar.
+
+## Reporting bugs
+
+Open a [GitHub issue](https://github.com/kubeswift-io/kubeswift/issues). The
+most useful reports include:
+
+- what you expected and what happened instead,
+- the KubeSwift version (`kubectl get deploy -n kubeswift-system controller-manager -o jsonpath='{.spec.template.spec.containers[0].image}'`),
+- Kubernetes version, CNI, and storage backend,
+- **real output** — `kubectl describe` on the affected resource, controller
+  logs, and launcher-pod logs. This project's convention is to diagnose from
+  actual cluster output rather than from a description of it, so a log excerpt
+  is worth more than a paragraph.
+
+For anything with security impact, do not open a public issue — see
+[Security](#security) below.
+
+## Proposing changes
+
+For a small fix, open a pull request directly. For anything that adds a CRD
+field, changes an API, or alters runtime behaviour, open an issue first so the
+design can be discussed before you write it — API surface is hard to remove
+once released.
+
+## Development setup
+
+You will need:
+
+- **Go** — see the `go` directive in `go.mod` for the minimum version
+- **Rust** (stable) for the `rust/` workspace
+- **Docker** or another OCI builder, for container images
+- **A Kubernetes cluster** for anything beyond unit tests. KubeSwift launches
+  real VMs, so meaningful testing needs a cluster whose nodes have `/dev/kvm`.
+
+```bash
+make build          # Go binaries + Rust crates
+go test ./...       # Go unit tests
+cargo test          # Rust tests (from rust/)
+make help           # every available target
+```
+
+`make help` is the source of truth for targets; the e2e suites
+(`make e2e-tests`, `make smoke-test`) require a live cluster.
+
+## The one trap to know about
+
+**After any change under `api/`, run `make generate`.**
+
+```bash
+make generate
+```
+
+This regenerates the CRDs and deepcopy functions and syncs `charts/kubeswift/crds/`.
+If you skip it, the shipped CRD schema no longer matches the Go types, and the
+API server **silently drops** any field it does not know about — no error, the
+field simply disappears. CI enforces this, but it is much easier to catch
+locally.
+
+Related: `helm upgrade` does not upgrade CRDs (Helm treats `crds/` as
+install-only), which is why release notes always tell operators to apply them
+separately.
+
+## Commit conventions
+
+**Sign off every commit** with the Developer Certificate of Origin:
+
+```bash
+git commit -s
+```
+
+This adds a `Signed-off-by:` line certifying that you have the right to submit
+the work under the project's licence. Commits must also be cryptographically
+signed — the repository ruleset requires it.
+
+Write commit messages that explain **why**, not just what. The diff already
+shows what changed; the message should say what problem it solves and, where
+relevant, what you ruled out. A good message is the difference between a future
+reader trusting the change and re-deriving it from scratch.
+
+## Pull requests
+
+1. **Branch off `main`.** Do not commit to `main` directly.
+2. Keep the change focused. Unrelated fixes belong in their own PR.
+3. **Add tests.** For a bug fix, a test that fails without the fix. For a new
+   guard or check, verify it can actually fail — a check that has never gone
+   red is not known to work.
+4. Update documentation in the same PR. If you add a CRD field, it belongs in
+   `docs/crds.md` and the relevant `docs/api/` page, not only in a guide.
+5. Make sure CI is green. The pipeline runs Go and Rust builds and tests,
+   `gofmt`/`cargo fmt`, CRD generation drift, proto generation drift, container
+   image builds, CodeQL, gosec, and vulnerability scanning.
+6. PRs are merged by **squash merge**, so the PR title and description become
+   the commit message on `main`. Write them accordingly.
+
+Maintainers may ask for changes; that is normal and not a judgement of the
+work.
+
+## Code conventions
+
+**Go** — standard `gofmt`. Controllers follow controller-runtime patterns
+(reconcile loop, status conditions, status subresource). New CRD fields need
+`+kubebuilder:` markers, and new API groups need scheme registration.
+
+**Rust** — `cargo fmt`. The workspace lives at `rust/Cargo.toml`; new crates are
+added as workspace members. Async work uses tokio; errors use `anyhow` in
+binaries and `thiserror` in libraries.
+
+**Both** — match the surrounding code. Comment density, naming, and structure
+should look like the file you are editing rather than like a different project.
+
+## Documentation
+
+Documentation lives in `docs/`, indexed by `docs/index.md`. Two conventions:
+
+- Install commands must pin the current chart version; CI fails otherwise
+  (`hack/verify-doc-versions.sh`).
+- Prose recording when a feature appeared — "a v0.13.11 field" — is history and
+  should **not** be updated to the current version. It is correct as written.
+
+Prefer plain, direct prose. Explain the mechanism rather than restating the
+field name.
+
+## Security
+
+Do not report vulnerabilities through public issues. Use GitHub's
+[private vulnerability reporting](https://github.com/kubeswift-io/kubeswift/security/advisories/new)
+so the issue can be fixed before it is disclosed.
+
+Note that the VM **launcher** pod runs privileged by design — it manages KVM,
+tap devices, and VFIO — and is therefore a node-level trust boundary. See
+[`docs/security-audit.md`](docs/security-audit.md) before filing a report about
+it, as this is deliberate rather than an oversight.
+
+## Licence
+
+KubeSwift is licensed under the
+[GNU Affero General Public License v3.0](LICENSE). By contributing, you agree
+that your contributions are licensed under the same terms.


### PR DESCRIPTION
The repo had `LICENSE` and nothing else a would-be contributor or adopter looks
for — no contribution guide, no adopter list, no statement of how a change gets
merged.

## ADOPTERS.md

Follows the CNCF layout: an **Organization / Contact / Status / Description**
table, a status legend (`evaluating`, `testing`, `production`), and
instructions for adding *and removing* yourself.

The Description column is the one that earns its place. It records which
hardware, CNI and storage combinations are actually in use, which is what tells
maintainers what must not break — more useful to the project than the
organization name.

A commented template row explains each column so the first real entry does not
have to guess the format.

## CONTRIBUTING.md

Documents *this* repo rather than generic advice:

- **DCO sign-off** (`git commit -s`) alongside the ruleset's signed-commit
  requirement. Sign-off is already used on every commit; this writes it down.
- **Branch off `main`, squash merge** — and therefore that the PR title and
  description become the commit message.
- **The `make generate` trap**, which costs the most time here: skipping it
  after an `api/` change leaves the shipped CRD schema behind the Go types, and
  the API server then **silently drops** unknown fields. No error — the field
  simply disappears.
- **Reporting bugs with real output**, matching how this project actually
  diagnoses: a log excerpt beats a paragraph describing one.
- **The docs-version rule** that `hack/verify-doc-versions.sh` enforces,
  including the distinction the check is built around — install commands must
  pin the current chart, while prose recording when a field appeared
  ("a v0.13.11 field") is history and must not be rewritten.
- **Security reporting** via private advisories, with a pointer to
  `docs/security-audit.md` noting the privileged launcher is deliberate, so
  reports about it start from the right place.

## Notes

**No `CODE_OF_CONDUCT.md`.** CONTRIBUTING carries a short behaviour section
instead — better than linking a file that does not exist. Say the word if you
want the full Contributor Covenant as a separate file and I will add it.

Verified: no third-party project names, no infrastructure identifiers, and
every internal link (`LICENSE`, `docs/security-audit.md`, `docs/crds.md`,
`docs/index.md`) resolves. `hack/verify-doc-versions.sh` still passes — neither
file introduces a version pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)