### PR TITLE
release: v0.13.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,88 @@ All notable changes to KubeSwift are documented here.
 
 ---
 
+## [v0.13.14] — 2026-09-11
+
+A bug-fix release for scheduled snapshots. Three separate defects in
+`SwiftSnapshotSchedule`, each of which let a schedule stop doing its job without
+saying so: a cron expression evaluated in the wrong timezone, a parser panic on
+one input shape, and an unparseable schedule that was logged and discarded.
+
+Also moves the chart's console to kubeswift-ui v0.12.4, which clears every
+outstanding npm advisory in the UI (27 to 0, including an Angular i18n XSS and a
+cache-key ambiguity that leaked responses across requests).
+
+**One CRD gains a print column.** No new fields, so a stale schema drops
+nothing -- but `kubectl get sss` will not show READY until you apply the CRDs.
+
+### Upgrade
+
+```bash
+helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.14 \
+  -n kubeswift-system -f <(helm get values kubeswift -n kubeswift-system -o yaml)
+kubectl apply -f charts/kubeswift/crds/    # for the READY column on schedules
+```
+
+`ui.image.tag` moves from `v0.12.3` to `v0.12.4`. No values keys were added or
+removed.
+
+### Fixed
+
+- **Schedules ran on the pod's local wall-clock, not UTC** (#580).
+  `spec.schedule` is documented as UTC in the Go type, `docs/crds.md` and the
+  guide, but `cron.ParseStandard` leaves an unzoned expression at `time.Local`
+  and `metav1.Time` decodes to local, so `Next()` evaluated every schedule
+  locally. Under `Europe/Rome`, `0 2 * * *` fired at 00:00 UTC and shifted again
+  across DST; with `startingDeadlineSeconds` set, a displaced tick is skipped --
+  so the snapshot is not late, it is missing. The shipped distroless image
+  carries no tzdata and resolves `time.Local` to UTC, so a default install was
+  unaffected; a mounted `/etc/localtime`, a different base image, or running
+  outside a container was not. A `CRON_TZ=`/`TZ=` prefix still selects another
+  zone.
+
+- **A `TZ=` prefix with no cron fields panicked the controller** (#583).
+  cron v3.0.1 extracts the zone with `spec[eq+1:i]`, where `i` is the index of
+  the first space; with no space `i` is -1 and the slice panics with
+  `slice bounds out of range [:-1]`. `spec.schedule` is user-supplied, so
+  `TZ=Europe/Rome` with nothing after it reached that line straight from a CR.
+  The controller and the webhook now parse through one guarded helper, so a
+  check added to one cannot miss the other. Reported upstream as
+  `robfig/cron#470` (also `robfig/cron#566`, `robfig/cron#574`), all still open,
+  with the project last pushed in July 2024 -- so guarding locally is the fix,
+  not a stopgap.
+
+- **An unparseable schedule was logged and dropped** (#584). The reconciler
+  returned without touching status, so the object read as healthy under
+  `kubectl get` -- schedule, suspend, guest and age all populated -- and simply
+  never fired. A schedule now reports a `Ready` condition (`Scheduled`,
+  `InvalidSchedule` or `Suspended`) carrying the parse error in its message,
+  surfaced as a `READY` print column. The `Conditions` field and its `Ready`
+  constant had been declared and documented since the kind shipped, and
+  populated nowhere.
+
+### Changed
+
+- `ui.image.tag` now defaults to `v0.12.4` (was `v0.12.3`).
+- `sigs.k8s.io/controller-runtime` 0.24.1 to 0.25.0 (#577); and
+  `go-containerregistry` 0.22.1, `docker/cli` 29.8.0, `go-jose/v4` 4.1.5,
+  `golang.org/x/crypto` 0.56.0 (#578). govulncheck reports no reachable
+  vulnerabilities and the image scan is clean.
+
+### Docs
+
+- `ADOPTERS.md` and `CONTRIBUTING.md` (#579).
+- The UTC wording on `spec.schedule` is now unambiguous and the `CRON_TZ=`
+  escape hatch is documented (#582).
+- Install commands are checked against the chart version by
+  `hack/verify-doc-versions.sh`, after the README and eight pages sat three
+  releases behind (#576).
+- `docs/snapshots/scheduled-snapshots.md` gains a Status section for the new
+  condition, and the claim that the webhook validates the cron expression up
+  front is corrected -- that holds only when `webhook.enabled` is on, which by
+  default it is not.
+
+---
+
 ## [v0.13.13] — 2026-09-05
 
 A feature release: guests can now be pinned to dedicated host CPUs and backed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KubeSwift runs lightweight virtual machines as native Kubernetes workloads using
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.13 \
+  --version 0.13.14 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/charts/kubeswift/Chart.yaml
+++ b/charts/kubeswift/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: kubeswift
 description: KubeSwift - Cloud Hypervisor-first Kubernetes VM operator
 type: application
-version: 0.13.13
+version: 0.13.14
 # Bare X.Y.Z, with NO leading "v". The imageTag helper adds the "v" when it
 # derives a default image tag, so "v0.13.11" here renders "vv0.13.11" and every
 # image points at a tag that was never published. The helper now trims a stray
 # "v" and hack/verify-image-tags.sh fails the build on a malformed tag, but
 # write it bare: the release workflows pass `--app-version "${TAG#v}"`, and this
 # line should match what they publish.
-appVersion: "0.13.13"
+appVersion: "0.13.14"
 keywords:
   - kubeswift
   - cloud-hypervisor

--- a/charts/kubeswift/README.md
+++ b/charts/kubeswift/README.md
@@ -155,7 +155,7 @@ point `ui.gateway.url` at an externally reachable gateway).
 |---|---|---|
 | `ui.enabled` | Deploy the web console (auto-on for `role=hub`) | `false` |
 | `ui.image.repository` | UI image repo (a top-level package, not chart-derived) | `ghcr.io/kubeswift-io/kubeswift-ui` |
-| `ui.image.tag` | Published UI tag (not chart-derived; `v0.12.3` is the floor for read-only-root) | `v0.12.3` |
+| `ui.image.tag` | Published UI tag (not chart-derived; `v0.12.3` is the floor for read-only-root) | `v0.12.4` |
 | `ui.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `ui.imagePullSecrets` | Pull Secret(s) if the UI package is private | `[]` |
 | `ui.replicas` | UI replicas | `1` |

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -284,7 +284,7 @@ ui:
     # kubeswift-ui releases on its own cadence from its own repo, so this is
     # NOT chart-derived and a chart bump does not move it: check the UI repo's
     # releases and raise this when you want a newer console.
-    tag: v0.12.3
+    tag: v0.12.4
     pullPolicy: IfNotPresent
   # New ghcr packages default PRIVATE; until the kubeswift-ui package is made
   # public (one-time, web UI), reference a docker-registry pull Secret here,

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,9 +46,9 @@ For air-gapped or custom registry installs:
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version <version> -n kubeswift-system --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.13 \
+  --set controllerManager.image.tag=v0.13.14 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.13
+  --set swiftletd.image.tag=v0.13.14
 ```
 
 ### Release workflow

--- a/docs/gitops/quickstart.md
+++ b/docs/gitops/quickstart.md
@@ -51,7 +51,7 @@ Three load-bearing choices:
 - **Pin the chart to a minor range, not `>=0.1.0`.** KubeSwift is pre-1.0 and
   its APIs are `v1alpha1`: a wide-open range lets Flux roll the platform across
   a breaking minor unattended. `"0.13.x"` takes patches automatically and makes
-  a minor bump a reviewed commit. Pin exactly (`0.13.13`) if you want even
+  a minor bump a reviewed commit. Pin exactly (`0.13.14`) if you want even
   patches gated.
 - **`webhook.enabled: true` needs cert-manager** on the cluster (the chart's
   Certificate/Issuer objects require its CRDs). Without cert-manager, set it

--- a/docs/gpu/dra-allocation.md
+++ b/docs/gpu/dra-allocation.md
@@ -98,7 +98,7 @@ the DRA driver does its own discovery, so a DRA-only cluster keeps
 
 ```bash
 helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.13 -n kubeswift-system --create-namespace \
+  --version 0.13.14 -n kubeswift-system --create-namespace \
   --set dra.enabled=true
 ```
 

--- a/docs/install/helm-oci.md
+++ b/docs/install/helm-oci.md
@@ -31,7 +31,7 @@ Stored artifact: `ghcr.io/kubeswift-io/charts/kubeswift:<version>`.
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.13 \
+  --version 0.13.14 \
   -n kubeswift-system \
   --create-namespace
 ```
@@ -56,7 +56,7 @@ Requires [cert-manager](https://cert-manager.io/):
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.13 \
+  --version 0.13.14 \
   -n kubeswift-system \
   --create-namespace \
   --set webhook.enabled=true
@@ -66,13 +66,13 @@ helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.13 \
+  --version 0.13.14 \
   -n kubeswift-system \
   --create-namespace \
   --set controllerManager.image.registry=my-registry.io \
-  --set controllerManager.image.tag=v0.13.13 \
+  --set controllerManager.image.tag=v0.13.14 \
   --set swiftletd.image.registry=my-registry.io \
-  --set swiftletd.image.tag=v0.13.13
+  --set swiftletd.image.tag=v0.13.14
 ```
 
 ## Migration: previously published charts

--- a/docs/install/remote-cluster.md
+++ b/docs/install/remote-cluster.md
@@ -19,7 +19,7 @@ Use this path for **remote clusters** (cloud, on-prem, etc.): install from the O
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.13 \
+  --version 0.13.14 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -50,9 +50,9 @@ kubectl logs -n kubeswift-system deployment/controller-manager --previous
 
 - **OCI install:** Use a chart version whose images exist. The chart (as of the fix) defaults image tags to match the chart version. Reinstall or upgrade:
   ```bash
-  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.13 -n kubeswift-system \
-    --set controllerManager.image.tag=v0.13.13 \
-    --set swiftletd.image.tag=v0.13.13
+  helm upgrade kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.14 -n kubeswift-system \
+    --set controllerManager.image.tag=v0.13.14 \
+    --set swiftletd.image.tag=v0.13.14
   ```
   For dev: use `--version 0.0.0-dev.<sha>` and `--set controllerManager.image.tag=sha-<sha> --set swiftletd.image.tag=sha-<sha>`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ ls -la /dev/kvm
 
 ```bash
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  --version 0.13.13 \
+  --version 0.13.14 \
   -n kubeswift-system \
   --create-namespace
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@ KubeSwift uses three release types: **dev** (main branch), **RC** (release candi
 helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.0.0-dev.a1b2c3d -n kubeswift-system --create-namespace
 
 # Stable
-helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.13 -n kubeswift-system --create-namespace
+helm install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version 0.13.14 -n kubeswift-system --create-namespace
 ```
 
 ## CI workflows


### PR DESCRIPTION
Patch release. Three scheduled-snapshot fixes, plus the console moves to a UI build with no outstanding npm advisories.

## What's in it

| | |
|---|---|
| #580 | schedules evaluated cron on the pod's local wall-clock, not UTC |
| #583 | a `TZ=` prefix with no cron fields panicked the parser |
| #584 | an unparseable schedule was logged and dropped, invisible on the object |
| #577 #578 | dependency bumps; govulncheck clean, image scan clean |
| #579 #582 #576 | ADOPTERS/CONTRIBUTING, UTC wording, doc version pinning |

## Sweep

- `Chart.yaml` version + appVersion → `0.13.14`
- `ui.image.tag` → `v0.12.4` (kubeswift-ui released separately, [v0.12.4](https://github.com/kubeswift-io/kubeswift-ui/releases/tag/v0.12.4))
- 17 install pins across README and `docs/` → `0.13.14` (`hack/verify-doc-versions.sh` passes)
- the "pin exactly (`0.13.13`)" example in the GitOps quickstart → `0.13.14`. That one is *advice*, not a note about when a field appeared, so it should track the current release
- **`charts/kubeswift/README.md` had the `ui.image.tag` default column still at `v0.12.3`** — stale against `values.yaml` and caught by the sweep
- the three `v0.12.3` *floor* comments are left alone: they record when read-only-root became safe, which is history

## CRD

One CRD changes — `swiftsnapshotschedules` gains a `READY` print column. No new fields, so a stale schema drops nothing, but the column needs `kubectl apply -f charts/kubeswift/crds/`.

## Notes

The release workflow assembles the release page from the CHANGELOG entry and **hard-fails when the entry is missing**, so it is written in this PR rather than after tagging.

Upstream cron issues are written as `robfig/cron#470` etc. — bare `#NNN` in the CHANGELOG means a PR in this repo, and 566/574 exist in both.

Verified: `helm lint` clean, chart renders `kubeswift-ui:v0.12.4`, `verify-crd-sync` and `verify-doc-versions` pass, `go test` 0 failures, and the workflow's own awk extractor pulls 82 lines for this tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)