### PR TITLE
fix(ci): stop verify-render-coverage failing on a check that matched

### DIFF
--- a/hack/verify-render-coverage.sh
+++ b/hack/verify-render-coverage.sh
@@ -65,13 +65,16 @@ ValidatingAdmissionPolicyBinding/kubeswift-launcher-sa-gate"
 
 for want in $GUARDED; do
   kind="${want%%/*}"; name="${want##*/}"
-  if ! printf '%s' "$rendered" | grep -q "^kind: ${kind}$"; then
+  # Here-strings, not `printf ... | grep -q`: grep -q exits at its first match,
+  # the still-writing printf takes SIGPIPE, and pipefail fails a check that
+  # matched. The render is ~160 KB, well past the pipe buffer, so that happened.
+  if ! grep -q "^kind: ${kind}$" <<<"$rendered"; then
     echo "verify-render-coverage: ${kind} is missing from the render." >&2
     echo "It is capability-guarded — check hack/render-lint-profile.sh passes" >&2
     echo "--api-versions for it, or the policy check is scanning nothing." >&2
     exit 1
   fi
-  printf '%s' "$rendered" | grep -q "name: ${name}$" || {
+  grep -q "name: ${name}$" <<<"$rendered" || {
     echo "verify-render-coverage: ${kind} rendered but not named ${name}." >&2
     exit 1
   }


### PR DESCRIPTION
## Summary

`hack/verify-render-coverage.sh` could fail on a check that matched, turning **Manifests / Render + validate** red at random. The two guarded-object checks now read the render from a here-string.

## Cause

The script runs under `set -euo pipefail` and checked the launcher-SA gate objects with:

```bash
printf '%s' "$rendered" | grep -q "name: ${name}$"
```

`grep -q` exits at its first match. The render is about 160 KB, well past the 64 KB pipe buffer, so `printf` can still be writing when grep exits. It takes SIGPIPE, and `pipefail` reports **exit 141** for a pipeline whose grep matched. The script then prints "rendered but not named kubeswift-launcher-sa-gate" (or "missing from the render") with nothing wrong. It happened for real during local verification.

A here-string has no writer process to kill, so the race is gone rather than made rarer.

## Verification

- **Head-to-head, same render, 20,000 checks each:** the old pipelines failed 24 times, every one exit 141; the here-string form failed 0 times. The script makes four such checks per run, so that was roughly one false red per 200 runs.
- **50 full runs** of the fixed script: all pass.
- **Still goes red for real:**
  - Dropping `--api-versions` from `render-lint-profile.sh` gives "ValidatingAdmissionPolicy is missing from the render".
  - Renaming the policy gives "rendered but not named".
- shellcheck output is unchanged versus `main` (the same two pre-existing unused-variable warnings). `verify-values-schema`, `verify-image-tags` and `verify-doc-versions` pass.

## Same pattern elsewhere, left alone

Other early-exit readers behind a pipe in CI code can't outrun the pipe buffer:
- `verify-release.yaml` pipes an image index into `grep -q`; the published indexes are 857 bytes.
- The two `| head -1` uses read a one-line `sed` result and a few-line `helm push` log.

`test/storage/w9x-snapshot-block.sh` has one too, but it's a manual repro inside a 90 s retry loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
