### PR TITLE
feat(chart): reject values keys the chart does not read

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -28,6 +28,7 @@ on:
       - 'hack/verify-render-coverage.sh'
       - 'hack/verify-image-tags.sh'
       - 'hack/verify-doc-versions.sh'
+      - 'hack/verify-values-schema.sh'
       - 'README.md'
       - 'docs/**'
       - '.github/workflows/manifests.yaml'
@@ -49,6 +50,7 @@ on:
       - 'hack/verify-render-coverage.sh'
       - 'hack/verify-image-tags.sh'
       - 'hack/verify-doc-versions.sh'
+      - 'hack/verify-values-schema.sh'
       - 'README.md'
       - 'docs/**'
       - '.github/workflows/manifests.yaml'
@@ -80,6 +82,19 @@ jobs:
       # coverage is established before anything is judged.
       - name: Verify render coverage
         run: ./hack/verify-render-coverage.sh
+
+      # Helm ignores a values key no template reads, so a typo is a setting
+      # that never takes effect. `snapshotOras` (the real key is snapshotORAS)
+      # rode along in real values for four releases that way, with the snapshot
+      # image frozen underneath it. values.schema.json makes such a key an
+      # install/upgrade error.
+      #
+      # Every render in this job would still pass with that schema deleted or
+      # loosened, so none of them shows it works. This asserts misspelt keys
+      # FAIL at three depths, free-form maps and `global` still pass, and the
+      # schema has not drifted from values.yaml.
+      - name: Verify values schema
+        run: ./hack/verify-values-schema.sh
 
       # Rendered through the shared script, NOT an inline `helm template` line.
       # verify-render-coverage above uses the same script, so the set of objects

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ help:
 	@echo "  generate              Generate CRDs and deepcopy (also syncs charts/ + runs verify-crd-sync)"
 	@echo "  verify-crd-sync       Fail if config/crd/kustomization.yaml drifts from config/crd/bases/"
 	@echo "  verify-render-coverage Fail if the lint profile stops rendering a workload CI expects to scan"
+	@echo "  verify-values-schema  Fail if the chart's values.schema.json stops rejecting unknown keys or drifts from values.yaml"
 	@echo "  deploy                Deploy controller-manager (minimal install, no webhooks). Use deploy-with-webhook for webhook-enabled deploys (requires cert-manager)."
 	@echo "  deploy-with-webhook   Deploy controller-manager with admission webhooks enabled (requires cert-manager cluster-side; applies config/overlays/webhook on top of the minimal install)"
 	@echo "  deploy-with-mtls      Deploy controller-manager with live-migration mTLS cert provisioner enabled (Phase 3c; requires cert-manager cluster-side; applies config/overlays/migration-mtls on top of the minimal install)"
@@ -203,6 +204,9 @@ verify-render-coverage:
 
 verify-image-tags:
 	./hack/verify-image-tags.sh
+
+verify-values-schema:
+	./hack/verify-values-schema.sh
 
 verify-cosign-interop: ## Cross-check that our cosign signatures verify (#486). Needs docker.
 	@# Not in any CI gate: it pulls release binaries and runs a local registry.

--- a/charts/kubeswift/README.md
+++ b/charts/kubeswift/README.md
@@ -52,6 +52,10 @@ helm upgrade kubeswift … --set monitoring.enabled=true \
 `helm upgrade` reuses previously-set values only when you pass none; pass
 `--reset-values` to drop old overrides.
 
+The chart rejects values keys it does not read (`values.schema.json`). A typo,
+or a stale key that `helm get values` carries into every upgrade, fails with the
+key named instead of being silently ignored. Delete the key.
+
 ## Values
 
 ### Core

--- a/charts/kubeswift/values.schema.json
+++ b/charts/kubeswift/values.schema.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "KubeSwift chart values",
+  "description": "Rejects keys the chart does not read, so a misspelt key fails the install or upgrade instead of being ignored. It checks key names only, not types. An object with additionalProperties false is a closed set of keys; {} accepts any value, including free-form maps such as annotations, labels and resources. global is accepted because Helm adds it to a chart's values whenever the chart is used as a dependency.",
+  "additionalProperties": false,
+  "properties": {
+    "global": {},
+    "namespace": {},
+    "createNamespace": {},
+    "controllerManager": {
+      "additionalProperties": false,
+      "properties": {
+        "image": { "$ref": "#/definitions/image" },
+        "replicas": {},
+        "resources": {}
+      }
+    },
+    "swiftletd": {
+      "additionalProperties": false,
+      "properties": {
+        "daemonset": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {}
+          }
+        },
+        "image": { "$ref": "#/definitions/image" },
+        "resources": {},
+        "imagePullSecrets": {}
+      }
+    },
+    "snapshotS3": {
+      "additionalProperties": false,
+      "properties": {
+        "image": { "$ref": "#/definitions/image" }
+      }
+    },
+    "sandboxMaterialize": {
+      "additionalProperties": false,
+      "properties": {
+        "image": { "$ref": "#/definitions/image" }
+      }
+    },
+    "snapshotORAS": {
+      "additionalProperties": false,
+      "properties": {
+        "image": { "$ref": "#/definitions/image" }
+      }
+    },
+    "migrationStunnel": {
+      "additionalProperties": false,
+      "properties": {
+        "image": { "$ref": "#/definitions/image" }
+      }
+    },
+    "gpuDiscovery": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {},
+        "image": { "$ref": "#/definitions/image" },
+        "interval": {},
+        "resources": {}
+      }
+    },
+    "dra": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {},
+        "image": { "$ref": "#/definitions/image" },
+        "deviceClass": {
+          "additionalProperties": false,
+          "properties": {
+            "create": {},
+            "name": {}
+          }
+        },
+        "resources": {}
+      }
+    },
+    "federation": {
+      "additionalProperties": false,
+      "properties": {
+        "role": {},
+        "selfRegister": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {},
+            "displayName": {},
+            "prometheusEndpoint": {}
+          }
+        },
+        "edge": {
+          "additionalProperties": false,
+          "properties": {
+            "applyMemberRBAC": {},
+            "operatorGroups": {},
+            "displayName": {}
+          }
+        }
+      }
+    },
+    "gateway": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {},
+        "image": { "$ref": "#/definitions/image" },
+        "replicas": {},
+        "port": {},
+        "authMode": {},
+        "allowInsecureIngress": {},
+        "oidc": {
+          "additionalProperties": false,
+          "properties": {
+            "issuerURL": {},
+            "clientID": {},
+            "usernameClaim": {},
+            "groupsClaim": {},
+            "usernamePrefix": {},
+            "groupsPrefix": {},
+            "caSecret": {},
+            "caKey": {}
+          }
+        },
+        "corsAllowOrigin": {},
+        "prometheusDiscovery": {
+          "additionalProperties": false,
+          "properties": {
+            "namespaces": {}
+          }
+        },
+        "service": { "$ref": "#/definitions/service" },
+        "ingress": { "$ref": "#/definitions/ingress" },
+        "resources": {}
+      }
+    },
+    "ui": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {},
+        "image": {
+          "additionalProperties": false,
+          "properties": {
+            "repository": {},
+            "tag": {},
+            "pullPolicy": {}
+          }
+        },
+        "imagePullSecrets": {},
+        "replicas": {},
+        "gateway": {
+          "additionalProperties": false,
+          "properties": {
+            "mode": {},
+            "service": {},
+            "port": {},
+            "url": {}
+          }
+        },
+        "oidc": {
+          "additionalProperties": false,
+          "properties": {
+            "issuer": {},
+            "clientId": {}
+          }
+        },
+        "service": { "$ref": "#/definitions/service" },
+        "ingress": { "$ref": "#/definitions/ingress" },
+        "resources": {}
+      }
+    },
+    "webhook": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {}
+      }
+    },
+    "scopedLauncherRBAC": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {}
+      }
+    },
+    "launcherSAGate": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {},
+        "guestServiceAccountName": {},
+        "sandboxServiceAccountName": {}
+      }
+    },
+    "monitoring": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {},
+        "serviceMonitor": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {},
+            "interval": {},
+            "additionalLabels": {}
+          }
+        },
+        "dashboards": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {},
+            "label": {},
+            "namespace": {},
+            "annotations": {}
+          }
+        },
+        "prometheusRule": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {},
+            "additionalLabels": {}
+          }
+        }
+      }
+    },
+    "migration": {
+      "additionalProperties": false,
+      "properties": {
+        "mtls": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {}
+          }
+        }
+      }
+    },
+    "swiftGuest": {
+      "additionalProperties": false,
+      "properties": {
+        "allowedHostPathPrefixes": {}
+      }
+    }
+  },
+  "definitions": {
+    "image": {
+      "additionalProperties": false,
+      "properties": {
+        "registry": {},
+        "tag": {}
+      }
+    },
+    "service": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {},
+        "port": {}
+      }
+    },
+    "ingress": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {},
+        "className": {},
+        "host": {},
+        "tlsAuto": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {},
+            "clusterIssuer": {},
+            "issuer": {},
+            "secretName": {}
+          }
+        },
+        "annotations": {},
+        "tls": {}
+      }
+    }
+  }
+}

--- a/hack/verify-values-schema.sh
+++ b/hack/verify-values-schema.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# verify-values-schema — prove charts/kubeswift/values.schema.json still rejects
+# unknown values keys, and still matches values.yaml.
+#
+# THE FAILURE MODE. Helm ignores a values key that no template reads. One
+# mistyped `--set snapshotOras.image.tag=...` (the real key is snapshotORAS)
+# left a decoy that `helm get values` carried into every later upgrade, so the
+# real tag froze for four releases while the values looked current. The schema
+# turns that into an install/upgrade error.
+#
+# Rendering valid values cannot tell whether the schema works: a schema that is
+# deleted, renamed, excluded by .helmignore, or has lost an
+# `additionalProperties: false` renders them just as cleanly. So the cases
+# below must FAIL, not just pass.
+#
+# Run via:
+#   make verify-values-schema
+#   ./hack/verify-values-schema.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHART="$ROOT/charts/kubeswift"
+
+command -v helm >/dev/null || { echo "verify-values-schema: helm not found" >&2; exit 1; }
+command -v jq >/dev/null || { echo "verify-values-schema: jq not found" >&2; exit 1; }
+[[ -f "$CHART/values.schema.json" ]] || { echo "verify-values-schema: $CHART/values.schema.json is missing" >&2; exit 1; }
+
+fail=0
+
+# expect_reject KEY ARGS... — rendering must fail on a schema error naming KEY.
+expect_reject() {
+  local key="$1"; shift
+  local out errs
+  if out="$(helm template kubeswift "$CHART" "$@" 2>&1)"; then
+    echo "verify-values-schema: ACCEPTED $*" >&2
+    echo "  expected a schema error for '$key'" >&2
+    fail=1
+    return
+  fi
+  # Helm < 3.18:          Additional property KEY is not allowed
+  # Helm >= 3.18 and 4.x: additional properties 'KEY' not allowed
+  errs="$(grep -E 'dditional propert(y|ies)' <<<"$out" || true)"
+  if ! grep -qw -- "$key" <<<"$errs"; then
+    echo "verify-values-schema: $* failed, but not on a schema error for '$key':" >&2
+    echo "$out" >&2
+    fail=1
+  fi
+}
+
+# expect_accept ARGS... — rendering must succeed.
+expect_accept() {
+  local out
+  if ! out="$(helm template kubeswift "$CHART" "$@" 2>&1)"; then
+    echo "verify-values-schema: REJECTED $*" >&2
+    echo "$out" >&2
+    fail=1
+  fi
+}
+
+# The incident, and the correct spelling.
+expect_reject snapshotOras --set snapshotOras.image.tag=v1
+expect_accept --set snapshotORAS.image.tag=v1
+
+# Below the top level. gateway.oidc spells it clientID but ui.oidc spells it
+# clientId, which makes that one an easy slip.
+expect_reject tga --set controllerManager.image.tga=v1
+expect_reject clientID --set ui.oidc.clientID=kubeswift
+expect_reject clusterissuer --set gateway.ingress.tlsAuto.clusterissuer=letsencrypt
+
+# Free-form maps must stay open. So must global: Helm adds it to a chart's
+# values whenever the chart is used as a dependency, so rejecting it would make
+# the chart unusable as one.
+expect_accept \
+  --set global.imageRegistry=registry.example.com \
+  --set 'gateway.ingress.annotations.example\.com/key=value' \
+  --set monitoring.serviceMonitor.additionalLabels.release=kube-prometheus-stack \
+  --set controllerManager.resources.limits.memory=1Gi \
+  --set 'swiftletd.imagePullSecrets[0].name=regcred'
+
+# Drift. A key added to values.yaml but not to the schema fails every render
+# already. The reverse does not: a key removed from values.yaml but left in the
+# schema stays silently accepted. So require every key the schema declares
+# (global aside) and lint values.yaml against that.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cp -r "$CHART" "$tmp/kubeswift"
+jq 'walk(if type == "object" and .additionalProperties == false
+         then .required = (((.properties // {}) | keys) - ["global"])
+         else . end)' \
+  "$CHART/values.schema.json" > "$tmp/kubeswift/values.schema.json"
+if ! out="$(helm lint "$tmp/kubeswift" 2>&1)"; then
+  echo "verify-values-schema: values.yaml and values.schema.json disagree:" >&2
+  grep -F '[ERROR]' <<<"$out" >&2 || echo "$out" >&2
+  echo >&2
+  echo "  A key in values.yaml needs an entry in the schema, or a key the schema" >&2
+  echo "  declares is no longer in values.yaml and should be removed from it." >&2
+  fail=1
+fi
+
+if [[ $fail -ne 0 ]]; then
+  exit 1
+fi
+echo "verify-values-schema: OK — unknown keys rejected, free-form maps and global accepted, schema matches values.yaml."


### PR DESCRIPTION
## Summary

Adds `charts/kubeswift/values.schema.json`. `helm install`, `upgrade`, `template` and `lint` now fail on any values key the chart does not read, and the error names the key. Until now such keys were accepted and ignored.

> [!WARNING]
> **Behaviour change.** Values that installed silently before can now fail. An operator carrying a stale or misspelt key will see the next upgrade **fail** and must delete the key. That is intended (the key never did anything), but the release that ships this must say so. Draft CHANGELOG text is at the bottom.

## Why

A mistyped `--set snapshotOras.image.tag=…` (the real key is `snapshotORAS`) was accepted and ignored. `helm get values` carries every key forward, so each later upgrade re-applied the decoy while the real key stayed put. OCI snapshot Jobs ran a `snapshot-oras` image four releases old, while the values file looked current. A schema would have failed that `--set` on the spot.

## Decisions

**`global` is allowed** (any value, unchecked). Nothing in the chart reads it, but Helm adds `global: {}` to a chart's values whenever the chart is used as a dependency. Without it, an umbrella chart that depends on this one fails validation even if it never mentions `global`. Verified on Helm 3.17, 3.21, 3.22 and 4.3 with a throwaway parent chart. The cost is that keys under `global` go unchecked. That is true of every chart, and nothing under `global` can change this one.

**Closed at every level, not only the top.** This also catches `image.tga`, `gateway.oidc.issuerUrl`, and `ui.oidc.clientID` (the UI block spells it `clientId`, the gateway block `clientID`). It is safe because the chart has only ever added keys: no key in any released `values.yaml` (v0.0.0-dev … v0.13.14), and no `.Values` path any released template read, is missing today. Values written against any past release can fail only on a key that never had an effect.

These stay open, because they take arbitrary content: every `resources`, ingress `annotations` and `tls`, `monitoring.*.additionalLabels`, `monitoring.dashboards.annotations`, both `imagePullSecrets`, `federation.edge.operatorGroups`, `gateway.prometheusDiscovery.namespaces` and `swiftGuest.allowedHostPathPrefixes`.

**Key names only.** There are no `type`, `enum` or `required` constraints, so the only thing that can newly fail is an unknown key. Type constraints would reject configs that work today: `monitoring: false` renders fine because the monitoring templates are nil-safe.

`values.yaml` and the templates agree exactly: 19/19 top-level keys, and the same at every nested level. No key is unread, and no key read by a template is missing from `values.yaml`.

## CI

`hack/verify-values-schema.sh` (also `make verify-values-schema`) runs in **Manifests / Render + validate**. The existing renders there would still pass with the schema deleted, so this check asserts failures:

- `snapshotOras`, `controllerManager.image.tga`, `ui.oidc.clientID` and `gateway.ingress.tlsAuto.clusterissuer` are rejected, with a schema error naming the key. It matches both Helm error formats (before and after 3.18).
- `snapshotORAS`, `global.*`, and arbitrary keys under annotations, labels, `resources` and `imagePullSecrets` are accepted.
- Every key the schema declares exists in `values.yaml`. A key added to `values.yaml` without the schema already fails every render; this covers the reverse, where a removed key left in the schema would otherwise stay accepted.

I mutation-tested it on Helm 3.17.2, 3.21.4 (the CI runner's), 3.22.0 and 4.3.0. Each of these turns it red:

- schema deleted, or listed in `.helmignore`
- root `additionalProperties` removed, or the `image` definition opened
- `global` removed, or ingress `annotations` closed
- a stale key left in the schema
- a key added to `values.yaml`, top-level or nested, without updating the schema

## Validation

- `helm lint` and `helm template` pass with defaults, and `values.schema.json` is in the packaged chart.
- `--set snapshotOras.image.tag=v1` fails with a schema error; `--set snapshotORAS.image.tag=v1` renders.
- **Real deployment values** from two live clusters rendered **byte-identically** with and without the schema, on Helm 3.17, 3.21 and 4.3:
  - a hub: UI, ingress with `tlsAuto`, OIDC on gateway and UI, monitoring labels, DRA, GPU discovery, webhook
  - an edge member with `operatorGroups`
- A client-side `helm upgrade --dry-run` of this chart passes on both clusters via `-f <(helm get values …)`, via `--reuse-values`, and with no values flags. Adding the `snapshotOras` decoy makes that upgrade fail. No release revision changed.
- All 28 documented `--set` groups (in `docs/`, `README.md`, the chart README, NOTES, samples and CHANGELOG) give the same result as before, with no schema errors. Three more belong to the OVN-Kubernetes chart and were skipped.
- Validation works with no network (a container run with `--network none`), so air-gapped installs are unaffected.
- `hack/verify-doc-versions.sh`, `hack/verify-crd-sync.sh`, `verify-render-coverage`, `verify-image-tags`, actionlint and shellcheck are all clean.

## Release note

For the CHANGELOG entry of whichever release ships this:

````markdown
### Upgrade

**The chart now rejects values keys it does not read.** `values.schema.json`
lists every key, and `helm install` / `helm upgrade` fail on anything else,
naming the key. Helm used to ignore such keys silently -- including stale or
misspelt ones that `helm get values` carries into every upgrade. If the upgrade
fails with `additional properties '<key>' not allowed` (or `Additional property
<key> is not allowed` on Helm older than 3.18), that key never did anything:
delete it from your values and upgrade again.

To check before upgrading:

```bash
helm template kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift --version X.Y.Z \
  -f <(helm get values kubeswift -n kubeswift-system -o yaml) > /dev/null
```

`--skip-schema-validation` bypasses the check if you must upgrade before
cleaning up.

### Changed

- **Unknown values keys are an error.** Checked at every level, so
  `image.tga` fails as well as a misspelt top-level block. Free-form maps
  (`resources`, annotations, labels, `tls`, `imagePullSecrets`) accept any key,
  and `global` is allowed. Key names only -- no type checks.
````

🤖 Generated with [Claude Code](https://claude.com/claude-code)
