### PR TITLE
fix(swiftguest): report a disallowed host path on the guest, before cloning its disk

### DIFF
--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -485,6 +485,36 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
+	// Host-path allowlist, BEFORE the root-disk clone. buildPod checks it too,
+	// but too late: a disk-boot guest has cloned its root disk by then, and a
+	// buildPod error is only logged and retried, so a rejected guest showed no
+	// reason at all (a fresh one had no phase and no conditions). With the
+	// webhook off (the chart default), the controller is the only enforcement.
+	//
+	// A launcher pod that already exists predates the allowlist change. The
+	// controller never edits a live launcher, so it is left running and keeps
+	// being reported, with the violation on Resolved. It is not recreated.
+	hostPathErr := checkHostPaths(&guest, r.AllowedHostPathPrefixes)
+	if hostPathErr != nil {
+		SetResolvedCondition(status, false, hostPathErr.Error())
+		var live corev1.Pod
+		podErr := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: canonicalPodName(&guest)}, &live)
+		if podErr != nil && !apierrors.IsNotFound(podErr) {
+			return ctrl.Result{}, podErr
+		}
+		if apierrors.IsNotFound(podErr) {
+			status.Phase = swiftv1alpha1.SwiftGuestPhaseFailed
+			recordGuestMetrics(&guest, &guest.Status, status, nil)
+			if patchErr := r.patchStatus(ctx, &guest, status); patchErr != nil {
+				return ctrl.Result{}, patchErr
+			}
+			logger.Info("rejected guest: host path outside the allowlist", "error", hostPathErr.Error())
+			return ctrl.Result{}, nil
+		}
+		logger.Info("host path outside the allowlist; leaving the running launcher pod, which will not be recreated",
+			"pod", live.Name, "error", hostPathErr.Error())
+	}
+
 	// For disk boot, ensure per-guest root disk clone exists and is ready.
 	// RootDisk.FromOCI (a source-independent full-state clone) has NO prepared
 	// image — its disk is materialized from the snapshot's oci disk artifact
@@ -540,23 +570,28 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
-	// Build and create/update pod
-	desiredPod, err := r.buildPod(ctx, &guest, rg, seedConfigMapName, intentConfigMapName, rootDiskClone)
-	if err != nil {
-		logger.Error(err, "failed to build pod spec")
-		return ctrl.Result{}, err
-	}
-	// OVN primary-on-NAD: stamp the guest's MAC (+ pinned IP) so the OVN
-	// logical-switch port identity is the guest, not the pod NIC — otherwise the
-	// bridged guest MAC is unreachable on the segment. Dispatches to the backend
-	// that owns the guest's primary network (kube-ovn today). No-op for every other
-	// networking mode. Fails closed on a NAD Get error (boot-time correctness).
-	if err := r.stampOVNIdentity(ctx, &guest, desiredPod); err != nil {
-		logger.Error(err, "failed to stamp OVN primary-NAD identity")
-		return ctrl.Result{}, err
-	}
-	if err := controllerutil.SetControllerReference(&guest, desiredPod, r.Scheme); err != nil {
-		return ctrl.Result{}, err
+	// Build and create/update pod. The desired pod is only ever used to create a
+	// missing launcher, so it is not built past a host-path rejection: that gets
+	// here only with a launcher already running (see the allowlist check above).
+	var desiredPod *corev1.Pod
+	if hostPathErr == nil {
+		desiredPod, err = r.buildPod(ctx, &guest, rg, seedConfigMapName, intentConfigMapName, rootDiskClone)
+		if err != nil {
+			logger.Error(err, "failed to build pod spec")
+			return ctrl.Result{}, err
+		}
+		// OVN primary-on-NAD: stamp the guest's MAC (+ pinned IP) so the OVN
+		// logical-switch port identity is the guest, not the pod NIC — otherwise the
+		// bridged guest MAC is unreachable on the segment. Dispatches to the backend
+		// that owns the guest's primary network (kube-ovn today). No-op for every other
+		// networking mode. Fails closed on a NAD Get error (boot-time correctness).
+		if err := r.stampOVNIdentity(ctx, &guest, desiredPod); err != nil {
+			logger.Error(err, "failed to stamp OVN primary-NAD identity")
+			return ctrl.Result{}, err
+		}
+		if err := controllerutil.SetControllerReference(&guest, desiredPod, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	var existingPod corev1.Pod
@@ -565,6 +600,12 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: canonicalPodName(&guest)}, &existingPod); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
+		}
+		if desiredPod == nil {
+			// The launcher was running at the host-path check and has gone since.
+			// Retry: the next pass finds no pod and fails the guest with the
+			// reason instead of recreating the launcher.
+			return ctrl.Result{}, hostPathErr
 		}
 		// Self-heal a stale migration PodRef before creating the pod.
 		// If status.PodRef points at a <guest>-mig-<uid> pod from a prior

--- a/internal/controller/swiftguest/gpu.go
+++ b/internal/controller/swiftguest/gpu.go
@@ -300,9 +300,9 @@ func (r *SwiftGuestReconciler) buildPod(
 	if err != nil {
 		return nil, err
 	}
-	// Re-apply the host-path allowlist here, not only in the webhook: the
-	// webhook is off by default, and the launcher is privileged. See
-	// hostpathguard.go.
+	// Backstop for the host-path allowlist: Reconcile rejects a disallowed path
+	// before it gets here, but no caller may build a privileged launcher that
+	// mounts one. See hostpathguard.go.
 	if err := checkHostPaths(guest, r.AllowedHostPathPrefixes); err != nil {
 		return nil, err
 	}
@@ -342,8 +342,8 @@ func (r *SwiftGuestReconciler) buildBasePod(
 	// BOTH together (ReleaseFromNode(source) + stamp status.GPU=target, THEN
 	// patch spec.NodeName=target), so by the time the dst pod is built they
 	// agree. A disagreement here is therefore a real bug or an out-of-band
-	// edit — refuse to build, surfaced as Resolved=False via the controller's
-	// ResolutionError mapping.
+	// edit — refuse to build. Note the error is only logged and retried by
+	// Reconcile; nothing is written to the guest's status.
 	//
 	// LOAD-BEARING (W26-class): do NOT weaken this to "trust spec.NodeName
 	// alone" — status.GPU.NodeName must stay the binding source, or a

--- a/internal/controller/swiftguest/hostpathguard.go
+++ b/internal/controller/swiftguest/hostpathguard.go
@@ -18,8 +18,10 @@ import (
 //
 // Since the launcher is privileged, an unconfined host path is node-root. A
 // guard that only runs in an optional component is not a guard, so it is
-// enforced here too: the controller refuses to build the pod, which surfaces
-// as a Resolved=False condition rather than a silently over-privileged VM.
+// enforced here too. Reconcile checks it before the root-disk clone: a guest
+// with no launcher pod goes Failed with the violation on Resolved=False, and a
+// launcher that already runs is left alone but not recreated. buildPod checks
+// again as a backstop.
 func checkHostPaths(guest *swiftv1alpha1.SwiftGuest, allowed []string) error {
 	spec := &guest.Spec
 	for i := range spec.Filesystems {

--- a/internal/controller/swiftguest/hostpathguard_test.go
+++ b/internal/controller/swiftguest/hostpathguard_test.go
@@ -1,9 +1,23 @@
 package swiftguest
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	imagev1alpha1 "github.com/kubeswift-io/kubeswift/api/image/v1alpha1"
+	kernelv1alpha1 "github.com/kubeswift-io/kubeswift/api/kernel/v1alpha1"
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/scheme"
 )
 
 // The webhook is the primary gate but defaults to disabled (it needs
@@ -27,5 +41,225 @@ func TestCheckHostPaths_EnforcedWithoutTheWebhook(t *testing.T) {
 	// Empty allowlist denies, matching the webhook's posture.
 	if err := checkHostPaths(g, nil); err == nil {
 		t.Error("empty allowlist should deny")
+	}
+}
+
+// vhost-user sockets are host paths too: the pod builder mounts the socket's
+// directory into the privileged launcher.
+func TestCheckHostPaths_VhostUserSockets(t *testing.T) {
+	iface := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{
+		Interfaces: []swiftv1alpha1.GuestInterface{{
+			Name: "net0", Type: swiftv1alpha1.InterfaceTypeVhostUser, Socket: "/etc/vhost/net0.sock",
+		}},
+	}}
+	err := checkHostPaths(iface, []string{"/run/vhost"})
+	if err == nil || !strings.Contains(err.Error(), "spec.interfaces[0].socket") {
+		t.Errorf("interface socket outside the allowlist: got %v", err)
+	}
+	dev := &swiftv1alpha1.SwiftGuest{Spec: swiftv1alpha1.SwiftGuestSpec{
+		VhostUserDevices: []swiftv1alpha1.VhostUserDevice{{
+			Name: "blk0", Type: swiftv1alpha1.VhostUserDeviceTypeBlk, Socket: "/etc/vhost/blk0.sock",
+		}},
+	}}
+	err = checkHostPaths(dev, []string{"/run/vhost"})
+	if err == nil || !strings.Contains(err.Error(), "spec.vhostUserDevices[0].socket") {
+		t.Errorf("device socket outside the allowlist: got %v", err)
+	}
+	dev.Spec.VhostUserDevices[0].Socket = "/run/vhost/blk0.sock"
+	if err := checkHostPaths(dev, []string{"/run/vhost"}); err != nil {
+		t.Errorf("rejected an allowed socket: %v", err)
+	}
+}
+
+// The reconcile-level tests below cover what the operator sees. The checks
+// above only prove the rule; a rejection that reaches nothing but the
+// controller log is not something anyone can act on.
+
+const hostPathGuestName = "g"
+
+var hostPathGuestKey = types.NamespacedName{Namespace: "ns", Name: hostPathGuestName}
+
+// hostPathGuest shares path into a kernel-boot guest, which needs only a class
+// and a Ready kernel to resolve.
+func hostPathGuest(path string) *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: hostPathGuestName, Namespace: "ns"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			KernelRef:     &corev1.LocalObjectReference{Name: "k"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "cls"},
+			RunPolicy:     swiftv1alpha1.RunPolicyRunning,
+			Filesystems: []swiftv1alpha1.Filesystem{{
+				Name: "share", Source: swiftv1alpha1.FilesystemSource{HostPath: &path},
+			}},
+		},
+	}
+}
+
+func readyKernel() *kernelv1alpha1.SwiftKernel {
+	return &kernelv1alpha1.SwiftKernel{
+		ObjectMeta: metav1.ObjectMeta{Name: "k", Namespace: "ns"},
+		Status:     kernelv1alpha1.SwiftKernelStatus{Phase: kernelv1alpha1.SwiftKernelPhaseReady},
+	}
+}
+
+func reconcileHostPathGuest(t *testing.T, allowed []string, objs ...client.Object) (*swiftv1alpha1.SwiftGuest, client.Client, ctrl.Result, error) {
+	t.Helper()
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).
+		WithStatusSubresource(&swiftv1alpha1.SwiftGuest{}).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme, AllowedHostPathPrefixes: allowed}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: hostPathGuestKey})
+	var got swiftv1alpha1.SwiftGuest
+	if getErr := c.Get(context.Background(), hostPathGuestKey, &got); getErr != nil {
+		t.Fatalf("get guest: %v", getErr)
+	}
+	return &got, c, res, err
+}
+
+func resolvedCondition(t *testing.T, g *swiftv1alpha1.SwiftGuest) metav1.Condition {
+	t.Helper()
+	c := findCondition(&g.Status, ConditionResolved)
+	if c == nil {
+		t.Fatalf("guest has no Resolved condition; status = %+v", g.Status)
+	}
+	return *c
+}
+
+func launcherPods(t *testing.T, c client.Client) []corev1.Pod {
+	t.Helper()
+	var pods corev1.PodList
+	if err := c.List(context.Background(), &pods, client.InNamespace("ns")); err != nil {
+		t.Fatal(err)
+	}
+	return pods.Items
+}
+
+// The control for the rejections below: the same guest with its path allowed
+// gets a launcher pod, so "no pod" there means rejected, not a harness that
+// cannot build one.
+func TestReconcile_AllowedHostPathCreatesTheLauncher(t *testing.T) {
+	got, c, _, err := reconcileHostPathGuest(t, []string{"/srv/vm"},
+		hostPathGuest("/srv/vm/share"), testGuestClass(), readyKernel())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n := len(launcherPods(t, c)); n != 1 {
+		t.Fatalf("allowed host path: %d launcher pods, want 1", n)
+	}
+	if cond := resolvedCondition(t, got); cond.Status != metav1.ConditionTrue {
+		t.Errorf("allowed host path: Resolved=%s (%s)", cond.Status, cond.Message)
+	}
+}
+
+// With the webhook off, a disallowed host path used to fail only inside
+// buildPod: the error was logged and retried forever, and a fresh guest had no
+// phase and no conditions at all. It must fail the guest, say why, and stop.
+func TestReconcile_DisallowedHostPathFailsTheGuestWithTheReason(t *testing.T) {
+	got, c, res, err := reconcileHostPathGuest(t, nil,
+		hostPathGuest("/etc"), testGuestClass(), readyKernel())
+	if err != nil {
+		t.Fatalf("a policy rejection is terminal, not a retryable error: %v", err)
+	}
+	if res != (ctrl.Result{}) {
+		t.Errorf("requeued a guest that cannot run until its spec or the allowlist changes: %+v", res)
+	}
+	if got.Status.Phase != swiftv1alpha1.SwiftGuestPhaseFailed {
+		t.Errorf("phase = %q, want Failed", got.Status.Phase)
+	}
+	cond := resolvedCondition(t, got)
+	if cond.Status != metav1.ConditionFalse || !strings.Contains(cond.Message, "spec.filesystems[0].source.hostPath") {
+		t.Errorf("Resolved = %s %q; want False naming the field", cond.Status, cond.Message)
+	}
+	if n := len(launcherPods(t, c)); n != 0 {
+		t.Errorf("created %d launcher pods for a rejected guest", n)
+	}
+}
+
+// Failed is not sticky: allowing the prefix (a controller restart with the new
+// flag, which reconciles every guest) lets the same guest start.
+func TestReconcile_HostPathRejectionRecoversOnceAllowed(t *testing.T) {
+	_, c, _, err := reconcileHostPathGuest(t, nil,
+		hostPathGuest("/srv/vm/share"), testGuestClass(), readyKernel())
+	if err != nil {
+		t.Fatalf("rejecting pass: %v", err)
+	}
+	r := &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme, AllowedHostPathPrefixes: []string{"/srv/vm"}}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: hostPathGuestKey}); err != nil {
+		t.Fatalf("pass after allowing the prefix: %v", err)
+	}
+	var got swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), hostPathGuestKey, &got); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(launcherPods(t, c)); n != 1 {
+		t.Fatalf("after allowing the prefix: %d launcher pods, want 1", n)
+	}
+	if got.Status.Phase == swiftv1alpha1.SwiftGuestPhaseFailed {
+		t.Error("guest stayed Failed after its host path was allowed")
+	}
+	if cond := resolvedCondition(t, &got); cond.Status != metav1.ConditionTrue {
+		t.Errorf("after allowing the prefix: Resolved=%s (%s)", cond.Status, cond.Message)
+	}
+}
+
+// A disk-boot guest used to clone its root disk before buildPod rejected it,
+// then sat in Scheduling with Resolved=True. The check has to come first.
+func TestReconcile_DisallowedHostPathDoesNotCloneTheRootDisk(t *testing.T) {
+	guest := hostPathGuest("/etc")
+	guest.Spec.KernelRef = nil
+	guest.Spec.ImageRef = &corev1.LocalObjectReference{Name: "img"}
+	img := &imagev1alpha1.SwiftImage{
+		ObjectMeta: metav1.ObjectMeta{Name: "img", Namespace: "ns"},
+		Status: imagev1alpha1.SwiftImageStatus{
+			Phase: imagev1alpha1.SwiftImagePhaseReady,
+			PreparedArtifact: &imagev1alpha1.PreparedArtifactRef{
+				PVCRef: &imagev1alpha1.PVCObjectReference{Name: "img-prepared"},
+			},
+		},
+	}
+	prepared := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "img-prepared", Namespace: "ns"}}
+
+	got, c, _, err := reconcileHostPathGuest(t, nil, guest, testGuestClass(), img, prepared)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got.Status.Phase != swiftv1alpha1.SwiftGuestPhaseFailed {
+		t.Errorf("phase = %q, want Failed", got.Status.Phase)
+	}
+	var clone corev1.PersistentVolumeClaim
+	cloneErr := c.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: RootDiskCloneName(hostPathGuestName)}, &clone)
+	if !apierrors.IsNotFound(cloneErr) {
+		t.Errorf("root disk clone PVC for a rejected guest: err = %v, want NotFound", cloneErr)
+	}
+	var jobs batchv1.JobList
+	if err := c.List(context.Background(), &jobs, client.InNamespace("ns")); err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs.Items) != 0 {
+		t.Errorf("created %d Jobs for a rejected guest", len(jobs.Items))
+	}
+}
+
+// A launcher that already runs predates the allowlist change. The controller
+// never edits a live launcher, so it must stay up and keep being reported --
+// not be marked Failed while the VM runs -- with the violation on Resolved.
+func TestReconcile_DisallowedHostPathLeavesARunningLauncherAlone(t *testing.T) {
+	running := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: hostPathGuestName, Namespace: "ns"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	got, c, _, err := reconcileHostPathGuest(t, nil,
+		hostPathGuest("/etc"), testGuestClass(), readyKernel(), running)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n := len(launcherPods(t, c)); n != 1 {
+		t.Fatalf("running launcher: %d pods after reconcile, want it left in place", n)
+	}
+	if got.Status.Phase == swiftv1alpha1.SwiftGuestPhaseFailed {
+		t.Error("marked a guest Failed while its launcher is running")
+	}
+	cond := resolvedCondition(t, got)
+	if cond.Status != metav1.ConditionFalse || !strings.Contains(cond.Message, "spec.filesystems[0].source.hostPath") {
+		t.Errorf("Resolved = %s %q; want False naming the field", cond.Status, cond.Message)
 	}
 }


### PR DESCRIPTION
## Summary

With the webhook off (the chart default), a guest rejected by the host-path allowlist now says so on the guest: `Phase=Failed`, with `Resolved=False` naming the field. It is rejected **before** a disk-boot guest clones its root disk.

## What was wrong

The controller enforced `swiftGuest.allowedHostPathPrefixes` only inside `buildPod`. `Reconcile` just logs a `buildPod` error and retries; it never writes it to status. Reproduced against `main` with a reconcile-level test:

- **Kernel boot:** the guest had **no phase and no conditions**. The reason existed only as a controller ERROR line, repeated on every retry.
- **Disk boot:** the controller first provisioned the root-disk clone (a full image copy), then sat in `Scheduling` with `Resolved=True` and `StorageReady=True`, indefinitely.

`hostpathguard.go` promised a `Resolved=False` condition. Nothing ever set one: `buildPod` errors have only been logged since `buildPod` was introduced.

## Fix

`Reconcile` checks the allowlist before the root-disk clone, next to the #444 node-placement check.

| Launcher pod | Result |
|---|---|
| none | `Phase=Failed`, `Resolved=False` naming the field (e.g. `spec.filesystems[0].source.hostPath`), no requeue |
| already running | left running and still reported, with the violation on `Resolved=False`; not recreated once it goes |

**Why not copy #444 as-is.** A launcher can already be running with a now-disallowed path: the allowlist was narrowed, or the guest predates it. The controller never edits a live launcher, and #444's pattern would mark that guest `Failed` while its VM runs. `buildPod` is skipped in that case, since the desired pod is only ever used to create a missing launcher. If that pod disappears between the check and the create, the pass returns the error, and the next pass fails the guest instead of recreating it.

**Not sticky.** Allowing the prefix (a controller restart with the new flag, which reconciles every guest) lets the same guest start.

`buildPod` keeps its check as a backstop. The comment on the GPU node-disagreement check made the same false `Resolved=False` claim; it now says that error is only logged.

## Verification

- New reconcile-level tests against a fake client:
  - an allowed path creates the launcher (the control, so "no pod" elsewhere means rejected);
  - a disallowed path fails the guest with the reason and no requeue;
  - a disk-boot guest gets no clone PVC and no Job;
  - a running launcher is left in place and not marked `Failed`;
  - the guest recovers once the prefix is allowed.
- Red first: the three rejection tests fail on `main`. A mutation that makes the rejection terminal even with a live pod fails exactly the running-launcher test.
- Unit coverage added for the vhost-user socket fields (`spec.interfaces[].socket`, `spec.vhostUserDevices[].socket`).
- `gofmt -s`, `go vet`, `go build ./cmd/...` and the full `go test ./...` pass. golangci-lint reports nothing in the changed files; its 10 existing findings are elsewhere in the package.

Not validated on a cluster. That would need a controller image from this branch on a cluster with the webhook off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
