### PR TITLE
fix(snapshots): a schedule like "0 0 31 4 *" spins the controller forever

### DIFF
--- a/docs/snapshots/scheduled-snapshots.md
+++ b/docs/snapshots/scheduled-snapshots.md
@@ -51,6 +51,11 @@ credentials) — see [`config/samples/snapshot-schedule/02-schedule-s3-ttl.yaml`
 - **`startingDeadlineSeconds`** skips a tick missed by more than this (e.g. after
   an outage) instead of firing it late.
 - **`suspend: true`** pauses firing without deleting the schedule or its snapshots.
+- **A date that never occurs is refused**, rather than accepted and never fired:
+  30 or 31 February, and the 31st of April, June, September or November. Cron
+  considers these well-formed — 31 is a legal day and April a legal month — and
+  only fails to match them once running. 29 February is not one of them; it
+  fires in leap years.
 
 ## Retention — keep-N vs ttl
 
@@ -90,7 +95,7 @@ condition:
 | Ready | Reason | Meaning |
 |---|---|---|
 | `True` | `Scheduled` | `spec.schedule` parses; a snapshot is created on each tick. |
-| `False` | `InvalidSchedule` | `spec.schedule` does not parse — the schedule will never fire. `message` carries the parse error. |
+| `False` | `InvalidSchedule` | `spec.schedule` is unusable — it does not parse, or it names a date that never occurs. The schedule will never fire; `message` carries the reason. |
 | `False` | `Suspended` | `spec.suspend` is set. |
 
 `InvalidSchedule` is the one to watch for. The admission webhook that rejects a

--- a/internal/controller/swiftsnapshotschedule/controller.go
+++ b/internal/controller/swiftsnapshotschedule/controller.go
@@ -148,11 +148,15 @@ func parseScheduleUTC(spec string) (cron.Schedule, error) {
 // mostRecentDue returns the latest scheduled time in (earliest, now], and
 // whether one exists. It fires at most once per reconcile (the most recent
 // missed tick), coalescing a backlog after an outage rather than stampeding.
+//
+// A zero Next means no occurrence within the five years cron searches, so
+// nothing is due. Unguarded it precedes every "now" and reads as permanently
+// due — one snapshot named for year 1 per reconcile.
 func mostRecentDue(sched cron.Schedule, earliest, now time.Time) (time.Time, bool) {
 	var due time.Time
 	found := false
 	t := sched.Next(earliest)
-	for i := 0; !t.After(now); i++ {
+	for i := 0; !t.IsZero() && !t.After(now); i++ {
 		due, found = t, true
 		if i >= missedTickCap {
 			break
@@ -170,8 +174,16 @@ func tooLate(sched *snapshotv1alpha1.SwiftSnapshotSchedule, tick, now time.Time)
 
 // requeueToNext returns the capped wait until the next scheduled time
 // (computed from the injected now, not the wall clock).
+//
+// No next occurrence means nothing to wait for, so re-check at the slow cadence.
+// Subtracting the zero time instead gives a vast negative wait that clamps to
+// the one-second floor and busy-loops the reconciler.
 func requeueToNext(sched cron.Schedule, now time.Time) time.Duration {
-	wait := sched.Next(now).Sub(now)
+	next := sched.Next(now)
+	if next.IsZero() {
+		return maxRequeue
+	}
+	wait := next.Sub(now)
 	if wait < time.Second {
 		wait = time.Second
 	}

--- a/internal/controller/swiftsnapshotschedule/controller_test.go
+++ b/internal/controller/swiftsnapshotschedule/controller_test.go
@@ -427,3 +427,68 @@ func TestReconcile_SteadyStateDoesNotRewriteStatus(t *testing.T) {
 			first.ResourceVersion, second.ResourceVersion)
 	}
 }
+
+// A date that never occurs is now rejected at parse time, so it takes the same
+// visible path as a syntax error. Before the guard this schedule created a
+// SwiftSnapshot named "nightly--62135596800" — the zero time in Unix seconds —
+// and put it back one reconcile after an operator deleted it.
+func TestReconcile_ImpossibleDate_SurfacesReadyFalseAndCreatesNothing(t *testing.T) {
+	sched := schedule(func(s *snapshotv1alpha1.SwiftSnapshotSchedule) {
+		s.Spec.Schedule = "0 0 31 4 *" // 31 April
+	})
+	r, c := newSched(t, baseTime, sched)
+	res, err := r.Reconcile(context.Background(), req())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := len(listSnaps(t, c)); n != 0 {
+		t.Errorf("a schedule that can never fire must create nothing; got %d snapshots", n)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("requeue = %v, want 0 — re-reconciled by its watch when the spec is fixed", res.RequeueAfter)
+	}
+	cond := readyCond(t, c)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "InvalidSchedule" {
+		t.Fatalf("Ready condition = %+v, want False/InvalidSchedule", cond)
+	}
+	if !strings.Contains(cond.Message, "can never fire") {
+		t.Errorf("message must tell the operator the date is the problem, got %q", cond.Message)
+	}
+}
+
+// leapDayPastHorizon returns a schedule and a "now" where cron finds no next
+// occurrence: 29 February from 2097, since 2100 is not a leap year and 2104 is
+// past the five years cron looks ahead.
+//
+// Parse cannot screen this out — the expression is valid and does fire at other
+// times — which is why the reconcile loop guards the zero time itself.
+func leapDayPastHorizon(t *testing.T) (cron.Schedule, time.Time) {
+	t.Helper()
+	sched, err := parseScheduleUTC("0 0 29 2 *")
+	if err != nil {
+		t.Fatalf("29 February must parse: %v", err)
+	}
+	now := time.Date(2097, 3, 1, 0, 0, 0, 0, time.UTC)
+	if !sched.Next(now).IsZero() {
+		t.Fatal("precondition failed: cron found an occurrence, so this no longer tests the zero-time path")
+	}
+	return sched, now
+}
+
+// Without the check the wait is a vast negative that clamps to one second, and
+// the reconciler spins for the lifetime of the object.
+func TestRequeueToNext_NoOccurrenceBacksOff(t *testing.T) {
+	sched, now := leapDayPastHorizon(t)
+	if got := requeueToNext(sched, now); got != maxRequeue {
+		t.Errorf("requeue = %v, want %v (nothing to wait for)", got, maxRequeue)
+	}
+}
+
+// The zero time precedes every "now", so unguarded it reads as permanently due.
+func TestMostRecentDue_NoOccurrenceIsNotDue(t *testing.T) {
+	sched, now := leapDayPastHorizon(t)
+	tick, due := mostRecentDue(sched, now.Add(-24*time.Hour), now)
+	if due {
+		t.Errorf("due = true (tick %v); no occurrence exists, so nothing is due", tick)
+	}
+}

--- a/internal/snapshot/cronspec/cronspec.go
+++ b/internal/snapshot/cronspec/cronspec.go
@@ -35,7 +35,40 @@ func Parse(spec string) (cron.Schedule, error) {
 	if ss, ok := sched.(*cron.SpecSchedule); ok && !namesTimezone(spec) {
 		ss.Location = time.UTC
 	}
+	if err := checkSatisfiable(sched, spec); err != nil {
+		return nil, err
+	}
 	return sched, nil
+}
+
+// satisfiableRef is the instant the check below probes from. Any instant gives
+// the same answer for a date that never occurs, and a fixed one keeps Parse
+// deterministic — no schedule starts being rejected depending on when it was
+// applied. Checked over all 2976 day-of-month × month × day-of-week
+// combinations against references from 1971 to 2090: no disagreement.
+var satisfiableRef = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// checkSatisfiable rejects a date that never occurs, such as "0 0 31 4 *" —
+// the 31st of April.
+//
+// cron accepts these and only fails to match them once running: after five
+// years of searching it returns the ZERO time rather than an error. A zero tick
+// precedes every "now", so it reads as permanently due.
+//
+// Exactly six are impossible: 30 and 31 February, and the 31st of April, June,
+// September and November. 29 February is not one of them — rare, not
+// impossible, and it must keep working.
+func checkSatisfiable(sched cron.Schedule, spec string) error {
+	// @every is an interval, not a calendar date. It always fires.
+	if _, ok := sched.(*cron.SpecSchedule); !ok {
+		return nil
+	}
+	if sched.Next(satisfiableRef).IsZero() {
+		return fmt.Errorf(
+			"cron expression %q can never fire: its day-of-month and month fields "+
+				"describe a date that does not exist, such as 31 April or 30 February", spec)
+	}
+	return nil
 }
 
 // checkTimezonePrefix rejects the one input shape that makes ParseStandard

--- a/internal/snapshot/cronspec/cronspec_test.go
+++ b/internal/snapshot/cronspec/cronspec_test.go
@@ -1,6 +1,7 @@
 package cronspec
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -112,5 +113,84 @@ func TestParse_ExplicitZoneIsHonoured(t *testing.T) {
 	want := time.Date(2026, 6, 7, 2, 0, 0, 0, tokyo)
 	if got := sched.Next(from); !got.Equal(want) {
 		t.Errorf("next tick = %v (%v UTC), want %v", got, got.UTC(), want)
+	}
+}
+
+// The other shape cron accepts and cannot honour: a day-of-month and month that
+// never coincide. Silent, unlike a parse error — cron returns the ZERO time,
+// which precedes every "now", so the schedule reads as permanently due and
+// creates a snapshot named for year 1 on every reconcile.
+func TestParse_ImpossibleDatesAreRejected(t *testing.T) {
+	// The complete set. Every other day/month pair occurs at least once.
+	for _, spec := range []string{
+		"0 0 30 2 *",  // 30 February
+		"0 0 31 2 *",  // 31 February
+		"0 0 31 4 *",  // 31 April
+		"0 0 31 6 *",  // 31 June
+		"0 0 31 9 *",  // 31 September
+		"0 0 31 11 *", // 31 November
+	} {
+		t.Run(spec, func(t *testing.T) {
+			sched, err := Parse(spec)
+			if err == nil {
+				t.Fatalf("Parse(%q) returned no error; this date never occurs", spec)
+			}
+			if sched != nil {
+				t.Errorf("Parse(%q) returned a schedule alongside an error", spec)
+			}
+			// An operator reading this has to understand it is the date, not the syntax.
+			if !strings.Contains(err.Error(), "can never fire") {
+				t.Errorf("error should say the schedule can never fire, got: %v", err)
+			}
+		})
+	}
+}
+
+// 29 February is the near miss: rare, not impossible. It is the case a naive
+// "that date looks odd" check gets wrong, and rejecting it would break anyone
+// snapshotting on a leap day.
+func TestParse_LeapDayIsAccepted(t *testing.T) {
+	sched, err := Parse("0 0 29 2 *")
+	if err != nil {
+		t.Fatalf("29 February must be accepted: %v", err)
+	}
+	from := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	want := time.Date(2028, 2, 29, 0, 0, 0, 0, time.UTC)
+	if got := sched.Next(from); !got.Equal(want) {
+		t.Errorf("next tick = %v, want %v", got, want)
+	}
+}
+
+// The guard must claim those six and nothing else. Sweeping the whole space is
+// what proves the fixed reference instant decides correctly — a spot check
+// could not tell it apart from a rule that is merely close.
+func TestParse_RejectsExactlyTheImpossibleDates(t *testing.T) {
+	impossible := map[string]bool{
+		"0 0 30 2": true, "0 0 31 2": true, "0 0 31 4": true,
+		"0 0 31 6": true, "0 0 31 9": true, "0 0 31 11": true,
+	}
+	var rejected int
+	for dom := 1; dom <= 31; dom++ {
+		for mon := 1; mon <= 12; mon++ {
+			for dow := 0; dow <= 7; dow++ {
+				spec := fmt.Sprintf("0 0 %d %d *", dom, mon)
+				if dow < 7 {
+					spec = fmt.Sprintf("0 0 %d %d %d", dom, mon, dow)
+				}
+				_, err := Parse(spec)
+				// A day-of-week restriction makes the date reachable again:
+				// cron ORs day-of-month and day-of-week when both are set.
+				want := impossible[fmt.Sprintf("0 0 %d %d", dom, mon)] && dow == 7
+				if got := err != nil; got != want {
+					t.Errorf("Parse(%q): rejected=%v, want %v (err=%v)", spec, got, want, err)
+				}
+				if err != nil {
+					rejected++
+				}
+			}
+		}
+	}
+	if rejected != len(impossible) {
+		t.Errorf("rejected %d expressions, want exactly %d", rejected, len(impossible))
 	}
 }


### PR DESCRIPTION
There is no 31 April, but cron takes `0 0 31 4 *` anyway — 31 is a valid day, 4 a valid month, and it only finds out the two never meet while searching forward. After five years it gives up and hands back the **zero time** instead of an error.

The zero time is before every "now", so the tick always looks due. Driving the real reconciler with such a schedule:

```
reconcile 1: RequeueAfter=1s  snapshots=1  lastScheduleTime=<nil>
reconcile 5: RequeueAfter=1s  snapshots=1  lastScheduleTime=<nil>
--- deleted "nightly--62135596800", 0 left
--- after one reconcile: 1 snapshot
    recreated: "nightly--62135596800"
Ready = True (Scheduled): schedule "0 0 30 2 *" is valid; a snapshot is created on each tick
```

So: a SwiftSnapshot named for the zero time in Unix seconds, put back a second after an operator deletes it, a requeue every 1s for as long as the object exists, and a `Ready=True` saying it is all fine. `lastScheduleTime` stays `<nil>` because the zero time marshals to null, which is why it never advances out of the state. With `startingDeadlineSeconds` set the snapshot goes away but the loop stays.

## Two changes, because neither covers the other

**`cronspec.Parse` rejects an expression that can never fire**, so it lands on the same `Ready=False`/`InvalidSchedule` path #584 built — at admission when the webhook is on, at reconcile when it is not.

Exactly six expressions are impossible: 30 and 31 February, and the 31st of April, June, September and November. **29 February is not one of them** — rare, not impossible, and it keeps working.

The check probes from a fixed instant rather than the wall clock, so `Parse` stays deterministic and no schedule starts being rejected depending on when it was applied. To convince myself that a fixed instant decides correctly I swept all 2976 day-of-month × month × day-of-week combinations against a panel of references from 1971 to 2090: they agree on every one, and exactly six come back unsatisfiable. That sweep is in the tests. It also turned up the case worth knowing — when a day-of-week restriction is present cron ORs it with day-of-month, so the impossible date becomes reachable again and must **not** be rejected.

**The reconcile loop guards the zero time itself**, because parsing cannot catch everything. 29 February searched from 2097 genuinely has no next occurrence: 2100 is not a leap year and 2104 is past cron's five-year horizon. `mostRecentDue` now treats a zero `Next` as nothing due; `requeueToNext` backs off to the hourly cap instead of the one-second floor. The test uses that real date rather than a stub schedule.

## Verification

Each guard has a test that goes red without it — I removed them one at a time to check, rather than trusting that they would:

| guard removed | test | failure |
|---|---|---|
| `checkSatisfiable` | `TestParse_ImpossibleDatesAreRejected`, `TestParse_RejectsExactlyTheImpossibleDates`, `TestReconcile_ImpossibleDate_...` | no error returned |
| `!t.IsZero()` in `mostRecentDue` | `TestMostRecentDue_NoOccurrenceIsNotDue` | `due = true (tick 0001-01-01 00:00:00 +0000 UTC)` |
| zero check in `requeueToNext` | `TestRequeueToNext_NoOccurrenceBacksOff` | `requeue = 1s, want 1h0m0s` |

`Parse` runs on every reconcile, so I measured the probe: **~28ns** on a normal expression (807 → 836ns). That is why it sits in the parse path and not behind a flag.

Also green locally: `gofmt -l .`, `go vet ./...`, the full `go test ./...`, `hack/verify-doc-versions.sh`. No `api/` changes, so no CRD regeneration.

## Honest note on severity

This needs a specific typo to hit — it is not something that happens by accident often. But when it does it is silent, the bogus snapshot repairs itself in the wrong direction, and the status actively says the schedule is healthy. That profile looked close enough to #583/#584 to be worth fixing rather than documenting.
