### PR TITLE
docs(snapshots): clarify the UTC wording and document the CRON_TZ escape hatch

### DIFF
--- a/api/snapshot/v1alpha1/swiftsnapshotschedule_types.go
+++ b/api/snapshot/v1alpha1/swiftsnapshotschedule_types.go
@@ -50,8 +50,12 @@ type SnapshotTemplate struct {
 
 // SwiftSnapshotScheduleSpec defines the desired state of a SwiftSnapshotSchedule.
 type SwiftSnapshotScheduleSpec struct {
-	// Schedule is a standard 5-field cron expression, evaluated in UTC.
+	// Schedule is a standard 5-field cron expression, evaluated in UTC
+	// regardless of the controller pod's own timezone.
 	// Example: "0 2 * * *" (daily at 02:00 UTC).
+	// To schedule in another zone, prefix with CRON_TZ=, e.g.
+	// "CRON_TZ=Europe/Rome 0 2 * * *" — that fires at 02:00 Rome time and
+	// shifts against UTC across DST.
 	Schedule string `json:"schedule"`
 
 	// Suspend pauses the schedule (no new snapshots) without deleting it or its

--- a/charts/kubeswift/crds/snapshot.kubeswift.io_swiftsnapshotschedules.yaml
+++ b/charts/kubeswift/crds/snapshot.kubeswift.io_swiftsnapshotschedules.yaml
@@ -88,8 +88,12 @@ spec:
                 type: object
               schedule:
                 description: |-
-                  Schedule is a standard 5-field cron expression, evaluated in UTC.
+                  Schedule is a standard 5-field cron expression, evaluated in UTC
+                  regardless of the controller pod's own timezone.
                   Example: "0 2 * * *" (daily at 02:00 UTC).
+                  To schedule in another zone, prefix with CRON_TZ=, e.g.
+                  "CRON_TZ=Europe/Rome 0 2 * * *" — that fires at 02:00 Rome time and
+                  shifts against UTC across DST.
                 type: string
               startingDeadlineSeconds:
                 description: |-

--- a/config/crd/bases/snapshot.kubeswift.io_swiftsnapshotschedules.yaml
+++ b/config/crd/bases/snapshot.kubeswift.io_swiftsnapshotschedules.yaml
@@ -88,8 +88,12 @@ spec:
                 type: object
               schedule:
                 description: |-
-                  Schedule is a standard 5-field cron expression, evaluated in UTC.
+                  Schedule is a standard 5-field cron expression, evaluated in UTC
+                  regardless of the controller pod's own timezone.
                   Example: "0 2 * * *" (daily at 02:00 UTC).
+                  To schedule in another zone, prefix with CRON_TZ=, e.g.
+                  "CRON_TZ=Europe/Rome 0 2 * * *" — that fires at 02:00 Rome time and
+                  shifts against UTC across DST.
                 type: string
               startingDeadlineSeconds:
                 description: |-

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -494,7 +494,7 @@ Cron-creates SwiftSnapshots of a guest and prunes to a kept count (composes with
 
 | Key field | Type | Description |
 |-----------|------|-------------|
-| `schedule` | string | Standard cron expression (UTC). |
+| `schedule` | string | Standard cron expression, evaluated in UTC regardless of the controller pod's timezone. Prefix with `CRON_TZ=` to use another zone (e.g. `CRON_TZ=Europe/Rome 0 2 * * *`). |
 | `suspend` | bool | Pause the schedule without deleting it. |
 | `concurrencyPolicy` | enum | `Forbid` (default) skips a tick while a prior snapshot is in-flight. |
 | `startingDeadlineSeconds` | int64 | Skip a missed tick older than this. |

--- a/docs/snapshots/scheduled-snapshots.md
+++ b/docs/snapshots/scheduled-snapshots.md
@@ -39,8 +39,10 @@ credentials) — see [`config/samples/snapshot-schedule/02-schedule-s3-ttl.yaml`
 
 ## Semantics
 
-- **Cron** is standard 5-field, evaluated in **UTC** — whatever timezone the
-  controller pod itself runs in. After a controller outage the schedule fires
+- **Cron** is standard 5-field, evaluated in **UTC** regardless of the timezone
+  the controller pod runs in. To schedule in another zone, prefix the expression
+  with `CRON_TZ=`: `CRON_TZ=Europe/Rome 0 2 * * *` fires at 02:00 Rome time,
+  shifting against UTC across DST. After a controller outage the schedule fires
   **at most one** catch-up snapshot (the most recent missed tick), never a
   backlog.
 - **`concurrencyPolicy: Forbid`** (default) skips a tick while a prior scheduled


### PR DESCRIPTION
The two documentation follow-ups from the #580 review. No behaviour change.

## 1. The wording was ambiguous

#580 added:

> evaluated in **UTC** — whatever timezone the controller pod itself runs in

which parses as though UTC *were* the pod's zone — the opposite of what the fix
does. Now reads "**regardless of** the timezone the controller pod runs in".

## 2. `CRON_TZ=` was supported but undiscoverable

#580 made honouring an explicit `CRON_TZ=`/`TZ=` prefix **deliberate and
tested** (`TestParseScheduleUTC_HonoursExplicitZone`), but nothing told users it
exists. Every place someone would look said only "UTC":

- the Go type comment — which is what `kubectl explain
  swiftsnapshotschedule.spec.schedule` prints
- `docs/crds.md`
- the scheduled-snapshots guide

So the single supported way to schedule in a non-UTC zone was reachable only by
reading the controller source. All three now document it with a worked example,
including that such a schedule shifts against UTC across DST — the thing that
surprises people about local-time cron.

## Verified

- Regenerated CRDs after the `api/` comment change: **descriptions only, 0
  structural lines** (no `type`/`required`/`enum`/`default`/`properties`).
- The documented example was **executed** against `parseScheduleUTC` before
  landing — `CRON_TZ=Europe/Rome 0 2 * * *` really does next-fire at 02:00 Rome
  — rather than assumed to work. Documenting an escape hatch that turned out not
  to function would be worse than not documenting it.
- `gofmt`, build, the schedule controller + webhook suites, and
  `hack/verify-doc-versions.sh` all pass.

## Related

The other review finding is filed separately as #581 — a pre-existing panic in
`robfig/cron` on a `TZ=` prefix with no space, reachable from `spec.schedule`.
Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)