### PR TITLE
fix(snapshots): evaluate schedule cron in UTC, not the pod's local timezone

### DIFF
--- a/docs/snapshots/scheduled-snapshots.md
+++ b/docs/snapshots/scheduled-snapshots.md
@@ -39,9 +39,10 @@ credentials) — see [`config/samples/snapshot-schedule/02-schedule-s3-ttl.yaml`
 
 ## Semantics
 
-- **Cron** is standard 5-field, evaluated in **UTC**. After a controller outage
-  the schedule fires **at most one** catch-up snapshot (the most recent missed
-  tick), never a backlog.
+- **Cron** is standard 5-field, evaluated in **UTC** — whatever timezone the
+  controller pod itself runs in. After a controller outage the schedule fires
+  **at most one** catch-up snapshot (the most recent missed tick), never a
+  backlog.
 - **`concurrencyPolicy: Forbid`** (default) skips a tick while a prior scheduled
   snapshot is still capturing/uploading — captures are heavy; this prevents them
   stacking. `Allow` lets them overlap.

--- a/internal/controller/swiftsnapshotschedule/controller.go
+++ b/internal/controller/swiftsnapshotschedule/controller.go
@@ -7,6 +7,7 @@ package swiftsnapshotschedule
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -58,7 +59,7 @@ func (r *SwiftSnapshotScheduleReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{RequeueAfter: suspendedRequeue}, nil
 	}
 
-	cronSched, err := cron.ParseStandard(sched.Spec.Schedule)
+	cronSched, err := parseScheduleUTC(sched.Spec.Schedule)
 	if err != nil {
 		// Invalid cron (the webhook rejects this once it lands). Don't hot-loop —
 		// the schedule is re-reconciled when the spec is fixed.
@@ -112,6 +113,30 @@ func (r *SwiftSnapshotScheduleReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	return ctrl.Result{RequeueAfter: requeueToNext(cronSched, now)}, nil
+}
+
+// parseScheduleUTC parses a 5-field cron expression, pinned to UTC.
+//
+// ParseStandard defaults an unzoned expression to time.Local, and Next() then
+// evaluates it in the zone of the time it is given — always local here, since
+// metav1.Time decodes to time.Local. A pod with a timezone would otherwise run
+// every schedule on local wall-clock, while spec.schedule documents UTC.
+// An explicit TZ=/CRON_TZ= prefix keeps the zone it names.
+func parseScheduleUTC(spec string) (cron.Schedule, error) {
+	sched, err := cron.ParseStandard(spec)
+	if err != nil {
+		return nil, err
+	}
+	// @every parses to a plain interval, with no location to pin.
+	if ss, ok := sched.(*cron.SpecSchedule); ok && !namesTimezone(spec) {
+		ss.Location = time.UTC
+	}
+	return sched, nil
+}
+
+// namesTimezone reports whether spec carries a zone prefix ParseStandard honours.
+func namesTimezone(spec string) bool {
+	return strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=")
 }
 
 // mostRecentDue returns the latest scheduled time in (earliest, now], and

--- a/internal/controller/swiftsnapshotschedule/controller_test.go
+++ b/internal/controller/swiftsnapshotschedule/controller_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+	// Embedded zoneinfo, so the explicit-zone test does not depend on host tzdata.
+	_ "time/tzdata"
 
 	"github.com/robfig/cron/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -228,6 +230,71 @@ func TestReconcile_StartingDeadline_SkipsTooLate(t *testing.T) {
 	_ = c.Get(context.Background(), req().NamespacedName, &after)
 	if after.Status.LastScheduleTime == nil || !after.Status.LastScheduleTime.Time.Equal(midnight) {
 		t.Errorf("skipped tick should still advance lastScheduleTime to %v; got %v", midnight, after.Status.LastScheduleTime)
+	}
+}
+
+// withLocalTZ stands in for a pod given a timezone (a mounted /etc/localtime),
+// or a contributor running the suite outside UTC.
+func withLocalTZ(t *testing.T, offset time.Duration) {
+	t.Helper()
+	orig := time.Local
+	time.Local = time.FixedZone("TEST", int(offset/time.Second))
+	t.Cleanup(func() { time.Local = orig })
+}
+
+// spec.schedule is documented as UTC; unpinned, it would follow the zone of the
+// times the reconcile loop hands it, which are always local.
+func TestParseScheduleUTC_IgnoresProcessTimezone(t *testing.T) {
+	withLocalTZ(t, 5*time.Hour)
+
+	sched, err := parseScheduleUTC("0 2 * * *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A local-zone time, as the reconcile loop passes.
+	from := time.Date(2026, 6, 6, 0, 0, 0, 0, time.Local)
+	want := time.Date(2026, 6, 6, 2, 0, 0, 0, time.UTC)
+	if got := sched.Next(from); !got.Equal(want) {
+		t.Errorf("next tick = %v (%v UTC), want %v", got, got.UTC(), want)
+	}
+}
+
+// Pinning UTC must not override a zone the expression asked for.
+func TestParseScheduleUTC_HonoursExplicitZone(t *testing.T) {
+	withLocalTZ(t, 5*time.Hour)
+
+	sched, err := parseScheduleUTC("CRON_TZ=Asia/Tokyo 0 2 * * *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 00:00 UTC is already 09:00 in Tokyo, so the next 02:00 there is tomorrow's.
+	from := time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC)
+	want := time.Date(2026, 6, 7, 2, 0, 0, 0, tokyo)
+	if got := sched.Next(from); !got.Equal(want) {
+		t.Errorf("next tick = %v (%v UTC), want %v", got, got.UTC(), want)
+	}
+}
+
+// @every has no location; pinning must not drop it on the type assertion.
+func TestParseScheduleUTC_IntervalSchedule(t *testing.T) {
+	sched, err := parseScheduleUTC("@every 30m")
+	if err != nil {
+		t.Fatal(err)
+	}
+	from := time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC)
+	if got, want := sched.Next(from), from.Add(30*time.Minute); !got.Equal(want) {
+		t.Errorf("next tick = %v, want %v", got, want)
+	}
+}
+
+// Parser errors pass through unchanged.
+func TestParseScheduleUTC_RejectsInvalid(t *testing.T) {
+	if _, err := parseScheduleUTC("not a cron"); err == nil {
+		t.Error("expected an error for an invalid cron expression")
 	}
 }
 


### PR DESCRIPTION
`spec.schedule` is documented as UTC — in the Go type comment, `docs/crds.md` and the scheduled-snapshots guide — but it was evaluated in the timezone of the process.

`cron.ParseStandard` leaves an unzoned expression at `Location: time.Local`, and `SpecSchedule.Next` then evaluates it in the zone of the time it is given. Those times are always local: `metav1.Time` converts to `time.Local` as it decodes the API server's RFC3339, so both `lastScheduleTime` and `creationTimestamp` come back local.

A controller pod that has a timezone therefore runs every schedule on local wall-clock. Under `Europe/Rome`, `0 2 * * *` fires at **00:00 UTC**, and shifts again across DST. `startingDeadlineSeconds` compounds it: a tick displaced past the deadline is skipped, so the snapshot is not late, it is missing.

**Reachability.** The shipped `distroless/static` image carries no tzdata, so `time.Local` resolves to UTC and a default install is unaffected. It bites when `/etc/localtime` is mounted into pods, when the image is rebuilt on another base, or when the manager runs outside a container.

It also breaks `go test ./...` on any host that is not UTC, which is how this surfaced:

```
--- FAIL: TestReconcile_StartingDeadline_SkipsTooLate (0.02s)
    controller_test.go:230: skipped tick should still advance lastScheduleTime to
      2026-06-06 00:00:00 +0000 UTC; got 2026-06-06 00:00:00 +0200 CEST
```

## Change

`parseScheduleUTC` pins the location when the expression names no zone. An explicit `TZ=`/`CRON_TZ=` prefix keeps the zone it names, and `@every` intervals have no location to pin. The webhook is left alone: its `ParseStandard` call is a syntax check, and location does not affect what it accepts.

## Tests

Four unit tests plus the existing reconcile guard, all confirmed to go red without the fix: 2 failures under `Europe/Rome` and `America/New_York`, 1 under `UTC`. `TestParseScheduleUTC_IgnoresProcessTimezone` fails even under `UTC` because it pins `time.Local` itself, so the guard does not depend on where CI runs; the explicit-zone test imports `time/tzdata` (test binary only) for the same reason. Green in five zones, along with `gofmt`, `go vet`, the full suite and `hack/verify-doc-versions.sh`. No `api/` changes, so no CRD regeneration.

One process note: `CONTRIBUTING.md` asks for an issue first on runtime behaviour changes. I read this as the "small fix" case, since it makes the code match a contract the API and docs already state and no CRD field moves — happy to open an issue first if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
