### PR TITLE
fix(swiftguestpool): back off replacing replicas that keep failing

### DIFF
--- a/api/swift/v1alpha1/types_swiftguestpool.go
+++ b/api/swift/v1alpha1/types_swiftguestpool.go
@@ -235,6 +235,10 @@ const (
 	LabelPoolName          = "swift.kubeswift.io/pool"
 	LabelPoolIndex         = "swift.kubeswift.io/pool-index"
 	AnnotationTemplateHash = "swift.kubeswift.io/template-hash"
+	// AnnotationReplacementAttempt counts the replacements of a replica's index
+	// that each failed soon after being created. It sets how long the pool waits
+	// before replacing this replica if it fails too. Absent means zero.
+	AnnotationReplacementAttempt = "swift.kubeswift.io/replacement-attempt"
 )
 
 // SwiftGuestPoolList contains a list of SwiftGuestPool.

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -236,7 +236,8 @@ func main() {
 	}
 
 	if err = (&swiftguestpool.SwiftGuestPoolReconciler{
-		Client: mgr.GetClient(),
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor("swiftguestpool-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create SwiftGuestPool controller")
 		os.Exit(1)

--- a/docs/swiftguestpool-guide.md
+++ b/docs/swiftguestpool-guide.md
@@ -19,7 +19,7 @@ For complete use-case manifests, see [swiftguestpool-use-cases.md](swiftguestpoo
 
 ### What is SwiftGuestPool
 
-SwiftGuestPool manages a fleet of identical SwiftGuest VMs. You provide a replica count and a template; the controller creates and maintains that many VMs. When you change the template, the controller performs a rolling update. When a VM fails, the controller replaces it.
+SwiftGuestPool manages a fleet of identical SwiftGuest VMs. You provide a replica count and a template; the controller creates and maintains that many VMs. When you change the template, the controller performs a rolling update. When a VM fails, the controller replaces it, backing off if replacements keep failing (see [Replica keeps failing](#replica-keeps-failing)).
 
 ### Prerequisites
 
@@ -549,6 +549,24 @@ Common causes:
 - The new template references an image that is not Ready.
 - The guest class does not have enough resources for the new spec.
 - Node capacity exhausted -- no room for new replicas.
+
+### Replica keeps failing
+
+Symptom: `FAILED` stays non-zero, the pool's events show `BackOff`.
+
+A replica that fails soon after it is created is not replaced straight away: a
+new copy usually fails the same way (a missing image or class, a host path the
+cluster does not allow). The pool waits 10s after creating it, doubling with each
+replacement that fails again, up to 5m. A replica that ran for 10m before failing
+is replaced at once, and so is a failed replica when you change the template.
+
+```bash
+kubectl describe sgpool <name>          # BackOff events carry the reason
+kubectl describe sg <pool>-<index>      # the Resolved condition says what failed
+```
+
+Fix the cause and the next replacement picks it up, or change the template to
+replace the replica immediately.
 
 ### PVC binding failures
 

--- a/internal/controller/swiftguestpool/controller.go
+++ b/internal/controller/swiftguestpool/controller.go
@@ -10,6 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,7 +22,27 @@ import (
 // SwiftGuestPoolReconciler reconciles SwiftGuestPool objects.
 type SwiftGuestPoolReconciler struct {
 	client.Client
+	// Recorder reports failed-replica replacement on the pool. Optional.
+	Recorder record.EventRecorder
+
+	now func() time.Time // replacement back-off clock; nil means time.Now
 }
+
+// Replacing a Failed replica backs off the way the kubelet does for a crashing
+// container: 10s, doubling to a 5m cap, reset once a replica has lived 10m.
+//
+// It is measured from the replica's creation. A replica that fails as soon as it
+// exists usually hits something a new copy would hit too -- a template or policy
+// rejection, a missing image or class -- and replacing it at once only looped:
+// delete, recreate, fail, delete, as fast as the controllers could go. Now such
+// a replica stays visible with its reason and is retried at most every 5m, which
+// still picks up a fix made outside the template. A replica that ran fine for a
+// while and then failed is replaced at once, as before.
+const (
+	replacementBackoffBase  = 10 * time.Second
+	replacementBackoffCap   = 5 * time.Minute
+	replacementBackoffReset = 10 * time.Minute
+)
 
 // Reconcile maintains the desired number of SwiftGuest replicas for a pool,
 // handles rolling updates, and manages per-replica PVCs.
@@ -45,21 +66,40 @@ func (r *SwiftGuestPoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	currentHash := computeTemplateHash(&pool.Spec.Template)
 	requeueNeeded := false
 
-	// --- Failed VM replacement ---
+	// --- Failed VM replacement, with back-off ---
+	attempts := map[int]int{}        // index -> replacement attempt its new replica carries
+	var backoffRequeue time.Duration // soonest a deferred replacement falls due
 	for idx, guest := range indexMap {
-		if idx < desired && guest.Status.Phase == swiftv1alpha1.SwiftGuestPhaseFailed {
-			policy := guest.Spec.RunPolicy
-			if policy == swiftv1alpha1.RunPolicyRunning ||
-				policy == swiftv1alpha1.RunPolicyAlways ||
-				policy == swiftv1alpha1.RunPolicyRestartOnFailure {
-				klog.InfoS("deleting failed guest for replacement",
-					"pool", pool.Name, "guest", guest.Name, "index", idx)
-				if err := r.Delete(ctx, &guest); err != nil {
-					return ctrl.Result{}, err
-				}
-				delete(indexMap, idx)
-			}
+		if idx >= desired || guest.Status.Phase != swiftv1alpha1.SwiftGuestPhaseFailed {
+			continue
 		}
+		policy := guest.Spec.RunPolicy
+		if policy != swiftv1alpha1.RunPolicyRunning &&
+			policy != swiftv1alpha1.RunPolicyAlways &&
+			policy != swiftv1alpha1.RunPolicyRestartOnFailure {
+			continue
+		}
+		reason := replicaFailureReason(&guest)
+		wait, next := replacementDelay(&guest, currentHash, r.clock())
+		if wait > 0 {
+			klog.InfoS("failed replica in replacement back-off",
+				"pool", pool.Name, "guest", guest.Name, "index", idx, "retryIn", wait, "reason", reason)
+			r.event(&pool, corev1.EventTypeWarning, "BackOff",
+				"replica %s failed (%s); back-off %s before replacing it", guest.Name, reason, replacementBackoff(next-1))
+			if backoffRequeue == 0 || wait < backoffRequeue {
+				backoffRequeue = wait
+			}
+			continue
+		}
+		klog.InfoS("deleting failed guest for replacement",
+			"pool", pool.Name, "guest", guest.Name, "index", idx, "attempt", next, "reason", reason)
+		if err := r.Delete(ctx, &guest); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.event(&pool, corev1.EventTypeWarning, "ReplacedFailedReplica",
+			"replaced failed replica %s (%s)", guest.Name, reason)
+		delete(indexMap, idx)
+		attempts[idx] = next
 	}
 
 	// --- Scale down: delete highest indices first ---
@@ -77,7 +117,7 @@ func (r *SwiftGuestPoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	missing := findMissingIndices(indexMap, desired)
 	for _, idx := range missing {
 		klog.InfoS("creating replica", "pool", pool.Name, "index", idx)
-		if err := r.createSwiftGuest(ctx, &pool, idx, currentHash); err != nil {
+		if err := r.createSwiftGuest(ctx, &pool, idx, currentHash, attempts[idx]); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -102,10 +142,72 @@ func (r *SwiftGuestPoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	if requeueNeeded {
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	requeueAfter := backoffRequeue
+	if requeueNeeded && (requeueAfter == 0 || requeueAfter > 10*time.Second) {
+		requeueAfter = 10 * time.Second
 	}
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+func (r *SwiftGuestPoolReconciler) clock() time.Time {
+	if r.now != nil {
+		return r.now()
+	}
+	return time.Now()
+}
+
+func (r *SwiftGuestPoolReconciler) event(pool *swiftv1alpha1.SwiftGuestPool, eventType, reason, format string, args ...any) {
+	if r.Recorder != nil {
+		r.Recorder.Eventf(pool, eventType, reason, format, args...)
+	}
+}
+
+// replacementBackoff is the wait before replacing a replica carrying attempt.
+func replacementBackoff(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	d := replacementBackoffBase
+	for i := 0; i < attempt && d < replacementBackoffCap; i++ {
+		d *= 2
+	}
+	return min(d, replacementBackoffCap)
+}
+
+// replacementDelay says how long a Failed replica must still wait before it is
+// replaced (zero: now), and the attempt its replacement carries.
+func replacementDelay(g *swiftv1alpha1.SwiftGuest, currentHash string, now time.Time) (time.Duration, int) {
+	// A template change may be the fix, so it replaces at once and starts over.
+	if g.Annotations[swiftv1alpha1.AnnotationTemplateHash] != currentHash {
+		return 0, 0
+	}
+	// A replica that lived a good while before failing failed on its own; its
+	// replacement starts over too. (A zero creationTimestamp, which only a test
+	// fake produces, counts as long-lived.)
+	age := now.Sub(g.CreationTimestamp.Time)
+	if g.CreationTimestamp.IsZero() || age >= replacementBackoffReset {
+		return 0, 0
+	}
+	attempt, err := strconv.Atoi(g.Annotations[swiftv1alpha1.AnnotationReplacementAttempt])
+	if err != nil || attempt < 0 {
+		attempt = 0
+	}
+	if wait := replacementBackoff(attempt) - age; wait > 0 {
+		return wait, attempt + 1
+	}
+	return 0, attempt + 1
+}
+
+// replicaFailureReason is the most specific reason a Failed replica reports.
+func replicaFailureReason(g *swiftv1alpha1.SwiftGuest) string {
+	for _, t := range []string{"Resolved", "GuestRunning", "PodScheduled"} {
+		for _, c := range g.Status.Conditions {
+			if c.Type == t && c.Status == metav1.ConditionFalse && c.Message != "" {
+				return c.Message
+			}
+		}
+	}
+	return "phase Failed"
 }
 
 // --- Rolling Update ---
@@ -196,7 +298,7 @@ func (r *SwiftGuestPoolReconciler) reconcileRollingUpdate(
 		klog.InfoS("rolling update: creating replacement",
 			"pool", pool.Name, "index", idx,
 			"surge", surge, "maxSurge", maxSurge)
-		if err := r.createSwiftGuest(ctx, pool, idx, currentHash); err != nil {
+		if err := r.createSwiftGuest(ctx, pool, idx, currentHash, 0); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -208,7 +310,7 @@ func (r *SwiftGuestPoolReconciler) reconcileRollingUpdate(
 
 // --- Guest Creation ---
 
-func (r *SwiftGuestPoolReconciler) createSwiftGuest(ctx context.Context, pool *swiftv1alpha1.SwiftGuestPool, index int, templateHash string) error {
+func (r *SwiftGuestPoolReconciler) createSwiftGuest(ctx context.Context, pool *swiftv1alpha1.SwiftGuestPool, index int, templateHash string, attempt int) error {
 	name := fmt.Sprintf("%s-%d", pool.Name, index)
 
 	// Ensure per-replica PVCs exist.
@@ -238,6 +340,11 @@ func (r *SwiftGuestPoolReconciler) createSwiftGuest(ctx context.Context, pool *s
 		annotations[k] = v
 	}
 	annotations[swiftv1alpha1.AnnotationTemplateHash] = templateHash
+	if attempt > 0 {
+		annotations[swiftv1alpha1.AnnotationReplacementAttempt] = strconv.Itoa(attempt)
+	} else {
+		delete(annotations, swiftv1alpha1.AnnotationReplacementAttempt) // never inherited from the template
+	}
 
 	spec := pool.Spec.Template.Spec.DeepCopy()
 

--- a/internal/controller/swiftguestpool/failed_replacement_test.go
+++ b/internal/controller/swiftguestpool/failed_replacement_test.go
@@ -1,0 +1,276 @@
+package swiftguestpool
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	swiftv1alpha1 "github.com/kubeswift-io/kubeswift/api/swift/v1alpha1"
+	"github.com/kubeswift-io/kubeswift/internal/scheme"
+)
+
+var (
+	testPoolKey    = types.NamespacedName{Namespace: "ns", Name: "p"}
+	testReplicaKey = types.NamespacedName{Namespace: "ns", Name: "p-0"}
+)
+
+func failingPool() *swiftv1alpha1.SwiftGuestPool {
+	return &swiftv1alpha1.SwiftGuestPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "pool-uid"},
+		Spec: swiftv1alpha1.SwiftGuestPoolSpec{
+			Replicas: 1,
+			Template: swiftv1alpha1.SwiftGuestTemplateSpec{Spec: swiftv1alpha1.SwiftGuestSpec{
+				KernelRef:     &corev1.LocalObjectReference{Name: "k"},
+				GuestClassRef: corev1.LocalObjectReference{Name: "cls"},
+				RunPolicy:     swiftv1alpha1.RunPolicyRunning,
+			}},
+		},
+	}
+}
+
+// stampedPoolClient stamps creationTimestamp on create from clock, as the
+// apiserver would; the fake client leaves it zero.
+func stampedPoolClient(clock *time.Time, objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).
+		WithStatusSubresource(&swiftv1alpha1.SwiftGuestPool{}, &swiftv1alpha1.SwiftGuest{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				obj.SetCreationTimestamp(metav1.NewTime(*clock))
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+}
+
+func reconcilePool(t *testing.T, r *SwiftGuestPoolReconciler) ctrl.Result {
+	t.Helper()
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: testPoolKey})
+	if err != nil {
+		t.Fatalf("reconcile pool: %v", err)
+	}
+	return res
+}
+
+// failReplica marks p-0 as the SwiftGuest controller does on a rejection that a
+// new copy of the replica would hit too, and tags it so a replacement is
+// distinguishable from the original.
+func failReplica(t *testing.T, c client.Client, tag, reason string) {
+	t.Helper()
+	ctx := context.Background()
+	var g swiftv1alpha1.SwiftGuest
+	if err := c.Get(ctx, testReplicaKey, &g); err != nil {
+		t.Fatalf("replica p-0: %v", err)
+	}
+	if g.Labels == nil {
+		g.Labels = map[string]string{}
+	}
+	g.Labels["test-generation"] = tag
+	if err := c.Update(ctx, &g); err != nil {
+		t.Fatal(err)
+	}
+	g.Status.Phase = swiftv1alpha1.SwiftGuestPhaseFailed
+	g.Status.Conditions = []metav1.Condition{{
+		Type: "Resolved", Status: metav1.ConditionFalse, Reason: "ResolutionFailed", Message: reason,
+		LastTransitionTime: metav1.Now(),
+	}}
+	if err := c.Status().Update(ctx, &g); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func replicaTag(t *testing.T, c client.Client) string {
+	t.Helper()
+	var g swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), testReplicaKey, &g); err != nil {
+		t.Fatalf("replica p-0: %v", err)
+	}
+	return g.Labels["test-generation"]
+}
+
+// The reported churn: a replica that fails as soon as it exists was deleted and
+// recreated in the same pass, and the copy failed the same way, over and over.
+// A replica that has only just been created and already failed must be left in
+// place for now -- visible, with its reason -- not replaced straight away.
+func TestPool_FreshlyFailedReplicaIsNotReplacedStraightAway(t *testing.T) {
+	clock := time.Now()
+	c := stampedPoolClient(&clock, failingPool())
+	r := &SwiftGuestPoolReconciler{Client: c}
+	reconcilePool(t, r) // creates p-0
+	failReplica(t, c, "first", "SwiftImage not found: img")
+
+	reconcilePool(t, r)
+	if tag := replicaTag(t, c); tag != "first" {
+		t.Fatalf("replica p-0 was replaced the moment it failed (tag %q); a deterministic failure loops", tag)
+	}
+}
+
+func replicaAttempt(t *testing.T, c client.Client) string {
+	t.Helper()
+	var g swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), testReplicaKey, &g); err != nil {
+		t.Fatalf("replica p-0: %v", err)
+	}
+	return g.Annotations[swiftv1alpha1.AnnotationReplacementAttempt]
+}
+
+// Each replacement that fails again waits twice as long, measured from when the
+// replacement was created, and the pool requeues for exactly when it falls due.
+func TestPool_ReplacementBacksOffAndDoubles(t *testing.T) {
+	t0 := time.Date(2026, 9, 13, 10, 0, 0, 0, time.UTC)
+	clock := t0
+	c := stampedPoolClient(&clock, failingPool())
+	r := &SwiftGuestPoolReconciler{Client: c, now: func() time.Time { return clock }}
+	reconcilePool(t, r) // p-0 created at t0
+
+	failReplica(t, c, "first", "SwiftImage not found: img")
+	clock = t0.Add(time.Second)
+	if res := reconcilePool(t, r); res.RequeueAfter != 9*time.Second {
+		t.Errorf("first back-off: requeue %s, want 9s (10s from creation, 1s gone)", res.RequeueAfter)
+	}
+	if tag := replicaTag(t, c); tag != "first" {
+		t.Fatalf("replaced inside the first 10s back-off")
+	}
+
+	clock = t0.Add(10 * time.Second)
+	reconcilePool(t, r)
+	if tag := replicaTag(t, c); tag == "first" {
+		t.Fatal("not replaced once the 10s back-off was up")
+	}
+	if a := replicaAttempt(t, c); a != "1" {
+		t.Errorf("replacement carries attempt %q, want 1", a)
+	}
+
+	failReplica(t, c, "second", "SwiftImage not found: img")
+	clock = t0.Add(11 * time.Second)
+	if res := reconcilePool(t, r); res.RequeueAfter != 19*time.Second {
+		t.Errorf("second back-off: requeue %s, want 19s (20s from the replacement's creation)", res.RequeueAfter)
+	}
+	if tag := replicaTag(t, c); tag != "second" {
+		t.Fatal("replaced inside the second, 20s back-off")
+	}
+
+	clock = t0.Add(30 * time.Second)
+	reconcilePool(t, r)
+	if tag := replicaTag(t, c); tag == "second" {
+		t.Fatal("not replaced once the 20s back-off was up")
+	}
+	if a := replicaAttempt(t, c); a != "2" {
+		t.Errorf("second replacement carries attempt %q, want 2", a)
+	}
+}
+
+func TestReplacementBackoff_DoublesToACap(t *testing.T) {
+	for attempt, want := range map[int]time.Duration{
+		-1: 10 * time.Second, 0: 10 * time.Second, 1: 20 * time.Second, 2: 40 * time.Second,
+		4: 160 * time.Second, 5: 5 * time.Minute, 64: 5 * time.Minute,
+	} {
+		if got := replacementBackoff(attempt); got != want {
+			t.Errorf("attempt %d: back-off %s, want %s", attempt, got, want)
+		}
+	}
+}
+
+// A replica that ran for a while and then failed is not part of a failure loop:
+// it is replaced at once and its replacement starts the back-off over.
+func TestPool_ReplicaThatRanAWhileIsReplacedAtOnce(t *testing.T) {
+	t0 := time.Date(2026, 9, 13, 10, 0, 0, 0, time.UTC)
+	clock := t0
+	c := stampedPoolClient(&clock, failingPool())
+	r := &SwiftGuestPoolReconciler{Client: c, now: func() time.Time { return clock }}
+	reconcilePool(t, r)
+
+	var g swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), testReplicaKey, &g); err != nil {
+		t.Fatal(err)
+	}
+	g.Annotations[swiftv1alpha1.AnnotationReplacementAttempt] = "4" // it had a rough start
+	if err := c.Update(context.Background(), &g); err != nil {
+		t.Fatal(err)
+	}
+	failReplica(t, c, "long-lived", "launcher pod failed")
+
+	clock = t0.Add(30 * time.Minute)
+	reconcilePool(t, r)
+	if tag := replicaTag(t, c); tag == "long-lived" {
+		t.Fatal("a replica that ran for 30m before failing was held in back-off")
+	}
+	if a := replicaAttempt(t, c); a != "" {
+		t.Errorf("replacement carries attempt %q, want none: the back-off starts over", a)
+	}
+}
+
+// Changing the template may be the fix, so a failed replica on the old template
+// is replaced at once rather than waiting out its back-off.
+func TestPool_TemplateChangeReplacesAFailedReplicaAtOnce(t *testing.T) {
+	t0 := time.Date(2026, 9, 13, 10, 0, 0, 0, time.UTC)
+	clock := t0
+	c := stampedPoolClient(&clock, failingPool())
+	r := &SwiftGuestPoolReconciler{Client: c, now: func() time.Time { return clock }}
+	reconcilePool(t, r)
+	failReplica(t, c, "old-template", "SwiftImage not found: img")
+
+	var pool swiftv1alpha1.SwiftGuestPool
+	if err := c.Get(context.Background(), testPoolKey, &pool); err != nil {
+		t.Fatal(err)
+	}
+	pool.Spec.Template.Spec.KernelRef = &corev1.LocalObjectReference{Name: "k2"}
+	if err := c.Update(context.Background(), &pool); err != nil {
+		t.Fatal(err)
+	}
+
+	clock = t0.Add(time.Second)
+	reconcilePool(t, r)
+	var g swiftv1alpha1.SwiftGuest
+	if err := c.Get(context.Background(), testReplicaKey, &g); err != nil {
+		t.Fatal(err)
+	}
+	if g.Labels["test-generation"] == "old-template" {
+		t.Fatal("a failed replica on the old template waited out its back-off")
+	}
+	if g.Annotations[swiftv1alpha1.AnnotationTemplateHash] != computeTemplateHash(&pool.Spec.Template) {
+		t.Error("replacement is not on the new template")
+	}
+	if a := g.Annotations[swiftv1alpha1.AnnotationReplacementAttempt]; a != "" {
+		t.Errorf("replacement carries attempt %q, want none", a)
+	}
+}
+
+// The reason a replica keeps failing is the one thing an operator needs, so it
+// goes on the pool's events, both while waiting and when replacing.
+func TestPool_BackOffAndReplacementAreReportedWithTheReason(t *testing.T) {
+	t0 := time.Date(2026, 9, 13, 10, 0, 0, 0, time.UTC)
+	clock := t0
+	c := stampedPoolClient(&clock, failingPool())
+	rec := record.NewFakeRecorder(10)
+	r := &SwiftGuestPoolReconciler{Client: c, Recorder: rec, now: func() time.Time { return clock }}
+	reconcilePool(t, r)
+	failReplica(t, c, "first", "spec.filesystems[0].source.hostPath is not permitted")
+
+	clock = t0.Add(time.Second)
+	reconcilePool(t, r)
+	wantEvent(t, rec, "Warning BackOff replica p-0 failed (spec.filesystems[0].source.hostPath is not permitted); back-off 10s before replacing it")
+
+	clock = t0.Add(10 * time.Second)
+	reconcilePool(t, r)
+	wantEvent(t, rec, "Warning ReplacedFailedReplica replaced failed replica p-0 (spec.filesystems[0].source.hostPath is not permitted)")
+}
+
+func wantEvent(t *testing.T, rec *record.FakeRecorder, want string) {
+	t.Helper()
+	select {
+	case got := <-rec.Events:
+		if got != want {
+			t.Errorf("event:\n got  %q\n want %q", got, want)
+		}
+	default:
+		t.Errorf("no event; want %q", want)
+	}
+}


### PR DESCRIPTION
## Summary

A SwiftGuestPool no longer deletes and recreates a failed replica in a tight loop. Replacement now backs off the way the kubelet does for a crashing container: **10s, doubling to 5m, reset once a replica has lived 10m.** While it waits, the failed replica stays visible with its reason, which the pool also reports as events.

## What was wrong

The pool replaced a `Failed` replica by deleting it and recreating the same index in the same pass, with no delay. Reproduced with a fake-client test: the replica came back fresh (empty status, resourceVersion reset) on every pass.

When the failure is one a new copy hits too, that is a tight loop:
1. the replacement fails within one SwiftGuest reconcile;
2. its status update wakes the pool (it owns the replica);
3. the pool deletes and recreates it again.

Each turn recreates the replica's owned objects and bumps `kubeswift_vm_failures_total`. The causes include:
- a template referencing a missing or not-Ready SwiftImage, class or kernel;
- a host path outside the allowlist, with the webhook off (#591).

It also hid the cause: the failed replica was gone before anyone could run `kubectl describe` on it, so `FAILED` in `kubectl get sgpool` was almost always 0.

## Fix

Back-off is measured from the replica's creation. The attempt count rides on each replacement as the `swift.kubeswift.io/replacement-attempt` annotation.

| Failed replica | Replacement |
|---|---|
| failed soon after creation | waits 10s, then 20s, 40s … up to 5m per attempt |
| lived 10m before failing | at once, back-off starts over |
| on an outdated template | at once (the new template may be the fix), back-off starts over |

- A fix made **outside** the template (the class created, the allowlist changed) is picked up by the next replacement, within 5m at most.
- The pool requeues for when a deferred replacement falls due.
- Events on the pool carry the replica's failure reason:
  - `BackOff`: `replica p-0 failed (<reason>); back-off 20s before replacing it`
  - `ReplacedFailedReplica`: `replaced failed replica p-0 (<reason>)`

**The alternative: never replacing a `Resolved=False` replica.** It looked simpler but strands replicas:
- The SwiftGuest controller doesn't watch SwiftGuestClass or SwiftKernel, so a replica failed for a class that is created later would never re-resolve by itself.
- A default RollingUpdate (`maxUnavailable=1`, `maxSurge=0`) whose only replica stays unavailable could never roll to a fixed template.

## Verification

- Reconcile-level tests against a fake client that stamps `creationTimestamp` from an injected clock:
  - a freshly failed replica is **not replaced straight away** (fails on `main`);
  - the back-off doubles (10s, then 20s) and the requeue lands on exactly the due time;
  - the back-off caps at 5m;
  - a replica that ran for 30m is replaced at once, with the attempt reset;
  - a template change replaces a failed replica at once, on the new template;
  - `BackOff` and `ReplacedFailedReplica` events carry the reason.
- **Mutations, each caught by the intended test:** removing the back-off, the reset, the template bypass, the attempt carry-over, or the cap.
- `gofmt -s`, `go vet`, `go build ./cmd/...` and the full `go test ./...` pass.
- `make generate` (controller-gen v0.20.1, as in CI) produces no diff; the annotation key is a Go constant only.
- golangci-lint finds nothing in the changed lines; its findings in these files predate this change.
- Not validated on a cluster.

`docs/swiftguestpool-guide.md` gains a "Replica keeps failing" troubleshooting entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
