### PR TITLE
fix(snapshots): reject a TZ= prefix with no cron fields instead of panicking

### DIFF
--- a/internal/controller/swiftsnapshotschedule/controller.go
+++ b/internal/controller/swiftsnapshotschedule/controller.go
@@ -7,7 +7,6 @@ package swiftsnapshotschedule
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -20,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/snapshot/cronspec"
 )
 
 const (
@@ -117,26 +117,11 @@ func (r *SwiftSnapshotScheduleReconciler) Reconcile(ctx context.Context, req ctr
 
 // parseScheduleUTC parses a 5-field cron expression, pinned to UTC.
 //
-// ParseStandard defaults an unzoned expression to time.Local, and Next() then
-// evaluates it in the zone of the time it is given — always local here, since
-// metav1.Time decodes to time.Local. A pod with a timezone would otherwise run
-// every schedule on local wall-clock, while spec.schedule documents UTC.
-// An explicit TZ=/CRON_TZ= prefix keeps the zone it names.
+// Delegates to cronspec.Parse so the controller and the admission webhook
+// cannot drift: the webhook is off by default, which makes this the path a
+// malformed spec.schedule actually reaches.
 func parseScheduleUTC(spec string) (cron.Schedule, error) {
-	sched, err := cron.ParseStandard(spec)
-	if err != nil {
-		return nil, err
-	}
-	// @every parses to a plain interval, with no location to pin.
-	if ss, ok := sched.(*cron.SpecSchedule); ok && !namesTimezone(spec) {
-		ss.Location = time.UTC
-	}
-	return sched, nil
-}
-
-// namesTimezone reports whether spec carries a zone prefix ParseStandard honours.
-func namesTimezone(spec string) bool {
-	return strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=")
+	return cronspec.Parse(spec)
 }
 
 // mostRecentDue returns the latest scheduled time in (earliest, now], and

--- a/internal/snapshot/cronspec/cronspec.go
+++ b/internal/snapshot/cronspec/cronspec.go
@@ -1,0 +1,86 @@
+// Package cronspec parses the cron expression on SwiftSnapshotSchedule.
+//
+// It exists so the controller and the admission webhook parse the same string
+// the same way. They previously each called cron.ParseStandard directly, which
+// meant a guard added to one would not protect the other — and the webhook is
+// off by default (webhook.enabled=false), so the controller is the path that
+// actually needs protecting.
+package cronspec
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// Parse parses a 5-field cron expression, pinned to UTC.
+//
+// ParseStandard defaults an unzoned expression to time.Local, and Next() then
+// evaluates it in the zone of the time it is given — always local in the
+// reconcile loop, since metav1.Time decodes to time.Local. A pod with a
+// timezone would otherwise run every schedule on local wall-clock, while
+// spec.schedule documents UTC. An explicit TZ=/CRON_TZ= prefix keeps the zone
+// it names.
+func Parse(spec string) (cron.Schedule, error) {
+	if err := checkTimezonePrefix(spec); err != nil {
+		return nil, err
+	}
+	sched, err := cron.ParseStandard(spec)
+	if err != nil {
+		return nil, err
+	}
+	// @every parses to a plain interval, with no location to pin.
+	if ss, ok := sched.(*cron.SpecSchedule); ok && !namesTimezone(spec) {
+		ss.Location = time.UTC
+	}
+	return sched, nil
+}
+
+// checkTimezonePrefix rejects the one input shape that makes ParseStandard
+// PANIC rather than return an error.
+//
+// cron v3.0.1 extracts the zone with:
+//
+//	i := strings.Index(spec, " ")
+//	eq := strings.Index(spec, "=")
+//	time.LoadLocation(spec[eq+1 : i])
+//
+// When the spec carries a TZ=/CRON_TZ= prefix and contains no space at all, i
+// is -1 and the slice expression panics with "slice bounds out of range [:-1]".
+// spec.schedule is user-supplied, so "TZ=Europe/Rome" with no fields after it
+// reaches that line straight from a CR.
+//
+// The condition here is exactly the condition that panics — a prefix plus no
+// ASCII space — verified case by case against the parser, including the shapes
+// that look similar but do NOT panic: a trailing space with no fields
+// ("TZ=Europe/Rome ") and a tab separator ("TZ=Zone\t0 2 * * *"), both of which
+// contain a space that Index finds, so cron returns an error on its own.
+//
+// Upstream has had this reported since at least robfig/cron#470 (also #566,
+// #574), all still open, and the project was last pushed in 2024 — so guarding
+// locally is the only option, not a stopgap.
+func checkTimezonePrefix(spec string) error {
+	if namesTimezone(spec) && !strings.Contains(spec, " ") {
+		return fmt.Errorf(
+			"a %s prefix must be followed by a space and the cron fields, e.g. %q; got %q",
+			timezoneKeyword(spec), "CRON_TZ=Europe/Rome 0 2 * * *", spec)
+	}
+	return nil
+}
+
+// namesTimezone reports whether spec carries a zone prefix ParseStandard
+// honours. Deliberately byte-identical to cron's own check, so the two cannot
+// disagree about whether a prefix is present.
+func namesTimezone(spec string) bool {
+	return strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=")
+}
+
+// timezoneKeyword returns which prefix spec used, for the error message.
+func timezoneKeyword(spec string) string {
+	if strings.HasPrefix(spec, "CRON_TZ=") {
+		return "CRON_TZ="
+	}
+	return "TZ="
+}

--- a/internal/snapshot/cronspec/cronspec_test.go
+++ b/internal/snapshot/cronspec/cronspec_test.go
@@ -1,0 +1,116 @@
+package cronspec
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	// Embedded zoneinfo, so the explicit-zone case does not depend on host tzdata.
+	_ "time/tzdata"
+)
+
+// The defect this package exists for: a TZ=/CRON_TZ= prefix with no space
+// panics cron.ParseStandard (slice bounds out of range [:-1]) rather than
+// returning an error. spec.schedule is user-supplied, so these arrive from a CR.
+//
+// These cases would PANIC without checkTimezonePrefix, and a panic fails the
+// test outright — so this does not depend on any recover() elsewhere. That
+// matters: controller-runtime recovers reconciler panics by default, which
+// would otherwise let a regression look like a passing test.
+func TestParse_TimezonePrefixWithoutFieldsIsRejectedNotPanic(t *testing.T) {
+	for _, spec := range []string{
+		"TZ=Europe/Rome",
+		"CRON_TZ=UTC",
+		"TZ=",
+		"CRON_TZ=",
+	} {
+		t.Run(spec, func(t *testing.T) {
+			sched, err := Parse(spec)
+			if err == nil {
+				t.Fatalf("Parse(%q) returned no error; a prefix with no cron fields must be rejected", spec)
+			}
+			if sched != nil {
+				t.Errorf("Parse(%q) returned a schedule alongside an error", spec)
+			}
+			// The message has to tell the operator what to do about it.
+			if !strings.Contains(err.Error(), "followed by a space") {
+				t.Errorf("error should explain the fix, got: %v", err)
+			}
+		})
+	}
+}
+
+// Shapes that LOOK like the broken one but are cron's own business: each
+// contains a space, so cron finds it and errors by itself. The guard must not
+// claim these — over-rejecting would break valid-ish input and mask real parser
+// errors.
+func TestParse_SimilarShapesAreLeftToTheParser(t *testing.T) {
+	for _, tc := range []struct{ name, spec string }{
+		{"trailing space, no fields", "TZ=Europe/Rome "},
+		{"tab separator", "TZ=Zone\t0 2 * * *"},
+		{"bad zone name", "CRON_TZ=Bogus/Zone 0 2 * * *"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Must not panic, and must surface the parser's own error.
+			_, err := Parse(tc.spec)
+			if err == nil {
+				t.Fatalf("Parse(%q) unexpectedly succeeded", tc.spec)
+			}
+			if strings.Contains(err.Error(), "followed by a space") {
+				t.Errorf("guard claimed %q; it should have been left to the parser: %v", tc.spec, err)
+			}
+		})
+	}
+}
+
+// The guard must not disturb anything valid.
+func TestParse_ValidExpressionsStillWork(t *testing.T) {
+	for _, spec := range []string{
+		"0 2 * * *",
+		"*/15 * * * *",
+		"@daily",
+		"@every 30m",
+		"CRON_TZ=Asia/Tokyo 0 2 * * *",
+		"TZ=Asia/Tokyo 0 2 * * *",
+	} {
+		if _, err := Parse(spec); err != nil {
+			t.Errorf("Parse(%q) = %v, want success", spec, err)
+		}
+	}
+}
+
+// The UTC pinning this package inherited must survive the refactor: an unzoned
+// expression is evaluated in UTC no matter the process timezone.
+func TestParse_UnzonedIsPinnedToUTC(t *testing.T) {
+	orig := time.Local
+	time.Local = time.FixedZone("TEST", 5*60*60)
+	t.Cleanup(func() { time.Local = orig })
+
+	sched, err := Parse("0 2 * * *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	from := time.Date(2026, 6, 6, 0, 0, 0, 0, time.Local)
+	want := time.Date(2026, 6, 6, 2, 0, 0, 0, time.UTC)
+	if got := sched.Next(from); !got.Equal(want) {
+		t.Errorf("next tick = %v (%v UTC), want %v", got, got.UTC(), want)
+	}
+}
+
+// An explicit zone still wins over the UTC pin.
+func TestParse_ExplicitZoneIsHonoured(t *testing.T) {
+	sched, err := Parse("CRON_TZ=Asia/Tokyo 0 2 * * *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 00:00 UTC is already 09:00 in Tokyo, so the next 02:00 there is tomorrow's.
+	from := time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC)
+	want := time.Date(2026, 6, 7, 2, 0, 0, 0, tokyo)
+	if got := sched.Next(from); !got.Equal(want) {
+		t.Errorf("next tick = %v (%v UTC), want %v", got, got.UTC(), want)
+	}
+}

--- a/internal/webhook/swiftsnapshotschedule/validator.go
+++ b/internal/webhook/swiftsnapshotschedule/validator.go
@@ -8,11 +8,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/robfig/cron/v3"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	snapshotv1alpha1 "github.com/kubeswift-io/kubeswift/api/snapshot/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/snapshot/cronspec"
 	swiftsnapshotwebhook "github.com/kubeswift-io/kubeswift/internal/webhook/swiftsnapshot"
 )
 
@@ -50,7 +50,7 @@ func (v *Validator) ValidateDelete(_ context.Context, _ runtime.Object) (admissi
 }
 
 func validateSchedule(s *snapshotv1alpha1.SwiftSnapshotSchedule) error {
-	if _, err := cron.ParseStandard(s.Spec.Schedule); err != nil {
+	if _, err := cronspec.Parse(s.Spec.Schedule); err != nil {
 		return fmt.Errorf("spec.schedule is not a valid 5-field cron expression: %w", err)
 	}
 	if len(s.Name) > maxScheduleNameLen {


### PR DESCRIPTION
Closes #581.

## The defect

cron v3.0.1 extracts the zone with:

```go
i := strings.Index(spec, " ")   // -1 when there is no space
eq := strings.Index(spec, "=")
time.LoadLocation(spec[eq+1 : i])   // spec[3:-1] -> panic
```

A `TZ=`/`CRON_TZ=` prefix with no space **panics** rather than erroring.
`spec.schedule` is user-supplied, so `TZ=Europe/Rome` with no fields after it
reaches that line straight from a CR.

It was never a crash — controller-runtime recovers reconciler panics by default
— but the outcome was worse than an error: **the schedule silently never
fired**, with nothing on the object explaining why. And `webhook.enabled`
defaults to **false**, so there is normally no admission gate to reject it
first.

## The guard is exactly the panic condition

Not reasoned about — enumerated against the parser, case by case:

```
panics=true  guard=true   "TZ=Europe/Rome"
panics=true  guard=true   "CRON_TZ=UTC"
panics=true  guard=true   "TZ="
panics=false guard=false  "TZ=Europe/Rome 0 2 * * *"
panics=false guard=false  "TZ=Europe/Rome "          <- trailing space, no fields
panics=false guard=false  "TZ=Zone\t0 2 * * *"       <- tab, not space
panics=false guard=false  "CRON_TZ=Bogus/Zone 0 2 * * *"
```

The last three matter as much as the first three. Each contains a space that
cron's `Index` finds, so the parser errors on its own — over-rejecting them
would mask real parser errors. The guard deliberately leaves them alone.

## Both call sites now share one parser

The controller and the webhook each called `ParseStandard` directly, so a guard
added to one would not have protected the other. `internal/snapshot/cronspec`
now owns it, matching the existing `internal/snapshot/<topic>` layout.

`parseScheduleUTC` stays as a thin wrapper, so **the tests added with the UTC
fix in #580 keep exercising the same entry point, unchanged**.

## Upstream will not fix this

robfig/cron#470, #566 and #574 — all still open, last push 2024-07-08, 173 open
issues. Guarding locally is the option, not a stopgap.

## Tests

The new cases **panic outright without the guard** rather than merely failing,
so they cannot be satisfied by a `recover()` elsewhere — which matters, because
controller-runtime's default panic recovery would otherwise let a regression
look like a passing test. Verified by removing the guard:

```
--- FAIL: TestParse_TimezonePrefixWithoutFieldsIsRejectedNotPanic/TZ=Europe/Rome
panic: runtime error: slice bounds out of range [:-1] [recovered, repanicked]
```

Full suite green, `gofmt`/`vet` clean, and the #580 UTC behaviour re-verified
across UTC / Europe/Rome / America/New_York. No `api/` change, so no CRD
regeneration.

## Found while here, not fixed here

`SwiftSnapshotScheduleStatus.Conditions` is documented as "exposes Ready" but is
**never populated anywhere in the codebase** — the API promises a condition that
does not exist. That is why this PR does not surface the parse error as a
condition: implementing `Ready` only for the failure case, so it appears when
broken and never clears, would be worse than the current absence. It needs a
deliberate decision about when a schedule *is* Ready. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)