### PR TITLE
fix(snapshots): report an unparseable schedule instead of dropping it

### DIFF
--- a/api/snapshot/v1alpha1/swiftsnapshotschedule_types.go
+++ b/api/snapshot/v1alpha1/swiftsnapshotschedule_types.go
@@ -95,7 +95,11 @@ type SwiftSnapshotScheduleStatus struct {
 	// Active lists the names of in-flight (non-terminal) scheduled snapshots.
 	// +optional
 	Active []string `json:"active,omitempty"`
-	// Conditions exposes Ready.
+	// Conditions exposes Ready: True once spec.schedule parses and the schedule
+	// is live, False with reason InvalidSchedule when it does not parse, and
+	// False with reason Suspended while spec.suspend is set. An unparseable
+	// schedule is otherwise invisible -- nothing else in spec or status changes,
+	// and the schedule simply never fires.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
@@ -106,6 +110,7 @@ type SwiftSnapshotScheduleStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=swiftsnapshotschedules,scope=Namespaced,shortName=sss
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=`.spec.schedule`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Suspend",type=boolean,JSONPath=`.spec.suspend`
 // +kubebuilder:printcolumn:name="Guest",type=string,JSONPath=`.spec.template.spec.guestRef.name`
 // +kubebuilder:printcolumn:name="Last-Schedule",type=date,JSONPath=`.status.lastScheduleTime`
@@ -131,4 +136,5 @@ type SwiftSnapshotScheduleList struct {
 const ScheduleLabel = "snapshot.kubeswift.io/schedule"
 
 // SwiftSnapshotScheduleConditionReady is the schedule's Ready condition type.
+// Reasons: Scheduled (True); InvalidSchedule or Suspended (False).
 const SwiftSnapshotScheduleConditionReady = "Ready"

--- a/charts/kubeswift/crds/snapshot.kubeswift.io_swiftsnapshotschedules.yaml
+++ b/charts/kubeswift/crds/snapshot.kubeswift.io_swiftsnapshotschedules.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .spec.schedule
       name: Schedule
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
     - jsonPath: .spec.suspend
       name: Suspend
       type: boolean
@@ -350,7 +353,12 @@ spec:
                   type: string
                 type: array
               conditions:
-                description: Conditions exposes Ready.
+                description: |-
+                  Conditions exposes Ready: True once spec.schedule parses and the schedule
+                  is live, False with reason InvalidSchedule when it does not parse, and
+                  False with reason Suspended while spec.suspend is set. An unparseable
+                  schedule is otherwise invisible -- nothing else in spec or status changes,
+                  and the schedule simply never fires.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/config/crd/bases/snapshot.kubeswift.io_swiftsnapshotschedules.yaml
+++ b/config/crd/bases/snapshot.kubeswift.io_swiftsnapshotschedules.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .spec.schedule
       name: Schedule
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
     - jsonPath: .spec.suspend
       name: Suspend
       type: boolean
@@ -350,7 +353,12 @@ spec:
                   type: string
                 type: array
               conditions:
-                description: Conditions exposes Ready.
+                description: |-
+                  Conditions exposes Ready: True once spec.schedule parses and the schedule
+                  is live, False with reason InvalidSchedule when it does not parse, and
+                  False with reason Suspended while spec.suspend is set. An unparseable
+                  schedule is otherwise invisible -- nothing else in spec or status changes,
+                  and the schedule simply never fires.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/docs/snapshots/scheduled-snapshots.md
+++ b/docs/snapshots/scheduled-snapshots.md
@@ -82,6 +82,28 @@ keep-N safety:
 - **local**: ⚠️ writes a **fixed `hostPath`**, so scheduled local snapshots
   overwrite each other — **don't schedule the local backend**; use csi or s3.
 
+## Status
+
+`kubectl get sss` shows a `Ready` column, taken from the schedule's `Ready`
+condition:
+
+| Ready | Reason | Meaning |
+|---|---|---|
+| `True` | `Scheduled` | `spec.schedule` parses; a snapshot is created on each tick. |
+| `False` | `InvalidSchedule` | `spec.schedule` does not parse — the schedule will never fire. `message` carries the parse error. |
+| `False` | `Suspended` | `spec.suspend` is set. |
+
+`InvalidSchedule` is the one to watch for. The admission webhook that rejects a
+bad cron expression is off by default (`webhook.enabled=false`), so a malformed
+`spec.schedule` reaches the controller instead. Before this condition existed
+the only trace was a controller log line: the schedule read as healthy under
+`kubectl get` and silently never fired.
+
+```bash
+kubectl get sss nightly-db \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}'
+```
+
 ## Observability
 
 `kubeswift_snapshot_schedule_pruned_total` counts keep-N deletions. Scheduled
@@ -95,4 +117,6 @@ latency/size metrics (see [`observability.md`](observability.md)).
   Kubernetes' 63-character limit.
 - The cron expression and the `template.spec` are validated at schedule-create
   by the admission webhook (a bad template is rejected up front, not at the
-  first tick).
+  first tick) — **when the webhook is enabled**. `webhook.enabled` is false by
+  default; with it off, a bad cron expression is caught by the controller and
+  reported as `Ready=False` / `InvalidSchedule` instead (see [Status](#status)).

--- a/internal/controller/swiftsnapshotschedule/controller.go
+++ b/internal/controller/swiftsnapshotschedule/controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/robfig/cron/v3"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -55,20 +56,37 @@ func (r *SwiftSnapshotScheduleReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	status := sched.Status.DeepCopy()
+
 	if sched.Spec.Suspend {
+		setReady(status, &sched, metav1.ConditionFalse, "Suspended",
+			"spec.suspend is set; no snapshots are created while suspended")
+		if err := r.persistStatus(ctx, &sched, status); err != nil {
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{RequeueAfter: suspendedRequeue}, nil
 	}
 
 	cronSched, err := parseScheduleUTC(sched.Spec.Schedule)
 	if err != nil {
-		// Invalid cron (the webhook rejects this once it lands). Don't hot-loop —
-		// the schedule is re-reconciled when the spec is fixed.
+		// Invalid cron. Don't hot-loop — the schedule is re-reconciled when the
+		// spec is fixed.
+		//
+		// The condition is the whole point of this branch. Without it the failure
+		// is invisible: the validating webhook is off by default, so a malformed
+		// spec.schedule reaches the controller, and returning here leaves an
+		// object that reads as perfectly healthy under `kubectl get` — schedule,
+		// suspend, guest and age all populated — which never fires a snapshot.
+		// The only other trace is this log line.
 		logger.Error(err, "invalid spec.schedule; not scheduling", "schedule", sched.Spec.Schedule)
+		setReady(status, &sched, metav1.ConditionFalse, "InvalidSchedule", err.Error())
+		if perr := r.persistStatus(ctx, &sched, status); perr != nil {
+			return ctrl.Result{}, perr
+		}
 		return ctrl.Result{}, nil
 	}
 
 	now := r.clock()
-	status := sched.Status.DeepCopy()
 
 	// Refresh observed status (active + lastSuccessfulTime) from owned snapshots.
 	children, err := r.ownedSnapshots(ctx, &sched)
@@ -99,6 +117,9 @@ func (r *SwiftSnapshotScheduleReconciler) Reconcile(ctx context.Context, req ctr
 			setLastSchedule(status, dueTick)
 		}
 	}
+
+	setReady(status, &sched, metav1.ConditionTrue, "Scheduled",
+		fmt.Sprintf("schedule %q is valid; a snapshot is created on each tick", sched.Spec.Schedule))
 
 	if err := r.persistStatus(ctx, &sched, status); err != nil {
 		return ctrl.Result{}, err
@@ -252,6 +273,24 @@ func hasInFlight(children []snapshotv1alpha1.SwiftSnapshot) bool {
 func setLastSchedule(status *snapshotv1alpha1.SwiftSnapshotScheduleStatus, t time.Time) {
 	mt := metav1.NewTime(t)
 	status.LastScheduleTime = &mt
+}
+
+// setReady records the Ready condition on the status copy.
+//
+// Messages are derived from spec, never from the clock. persistStatus compares
+// whole statuses, so any part of a condition that differs between two otherwise
+// identical reconciles turns every requeue into a status write.
+// SetStatusCondition only moves LastTransitionTime when Status changes, so with
+// stable messages a steady-state reconcile produces an identical status and no
+// API call at all.
+func setReady(status *snapshotv1alpha1.SwiftSnapshotScheduleStatus, sched *snapshotv1alpha1.SwiftSnapshotSchedule, state metav1.ConditionStatus, reason, msg string) {
+	apimeta.SetStatusCondition(&status.Conditions, metav1.Condition{
+		Type:               snapshotv1alpha1.SwiftSnapshotScheduleConditionReady,
+		Status:             state,
+		Reason:             reason,
+		Message:            msg,
+		ObservedGeneration: sched.Generation,
+	})
 }
 
 func (r *SwiftSnapshotScheduleReconciler) persistStatus(ctx context.Context, sched *snapshotv1alpha1.SwiftSnapshotSchedule, status *snapshotv1alpha1.SwiftSnapshotScheduleStatus) error {

--- a/internal/controller/swiftsnapshotschedule/controller_test.go
+++ b/internal/controller/swiftsnapshotschedule/controller_test.go
@@ -9,6 +9,7 @@ import (
 	_ "time/tzdata"
 
 	"github.com/robfig/cron/v3"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -306,5 +307,123 @@ func TestMergeLabels(t *testing.T) {
 	// schedule label always wins / is set even with nil template labels.
 	if got := mergeLabels(nil, "s")[snapshotv1alpha1.ScheduleLabel]; got != "s" {
 		t.Errorf("schedule label not set on nil template labels; got %q", got)
+	}
+}
+
+func readyCond(t *testing.T, c client.Client) *metav1.Condition {
+	t.Helper()
+	var s snapshotv1alpha1.SwiftSnapshotSchedule
+	if err := c.Get(context.Background(), req().NamespacedName, &s); err != nil {
+		t.Fatal(err)
+	}
+	return apimeta.FindStatusCondition(s.Status.Conditions, snapshotv1alpha1.SwiftSnapshotScheduleConditionReady)
+}
+
+// The defect the Ready condition exists for.
+//
+// An unparseable spec.schedule was logged and dropped: nothing in spec or
+// status changed, so the object read as perfectly healthy under `kubectl get`
+// and silently never fired. The validating webhook that would reject it is off
+// by default, which makes the controller the path a malformed schedule
+// actually reaches.
+func TestReconcile_InvalidSchedule_SurfacesReadyFalse(t *testing.T) {
+	sched := schedule(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		s.Generation = 4
+		s.Spec.Schedule = "not a cron"
+	})
+	r, c := newSched(t, baseTime, sched)
+	res, err := r.Reconcile(context.Background(), req())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Still no hot-loop — the fix is visibility, not retry. The schedule is
+	// re-reconciled by its own watch when the spec is corrected.
+	if res.RequeueAfter != 0 {
+		t.Errorf("requeue = %v, want 0", res.RequeueAfter)
+	}
+	if n := len(listSnaps(t, c)); n != 0 {
+		t.Errorf("invalid schedule must not create snapshots; got %d", n)
+	}
+
+	cond := readyCond(t, c)
+	if cond == nil {
+		t.Fatal("no Ready condition — an invalid schedule is invisible again")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Ready = %v, want False", cond.Status)
+	}
+	if cond.Reason != "InvalidSchedule" {
+		t.Errorf("reason = %q, want InvalidSchedule", cond.Reason)
+	}
+	// The parse error is the only thing that tells an operator what to fix.
+	if !strings.Contains(cond.Message, "not a cron") && cond.Message == "" {
+		t.Errorf("message must carry the parse error, got %q", cond.Message)
+	}
+	if cond.ObservedGeneration != 4 {
+		t.Errorf("observedGeneration = %d, want 4 (must track the spec it judged)", cond.ObservedGeneration)
+	}
+}
+
+func TestReconcile_ValidSchedule_SetsReadyTrue(t *testing.T) {
+	r, c := newSched(t, baseTime, schedule(nil))
+	if _, err := r.Reconcile(context.Background(), req()); err != nil {
+		t.Fatal(err)
+	}
+	cond := readyCond(t, c)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("Ready = %v, want True", cond)
+	}
+	if cond.Reason != "Scheduled" {
+		t.Errorf("reason = %q, want Scheduled", cond.Reason)
+	}
+}
+
+func TestReconcile_Suspend_SetsReadyFalse(t *testing.T) {
+	sched := schedule(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) { s.Spec.Suspend = true })
+	r, c := newSched(t, baseTime, sched)
+	if _, err := r.Reconcile(context.Background(), req()); err != nil {
+		t.Fatal(err)
+	}
+	cond := readyCond(t, c)
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("Ready = %v, want False", cond)
+	}
+	if cond.Reason != "Suspended" {
+		t.Errorf("reason = %q, want Suspended", cond.Reason)
+	}
+}
+
+// A steady-state reconcile must not write status. persistStatus compares whole
+// statuses, so anything in a condition that varies between two identical
+// reconciles turns every requeue into an API write. Verified red by building the
+// Ready message from time.Now() instead of from spec, which moves the
+// resourceVersion on the second pass.
+//
+// Note this catches wall-clock drift specifically: r.clock() is pinned in tests,
+// so a message derived from the injected clock would stay stable here.
+func TestReconcile_SteadyStateDoesNotRewriteStatus(t *testing.T) {
+	sched := schedule(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		lt := metav1.NewTime(baseTime)
+		s.Status.LastScheduleTime = &lt // nothing is due at baseTime
+	})
+	r, c := newSched(t, baseTime, sched)
+
+	if _, err := r.Reconcile(context.Background(), req()); err != nil {
+		t.Fatal(err)
+	}
+	var first snapshotv1alpha1.SwiftSnapshotSchedule
+	if err := c.Get(context.Background(), req().NamespacedName, &first); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Reconcile(context.Background(), req()); err != nil {
+		t.Fatal(err)
+	}
+	var second snapshotv1alpha1.SwiftSnapshotSchedule
+	if err := c.Get(context.Background(), req().NamespacedName, &second); err != nil {
+		t.Fatal(err)
+	}
+	if first.ResourceVersion != second.ResourceVersion {
+		t.Errorf("status rewritten on an idle reconcile: rv %s -> %s",
+			first.ResourceVersion, second.ResourceVersion)
 	}
 }


### PR DESCRIPTION
## The defect

A `SwiftSnapshotSchedule` whose `spec.schedule` does not parse was logged and discarded:

```go
cronSched, err := parseScheduleUTC(sched.Spec.Schedule)
if err != nil {
    logger.Error(err, "invalid spec.schedule; not scheduling", ...)
    return ctrl.Result{}, nil
}
```

Nothing in spec or status changed, so the object read as entirely healthy — `kubectl get sss` prints schedule, suspend, guest, last-schedule and age, and not one of them reveals anything is wrong. It simply never fires a snapshot, indefinitely, with a single controller log line as the only trace.

The inline comment said the webhook rejects this "once it lands", but **`webhook.enabled` is `false` by default**, which makes the controller the path a malformed schedule actually reaches — as the `cronspec` package doc already notes. That is design principle 6, *no silent failures*.

## Why a condition, rather than dropping the field

The Ready condition was already half-landed. `Conditions` was declared and documented as "exposes Ready", and `SwiftSnapshotScheduleConditionReady` was declared with its own doc comment. **Neither was referenced anywhere.** SwiftSnapshotSchedule was the only kind in the repo that declares `Conditions` without populating them — SwiftSandbox, SwiftSandboxPool, SwiftMigration, SwiftGuestPool, fleet Cluster and SwiftSnapshot all do.

Dropping the field would have removed a misleading doc comment while leaving the actual defect in place.

## What this does

| Ready | Reason | When |
|---|---|---|
| `False` | `InvalidSchedule` | `spec.schedule` does not parse; `message` carries the parse error |
| `False` | `Suspended` | `spec.suspend` is set |
| `True` | `Scheduled` | the schedule is live |

Plus a `Ready` print column — the whole complaint is that the failure is invisible at a glance — and `ObservedGeneration` on each condition, so an operator can tell it judged the current spec.

Both early returns now persist status before returning. Suspend previously returned before the status copy existed, so it could leave a stale `Ready=True` behind. The invalid branch still does **not** requeue: the fix is visibility, not retry, and the schedule's own watch re-reconciles when the spec is corrected.

## Notes

Condition messages are built from spec rather than the clock. `persistStatus` compares whole statuses, so anything that varies between two otherwise identical reconciles would turn every requeue into an API write. A test pins that, **verified red** by building the message from `time.Now()`.

The three condition tests were each confirmed to fail without the controller change:

```
--- FAIL: TestReconcile_InvalidSchedule_SurfacesReadyFalse
    no Ready condition — an invalid schedule is invisible again
--- FAIL: TestReconcile_ValidSchedule_SetsReadyTrue
--- FAIL: TestReconcile_Suspend_SetsReadyFalse
```

`docs/snapshots/scheduled-snapshots.md` gains a Status section, and the constraint claiming the webhook validates the cron expression up front is corrected — true only when the webhook is enabled, which by default it is not.

**CRD change** (`swiftsnapshotschedules`, the print column), so `kubectl apply -f charts/kubeswift/crds/` is needed on upgrade. The `conditions` field itself was already in the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)