### PR TITLE
docs(chart): correct stale auth and host-path claims, fill missing values rows

### DIFF
--- a/charts/kubeswift/README.md
+++ b/charts/kubeswift/README.md
@@ -36,8 +36,13 @@ See [`docs/install/helm-oci.md`](../../docs/install/helm-oci.md).
 # Minimal operator only (default)
 helm install kubeswift … 
 
-# Management hub: gateway + web console + self-register this cluster
-helm install kubeswift … --set federation.role=hub
+# Management hub: gateway + web console + self-register this cluster.
+# The gateway defaults to authMode=oidc, which needs your IdP (docs/ui/auth.md).
+helm install kubeswift … --set federation.role=hub \
+  --set gateway.oidc.issuerURL=https://keycloak.example.com/realms/kubeswift \
+  --set gateway.oidc.clientID=kubeswift-gateway \
+  --set ui.oidc.issuer=https://keycloak.example.com/realms/kubeswift \
+  --set ui.oidc.clientId=kubeswift-gateway
 
 # Federated member (edge): mints a join credential; NOTES prints the hub manifest
 helm install kubeswift … --set federation.role=edge \
@@ -72,6 +77,8 @@ key named instead of being silently ignored. Delete the key.
 | `swiftletd.image.registry` | Launcher image registry | `ghcr.io/kubeswift-io/kubeswift` |
 | `swiftletd.image.tag` | Launcher image tag (as above) | `latest` |
 | `swiftletd.resources` | Requests/limits | `100m`/`128Mi` … `2`/`2Gi` |
+| `swiftletd.imagePullSecrets` | Pull Secrets for the launcher image on a private registry. Launcher pods run as their own ServiceAccount, so they do not inherit Secrets patched onto `default` | `[]` |
+| `sandboxMaterialize.image.registry` / `.tag` | SwiftSandbox rootfs init container, injected into sandbox pods by the controller | `ghcr.io/kubeswift-io/kubeswift` / `latest` |
 
 ### Snapshot backend images
 
@@ -131,9 +138,10 @@ still adds that component in any role. See [`docs/ui/gateway.md`](../../docs/ui/
 | `gateway.image.registry` / `.tag` | Gateway image | `ghcr.io/kubeswift-io/kubeswift` / `latest` |
 | `gateway.replicas` | Gateway replicas | `1` |
 | `gateway.port` | Container port | `8080` |
-| `gateway.authMode` | End-user auth: `oidc` (verify IdP token, impersonate) · `token` (bearer via TokenReview) · `insecure` (no per-user impersonation — **dev/lab only**) | `insecure` |
-| `gateway.oidc.issuerURL` | (authMode=oidc) IdP issuer, reachable from browser **and** gateway | `""` |
-| `gateway.oidc.clientID` | Client ID / audience the ID token must carry | `""` |
+| `gateway.authMode` | End-user auth: `oidc` (verify IdP token, impersonate) · `token` (bearer via TokenReview) · `insecure` (no authentication at all — **dev/lab only**) | `oidc` |
+| `gateway.allowInsecureIngress` | Accept `authMode=insecure` on a reachable gateway (a gateway or UI ingress, or a LoadBalancer/NodePort Service for either). Without it the chart refuses that combination, which publishes an unauthenticated control plane | `false` |
+| `gateway.oidc.issuerURL` | (authMode=oidc, required) IdP issuer, reachable from browser **and** gateway | `""` |
+| `gateway.oidc.clientID` | (authMode=oidc, required) Client ID / audience the ID token must carry | `""` |
 | `gateway.oidc.usernameClaim` | Claim used as the impersonated username | `email` |
 | `gateway.oidc.groupsClaim` | Claim used as the impersonated groups | `groups` |
 | `gateway.oidc.usernamePrefix` / `.groupsPrefix` | Mirror the apiserver `--oidc-*-prefix` flags | `""` |
@@ -167,7 +175,7 @@ point `ui.gateway.url` at an externally reachable gateway).
 | `ui.gateway.service` / `.port` | (proxy mode) In-cluster gateway Service name + port | `kubeswift-gateway` / `8080` |
 | `ui.gateway.url` | (url mode) Absolute, browser-reachable gateway URL | `""` |
 | `ui.oidc.issuer` | Browser login issuer — must match `gateway.oidc.issuerURL` | `""` |
-| `ui.oidc.clientId` | Public OIDC client the browser logs in with | `""` |
+| `ui.oidc.clientId` | Public OIDC client the browser logs in with. Login is on only when this and `ui.oidc.issuer` are both set | `""` |
 | `ui.service.type` / `.port` | UI Service | `ClusterIP` / `80` |
 | `ui.ingress.enabled` | Create an Ingress for the UI | `false` |
 | `ui.ingress.className` | `ingressClassName` | `""` |
@@ -182,6 +190,7 @@ point `ui.gateway.url` at an externally reachable gateway).
 | Parameter | Description | Default |
 |---|---|---|
 | `webhook.enabled` | Enable admission webhooks (runs the controller with `--webhook-enabled=true`). Requires cert-manager | `false` |
+| `swiftGuest.allowedHostPathPrefixes` | Host-path prefixes a SwiftGuest may mount (virtio-fs `hostPath` shares, vhost-user socket directories). Empty denies every host path. Enforced by the controller, and at admission too when `webhook.enabled` | `[]` |
 | `launcherSAGate.enabled` | Refuse any Pod that names a launcher ServiceAccount unless the KubeSwift controller creates it. **Closes a privilege escalation — see below before disabling** | `true` |
 | `launcherSAGate.guestServiceAccountName` | Guest launcher SA the gate protects. Must match what the controller stamps | `kubeswift-launcher` |
 | `launcherSAGate.sandboxServiceAccountName` | Sandbox launcher SA the gate protects | `kubeswift-sandbox-launcher` |

--- a/charts/kubeswift/values.yaml
+++ b/charts/kubeswift/values.yaml
@@ -346,27 +346,6 @@ ui:
 webhook:
   enabled: false
 
-# Launcher-ServiceAccount admission gate (#443). ON by default — it closes a
-# privilege escalation, and a security control that ships off is a security
-# control nobody has.
-#
-# Launcher pods run privileged and are a NODE-level trust boundary. swiftletd
-# needs `pods: patch` to report status, so the launcher ServiceAccounts carry
-# it — and Kubernetes has no RBAC gate on *which* ServiceAccount a pod may
-# name. Without this, anyone who can create a Pod in a namespace where a guest
-# runs can name the launcher SA, get its token, patch the privileged launcher's
-# image, and reach node root. Scoping the RBAC with resourceNames does NOT close
-# that (RBAC is additive and the SA is shared) — this gate does.
-#
-# Implemented as a ValidatingAdmissionPolicy, evaluated in-tree by the
-# apiserver, so unlike a webhook there is no server whose outage would block
-# pod creation cluster-wide. Rendered only when the cluster serves
-# admissionregistration.k8s.io/v1 ValidatingAdmissionPolicy (GA in k8s 1.30+);
-# on older clusters it is silently skipped and the namespace is a trust
-# boundary instead — see docs/security-audit.md.
-#
-# Turn OFF only if you operate the workload namespaces as a trust boundary
-# already, or a policy engine of your own enforces the same rule.
 # scopedLauncherRBAC — per-launcher-pod RBAC (#515), defence in depth.
 #
 # The controller ALWAYS creates a per-pod Role+RoleBinding granting a launcher
@@ -391,6 +370,27 @@ webhook:
 scopedLauncherRBAC:
   enabled: false
 
+# Launcher-ServiceAccount admission gate (#443). ON by default — it closes a
+# privilege escalation, and a security control that ships off is a security
+# control nobody has.
+#
+# Launcher pods run privileged and are a NODE-level trust boundary. swiftletd
+# needs `pods: patch` to report status, so the launcher ServiceAccounts carry
+# it — and Kubernetes has no RBAC gate on *which* ServiceAccount a pod may
+# name. Without this, anyone who can create a Pod in a namespace where a guest
+# runs can name the launcher SA, get its token, patch the privileged launcher's
+# image, and reach node root. Scoping the RBAC with resourceNames does NOT close
+# that (RBAC is additive and the SA is shared) — this gate does.
+#
+# Implemented as a ValidatingAdmissionPolicy, evaluated in-tree by the
+# apiserver, so unlike a webhook there is no server whose outage would block
+# pod creation cluster-wide. Rendered only when the cluster serves
+# admissionregistration.k8s.io/v1 ValidatingAdmissionPolicy (GA in k8s 1.30+);
+# on older clusters it is silently skipped and the namespace is a trust
+# boundary instead — see docs/security-audit.md.
+#
+# Turn OFF only if you operate the workload namespaces as a trust boundary
+# already, or a policy engine of your own enforces the same rule.
 launcherSAGate:
   enabled: true
   # Must match the constants the controller stamps on launcher pods
@@ -477,7 +477,8 @@ swiftGuest:
   # ".." is always rejected, and prefixes match whole path segments
   # ("/srv/vm" allows "/srv/vm/a" but not "/srv/vmsecrets").
   #
-  # Enforced by the validating webhook, so it requires webhook.enabled=true.
+  # Enforced by the controller, which refuses to build the launcher pod, and
+  # also at admission when webhook.enabled=true.
   #
   #   allowedHostPathPrefixes:
   #     - /srv/kubeswift-shares

--- a/docs/gitops/quickstart.md
+++ b/docs/gitops/quickstart.md
@@ -56,9 +56,9 @@ Three load-bearing choices:
 - **`webhook.enabled: true` needs cert-manager** on the cluster (the chart's
   Certificate/Issuer objects require its CRDs). Without cert-manager, set it
   false — admission validation is then skipped and the controllers' reconcile-
-  time checks are your only guard. Note that
-  `swiftGuest.allowedHostPathPrefixes` is webhook-enforced, so it does nothing
-  with the webhook off.
+  time checks are your only guard. `swiftGuest.allowedHostPathPrefixes` is one
+  of those checks: with the webhook off the controller still refuses to build a
+  launcher pod for a host path outside it.
 
 ### Image tags come from the chart version
 

--- a/docs/ui/auth.md
+++ b/docs/ui/auth.md
@@ -78,35 +78,52 @@ kcadm set-password -r kubeswift --username alice --new-password '<password>'
 
 ## 2. Point the gateway at the IdP
 
-Run the gateway in `oidc` mode (chart values or container args):
+`oidc` is the gateway's default auth mode, and the chart will not render it
+without an issuer and a client ID. In your values file (`kubeswift-values.yaml`):
 
-```bash
-helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
-  -n kubeswift-system \
-  --set gateway.enabled=true \
-  --set gateway.authMode=oidc
-# + the OIDC flags on the gateway container:
-#   --oidc-issuer-url=https://keycloak.example.com/realms/kubeswift
-#   --oidc-client-id=kubeswift-gateway
-#   --oidc-username-claim=email      (default; or preferred_username)
-#   --oidc-groups-claim=groups       (default)
-#   --oidc-username-prefix= / --oidc-groups-prefix=   (optional, mirror apiserver)
+```yaml
+gateway:
+  enabled: true
+  authMode: oidc
+  oidc:
+    issuerURL: https://keycloak.example.com/realms/kubeswift
+    clientID: kubeswift-gateway
+    usernameClaim: email   # default; or preferred_username
+    groupsClaim: groups    # default
 ```
+
+Optional: `usernamePrefix` and `groupsPrefix` mirror the apiserver's
+`--oidc-*-prefix` flags. `caSecret` (key `caKey`, default `ca.crt`) names a
+Secret in the KubeSwift namespace holding a private IdP CA for the gateway's
+JWKS fetch; it does nothing for the browser (see the note above).
 
 The gateway verifies tokens itself, so the **member API servers do not need
 `--oidc-*` flags**.
 
 ## 3. Point the UI at the IdP
 
-The UI reads two runtime globals (its `config.js`, injected by the chart from
-env). Setting both turns login on:
+Give the UI the same issuer and client. The key is `clientId` here and
+`clientID` on the gateway:
 
-```js
-window.__KUBESWIFT_OIDC_ISSUER__ = 'https://keycloak.example.com/realms/kubeswift';
-window.__KUBESWIFT_OIDC_CLIENT_ID__ = 'kubeswift-gateway';
+```yaml
+ui:
+  enabled: true
+  oidc:
+    issuer: https://keycloak.example.com/realms/kubeswift
+    clientId: kubeswift-gateway
 ```
 
-Unset → the UI runs with no login (dev/insecure mode).
+Install or upgrade with both blocks:
+
+```bash
+helm upgrade --install kubeswift oci://ghcr.io/kubeswift-io/charts/kubeswift \
+  -n kubeswift-system -f kubeswift-values.yaml
+```
+
+The chart writes both values into the UI's runtime config
+(`window.__KUBESWIFT_OIDC_ISSUER__`, `window.__KUBESWIFT_OIDC_CLIENT_ID__`).
+Login is on only when both are set. With either empty the UI runs without login,
+and an `oidc` gateway refuses every request it makes.
 
 ## 4. Member-side RBAC (impersonation + the user's permissions)
 

--- a/docs/ui/gateway.md
+++ b/docs/ui/gateway.md
@@ -48,7 +48,10 @@ or a Service of `type: LoadBalancer`. The gateway serves Connect/gRPC-Web over
 `spec.local: true`, using the gateway's own in-cluster ServiceAccount — no
 credential Secret), so the UI lists the hub's own VMs out of the box. Under
 `gateway.authMode` `oidc`/`token` it also grants the gateway SA
-impersonate-on-itself (skipped for `insecure`). Toggle the self entry with
+impersonate-on-itself (skipped for `insecure`). It does not pick an auth mode:
+with the default `oidc` the chart also needs `gateway.oidc.issuerURL` and
+`gateway.oidc.clientID` (see [`auth.md`](auth.md)), or pass
+`gateway.authMode=token` as above. Toggle the self entry with
 `federation.selfRegister.enabled`. `federation.role=standalone` (the default) is
 unchanged from today. Register *remote* members as below.
 


### PR DESCRIPTION
## Summary

Chart docs had drifted from the chart. Most of it dates from #441, which made the gateway secure by default and started enforcing the host-path allowlist in the controller. Docs and comments only; the chart renders byte-identically.

## What was wrong

- **`gateway.authMode` default.** The chart README said `insecure`; it has been `oidc` since #441. The `insecure` description also said only "no per-user impersonation", when it is no authentication at all.
- **Hub one-liner didn't render.** `helm install … --set federation.role=hub` turns the gateway on, and `oidc` fail-closes without `gateway.oidc.issuerURL` and `clientID`. The README command now carries the gateway and UI OIDC values. The hub shortcut in `docs/ui/gateway.md` now says what else it needs.
- **`docs/ui/auth.md` steps 2–3 predated the chart values.** Step 2 said to add raw `--oidc-*` flags to the gateway container, and its command failed the same guard. Both steps now use `gateway.oidc.*` and `ui.oidc.*`, and state that UI login needs both `ui.oidc` keys. Otherwise the UI runs login-less and the gateway refuses every request it makes; I checked that all 29 Connect handlers authenticate.
- **Missing values rows.** The README tables had no rows for `swiftletd.imagePullSecrets`, `sandboxMaterialize.image.*`, `gateway.allowInsecureIngress` or `swiftGuest.allowedHostPathPrefixes`.
- **Host-path allowlist enforcement.** `values.yaml` said it requires `webhook.enabled=true`, and `docs/gitops/quickstart.md` said it "does nothing with the webhook off". The controller has enforced it too since #441 (`hostpathguard.go`), and `docs/virtiofs.md` already said so.
- **Misplaced comment.** The `launcherSAGate` (#443) comment in `values.yaml` sat above `scopedLauncherRBAC`, so the two blocks read as one. Moved; the diff is 21 lines out, the same 21 in.

## Verification

- `values.yaml` parses identically to `main`. The chart renders byte-identically for defaults, the CI lint profile and two real deployment configs.
- Every command and snippet touched was rendered against the chart:
  - The README hub command renders.
  - `federation.role=hub` with `gateway.authMode=token` renders.
  - The `auth.md` YAML, extracted from the doc itself, produces `--auth-mode=oidc`, `--oidc-issuer-url`, `--oidc-client-id` and both claim flags, plus both `KUBESWIFT_OIDC_*` env vars on the UI.
  - The optional keys named in the prose (`usernamePrefix`, `groupsPrefix`, `caSecret`) wire through.
- Each claim was checked:
  - Rendering with no issuer or no client ID fails.
  - UI login env appears only when both `ui.oidc` keys are set.
- A mechanical check confirms every `values.yaml` leaf has a README row, and every row has the right column count.
- All 30 documented `--set` groups give the same result with and without the schema, none with a schema error.
- `verify-doc-versions`, `verify-values-schema`, `verify-render-coverage`, `verify-image-tags` and `verify-crd-sync` pass.

## Noticed, not fixed here

- `hostpathguard.go` says a disallowed host path "surfaces as a Resolved=False condition". But the check runs in `buildPod`, whose error is only logged and requeued. #444 fixed the same pattern for node placement. The docs above describe only the verified behaviour (the controller refuses to build the launcher pod); the status question is tracked separately.
- `hack/verify-render-coverage.sh` has an intermittent false failure: `printf "$rendered" | grep -q` under `pipefail` takes SIGPIPE (exit 141), measured at 2 in 3000. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
