### PR TITLE
fix(swiftguest): stop a cordon failing guests pinned to the node

### DIFF
--- a/docs/observability/alerts.md
+++ b/docs/observability/alerts.md
@@ -45,7 +45,9 @@ gives the aggregate cause.
 **warning · `kubeswift_guests{phase=~"Pending|Scheduling"} > 0` for 15m**
 A guest hasn't progressed past scheduling.
 → Check the referenced SwiftImage/SwiftKernel is `Ready`, the guest's node
-selector/capacity, and `kubectl describe swiftguest` conditions.
+selector/capacity, and `kubectl describe swiftguest` conditions. A guest pinned
+with `spec.nodeName` waits while that node is cordoned or tainted; its
+`PodScheduled` condition names the cause.
 
 ### KubeSwiftGuestCrashLooping
 **warning · `rate(kubeswift_vm_failures_total[15m]) > 0` for 15m**

--- a/internal/controller/swiftguest/controller.go
+++ b/internal/controller/swiftguest/controller.go
@@ -468,28 +468,23 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// SwiftGPU controller's Resolve stamps status.GPU after scheduling
 	// (status-only, not load-bearing for the runtime). Design doc §A2/§A6.
 
-	// Node placement, BEFORE anything that pins to that node (issue #444).
-	//
-	// The root-disk clone Job below pins to spec.nodeName too. If that node is
-	// unschedulable, the Job's pod sits Pending forever, reconcile never reaches
-	// buildPod, and the guest stalls in Scheduling with nothing explaining why.
-	// Checking here turns a silent stall into a terminal failure with a reason.
-	if err := checkNodePlacementFor(ctx, r.Client, &guest, nil); err != nil {
-		status.Phase = swiftv1alpha1.SwiftGuestPhaseFailed
-		SetResolvedCondition(status, false, err.Error())
-		recordGuestMetrics(&guest, &guest.Status, status, nil)
-		if patchErr := r.patchStatus(ctx, &guest, status); patchErr != nil {
-			return ctrl.Result{}, patchErr
-		}
-		logger.Info("rejected guest: unschedulable spec.nodeName", "error", err.Error())
-		return ctrl.Result{}, nil
+	// The launcher pod, if one already exists. The allowlist and placement checks
+	// below decide whether a launcher may be CREATED; neither fails a guest whose
+	// launcher is already running.
+	var live corev1.Pod
+	liveErr := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: canonicalPodName(&guest)}, &live)
+	if liveErr != nil && !apierrors.IsNotFound(liveErr) {
+		return ctrl.Result{}, liveErr
 	}
+	launcherExists := liveErr == nil
 
 	// Host-path allowlist, BEFORE the root-disk clone. buildPod checks it too,
 	// but too late: a disk-boot guest has cloned its root disk by then, and a
 	// buildPod error is only logged and retried, so a rejected guest showed no
 	// reason at all (a fresh one had no phase and no conditions). With the
 	// webhook off (the chart default), the controller is the only enforcement.
+	// It comes before node placement: a guest that can never run should say so,
+	// not wait for a node.
 	//
 	// A launcher pod that already exists predates the allowlist change. The
 	// controller never edits a live launcher, so it is left running and keeps
@@ -497,12 +492,7 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	hostPathErr := checkHostPaths(&guest, r.AllowedHostPathPrefixes)
 	if hostPathErr != nil {
 		SetResolvedCondition(status, false, hostPathErr.Error())
-		var live corev1.Pod
-		podErr := r.Get(ctx, client.ObjectKey{Namespace: guest.Namespace, Name: canonicalPodName(&guest)}, &live)
-		if podErr != nil && !apierrors.IsNotFound(podErr) {
-			return ctrl.Result{}, podErr
-		}
-		if apierrors.IsNotFound(podErr) {
+		if !launcherExists {
 			status.Phase = swiftv1alpha1.SwiftGuestPhaseFailed
 			recordGuestMetrics(&guest, &guest.Status, status, nil)
 			if patchErr := r.patchStatus(ctx, &guest, status); patchErr != nil {
@@ -513,6 +503,20 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		logger.Info("host path outside the allowlist; leaving the running launcher pod, which will not be recreated",
 			"pod", live.Name, "error", hostPathErr.Error())
+	}
+
+	// Node placement, BEFORE anything that pins to that node (issue #444): the
+	// root-disk clone Job below pins to spec.nodeName too, and on a node that
+	// cannot take it, it would sit Pending forever with nothing saying why.
+	//
+	// Only for a guest with no launcher yet. A cordon or taint added under a
+	// running launcher does not evict it, and failing the guest for one marked
+	// every VM on a cordoned node Failed while it ran (a SwiftGuestPool then
+	// deleted it to replace it). Creation is checked again below.
+	if !launcherExists {
+		if err := checkNodePlacementFor(ctx, r.Client, &guest, nil); err != nil {
+			return r.holdForNodePlacement(ctx, &guest, status, err)
+		}
 	}
 
 	// For disk boot, ensure per-guest root disk clone exists and is ready.
@@ -616,6 +620,13 @@ func (r *SwiftGuestReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// AlreadyExists (TFU #18 secondary trap). See staleMigrationPodRef.
 		if staleMigrationPodRef(&guest) {
 			status.PodRef = nil
+		}
+		// Placement again, at the moment of creation: spec.nodeName skips the
+		// scheduler's taint check, and the launcher is privileged. This also
+		// covers a launcher that existed at the lookup above and is gone now,
+		// such as one a drain has just evicted from a cordoned node.
+		if err := checkNodePlacement(ctx, r.Client, &guest, desiredPod); err != nil {
+			return r.holdForNodePlacement(ctx, &guest, status, err)
 		}
 		// Tolerate AlreadyExists. During the stale-PodRef self-heal above,
 		// the lookup name (canonicalPodName) and the create name

--- a/internal/controller/swiftguest/gpu.go
+++ b/internal/controller/swiftguest/gpu.go
@@ -306,11 +306,10 @@ func (r *SwiftGuestReconciler) buildPod(
 	if err := checkHostPaths(guest, r.AllowedHostPathPrefixes); err != nil {
 		return nil, err
 	}
-	// spec.NodeName binds the pod directly, skipping the scheduler -- so the
-	// taint predicate never runs. Reproduce it here; see nodeplacement.go.
-	if err := checkNodePlacement(ctx, r.Client, guest, pod); err != nil {
-		return nil, err
-	}
+	// No node-placement check here. buildPod also runs for a launcher that is
+	// already up, and a cordon or taint added since must not fail that guest.
+	// Reconcile checks placement where it matters, just before creating a
+	// launcher; see nodeplacement.go.
 	if r.MigrationMTLSEnabled && migrationEligible(guest) {
 		applyMigrationSourceSidecar(pod, guest)
 	}

--- a/internal/controller/swiftguest/hostpathguard_test.go
+++ b/internal/controller/swiftguest/hostpathguard_test.go
@@ -9,13 +9,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	imagev1alpha1 "github.com/kubeswift-io/kubeswift/api/image/v1alpha1"
-	kernelv1alpha1 "github.com/kubeswift-io/kubeswift/api/kernel/v1alpha1"
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/scheme"
 )
@@ -75,62 +71,25 @@ func TestCheckHostPaths_VhostUserSockets(t *testing.T) {
 // above only prove the rule; a rejection that reaches nothing but the
 // controller log is not something anyone can act on.
 
-const hostPathGuestName = "g"
-
-var hostPathGuestKey = types.NamespacedName{Namespace: "ns", Name: hostPathGuestName}
-
-// hostPathGuest shares path into a kernel-boot guest, which needs only a class
-// and a Ready kernel to resolve.
+// hostPathGuest shares path into the kernel-boot test guest.
 func hostPathGuest(path string) *swiftv1alpha1.SwiftGuest {
-	return &swiftv1alpha1.SwiftGuest{
-		ObjectMeta: metav1.ObjectMeta{Name: hostPathGuestName, Namespace: "ns"},
-		Spec: swiftv1alpha1.SwiftGuestSpec{
-			KernelRef:     &corev1.LocalObjectReference{Name: "k"},
-			GuestClassRef: corev1.LocalObjectReference{Name: "cls"},
-			RunPolicy:     swiftv1alpha1.RunPolicyRunning,
-			Filesystems: []swiftv1alpha1.Filesystem{{
-				Name: "share", Source: swiftv1alpha1.FilesystemSource{HostPath: &path},
-			}},
-		},
-	}
-}
-
-func readyKernel() *kernelv1alpha1.SwiftKernel {
-	return &kernelv1alpha1.SwiftKernel{
-		ObjectMeta: metav1.ObjectMeta{Name: "k", Namespace: "ns"},
-		Status:     kernelv1alpha1.SwiftKernelStatus{Phase: kernelv1alpha1.SwiftKernelPhaseReady},
-	}
+	g := kernelGuest()
+	g.Spec.Filesystems = []swiftv1alpha1.Filesystem{{
+		Name: "share", Source: swiftv1alpha1.FilesystemSource{HostPath: &path},
+	}}
+	return g
 }
 
 func reconcileHostPathGuest(t *testing.T, allowed []string, objs ...client.Object) (*swiftv1alpha1.SwiftGuest, client.Client, ctrl.Result, error) {
 	t.Helper()
-	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).
-		WithStatusSubresource(&swiftv1alpha1.SwiftGuest{}).Build()
-	r := &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme, AllowedHostPathPrefixes: allowed}
-	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: hostPathGuestKey})
-	var got swiftv1alpha1.SwiftGuest
-	if getErr := c.Get(context.Background(), hostPathGuestKey, &got); getErr != nil {
-		t.Fatalf("get guest: %v", getErr)
-	}
-	return &got, c, res, err
+	c := guestClientBuilder(objs...).Build()
+	got, res, err := reconcileGuest(t, &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme, AllowedHostPathPrefixes: allowed})
+	return got, c, res, err
 }
 
 func resolvedCondition(t *testing.T, g *swiftv1alpha1.SwiftGuest) metav1.Condition {
 	t.Helper()
-	c := findCondition(&g.Status, ConditionResolved)
-	if c == nil {
-		t.Fatalf("guest has no Resolved condition; status = %+v", g.Status)
-	}
-	return *c
-}
-
-func launcherPods(t *testing.T, c client.Client) []corev1.Pod {
-	t.Helper()
-	var pods corev1.PodList
-	if err := c.List(context.Background(), &pods, client.InNamespace("ns")); err != nil {
-		t.Fatal(err)
-	}
-	return pods.Items
+	return guestCondition(t, g, ConditionResolved)
 }
 
 // The control for the rejections below: the same guest with its path allowed
@@ -182,13 +141,9 @@ func TestReconcile_HostPathRejectionRecoversOnceAllowed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rejecting pass: %v", err)
 	}
-	r := &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme, AllowedHostPathPrefixes: []string{"/srv/vm"}}
-	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: hostPathGuestKey}); err != nil {
+	got, _, err := reconcileGuest(t, &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme, AllowedHostPathPrefixes: []string{"/srv/vm"}})
+	if err != nil {
 		t.Fatalf("pass after allowing the prefix: %v", err)
-	}
-	var got swiftv1alpha1.SwiftGuest
-	if err := c.Get(context.Background(), hostPathGuestKey, &got); err != nil {
-		t.Fatal(err)
 	}
 	if n := len(launcherPods(t, c)); n != 1 {
 		t.Fatalf("after allowing the prefix: %d launcher pods, want 1", n)
@@ -196,7 +151,7 @@ func TestReconcile_HostPathRejectionRecoversOnceAllowed(t *testing.T) {
 	if got.Status.Phase == swiftv1alpha1.SwiftGuestPhaseFailed {
 		t.Error("guest stayed Failed after its host path was allowed")
 	}
-	if cond := resolvedCondition(t, &got); cond.Status != metav1.ConditionTrue {
+	if cond := resolvedCondition(t, got); cond.Status != metav1.ConditionTrue {
 		t.Errorf("after allowing the prefix: Resolved=%s (%s)", cond.Status, cond.Message)
 	}
 }
@@ -204,21 +159,8 @@ func TestReconcile_HostPathRejectionRecoversOnceAllowed(t *testing.T) {
 // A disk-boot guest used to clone its root disk before buildPod rejected it,
 // then sat in Scheduling with Resolved=True. The check has to come first.
 func TestReconcile_DisallowedHostPathDoesNotCloneTheRootDisk(t *testing.T) {
-	guest := hostPathGuest("/etc")
-	guest.Spec.KernelRef = nil
-	guest.Spec.ImageRef = &corev1.LocalObjectReference{Name: "img"}
-	img := &imagev1alpha1.SwiftImage{
-		ObjectMeta: metav1.ObjectMeta{Name: "img", Namespace: "ns"},
-		Status: imagev1alpha1.SwiftImageStatus{
-			Phase: imagev1alpha1.SwiftImagePhaseReady,
-			PreparedArtifact: &imagev1alpha1.PreparedArtifactRef{
-				PVCRef: &imagev1alpha1.PVCObjectReference{Name: "img-prepared"},
-			},
-		},
-	}
-	prepared := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "img-prepared", Namespace: "ns"}}
-
-	got, c, _, err := reconcileHostPathGuest(t, nil, guest, testGuestClass(), img, prepared)
+	got, c, _, err := reconcileHostPathGuest(t, nil,
+		asDiskBoot(hostPathGuest("/etc")), testGuestClass(), readyImage(), preparedPVC())
 	if err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
@@ -226,7 +168,7 @@ func TestReconcile_DisallowedHostPathDoesNotCloneTheRootDisk(t *testing.T) {
 		t.Errorf("phase = %q, want Failed", got.Status.Phase)
 	}
 	var clone corev1.PersistentVolumeClaim
-	cloneErr := c.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: RootDiskCloneName(hostPathGuestName)}, &clone)
+	cloneErr := c.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: RootDiskCloneName(testGuestName)}, &clone)
 	if !apierrors.IsNotFound(cloneErr) {
 		t.Errorf("root disk clone PVC for a rejected guest: err = %v, want NotFound", cloneErr)
 	}
@@ -243,12 +185,8 @@ func TestReconcile_DisallowedHostPathDoesNotCloneTheRootDisk(t *testing.T) {
 // never edits a live launcher, so it must stay up and keep being reported --
 // not be marked Failed while the VM runs -- with the violation on Resolved.
 func TestReconcile_DisallowedHostPathLeavesARunningLauncherAlone(t *testing.T) {
-	running := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: hostPathGuestName, Namespace: "ns"},
-		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
-	}
 	got, c, _, err := reconcileHostPathGuest(t, nil,
-		hostPathGuest("/etc"), testGuestClass(), readyKernel(), running)
+		hostPathGuest("/etc"), testGuestClass(), readyKernel(), runningLauncher(""))
 	if err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}

--- a/internal/controller/swiftguest/nodeplacement.go
+++ b/internal/controller/swiftguest/nodeplacement.go
@@ -3,11 +3,14 @@ package swiftguest
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 )
@@ -49,6 +52,10 @@ func checkNodePlacement(ctx context.Context, c client.Reader, guest *swiftv1alph
 // created first and pins to the SAME node, its pod sits Pending forever, and
 // the reconcile never reaches buildPod where this check lived. The operator saw
 // a guest stuck in Scheduling with nothing saying why.
+//
+// It decides whether a NEW launcher may be created there. It says nothing about
+// a launcher already running: a cordon or taint added later does not evict it,
+// and Reconcile does not consult this for one.
 func checkNodePlacementFor(ctx context.Context, c client.Reader, guest *swiftv1alpha1.SwiftGuest, tolerations []corev1.Toleration) error {
 	if guest.Spec.NodeName == "" {
 		return nil // not pinned; the scheduler runs normally and applies taints itself
@@ -60,7 +67,22 @@ func checkNodePlacementFor(ctx context.Context, c client.Reader, guest *swiftv1a
 		}
 		return fmt.Errorf("resolve spec.nodeName=%q: %w", guest.Spec.NodeName, err)
 	}
-	if t, ok := untoleratedTaint(node.Spec.Taints, tolerations); ok {
+	// A cordon is spec.unschedulable, which the node lifecycle controller then
+	// mirrors as a taint. Either one alone counts: the taint lags behind both the
+	// cordon and the uncordon. It is routine and it passes, so it reads as a
+	// cordon, not as a taint the guest cannot tolerate -- and only once no other
+	// taint blocks, so an uncordon is not promised to fix a node it will not.
+	cordon := corev1.Taint{Key: corev1.TaintNodeUnschedulable, Effect: corev1.TaintEffectNoSchedule}
+	cordoned := node.Spec.Unschedulable && !tolerated(cordon, tolerations)
+	var others []corev1.Taint
+	for _, taint := range node.Spec.Taints {
+		if taint.Key != corev1.TaintNodeUnschedulable {
+			others = append(others, taint)
+		} else if _, blocks := untoleratedTaint([]corev1.Taint{taint}, tolerations); blocks {
+			cordoned = true
+		}
+	}
+	if t, ok := untoleratedTaint(others, tolerations); ok {
 		// NB: SwiftGuest has no spec.tolerations field — the launcher pod is
 		// built with none — so in practice a pinned guest cannot target a
 		// NoSchedule/NoExecute node at all. The message says that, rather than
@@ -71,7 +93,34 @@ func checkNodePlacementFor(ctx context.Context, c client.Reader, guest *swiftv1a
 				"pin the guest to an untainted node, or remove the taint",
 			guest.Spec.NodeName, t.Key, t.Value, t.Effect)
 	}
+	if cordoned {
+		return fmt.Errorf("spec.nodeName=%q is cordoned; the guest starts once the node is uncordoned", guest.Spec.NodeName)
+	}
 	return nil
+}
+
+// nodePlacementRetry is how often a guest held by its pinned node looks again.
+// Nothing watches Nodes, so this is what starts the guest once the node is
+// uncordoned or the taint is removed.
+const nodePlacementRetry = 30 * time.Second
+
+// holdForNodePlacement parks a pinned guest whose node cannot take a new
+// launcher: Pending, with the reason on PodScheduled, retried. It waits rather
+// than fails, like a pod whose only eligible node is cordoned. Cordons, pressure
+// taints and NotReady come and go, and Failed would count a VM failure and make
+// a SwiftGuestPool delete the guest. One that never gets placed still alerts, as
+// KubeSwiftGuestStuckPending.
+func (r *SwiftGuestReconciler) holdForNodePlacement(ctx context.Context, guest *swiftv1alpha1.SwiftGuest,
+	status *swiftv1alpha1.SwiftGuestStatus, cause error) (ctrl.Result, error) {
+	status.Phase = swiftv1alpha1.SwiftGuestPhasePending
+	SetPodScheduledCondition(status, nil, false, cause.Error())
+	recordGuestMetrics(guest, &guest.Status, status, nil)
+	if err := r.patchStatus(ctx, guest, status); err != nil {
+		return ctrl.Result{}, err
+	}
+	log.FromContext(ctx).Info("waiting for the pinned node to take a launcher",
+		"node", guest.Spec.NodeName, "reason", cause.Error())
+	return ctrl.Result{RequeueAfter: nodePlacementRetry}, nil
 }
 
 // untoleratedTaint returns the first NoSchedule/NoExecute taint not tolerated.

--- a/internal/controller/swiftguest/nodeplacement_test.go
+++ b/internal/controller/swiftguest/nodeplacement_test.go
@@ -6,8 +6,11 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
 	"github.com/kubeswift-io/kubeswift/internal/scheme"
@@ -126,6 +129,190 @@ func TestCheckNodePlacementFor_RunsWithoutAPod(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cp-1") {
 		t.Errorf("error does not name the node: %v", err)
+	}
+}
+
+// cordonedNode is what `kubectl cordon` leaves: spec.unschedulable, plus the
+// taint the node lifecycle controller mirrors from it.
+func cordonedNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.NodeSpec{
+			Unschedulable: true,
+			Taints:        []corev1.Taint{{Key: corev1.TaintNodeUnschedulable, Effect: corev1.TaintEffectNoSchedule}},
+		},
+	}
+}
+
+func pinnedGuest(nodeName string) *swiftv1alpha1.SwiftGuest {
+	g := kernelGuest()
+	g.Spec.NodeName = nodeName
+	return g
+}
+
+// A cordon is routine and passes, so it reads as a cordon rather than a taint
+// the guest "cannot tolerate". The taint trails spec.unschedulable in both
+// directions, so either one alone counts.
+func TestCheckNodePlacementFor_CordonReadsAsACordon(t *testing.T) {
+	for name, spec := range map[string]corev1.NodeSpec{
+		"cordoned": cordonedNode("worker-1").Spec,
+		"spec.unschedulable, taint not yet added": {Unschedulable: true},
+		"uncordoned, taint not yet cleared": {Taints: []corev1.Taint{{
+			Key: corev1.TaintNodeUnschedulable, Effect: corev1.TaintEffectNoSchedule,
+		}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+				WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}, Spec: spec}).Build()
+			err := checkNodePlacementFor(context.Background(), c, pinnedGuest("worker-1"), nil)
+			if err == nil {
+				t.Fatal("a new launcher was allowed onto a cordoned node")
+			}
+			if !strings.Contains(err.Error(), "cordoned") || strings.Contains(err.Error(), "cannot tolerate") {
+				t.Errorf("should say the node is cordoned: %v", err)
+			}
+		})
+	}
+}
+
+// A cordoned node that also carries a lasting taint must name the taint: an
+// uncordon alone would not let the guest start.
+func TestCheckNodePlacementFor_LastingTaintOutranksACordon(t *testing.T) {
+	n := cordonedNode("cp-1")
+	n.Spec.Taints = append(n.Spec.Taints, cpTaint)
+	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(n).Build()
+	err := checkNodePlacementFor(context.Background(), c, pinnedGuest("cp-1"), nil)
+	if err == nil || !strings.Contains(err.Error(), "node-role.kubernetes.io/control-plane") {
+		t.Errorf("want the control-plane taint named, got: %v", err)
+	}
+}
+
+// The reported bug: a cordon marked every running guest pinned to the node
+// Failed while its VM kept running, froze its status and counted a VM failure.
+// A SwiftGuestPool deletes Failed guests to replace them, so a pooled VM was
+// killed outright.
+func TestReconcile_CordonLeavesARunningPinnedGuestRunning(t *testing.T) {
+	c := guestClientBuilder(pinnedGuest("worker-1"), testGuestClass(), readyKernel(),
+		cordonedNode("worker-1"), runningLauncher("worker-1")).Build()
+	got, _, err := reconcileGuest(t, &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got.Status.Phase != swiftv1alpha1.SwiftGuestPhaseRunning {
+		t.Errorf("phase = %q, want Running: the VM is up", got.Status.Phase)
+	}
+	if got.Status.NodeName != "worker-1" {
+		t.Errorf("status.nodeName = %q: the running launcher is not being reported", got.Status.NodeName)
+	}
+	if n := len(launcherPods(t, c)); n != 1 {
+		t.Errorf("%d launcher pods, want the running one left alone", n)
+	}
+}
+
+// With no launcher yet, a cordoned pin holds the guest: no new launcher on a
+// cordoned node, but no failure either, because a cordon passes.
+func TestReconcile_CordonHoldsANewPinnedLauncher(t *testing.T) {
+	c := guestClientBuilder(pinnedGuest("worker-1"), testGuestClass(), readyKernel(), cordonedNode("worker-1")).Build()
+	got, res, err := reconcileGuest(t, &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n := len(launcherPods(t, c)); n != 0 {
+		t.Fatalf("created %d launcher pods on a cordoned node", n)
+	}
+	if got.Status.Phase != swiftv1alpha1.SwiftGuestPhasePending {
+		t.Errorf("phase = %q, want Pending", got.Status.Phase)
+	}
+	cond := guestCondition(t, got, ConditionPodScheduled)
+	if cond.Status != metav1.ConditionFalse || !strings.Contains(cond.Message, "cordoned") {
+		t.Errorf("PodScheduled = %s %q; want False saying the node is cordoned", cond.Status, cond.Message)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Error("no requeue: nothing watches Nodes, so the guest would not start after the uncordon")
+	}
+}
+
+// ...and starts the guest once the node is uncordoned.
+func TestReconcile_PinnedGuestStartsOnceUncordoned(t *testing.T) {
+	c := guestClientBuilder(pinnedGuest("worker-1"), testGuestClass(), readyKernel(), cordonedNode("worker-1")).Build()
+	r := &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme}
+	if _, _, err := reconcileGuest(t, r); err != nil {
+		t.Fatalf("held pass: %v", err)
+	}
+	var n corev1.Node
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "worker-1"}, &n); err != nil {
+		t.Fatal(err)
+	}
+	n.Spec.Unschedulable = false
+	n.Spec.Taints = nil
+	if err := c.Update(context.Background(), &n); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := reconcileGuest(t, r)
+	if err != nil {
+		t.Fatalf("pass after uncordon: %v", err)
+	}
+	if pods := launcherPods(t, c); len(pods) != 1 {
+		t.Fatalf("after uncordon: %d launcher pods, want 1", len(pods))
+	}
+	if got.Status.Phase != swiftv1alpha1.SwiftGuestPhaseScheduling {
+		t.Errorf("after uncordon: phase = %q, want Scheduling", got.Status.Phase)
+	}
+}
+
+// #444's case still holds: a disk-boot guest pinned to a node it cannot use
+// used to clone its root disk first, with a Job pinned to that node that never
+// ran. It must wait, name the taint, and clone nothing.
+func TestReconcile_TaintedPinnedNodeHoldsWithoutCloningTheRootDisk(t *testing.T) {
+	c := guestClientBuilder(asDiskBoot(pinnedGuest("cp-1")), testGuestClass(), readyImage(), preparedPVC(),
+		node("cp-1", cpTaint)).Build()
+	got, res, err := reconcileGuest(t, &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got.Status.Phase != swiftv1alpha1.SwiftGuestPhasePending {
+		t.Errorf("phase = %q, want Pending", got.Status.Phase)
+	}
+	cond := guestCondition(t, got, ConditionPodScheduled)
+	if cond.Status != metav1.ConditionFalse || !strings.Contains(cond.Message, "node-role.kubernetes.io/control-plane") {
+		t.Errorf("PodScheduled = %s %q; want False naming the taint", cond.Status, cond.Message)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Error("no requeue: removing the taint would not start the guest")
+	}
+	var clone corev1.PersistentVolumeClaim
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: RootDiskCloneName(testGuestName)}, &clone); !apierrors.IsNotFound(err) {
+		t.Errorf("root disk clone for a guest whose node cannot take it: err = %v, want NotFound", err)
+	}
+}
+
+// The creation-time check is the security boundary: spec.nodeName skips the
+// scheduler, and the launcher is privileged. A launcher present when the
+// reconcile starts can be gone by the time it creates one (a drain evicting it
+// from a cordoned node is exactly that), and the replacement must still be
+// checked.
+func TestReconcile_LauncherGoneMidReconcileIsNotRecreatedOnACordonedNode(t *testing.T) {
+	served := false
+	c := guestClientBuilder(pinnedGuest("worker-1"), testGuestClass(), readyKernel(), cordonedNode("worker-1")).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if pod, ok := obj.(*corev1.Pod); ok && key == testGuestKey && !served {
+					served = true
+					runningLauncher("worker-1").DeepCopyInto(pod)
+					return nil
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).Build()
+	got, _, err := reconcileGuest(t, &SwiftGuestReconciler{Client: c, Scheme: scheme.Scheme})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n := len(launcherPods(t, c)); n != 0 {
+		t.Fatalf("created %d launcher pods on a cordoned node after the running one went away", n)
+	}
+	if got.Status.Phase == swiftv1alpha1.SwiftGuestPhaseFailed {
+		t.Error("a cordon failed the guest")
 	}
 }
 

--- a/internal/controller/swiftguest/reconcile_fixtures_test.go
+++ b/internal/controller/swiftguest/reconcile_fixtures_test.go
@@ -1,0 +1,112 @@
+package swiftguest
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	imagev1alpha1 "github.com/kubeswift-io/kubeswift/api/image/v1alpha1"
+	kernelv1alpha1 "github.com/kubeswift-io/kubeswift/api/kernel/v1alpha1"
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/scheme"
+)
+
+// Fixtures for tests that drive Reconcile against a fake client, where what
+// matters is what the operator sees on the guest, not what a helper returns.
+
+const testGuestName = "g"
+
+var testGuestKey = types.NamespacedName{Namespace: "ns", Name: testGuestName}
+
+// kernelGuest is the smallest guest that reconciles all the way to a launcher
+// pod: kernel boot needs only testGuestClass and readyKernel.
+func kernelGuest() *swiftv1alpha1.SwiftGuest {
+	return &swiftv1alpha1.SwiftGuest{
+		ObjectMeta: metav1.ObjectMeta{Name: testGuestName, Namespace: "ns"},
+		Spec: swiftv1alpha1.SwiftGuestSpec{
+			KernelRef:     &corev1.LocalObjectReference{Name: "k"},
+			GuestClassRef: corev1.LocalObjectReference{Name: "cls"},
+			RunPolicy:     swiftv1alpha1.RunPolicyRunning,
+		},
+	}
+}
+
+func readyKernel() *kernelv1alpha1.SwiftKernel {
+	return &kernelv1alpha1.SwiftKernel{
+		ObjectMeta: metav1.ObjectMeta{Name: "k", Namespace: "ns"},
+		Status:     kernelv1alpha1.SwiftKernelStatus{Phase: kernelv1alpha1.SwiftKernelPhaseReady},
+	}
+}
+
+// asDiskBoot switches g to boot from readyImage. With preparedPVC present it
+// reaches the root-disk clone.
+func asDiskBoot(g *swiftv1alpha1.SwiftGuest) *swiftv1alpha1.SwiftGuest {
+	g.Spec.KernelRef = nil
+	g.Spec.ImageRef = &corev1.LocalObjectReference{Name: "img"}
+	return g
+}
+
+func readyImage() *imagev1alpha1.SwiftImage {
+	return &imagev1alpha1.SwiftImage{
+		ObjectMeta: metav1.ObjectMeta{Name: "img", Namespace: "ns"},
+		Status: imagev1alpha1.SwiftImageStatus{
+			Phase: imagev1alpha1.SwiftImagePhaseReady,
+			PreparedArtifact: &imagev1alpha1.PreparedArtifactRef{
+				PVCRef: &imagev1alpha1.PVCObjectReference{Name: "img-prepared"},
+			},
+		},
+	}
+}
+
+func preparedPVC() *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "img-prepared", Namespace: "ns"}}
+}
+
+// runningLauncher is the test guest's launcher pod, already up on nodeName.
+func runningLauncher(nodeName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: testGuestName, Namespace: "ns"},
+		Spec:       corev1.PodSpec{NodeName: nodeName},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func guestClientBuilder(objs ...client.Object) *fake.ClientBuilder {
+	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).
+		WithStatusSubresource(&swiftv1alpha1.SwiftGuest{})
+}
+
+// reconcileGuest runs one Reconcile of the test guest and returns it as stored.
+func reconcileGuest(t *testing.T, r *SwiftGuestReconciler) (*swiftv1alpha1.SwiftGuest, ctrl.Result, error) {
+	t.Helper()
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: testGuestKey})
+	var got swiftv1alpha1.SwiftGuest
+	if getErr := r.Get(context.Background(), testGuestKey, &got); getErr != nil {
+		t.Fatalf("get guest: %v", getErr)
+	}
+	return &got, res, err
+}
+
+func guestCondition(t *testing.T, g *swiftv1alpha1.SwiftGuest, condType string) metav1.Condition {
+	t.Helper()
+	c := findCondition(&g.Status, condType)
+	if c == nil {
+		t.Fatalf("guest has no %s condition; status = %+v", condType, g.Status)
+	}
+	return *c
+}
+
+func launcherPods(t *testing.T, c client.Client) []corev1.Pod {
+	t.Helper()
+	var pods corev1.PodList
+	if err := c.List(context.Background(), &pods, client.InNamespace("ns")); err != nil {
+		t.Fatal(err)
+	}
+	return pods.Items
+}


### PR DESCRIPTION
## Summary

Cordoning a node no longer marks the running guests pinned to it `Failed`. The node-placement check (#444) now gates **creating** a launcher, never a running one. A guest that can't be placed yet waits in `Pending` with the reason, instead of failing.

## What was wrong

A guest with `spec.nodeName` was checked against its node's taints on every reconcile, before anything looked at its launcher, and any hit was terminal. Reproduced on `main` with a reconcile-level test: `kubectl cordon` adds `node.kubernetes.io/unschedulable:NoSchedule`, and the next reconcile of a guest whose VM is running on that node set:

- `Phase=Failed`, with `Resolved=False` "has taint node.kubernetes.io/unschedulable … cannot tolerate taints";
- a frozen status, because the early return skips mapping the launcher;
- `kubeswift_vm_failures_total` incremented.

**For pooled guests it was destructive.** SwiftGuestPool deletes `Failed` guests to replace them, so a pooled VM pinned to the node was deleted outright. Its replacement then failed the same way, until the uncordon. Any taint added under a running launcher did the same: memory or disk pressure, NotReady.

Two more problems with the terminal `Failed`, even without a running launcher:

- Nothing watches Nodes, so after the uncordon the guest stayed `Failed` until a resync.
- A transient node read error also failed the guest.

## Fix

| Launcher | Node can't take a new one (cordon, taint, missing) |
|---|---|
| running | nothing changes; its status keeps being reported |
| none | `Phase=Pending`, `PodScheduled=False` with the reason, requeued every 30s; still checked before the root-disk clone, as #444 intended |

- **`buildPod` no longer checks placement.** It also runs for a live launcher, and has to: `stampOVNIdentity` re-ensures the OVN IPAMClaim that a later IP-preserving migration relies on.
- **The check moves to the moment of creation.** That is the security boundary: `spec.nodeName` skips the scheduler, and the launcher is privileged. It also covers a launcher that vanishes mid-reconcile, such as one a drain just evicted from the cordoned node, so a replacement cannot land there unchecked.
- **A cordon reads as a cordon:** "is cordoned; the guest starts once the node is uncordoned". `spec.unschedulable` now counts on its own. Before, a new pinned launcher could land on a freshly cordoned node before the lifecycle controller mirrored the taint. A lasting taint is still named first, so an uncordon isn't promised to fix a control-plane node.
- **Still alertable:** a guest that never gets placed (control-plane taint, missing node) shows up as `KubeSwiftGuestStuckPending`. The runbook for that alert now mentions pinned nodes.

**Behaviour change:** a guest pinned to a node it cannot use (e.g. a control-plane node) now waits in `Pending` instead of going `Failed`. That matches a pod whose only eligible node is tainted, and it recovers by itself.

**StopAndCopy is unaffected.** It rejects a cordoned target at validation (webhook and controller) and detects the destination by polling for its pod, not by the guest's phase.

## Verification

- New reconcile-level tests, with fixtures now shared with the #591 host-path tests:
  - a running pinned guest on a cordoned node stays `Running` and reported;
  - a new one is held `Pending` with the reason and a requeue, and starts after the uncordon;
  - a disk-boot guest pinned to a control-plane node holds without cloning its root disk;
  - a launcher that disappears mid-reconcile (simulated with a client interceptor) is not recreated on a cordoned node.
- Unit tests: cordon messaging for each of cordon, `spec.unschedulable` alone and taint alone; a lasting taint outranks a cordon.
- **Red on `main`:** 6 of the 7 new tests fail. The uncordon test pins existing behaviour. Every existing test passes on both old and new code.
- **Mutations, each caught by the intended test:** removing the creation-time check; checking placement despite a running launcher; dropping the requeue; ignoring `spec.unschedulable`; restoring the `buildPod` check.
- `gofmt -s`, `go vet`, `go build ./cmd/...` and the full `go test ./...` pass. golangci-lint reports nothing in the changed files.

Not validated on a cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
